### PR TITLE
Initial file upload concept

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3DC490521F29252700D1D1AE /* GraphQLFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC490511F29252700D1D1AE /* GraphQLFile.swift */; };
 		3DC490541F29254C00D1D1AE /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC490531F29254C00D1D1AE /* MultipartFormData.swift */; };
+		3DC490561F29541000D1D1AE /* SessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC490551F29541000D1D1AE /* SessionDelegate.swift */; };
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		9F0CA4461EE7F9E90032DD39 /* ApolloTestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -231,6 +232,7 @@
 /* Begin PBXFileReference section */
 		3DC490511F29252700D1D1AE /* GraphQLFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLFile.swift; sourceTree = "<group>"; };
 		3DC490531F29254C00D1D1AE /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
+		3DC490551F29541000D1D1AE /* SessionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDelegate.swift; sourceTree = "<group>"; };
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
 		9F19D8431EED568200C57247 /* ResultOrPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromise.swift; sourceTree = "<group>"; };
@@ -586,6 +588,7 @@
 				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
 				3DC490531F29254C00D1D1AE /* MultipartFormData.swift */,
+				3DC490551F29541000D1D1AE /* SessionDelegate.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -1085,6 +1088,7 @@
 				9FF33D811E48B98200F608A4 /* HTTPNetworkTransport.swift in Sources */,
 				9FCE2CEE1E6BE2D900E34457 /* NormalizedCache.swift in Sources */,
 				9FADC84A1E6B0B2300C677E6 /* Locking.swift in Sources */,
+				3DC490561F29541000D1D1AE /* SessionDelegate.swift in Sources */,
 				9F295E381E277B2A00A24949 /* GraphQLResultNormalizer.swift in Sources */,
 				9FE941CB1E5F20CA007CDD89 /* GraphQLOutputType.swift in Sources */,
 				3DC490521F29252700D1D1AE /* GraphQLFile.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3DC490521F29252700D1D1AE /* GraphQLFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC490511F29252700D1D1AE /* GraphQLFile.swift */; };
+		3DC490541F29254C00D1D1AE /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC490531F29254C00D1D1AE /* MultipartFormData.swift */; };
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		9F0CA4461EE7F9E90032DD39 /* ApolloTestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -227,6 +229,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3DC490511F29252700D1D1AE /* GraphQLFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLFile.swift; sourceTree = "<group>"; };
+		3DC490531F29254C00D1D1AE /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
 		9F19D8431EED568200C57247 /* ResultOrPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromise.swift; sourceTree = "<group>"; };
@@ -531,6 +535,7 @@
 				9FC9A9BE1E2C27FB0023C4D5 /* GraphQLResult.swift */,
 				9FC9A9D21E2FD48B0023C4D5 /* GraphQLError.swift */,
 				9FCDFD281E33D0CE007519DC /* GraphQLQueryWatcher.swift */,
+				3DC490511F29252700D1D1AE /* GraphQLFile.swift */,
 				9FC9A9CE1E2FD0CC0023C4D5 /* Network */,
 				9FC9A9CA1E2FD05C0023C4D5 /* Store */,
 				9F27D4601D40363A00715680 /* Execution */,
@@ -580,6 +585,7 @@
 				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
 				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
+				3DC490531F29254C00D1D1AE /* MultipartFormData.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -1080,9 +1086,12 @@
 				9FCE2CEE1E6BE2D900E34457 /* NormalizedCache.swift in Sources */,
 				9FADC84A1E6B0B2300C677E6 /* Locking.swift in Sources */,
 				9F295E381E277B2A00A24949 /* GraphQLResultNormalizer.swift in Sources */,
+				9FE941CB1E5F20CA007CDD89 /* GraphQLOutputType.swift in Sources */,
+				3DC490521F29252700D1D1AE /* GraphQLFile.swift in Sources */,
 				9F86B68B1E6438D700B885FF /* GraphQLSelectionSetMapper.swift in Sources */,
 				9F55347B1DE1DB2100E54264 /* ApolloStore.swift in Sources */,
 				9F69FFA91D42855900E000B1 /* NetworkTransport.swift in Sources */,
