### PR TITLE
Add docs & param names to NetworkTransport & OperationResultHandler

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -19,6 +19,11 @@ public enum CachePolicy {
   case returnCacheDataAndFetch
 }
 
+/// A handler for operation results.
+///
+/// - Parameters:
+///   - result: The result of the performed operation, or `nil` if an error occurred.
+///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
 public typealias OperationResultHandler<Operation: GraphQLOperation> = (_ result: GraphQLResult<Operation.Data>?, _ error: Error?) -> Void
 
 /// The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
@@ -65,8 +70,6 @@ public class ApolloClient {
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache.
   ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
   ///   - resultHandler: An optional closure that is called when query results are available or when an error occurs.
-  ///   - result: The result of the fetched query, or `nil` if an error occurred.
-  ///   - error: An error that indicates why the fetch failed, or `nil` if the fetch was succesful.
   /// - Returns: An object that can be used to cancel an in progress fetch.
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query, cachePolicy: CachePolicy = .returnCacheDataElseFetch, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Query>? = nil) -> Cancellable {
     return _fetch(query: query, cachePolicy: cachePolicy, queue: queue, resultHandler: resultHandler)
@@ -91,8 +94,6 @@ public class ApolloClient {
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
   ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
   ///   - resultHandler: An optional closure that is called when query results are available or when an error occurs.
-  ///   - result: The result of the fetched query, or `nil` if an error occurred.
-  ///   - error: An error that indicates why the fetch failed, or `nil` if the fetch was succesful.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   public func watch<Query: GraphQLQuery>(query: Query, cachePolicy: CachePolicy = .returnCacheDataElseFetch, queue: DispatchQueue = DispatchQueue.main, resultHandler: @escaping OperationResultHandler<Query>) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self, query: query, handlerQueue: queue, resultHandler: resultHandler)
@@ -106,8 +107,6 @@ public class ApolloClient {
   ///   - mutation: The mutation to perform.
   ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
   ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
-  ///   - result: The result of the performed mutation, or `nil` if an error occurred.
-  ///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
   /// - Returns: An object that can be used to cancel an in progress mutation.
   @discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Mutation>? = nil) -> Cancellable {
     return _perform(mutation: mutation, queue: queue, resultHandler: resultHandler)

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -67,7 +67,7 @@ public class HTTPNetworkTransport: NetworkTransport {
   ///   - response: The response received from the server, or `nil` if an error occurred.
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -8,5 +8,5 @@ public protocol NetworkTransport {
   ///   - response: The response received from the server, or `nil` if an error occurred.
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
-  func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable
+  func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable
 }

--- a/Tests/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Tests/ApolloTestSupport/MockNetworkTransport.swift
@@ -8,7 +8,7 @@ public final class MockNetworkTransport: NetworkTransport {
     self.body = body
   }
 
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
     DispatchQueue.global(qos: .default).async {
       completionHandler(GraphQLResponse(operation: operation, body: self.body), nil)
     }


### PR DESCRIPTION
Noticed this while looking at making the network transport throwing.

Before:
![skarmavbild 2017-10-17 kl 18 35 57](https://user-images.githubusercontent.com/1496135/31677096-098193b2-b36a-11e7-9aef-4dedf0307cf8.png)

After:
![skarmavbild 2017-10-17 kl 18 35 43](https://user-images.githubusercontent.com/1496135/31677095-095d00f6-b36a-11e7-9ef8-5e9544578113.png)