### PR TITLE
Get Swift-PM Build working

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,9 @@
 import PackageDescription
 
 let package = Package(
-    name: "Apollo"
+    name: "Apollo",
+    targets: [
+        Target(name: "Apollo"),
+    ],
+    exclude: ["Tests", "Sources/ApolloSQLite"]
 )

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 
 /// An object that can be used to cancel an in progress action.
 public protocol Cancellable: class {

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 func rootKey<Operation: GraphQLOperation>(forOperation operation: Operation) -> CacheKey {
   switch operation {
   case is GraphQLQuery:

--- a/Sources/Apollo/DataLoader.swift
+++ b/Sources/Apollo/DataLoader.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 public final class DataLoader<Key: Hashable, Value> {
   public typealias BatchLoad = ([Key]) -> Promise<[Value]>
   typealias Load = (key: Key, fulfill: (Value) -> Void, reject: (Error) -> Void)

--- a/Sources/Apollo/GraphQLError.swift
+++ b/Sources/Apollo/GraphQLError.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents an error encountered during the execution of a GraphQL operation.
 ///
 ///  - SeeAlso: [The Response Format section in the GraphQL specification](https://facebook.github.io/graphql/#sec-Response-Format)

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -1,3 +1,6 @@
+import Foundation
+import Dispatch
+
 /// A resolver is responsible for resolving a value for a field.
 public typealias GraphQLResolver = (_ object: JSONObject, _ info: GraphQLResolveInfo) -> ResultOrPromise<JSONValue?>
 

--- a/Sources/Apollo/GraphQLInputValue.swift
+++ b/Sources/Apollo/GraphQLInputValue.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol GraphQLInputValue {
   func evaluate(with variables: [String: JSONEncodable]?) throws -> JSONValue
 }

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 /// A `GraphQLQueryWatcher` is responsible for watching the store, and calling the result handler with a new result whenever any of the data the previous result depends on changes.
 public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, ApolloStoreSubscriber {
   weak var client: ApolloClient?

--- a/Sources/Apollo/GraphQLResponseGenerator.swift
+++ b/Sources/Apollo/GraphQLResponseGenerator.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class GraphQLResponseGenerator: GraphQLResultAccumulator {
   func accept(scalar: JSONValue, info: GraphQLResolveInfo) -> JSONValue {
     return scalar

--- a/Sources/Apollo/GraphQLResultNormalizer.swift
+++ b/Sources/Apollo/GraphQLResultNormalizer.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class GraphQLResultNormalizer: GraphQLResultAccumulator {
   private var records: RecordSet = [:]
   

--- a/Sources/Apollo/JSON.swift
+++ b/Sources/Apollo/JSON.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public typealias JSONValue = Any
 
 public typealias JSONObject = [String: JSONValue]

--- a/Sources/Apollo/JSONSerializationFormat.swift
+++ b/Sources/Apollo/JSONSerializationFormat.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public final class JSONSerializationFormat {
   public class func serialize(value: JSONEncodable) throws -> Data {
     return try JSONSerialization.data(withJSONObject: value.jsonValue, options: [])

--- a/Sources/Apollo/Locking.swift
+++ b/Sources/Apollo/Locking.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class Mutex {
   private var _lock = pthread_mutex_t()
   

--- a/Sources/Apollo/Promise.swift
+++ b/Sources/Apollo/Promise.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 public func whenAll<Value>(_ promises: [Promise<Value>], notifyOn queue: DispatchQueue = .global()) -> Promise<[Value]> {
   return Promise { (fulfill, reject) in
     let group = DispatchGroup()

--- a/Sources/Apollo/ResultOrPromise.swift
+++ b/Sources/Apollo/ResultOrPromise.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 public func whenAll<Value>(_ resultsOrPromises: [ResultOrPromise<Value>], notifyOn queue: DispatchQueue = .global()) -> ResultOrPromise<[Value]> {
   onlyResults: do {
     var results: [Result<Value>] = []


### PR DESCRIPTION
With this PR the `swift build` command successfully compiles the package.
Tested on macOS 10.12 with Apple Swift version 3.1 (swiftlang-802.0.53 clang-802.0.42)

Until now building for the Swift Package Manager failed. An attempt to execute `swift build` resulted in the following error:
```
error: the directory Tests/ApolloSQLiteTestSupport has an invalid name ('ApolloSQLiteTestSupport'): the name of a test module has no 'Tests' suffix
fix: rename the directory 'Tests/ApolloSQLiteTestSupport' to have a 'Tests' suffix
```

This would be also a first step to get this package running on Linux (and even Android) with a few additional fixes to make in the future.