### PR TITLE
Make parseResult public

### DIFF
--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -8,7 +8,7 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
     self.body = body
   }
 
-  func parseResult(cacheKeyForObject: CacheKeyForObject? = nil) throws -> Promise<(GraphQLResult<Operation.Data>, RecordSet?)>  {
+  public func parseResult(cacheKeyForObject: CacheKeyForObject? = nil) throws -> Promise<(GraphQLResult<Operation.Data>, RecordSet?)>  {
     let errors: [GraphQLError]?
     
     if let errorsEntry = body["errors"] as? [JSONObject] {


### PR DESCRIPTION
This ties in with #77. For background URL sessions, you as an app developer isn't in control of neither the app's nor the session's lifecycle. This currently makes you unable to use `ApolloClient` for doing background uploads because you can't really resume an operation from a previous launch.

By making `parseResult` public on `GraphQLResponse` you can manually parse and extract the data once a background session launches your app upon task completion. An alternative would be to have some way to report in a response directly to an `ApolloClient` but I feel that's a lot of more work, especially in finding a good API design.