### PR TITLE
Update `check-and-run-apollo-codegen.sh` to install `apollo-codegen`

### DIFF
--- a/scripts/check-and-run-apollo-codegen.sh
+++ b/scripts/check-and-run-apollo-codegen.sh
@@ -1,9 +1,30 @@
+# Only major and minor version should be specified here
 REQUIRED_APOLLO_CODEGEN_VERSION=0.11
+
+REQUIRED_APOLLO_CODEGEN_SEMVER="$REQUIRED_APOLLO_CODEGEN_VERSION.x"
 
 # Part of this code has been adapted from https://github.com/facebook/react-native/blob/master/packager/react-native-xcode.sh
 
 # This script is supposed to be invoked as part of the Xcode build process
 # and relies on environment variables set by Xcode
+
+install_apollo_codegen() {
+  npm install -g apollo-codegen@"$REQUIRED_APOLLO_CODEGEN_SEMVER"
+}
+
+# We consider versions to be compatible if the major and minor versions match
+are_versions_compatible() {
+  [[ "$(cut -d. -f1-2 <<< $1)" == "$(cut -d. -f1-2 <<< $2)" ]]
+}
+
+get_installed_version() {
+  version=$(apollo-codegen --version)
+  if [[ $? -eq 0 ]]; then
+    echo "$version"
+  else
+    echo "an unknown older version"
+  fi
+}
 
 if [[ -z "$CONFIGURATION" ]]; then
     echo "$0 must be invoked as part of an Xcode script phase"
@@ -25,29 +46,16 @@ if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
 fi
 
 if ! type "apollo-codegen" >/dev/null 2>&1; then
-  echo "error: Can't find apollo-codegen command; make sure to run 'npm install -g apollo-codegen' first."
-  exit 1
+  echo "Can't find apollo-codegen. Installing..."
+  install_apollo_codegen
 fi
 
-# We consider versions to be compatible if the major and minor versions match
-are_versions_compatible() {
-  [[ "$(cut -d. -f1-2 <<< $1)" == "$(cut -d. -f1-2 <<< $2)" ]]
-}
-
-get_installed_version() {
-  version=$(apollo-codegen --version)
-  if [[ $? -eq 0 ]]; then
-    echo "$version"
-  else
-    echo "an unknown older version"
-  fi
-}
 INSTALLED_APOLLO_CODEGEN_VERSION="$(get_installed_version)"
 
 if ! are_versions_compatible $INSTALLED_APOLLO_CODEGEN_VERSION $REQUIRED_APOLLO_CODEGEN_VERSION; then
-  echo "error: The version of Apollo.framework in your project requires the use of version $REQUIRED_APOLLO_CODEGEN_VERSION of apollo-codegen, \
-but $INSTALLED_APOLLO_CODEGEN_VERSION seems to be installed."
-  exit 1
+  echo "The version of Apollo.framework in your project requires apollo-codegen $REQUIRED_APOLLO_CODEGEN_SEMVER, \
+but $INSTALLED_APOLLO_CODEGEN_VERSION seems to be installed. Installing..."
+  install_apollo_codegen
 fi
 
 # Print commands before executing them (useful for troubleshooting)

--- a/scripts/check-and-run-apollo-codegen.sh
+++ b/scripts/check-and-run-apollo-codegen.sh
@@ -1,15 +1,13 @@
 # Only major and minor version should be specified here
 REQUIRED_APOLLO_CODEGEN_VERSION=0.11
 
-REQUIRED_APOLLO_CODEGEN_SEMVER="$REQUIRED_APOLLO_CODEGEN_VERSION.x"
-
 # Part of this code has been adapted from https://github.com/facebook/react-native/blob/master/packager/react-native-xcode.sh
 
 # This script is supposed to be invoked as part of the Xcode build process
 # and relies on environment variables set by Xcode
 
 install_apollo_codegen() {
-  npm install -g apollo-codegen@"$REQUIRED_APOLLO_CODEGEN_SEMVER"
+  npm install -g apollo-codegen@$REQUIRED_APOLLO_CODEGEN_VERSION
 }
 
 # We consider versions to be compatible if the major and minor versions match
@@ -53,7 +51,7 @@ fi
 INSTALLED_APOLLO_CODEGEN_VERSION="$(get_installed_version)"
 
 if ! are_versions_compatible $INSTALLED_APOLLO_CODEGEN_VERSION $REQUIRED_APOLLO_CODEGEN_VERSION; then
-  echo "The version of Apollo.framework in your project requires apollo-codegen $REQUIRED_APOLLO_CODEGEN_SEMVER, \
+  echo "The version of Apollo.framework in your project requires apollo-codegen $REQUIRED_APOLLO_CODEGEN_VERSION, \
 but $INSTALLED_APOLLO_CODEGEN_VERSION seems to be installed. Installing..."
   install_apollo_codegen
 fi


### PR DESCRIPTION
With a team the size of mine, I wouldn't be comfortable adding an Xcode Build Phase that requires everyone to manually install the appropriate version of `apollo-codegen`. This PR addresses that burden.

Additionally, this would allow Apollo-dependent Xcode projects to build in CI environments (provided they have `npm` installed).

An even better solution would be to somehow distribute `apollo-codegen` with `apollo-ios`, so that the appropriate `apollo-codegen` package would never have to be downloaded at build time. This would avoid build failures on CI machines when they're having network issues. It would also avoid the occasional super-frustrating failure when a developer attempts to build for the first time after a `git pull` in a place with no WiFi.

This seemed like an easy first step in the right direction.