+				3DC490541F29254C00D1D1AE /* MultipartFormData.swift in Sources */,
 				9FCDFD291E33D0CE007519DC /* GraphQLQueryWatcher.swift in Sources */,
 				9FC2333D1E66BBF7001E4541 /* GraphQLDependencyTracker.swift in Sources */,
 				9F19D8441EED568200C57247 /* ResultOrPromise.swift in Sources */,

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -21,6 +21,10 @@ public enum CachePolicy {
 
 public typealias OperationResultHandler<Operation: GraphQLOperation> = (_ result: GraphQLResult<Operation.Data>?, _ error: Error?) -> Void
 
+public typealias Progress = Int8
+
+public typealias OperationProgressHandler = (_ progress: Progress) -> Void
+
 /// The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
 public class ApolloClient {
   let networkTransport: NetworkTransport
@@ -109,15 +113,34 @@ public class ApolloClient {
   ///   - result: The result of the performed mutation, or `nil` if an error occurred.
   ///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
   /// - Returns: An object that can be used to cancel an in progress mutation.
-  @discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, files: [GraphQLFile]? = nil, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Mutation>? = nil) -> Cancellable {
-    return _perform(mutation: mutation, files: files, queue: queue, resultHandler: resultHandler)
+  @discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Mutation>? = nil) -> Cancellable {
+    return _perform(mutation: mutation, queue: queue, resultHandler: resultHandler)
   }
   
-  func _perform<Mutation: GraphQLMutation>(mutation: Mutation, files: [GraphQLFile]? = nil, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue, resultHandler: OperationResultHandler<Mutation>?) -> Cancellable {
-    return send(operation: mutation, files: files, context: context, handlerQueue: queue, resultHandler: resultHandler)
+  func _perform<Mutation: GraphQLMutation>(mutation: Mutation, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue, resultHandler: OperationResultHandler<Mutation>?) -> Cancellable {
+    return send(operation: mutation, context: context, handlerQueue: queue, resultHandler: resultHandler)
   }
-
-  fileprivate func send<Operation: GraphQLOperation>(operation: Operation, files: [GraphQLFile]? = nil, context: UnsafeMutableRawPointer?, handlerQueue: DispatchQueue, resultHandler: OperationResultHandler<Operation>?) -> Cancellable {
+  
+  /// Performs a mutation by sending it to the server.
+  ///
+  /// - Parameters:
+  ///   - mutation: The mutation to perform.
+  ///   - files: A list of files to send as a multipart request.
+  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - progressHandler: A closure to call periodically as the request is sent.
+  ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
+  ///   - result: The result of the performed mutation, or `nil` if an error occurred.
+  ///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
+  /// - Returns: An object that can be used to cancel an in progress mutation.
+  @discardableResult public func performUpload<Mutation: GraphQLMutation>(mutation: Mutation, files: [GraphQLFile]? = nil, queue: DispatchQueue = DispatchQueue.main, progressHandler: OperationProgressHandler? = nil, resultHandler: OperationResultHandler<Mutation>? = nil) -> Cancellable {
+    return _performUpload(mutation: mutation, files: files, queue: queue, progressHandler: progressHandler, resultHandler: resultHandler)
+  }
+  
+  func _performUpload<Mutation: GraphQLMutation>(mutation: Mutation, files: [GraphQLFile]? = nil, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue, progressHandler: OperationProgressHandler? = nil, resultHandler: OperationResultHandler<Mutation>?) -> Cancellable {
+    return send(operation: mutation, files: files, context: context, handlerQueue: queue, progressHandler: progressHandler, resultHandler: resultHandler)
+  }
+  
+  fileprivate func send<Operation: GraphQLOperation>(operation: Operation, files: [GraphQLFile]? = nil, context: UnsafeMutableRawPointer?, handlerQueue: DispatchQueue, progressHandler: OperationProgressHandler? = nil, resultHandler: OperationResultHandler<Operation>?) -> Cancellable {
     func notifyResultHandler(result: GraphQLResult<Operation.Data>?, error: Error?) {
       guard let resultHandler = resultHandler else { return }
       
@@ -126,7 +149,15 @@ public class ApolloClient {
       }
     }
     
-    return networkTransport.send(operation: operation, files: files) { (response, error) in
+    func notifyProgressHandler(_ progress: Progress) {
+      guard let progressHandler = progressHandler else { return }
+      
+      handlerQueue.async {
+        progressHandler(progress)
+      }
+    }
+    
+    func completionHandler(_ response: GraphQLResponse<Operation>?, _ error: Error?) {
       guard let response = response else {
         notifyResultHandler(result: nil, error: error)
         return
@@ -134,17 +165,23 @@ public class ApolloClient {
       
       firstly {
         try response.parseResult(cacheKeyForObject: self.store.cacheKeyForObject)
-      }.andThen { (result, records) in
-        notifyResultHandler(result: result, error: nil)
-        
-        if let records = records {
-          self.store.publish(records: records, context: context).catch { error in
-            preconditionFailure(String(describing: error))
+        }.andThen { (result, records) in
+          notifyResultHandler(result: result, error: nil)
+          
+          if let records = records {
+            self.store.publish(records: records, context: context).catch { error in
+              preconditionFailure(String(describing: error))
+            }
           }
+        }.catch { error in
+          notifyResultHandler(result: nil, error: error)
         }
-      }.catch { error in
-        notifyResultHandler(result: nil, error: error)
-      }
+    }
+    
+    if (files != nil && !files!.isEmpty) {
+      return networkTransport.upload(operation: operation, files: files, progressHandler: notifyProgressHandler, completionHandler: completionHandler)
+    } else {
+      return networkTransport.send(operation: operation, completionHandler: completionHandler)
     }
   }
 }

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -109,15 +109,15 @@ public class ApolloClient {
   ///   - result: The result of the performed mutation, or `nil` if an error occurred.
   ///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
   /// - Returns: An object that can be used to cancel an in progress mutation.
-  @discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Mutation>? = nil) -> Cancellable {
-    return _perform(mutation: mutation, queue: queue, resultHandler: resultHandler)
+  @discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, files: [GraphQLFile]? = nil, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Mutation>? = nil) -> Cancellable {
+    return _perform(mutation: mutation, files: files, queue: queue, resultHandler: resultHandler)
   }
   
-  func _perform<Mutation: GraphQLMutation>(mutation: Mutation, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue, resultHandler: OperationResultHandler<Mutation>?) -> Cancellable {
-    return send(operation: mutation, context: context, handlerQueue: queue, resultHandler: resultHandler)
+  func _perform<Mutation: GraphQLMutation>(mutation: Mutation, files: [GraphQLFile]? = nil, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue, resultHandler: OperationResultHandler<Mutation>?) -> Cancellable {
+    return send(operation: mutation, files: files, context: context, handlerQueue: queue, resultHandler: resultHandler)
   }
 
-  fileprivate func send<Operation: GraphQLOperation>(operation: Operation, context: UnsafeMutableRawPointer?, handlerQueue: DispatchQueue, resultHandler: OperationResultHandler<Operation>?) -> Cancellable {
+  fileprivate func send<Operation: GraphQLOperation>(operation: Operation, files: [GraphQLFile]? = nil, context: UnsafeMutableRawPointer?, handlerQueue: DispatchQueue, resultHandler: OperationResultHandler<Operation>?) -> Cancellable {
     func notifyResultHandler(result: GraphQLResult<Operation.Data>?, error: Error?) {
       guard let resultHandler = resultHandler else { return }
       
@@ -126,7 +126,7 @@ public class ApolloClient {
       }
     }
     
-    return networkTransport.send(operation: operation) { (response, error) in
+    return networkTransport.send(operation: operation, files: files) { (response, error) in
       guard let response = response else {
         notifyResultHandler(result: nil, error: error)
         return

--- a/Sources/Apollo/GraphQLFile.swift
+++ b/Sources/Apollo/GraphQLFile.swift
@@ -1,13 +1,43 @@
-public class GraphQLFile {
+public struct GraphQLFile {
   let fieldName: String
   let originalName: String
   let mimeType: String
-  let data: Data
+  let inputStream: InputStream
+  let contentLength: UInt64
   
-  public init(fieldName: String, originalName: String, mimeType: String, data: Data) {
+  public init(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", data: Data) {
+    self.init(fieldName: fieldName, originalName: originalName, mimeType: mimeType, inputStream: InputStream(data: data), contentLength: UInt64(data.count))
+  }
+  
+  public init?(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", fileURL: URL) {
+    if let inputStream = InputStream(url: fileURL) {
+      let contentLength = GraphQLFile.getFileSize(fileURL: fileURL)
+      self.init(fieldName: fieldName, originalName: originalName, mimeType: mimeType, inputStream: inputStream, contentLength: contentLength)
+    }
+    
+    return nil
+  }
+  
+  public init(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", inputStream: InputStream, contentLength: UInt64) {
     self.fieldName = fieldName
     self.originalName = originalName
     self.mimeType = mimeType
-    self.data = data
+    
+    self.inputStream = inputStream
+    self.contentLength = contentLength
+  }
+  
+  private static func getFileSize(fileURL: URL) -> UInt64 {
+    let fileSize: UInt64
+    
+    do {
+      guard let fileSize = try FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber else {
+        return 0
+      }
+      
+      return fileSize.uint64Value
+    } catch {
+      return 0
+    }
   }
 }

--- a/Sources/Apollo/GraphQLFile.swift
+++ b/Sources/Apollo/GraphQLFile.swift
@@ -1,0 +1,13 @@
+public class GraphQLFile {
+  let fieldName: String
+  let originalName: String
+  let mimeType: String
+  let data: Data
+  
+  public init(fieldName: String, originalName: String, mimeType: String, data: Data) {
+    self.fieldName = fieldName
+    self.originalName = originalName
+    self.mimeType = mimeType
+    self.data = data
+  }
+}

--- a/Sources/Apollo/GraphQLFile.swift
+++ b/Sources/Apollo/GraphQLFile.swift
@@ -10,12 +10,18 @@ public struct GraphQLFile {
   }
   
   public init?(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", fileURL: URL) {
-    if let inputStream = InputStream(url: fileURL) {
-      let contentLength = GraphQLFile.getFileSize(fileURL: fileURL)
-      self.init(fieldName: fieldName, originalName: originalName, mimeType: mimeType, inputStream: inputStream, contentLength: contentLength)
+    // TODO: Better error handling
+    
+    
+    guard let inputStream = InputStream(url: fileURL) else {
+      return nil
     }
     
-    return nil
+    guard let contentLength = GraphQLFile.getFileSize(fileURL: fileURL) else {
+      return nil
+    }
+    
+    self.init(fieldName: fieldName, originalName: originalName, mimeType: mimeType, inputStream: inputStream, contentLength: contentLength)
   }
   
   public init(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", inputStream: InputStream, contentLength: UInt64) {
@@ -27,17 +33,17 @@ public struct GraphQLFile {
     self.contentLength = contentLength
   }
   
-  private static func getFileSize(fileURL: URL) -> UInt64 {
+  private static func getFileSize(fileURL: URL) -> UInt64? {
     let fileSize: UInt64
     
     do {
       guard let fileSize = try FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber else {
-        return 0
+        return nil
       }
       
       return fileSize.uint64Value
     } catch {
-      return 0
+      return nil
     }
   }
 }

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -97,7 +97,7 @@ public class HTTPNetworkTransport: NetworkTransport {
       request.httpBody = try! serializationFormat.serialize(value: body)
     }
     
-    let task = session.dataTask(with: request) { (data: Data?, response: URLResponse?, error: Error?) in
+    func notifyCompletionHandler(data: Data?, response: URLResponse?, error: Error?) {
       if error != nil {
         completionHandler(nil, error)
         return
@@ -128,9 +128,9 @@ public class HTTPNetworkTransport: NetworkTransport {
       }
     }
     
-    if let progressHandler = progressHandler {
-      self.sessionDelegate.add(task: task, progressHandler: progressHandler)
-    }
+    let task = session.dataTask(with: request)
+    
+    self.sessionDelegate.add(task: task, completionHandler: notifyCompletionHandler, progressHandler: progressHandler)
     
     task.resume()
     

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -1,0 +1,70 @@
+public class MultipartFormData {
+  
+  public static let CRLF = "\r\n"
+  
+  public let boundary: String
+  
+  private var bodyParts: [BodyPart]
+  
+  public init() {
+    self.boundary = "apollo-ios.boundary.\(UUID().uuidString)"
+    self.bodyParts = []
+  }
+  
+  struct BodyPart {
+    let name: String
+    let data: Data
+    let contentType: String?
+    let filename: String?
+    
+    init(name: String, data: Data, contentType: String?, filename: String?) {
+      self.name = name
+      self.data = data
+      self.contentType = contentType
+      self.filename = filename
+    }
+    
+    func headers() -> String {
+      var headers = "Content-Disposition: form-data; name=\"\(self.name)\""
+      if let filename = self.filename {
+        headers += "; filename=\"\(filename)\""
+      }
+      headers += "\(MultipartFormData.CRLF)"
+      
+      if let contentType = self.contentType {
+        headers += "Content-Type: \(contentType)\(MultipartFormData.CRLF)"
+      }
+      
+      headers += "\(MultipartFormData.CRLF)"
+      
+      return headers
+    }
+  }
+  
+  public func appendPartWithString(string: String, name: String) {
+    self.appendPart(data: self.encode(string: string), name: name, contentType: nil)
+  }
+  
+  public func appendPart(data: Data, name: String, contentType: String? = nil, filename: String? = nil) {
+    self.bodyParts.append(BodyPart(name: name, data: data, contentType: contentType, filename: filename))
+  }
+  
+  public func toData() -> Data {
+    let data = NSMutableData()
+    
+    for p in self.bodyParts {
+      data.append(self.encode(string: "--\(self.boundary)\(MultipartFormData.CRLF)"))
+      data.append(self.encode(string: p.headers()))
+      data.append(p.data)
+      data.append(self.encode(string: "\(MultipartFormData.CRLF)\(MultipartFormData.CRLF)"))
+    }
+    
+    data.append(self.encode(string: "--".appending(self.boundary.appending("--"))))
+    
+    return data as Data
+  }
+  
+  private func encode(string: String) -> Data {
+    return string.data(using: String.Encoding.utf8, allowLossyConversion: false)!
+  }
+}

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -8,5 +8,5 @@ public protocol NetworkTransport {
   ///   - response: The response received from the server, or `nil` if an error occurred.
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
-  func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
+  func send<Operation>(operation: Operation, files: [GraphQLFile]?, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
 }

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -8,5 +8,23 @@ public protocol NetworkTransport {
   ///   - response: The response received from the server, or `nil` if an error occurred.
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
-  func send<Operation>(operation: Operation, files: [GraphQLFile]?, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
+  func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
+  
+  /// Send a GraphQL operation to a server and return a response.
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to send.
+  ///   - files: A list of files to send as a multipart request.
+  ///   - progressHandler: A closure to call periodically as the request is sent.
+  ///   - completionHandler: A closure to call when a request completes.
+  ///   - response: The response received from the server, or `nil` if an error occurred.
+  ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
+  /// - Returns: An object that can be used to cancel an in progress request.
+  func upload<Operation: GraphQLOperation>(operation: Operation, files: [GraphQLFile]?, progressHandler: ((Progress) -> Void)?, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
+}
+
+public extension NetworkTransport {
+  func upload<Operation: GraphQLOperation>(operation: Operation, files: [GraphQLFile]? = nil, progressHandler: ((Progress) -> Void)? = nil, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+    fatalError("NetworkTransport.upload(operation:files:progressHandler:completionHandler) not implemented.")
+  }
 }

--- a/Sources/Apollo/SessionDelegate.swift
+++ b/Sources/Apollo/SessionDelegate.swift
@@ -1,0 +1,38 @@
+class SessionDelegate: NSObject {
+  
+  private var tasks: [Int: (Progress) -> Void] = [:]
+  private let lock = NSLock()
+  
+  func add(task: URLSessionTask, progressHandler: @escaping (Progress) -> Void) {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    self.tasks[task.taskIdentifier] = progressHandler
+  }
+  
+  func get(task: URLSessionTask) -> ((Progress) -> Void)? {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    return self.tasks[task.taskIdentifier]
+  }
+  
+  func remove(task: URLSessionTask) {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    self.tasks.removeValue(forKey: task.taskIdentifier)
+  }
+}
+
+extension SessionDelegate: URLSessionTaskDelegate {
+  func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+    if let progressHandler = self.get(task: task) {
+      progressHandler(Progress((totalBytesSent/totalBytesExpectedToSend)) * 100)
+    }
+  }
+  
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    self.remove(task: task)
+  }
+}

--- a/Sources/Apollo/SessionDelegate.swift
+++ b/Sources/Apollo/SessionDelegate.swift
@@ -24,13 +24,13 @@ class SessionDelegate: NSObject {
     self.tasks[task.taskIdentifier] = SessionDelegateTask(completionHandler: completionHandler, progressHandler: progressHandler)
   }
   
-  func get(task: URLSessionTask) -> SessionDelegateTask? {
+  fileprivate func get(task: URLSessionTask) -> SessionDelegateTask? {
     return lock.withLock {
       return self.tasks[task.taskIdentifier]
     }
   }
   
-  func remove(task: URLSessionTask) {
+  fileprivate func remove(task: URLSessionTask) {
     self.lock.lock()
     defer { self.lock.unlock() }
     
@@ -47,7 +47,8 @@ extension SessionDelegate: URLSessionDataDelegate {
 extension SessionDelegate: URLSessionTaskDelegate {
   func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
     if let sessionTask = self.get(task: task), let progressHandler = sessionTask.progressHandler {
-      progressHandler(Progress((totalBytesSent/totalBytesExpectedToSend)) * 100)
+      let progress = Float(totalBytesSent)/Float(totalBytesExpectedToSend)
+      progressHandler(Progress(progress * 100))
     }
   }
   

--- a/Tests/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Tests/ApolloTestSupport/MockNetworkTransport.swift
@@ -7,7 +7,7 @@ public final class MockNetworkTransport: NetworkTransport {
     self.body = body
   }
   
-  public func send<Operation:>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+  public func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
     DispatchQueue.global(qos: .default).async {
       completionHandler(GraphQLResponse(operation: operation, body: self.body), nil)
     }

--- a/Tests/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Tests/ApolloTestSupport/MockNetworkTransport.swift
@@ -7,7 +7,7 @@ public final class MockNetworkTransport: NetworkTransport {
     self.body = body
   }
   
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+  public func send<Operation>(operation: Operation, files: [GraphQLFile]? = nil, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
     DispatchQueue.global(qos: .default).async {
       completionHandler(GraphQLResponse(operation: operation, body: self.body), nil)
     }

--- a/Tests/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Tests/ApolloTestSupport/MockNetworkTransport.swift
@@ -7,7 +7,7 @@ public final class MockNetworkTransport: NetworkTransport {
     self.body = body
   }
   
-  public func send<Operation>(operation: Operation, files: [GraphQLFile]? = nil, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+  public func send<Operation:>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
     DispatchQueue.global(qos: .default).async {
       completionHandler(GraphQLResponse(operation: operation, body: self.body), nil)
     }


### PR DESCRIPTION
As discussed in #114, this is an example of file upload support without forcing to a specific server spec.

I made this PR to get the conversation going. The naming, progress handling, GraphQLFile input error handling all need to be improved on.

An example of use:

```swift

let imageData: Data = ...
let imageFileURL: URL = ...
let pdfInputStream: InputStream = ...
let pdfContentLength: UInt64 = ...

var files: [GraphQLFile] = []
files.append(GraphQLFile(fieldName: "files.0", originalName: "test-file-1.png", mimeType: "image/png", data: imageData))
files.append(GraphQLFile(fieldName: "files.1", originalName: "test-file-2.png", mimeType: "image/png", fileURL: imageData))
files.append(GraphQLFile(fieldName: "files.2", originalName: "test-file-3.pdf", mimeType: "application/pdf", inputStream: pdfData, contentLength: pdfContentLength))

let mutation = MultipleUploadMutation(files: files.map({Upload(fieldName: $0.fieldName, name: $0.originalName, type: $0.mimeType, size: $0.count)}))

let progressHandler = { progress in
  print("Upload progress: \(progress)")
}

let client = ApolloClient( ... )

// progressHandler is optional
client.performUpload(mutation: mutation, files: files, progressHandler: progressHandler) { (result, error) in
  ...
}
```