### PR TITLE
Remove Development Team

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -642,7 +642,6 @@
 					};
 					9FC750431D2A532C00458D91 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 5TL236FN6U;
 						DevelopmentTeamName = "Martijn Walraven";
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;


### PR DESCRIPTION
There's no need to have a team listed for code-signing in a framework target.

Without this change the build fails while developing, because the Apollo Team credentials are not available on other people's machines.

This change should have no negative impact, and at the same time make it easier to contribute to this repo.