### PR TITLE
Add public init for GraphQLResultReader for use with a JSONObject input

### DIFF
--- a/Sources/GraphQLResultReader.swift
+++ b/Sources/GraphQLResultReader.swift
@@ -35,6 +35,13 @@ public final class GraphQLResultReader {
     resolveInfo = GraphQLResolveInfo()
   }
   
+  /// Init a GraphQLResultReader using a JSONObject that has come from an external source
+  public convenience init(jsonMap: JSONObject, variables: GraphQLMap? = [:]) {
+    self.init(variables: variables) { field, object, info in
+      return (object ?? jsonMap)[field.responseName]
+    }
+  }
+  
   // MARK: -
   
   public func value<T: JSONDecodable>(for field: Field) throws -> T {

--- a/Sources/GraphQLResultReader.swift
+++ b/Sources/GraphQLResultReader.swift
@@ -36,9 +36,9 @@ public final class GraphQLResultReader {
   }
   
   /// Init a GraphQLResultReader using a JSONObject that has come from an external source
-  public convenience init(jsonMap: JSONObject, variables: GraphQLMap? = [:]) {
-    self.init(variables: variables) { field, object, info in
-      return (object ?? jsonMap)[field.responseName]
+  public convenience init(rootObject: JSONObject) {
+    self.init() { field, object, info in
+      return (object ?? rootObject)[field.responseName]
     }
   }
   


### PR DESCRIPTION
For this PR to make sense it helps to understand our unusual use-case:

We have a React Native app in which we use the javascript Apollo Client to fetch data from our GraphQL server. One vital and performance-critical section of the app is an entirely native view though, and for that we use Apollo-iOS for two purposes:

1. An "out of the box" apollo-ios configuration for _testing_ our native view in a standalone app (in a non-react native container). With `apolloClient.fetch` (in Swift)
2. To parse the same data collected by Apollo Client (JS) into native data types for the same native views within the React Native App (in _production_)

I just updated our Apollo iOS version to take advantage of the fix that maps `GraphQLFloat` -> `Double`, and to be on par with the latest version of `apollo-codegen`. I then found that our production use case was broken, due to the way XYZQuery.Data is now constructed via a `Reader` instead of a `JSONMap`.

This is a very simple change that re-enables the above use case without making any unneccesary changes to access control elsewhere in the code. It could also be interesting for other cases like loading GraphQL data from a cached JSON string etc. I noticed there was some discussion about using alternative NetworkTransports etc., maybe this would be a simple solution to those discussions too