### PR TITLE
Option to use operation ids rather than operation text

### DIFF
--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -1,6 +1,7 @@
 public protocol GraphQLOperation: class {
   static var operationString: String { get }
   static var requestString: String { get }
+  static var operationIdentifier: String { get }
   
   var variables: GraphQLMap? { get }
   
@@ -11,7 +12,11 @@ public extension GraphQLOperation {
   static var requestString: String {
     return operationString
   }
-  
+
+  static var operationIdentifier: String {
+    return ""
+  }
+
   var variables: GraphQLMap? {
     return nil
   }

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -1,7 +1,7 @@
 public protocol GraphQLOperation: class {
   static var operationString: String { get }
   static var requestString: String { get }
-  static var operationIdentifier: String { get }
+  static var operationIdentifier: String? { get }
   
   var variables: GraphQLMap? { get }
   
@@ -13,8 +13,8 @@ public extension GraphQLOperation {
     return operationString
   }
 
-  static var operationIdentifier: String {
-    return ""
+  static var operationIdentifier: String? {
+    return nil
   }
 
   var variables: GraphQLMap? {

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -116,8 +116,7 @@ public class HTTPNetworkTransport: NetworkTransport {
 
   private func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
     if sendOperationIdentifiers {
-      let operationIdentifier = type(of: operation).operationIdentifier
-      guard !operationIdentifier.isEmpty else {
+      guard let operationIdentifier = type(of: operation).operationIdentifier else {
         preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
       }
       return ["id": operationIdentifier, "variables": operation.variables]

--- a/Tests/StarWarsAPI/API.swift
+++ b/Tests/StarWarsAPI/API.swift
@@ -720,6 +720,7 @@ public final class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
     "    ...FriendsNames" +
     "  }" +
     "}"
+
   public static var requestString: String { return operationString.appending(FriendsNames.fragmentString) }
 
   public var episode: Episode?
@@ -967,6 +968,7 @@ public final class HeroAppearsInWithFragmentQuery: GraphQLQuery {
     "    ...CharacterAppearsIn" +
     "  }" +
     "}"
+
   public static var requestString: String { return operationString.appending(CharacterAppearsIn.fragmentString) }
 
   public var episode: Episode?
@@ -1298,6 +1300,7 @@ public final class HeroDetailsWithFragmentQuery: GraphQLQuery {
     "    ...HeroDetails" +
     "  }" +
     "}"
+
   public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 
   public var episode: Episode?
@@ -1766,6 +1769,7 @@ public final class HeroNameWithFragmentQuery: GraphQLQuery {
     "    ...CharacterName" +
     "  }" +
     "}"
+
   public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
 
   public var episode: Episode?
@@ -1878,6 +1882,7 @@ public final class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
     "    ...CharacterNameAndAppearsIn" +
     "  }" +
     "}"
+
   public static var requestString: String { return operationString.appending(CharacterNameAndAppearsIn.fragmentString) }
 
   public var episode: Episode?

--- a/scripts/check-and-run-apollo-codegen.sh
+++ b/scripts/check-and-run-apollo-codegen.sh
@@ -1,5 +1,5 @@
 # Only major and minor version should be specified here
-REQUIRED_APOLLO_CODEGEN_VERSION=0.13
+REQUIRED_APOLLO_CODEGEN_VERSION=0.14
 
 # Part of this code has been adapted from https://github.com/facebook/react-native/blob/master/packager/react-native-xcode.sh
 

--- a/scripts/check-and-run-apollo-codegen.sh
+++ b/scripts/check-and-run-apollo-codegen.sh
@@ -1,5 +1,5 @@
 # Only major and minor version should be specified here
-REQUIRED_APOLLO_CODEGEN_VERSION=0.14
+REQUIRED_APOLLO_CODEGEN_VERSION=0.15
 
 # Part of this code has been adapted from https://github.com/facebook/react-native/blob/master/packager/react-native-xcode.sh
 


### PR DESCRIPTION
This PR introduces to `HTTPNetworkTransport` the option to use `operationIdentifier`s rather than `requestString`s when making requests.

The operation identifier is sent as the "id" field of the request's JSON payload, just like it is in the [network layer](https://github.com/apollographql/persistgraphql/blob/master/src/network_interface/ApolloNetworkInterface.ts) provided by `persistgraphql`. An important deviation from `persistgraphql`'s approach is that here we are not sending an "operationName" field. While the inclusion of this field may help debugging in some cases, I suspect most development will happen with `sendOperationIdentifiers = false`, and that most developers will have access to a mapping between operation identifiers and their corresponding text, allowing for debugging anyway. Furthermore, inclusion of "operationName" makes requests a bit bigger and a bit easier to understand if intercepted.

Note that I'm using the argument name `sendOperationIdentifiers` rather than `persistgraphql`'s `enablePersistedQueries`. The Apollo client is concerned only with client behavior, and `sendOperationIdentifiers` seems to me to be a clearer description of how the flag alters client behavior than `enablePersistedQueries`.