### PR TITLE
Use single argument completion handler

### DIFF
--- a/Apollo/ApolloClient.swift
+++ b/Apollo/ApolloClient.swift
@@ -29,7 +29,7 @@ public class ApolloClient {
     self.init(networkTransport: HTTPNetworkTransport(url: url))
   }
   
-  public func fetch<Query: GraphQLQuery>(query: Query, completionHandler: @escaping (_ result: GraphQLResult<Query.Data>?, _ error: Error?) -> Void) {
-    networkTransport.send(query: query, completionHandler: completionHandler)
+  public func fetch<Query: GraphQLQuery>(query: Query, onCompletion: @escaping (GraphQLResult<Query.Data>) -> Void, onError: @escaping ( _ error: Error) -> Void) {
+    networkTransport.send(query: query, onCompletion: onCompletion, onError: onError)
   }
 }


### PR DESCRIPTION
If a request finishes, it is either a success with a response or it is an error. But bot can be nil at the same time. Two completion handler for success and error solve this problem.
