### PR TITLE
Make parseResult public again

### DIFF
--- a/Sources/GraphQLResponse.swift
+++ b/Sources/GraphQLResponse.swift
@@ -7,7 +7,7 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
     self.body = body
   }
 
-  func parseResult(cacheKeyForObject: CacheKeyForObject? = nil) throws -> (GraphQLResult<Operation.Data>, RecordSet?)  {
+  public func parseResult(cacheKeyForObject: CacheKeyForObject? = nil) throws -> (GraphQLResult<Operation.Data>, RecordSet?)  {
     let data: Operation.Data?
     let dependentKeys: Set<CacheKey>?
     let records: RecordSet?


### PR DESCRIPTION
We currently use Apollo as de-/serialiser for our graphql requests within our pre-existing network stack and it works really well. 

We used this method for achieving this but it was recently made internal.