### PR TITLE
Fixed issue where a field that was removed from a Record would still exist after a merge.

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1FACE8FF1E708BE600E0B443 /* RecordSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FACE8FE1E708BE600E0B443 /* RecordSetTests.swift */; };
 		9F27D4641D40379500715680 /* JSONStandardTypeConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F27D4631D40379500715680 /* JSONStandardTypeConversions.swift */; };
 		9F295E2D1E27419800A24949 /* StarWarsServerCachingRoundtripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F295E2B1E27418F00A24949 /* StarWarsServerCachingRoundtripTests.swift */; };
 		9F295E311E27534800A24949 /* NormalizeQueryResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F295E301E27534800A24949 /* NormalizeQueryResults.swift */; };
@@ -143,6 +144,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FACE8FE1E708BE600E0B443 /* RecordSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordSetTests.swift; sourceTree = "<group>"; };
 		9F27D4631D40379500715680 /* JSONStandardTypeConversions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONStandardTypeConversions.swift; sourceTree = "<group>"; };
 		9F295E2B1E27418F00A24949 /* StarWarsServerCachingRoundtripTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StarWarsServerCachingRoundtripTests.swift; sourceTree = "<group>"; };
 		9F295E301E27534800A24949 /* NormalizeQueryResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NormalizeQueryResults.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 				9FC9A9C71E2EFE6E0023C4D5 /* CacheKeyForFieldTests.swift */,
 				9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */,
 				9FADC8531E6B86D900C677E6 /* DataLoaderTests.swift */,
+				1FACE8FE1E708BE600E0B443 /* RecordSetTests.swift */,
 				9FCDFD2E1E3579B6007519DC /* MockNetworkTransport.swift */,
 				9FF90A751DDDEB4C0034C3B6 /* Utilities.swift */,
 				9FC9A9D51E2FD5690023C4D5 /* Integration */,
@@ -786,6 +789,7 @@
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,
 				9FF90A711DDDEB420034C3B6 /* GraphQLExecutorFieldValueTests.swift in Sources */,
 				9FCDFD2C1E35784B007519DC /* WatchQueryTests.swift in Sources */,
+				1FACE8FF1E708BE600E0B443 /* RecordSetTests.swift in Sources */,
 				9F295E311E27534800A24949 /* NormalizeQueryResults.swift in Sources */,
 				9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */,
 			);

--- a/Sources/RecordSet.swift
+++ b/Sources/RecordSet.swift
@@ -45,6 +45,13 @@ public struct RecordSet {
         oldRecord[key] = value
         changedKeys.insert([record.key, key].joined(separator: "."))
       }
+      
+      let removedFieldKeys = Set(oldRecord.fields.keys).subtracting(record.fields.keys)
+      for removedFieldKey in removedFieldKeys {
+        oldRecord[removedFieldKey] = nil
+        changedKeys.insert([oldRecord.key, removedFieldKey].joined(separator: "."))
+      }
+      
       storage[record.key] = oldRecord
       return changedKeys
     } else {

--- a/Tests/ApolloTests/RecordSetTests.swift
+++ b/Tests/ApolloTests/RecordSetTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Apollo
+
+class RecordSetTests: XCTestCase {
+  func testMergingWhenFieldIsRemoved() {
+    let original = Record(key: "hero", ["name": "Luke Skywalker"])
+    var set = RecordSet(records: [original])
+    let new = Record(key: "hero")
+    let changed = set.merge(record: new)
+    
+    XCTAssertTrue(changed.contains("hero.name"))
+    
+    guard let merged = set["hero"] else {
+      XCTFail("missing record")
+      return
+    }
+    
+    XCTAssertNil(merged.fields["name"])
+  }
+}


### PR DESCRIPTION
This could happen when a value changed to `null`. This fixes a bug in the following scenario:

1. Make a query where field `x` has value `y`. The result is cached.
2. Make the same query but bypass the cache. This time the field `x` has value `null`.
3. Make the same query again but allow fetching from the cache.

*Expected Result*: field `x` has value `null`.
*Actual Result*: field `x` still has value `y`.

The fix was to ensure that keys/fields that do not exist in a new record are removed from the old record during a merge.