### PR TITLE
Enable to add additional headers after creating a client

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -4,19 +4,21 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   let query: Query
   let handlerQueue: DispatchQueue
   let resultHandler: OperationResultHandler<Query>
-  
+  let additionalHeaders: [String: String]?
+    
   private var context = 0
   
   private weak var fetching: Cancellable?
   
   private var dependentKeys: Set<CacheKey>?
   
-  init(client: ApolloClient, query: Query, handlerQueue: DispatchQueue, resultHandler: @escaping OperationResultHandler<Query>) {
+    init(client: ApolloClient, query: Query, additionalHeaders: [String: String]?, handlerQueue: DispatchQueue, resultHandler: @escaping OperationResultHandler<Query>) {
     self.client = client
     self.query = query
     self.handlerQueue = handlerQueue
     self.resultHandler = resultHandler
-    
+    self.additionalHeaders = additionalHeaders
+        
     client.store.subscribe(self)
   }
   
@@ -26,7 +28,7 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
   
   func fetch(cachePolicy: CachePolicy) {
-    fetching = client?._fetch(query: query, cachePolicy: cachePolicy, context: &context, queue: handlerQueue) { (result, error) in
+    fetching = client?._fetch(query: query, cachePolicy: cachePolicy, context: &context, additionalHeaders: additionalHeaders, queue: handlerQueue) { (result, error) in
       self.dependentKeys = result?.dependentKeys
       self.resultHandler(result, error)
     }

--- a/Sources/Apollo/JSONStandardTypeConversions.swift
+++ b/Sources/Apollo/JSONStandardTypeConversions.swift
@@ -151,3 +151,10 @@ extension URL: JSONDecodable, JSONEncodable {
     return self.absoluteString
   }
 }
+
+// Fix for crash when performing mutation that contains variables in the graphQL query
+extension Variable : JSONEncodable {
+    public var jsonValue: JSONValue {
+        return self.name
+    }
+}

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -8,5 +8,5 @@ public protocol NetworkTransport {
   ///   - response: The response received from the server, or `nil` if an error occurred.
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
-  func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
+  func send<Operation: GraphQLOperation>(operation: Operation, additionalHeaders: [String: String]?, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
 }


### PR DESCRIPTION
Right now, additional headers can only be specified when creating a client. This Pull Request provides a solution to add additional headers for each request after creating a client.