### PR TITLE
Fix crash in RawRepresentable parsing by throwing `couldNotConvert`

### DIFF
--- a/Sources/JSONStandardTypeConversions.swift
+++ b/Sources/JSONStandardTypeConversions.swift
@@ -68,7 +68,11 @@ extension Bool: JSONDecodable, JSONEncodable {
 extension RawRepresentable where RawValue: JSONDecodable {
   public init(jsonValue value: JSONValue) throws {
     let rawValue = try RawValue(jsonValue: value)
-    self.init(rawValue: rawValue)!
+    if let tempSelf = Self(rawValue: rawValue) {
+      self = tempSelf
+    } else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
+    }
   }
 }
 

--- a/Tests/ApolloTests/GraphQLResultReaderTests.swift
+++ b/Tests/ApolloTests/GraphQLResultReaderTests.swift
@@ -35,7 +35,8 @@ class GraphQLResultReaderTests: XCTestCase {
       ("testGetOptionalListWithWrongType", testGetOptionalListWithWrongType),
       ("testGetOptionalListWithMissingKey", testGetOptionalListWithMissingKey),
       ("testGetListWithOptionalElements", testGetListWithOptionalElements),
-      ("testGetOptionalListWithOptionalElements", testGetOptionalListWithOptionalElements)
+      ("testGetOptionalListWithOptionalElements", testGetOptionalListWithOptionalElements),
+      ("testGetValueWithMissingEnumCase", testGetValueWithMissingEnumCase)
     ]
   }
   
@@ -219,5 +220,18 @@ class GraphQLResultReaderTests: XCTestCase {
     let reader = read(from: ["appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"]])
     let value: [Episode?]? = try reader.optionalList(for: Field(responseName: "appearsIn"))
     XCTAssertEqual(value, [.newhope, .empire, .jedi] as [Episode?])
+  }
+    
+  func testGetValueWithMissingEnumCase() throws {
+    let reader = read(from: ["episode": "NOT AN EPISODE"])
+    
+    XCTAssertThrowsError(try with(returnType: Episode.self, reader.value(for: Field(responseName: "episode")))) { (error) in
+      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
+        XCTAssertEqual(value as? String , "NOT AN EPISODE")
+        XCTAssert(expectedType == Episode.self)
+      } else {
+        XCTFail("Unexpected error: \(error)")
+      }
+    }
   }
 }


### PR DESCRIPTION
This prevents a crash if receiving an unexpected enum case. Instead, the code will throw an error.

I suggest this should be merged in as a hot fix, creating a `0.5.7` release.

I'm also about to make optional enums parse as `nil` instead of throwing an error to make the client more robust to schema changes. Would you consider it a good default behavior? Ideally, you would both get `nil` for that enum case and an error in the `GraphQLResult` struct but I don't know if that's tricky in the current framework code.