### PR TITLE
Aynchronous request modification

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -240,7 +240,7 @@
 		9F295E371E277B2A00A24949 /* GraphQLResultNormalizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLResultNormalizer.swift; sourceTree = "<group>"; };
 		9F3750501ECEFD2300C68F5E /* CharacterAndSubTypesFragments.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CharacterAndSubTypesFragments.graphql; sourceTree = "<group>"; };
 		9F438D0B1E6C494C007BDC1A /* BatchedLoadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchedLoadTests.swift; sourceTree = "<group>"; };
-		9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPNetworkTransport.swift; sourceTree = "<group>"; };
+		9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = HTTPNetworkTransport.swift; sourceTree = "<group>"; tabWidth = 2; };
 		9F55347A1DE1DB2100E54264 /* ApolloStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloStore.swift; sourceTree = "<group>"; };
 		9F578D8F1D8D2CB300C0EA36 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		9F69FFA81D42855900E000B1 /* NetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTransport.swift; sourceTree = "<group>"; };

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
+		865624BF1FA1C31200FD840E /* PromisedCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865624BE1FA1C31200FD840E /* PromisedCancellable.swift */; };
+		865624C11FA1C3B400FD840E /* PromisedCancellableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865624C01FA1C3B400FD840E /* PromisedCancellableTests.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		9F0CA4461EE7F9E90032DD39 /* ApolloTestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F10A51E1EC1BA0F0045E62B /* MockNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */; };
@@ -228,6 +230,8 @@
 
 /* Begin PBXFileReference section */
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
+		865624BE1FA1C31200FD840E /* PromisedCancellable.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PromisedCancellable.swift; sourceTree = "<group>"; tabWidth = 2; };
+		865624C01FA1C3B400FD840E /* PromisedCancellableTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PromisedCancellableTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
 		9F19D8431EED568200C57247 /* ResultOrPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromise.swift; sourceTree = "<group>"; };
 		9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromiseTests.swift; sourceTree = "<group>"; };
@@ -318,7 +322,7 @@
 		9FD637EA1E6ACF88001EDBC8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9FD637ED1E6ACF88001EDBC8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9FD637EF1E6ACF88001EDBC8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; };
+		9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 		9FE3F3971DADBD870072078F /* check-and-run-apollo-codegen.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = "check-and-run-apollo-codegen.sh"; path = "scripts/check-and-run-apollo-codegen.sh"; sourceTree = SOURCE_ROOT; };
 		9FE941CF1E62C771007CDD89 /* Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
 		9FEB050C1DB5732300DA3B44 /* JSONSerializationFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializationFormat.swift; sourceTree = "<group>"; };
@@ -554,6 +558,7 @@
 				9F91CF8E1F6C0DB2008DD0BE /* MutatingResultsTests.swift */,
 				9FC9A9C71E2EFE6E0023C4D5 /* CacheKeyForFieldTests.swift */,
 				9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */,
+				865624C01FA1C3B400FD840E /* PromisedCancellableTests.swift */,
 				9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */,
 				9FADC8531E6B86D900C677E6 /* DataLoaderTests.swift */,
 				9FC750551D2A532D00458D91 /* Info.plist */,
@@ -591,6 +596,7 @@
 				9FCDFD221E33A0D8007519DC /* AsynchronousOperation.swift */,
 				9FEC15B81E6965E300D461B4 /* Result.swift */,
 				9FE941CF1E62C771007CDD89 /* Promise.swift */,
+				865624BE1FA1C31200FD840E /* PromisedCancellable.swift */,
 				9F19D8431EED568200C57247 /* ResultOrPromise.swift */,
 				9FEC15B31E681DAD00D461B4 /* Collections.swift */,
 				9FADC8491E6B0B2300C677E6 /* Locking.swift */,
@@ -1089,6 +1095,7 @@
 				9FC9A9BF1E2C27FB0023C4D5 /* GraphQLResult.swift in Sources */,
 				9FC9A9D31E2FD48B0023C4D5 /* GraphQLError.swift in Sources */,
 				9FEB050D1DB5732300DA3B44 /* JSONSerializationFormat.swift in Sources */,
+				865624BF1FA1C31200FD840E /* PromisedCancellable.swift in Sources */,
 				54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */,
 				9FC9A9C51E2D6CE70023C4D5 /* GraphQLSelectionSet.swift in Sources */,
 				9FCDFD231E33A0D8007519DC /* AsynchronousOperation.swift in Sources */,
@@ -1120,6 +1127,7 @@
 				9F19D8461EED8D3B00C57247 /* ResultOrPromiseTests.swift in Sources */,
 				9F533AB31E6C4A4200CBE097 /* BatchedLoadTests.swift in Sources */,
 				9FF90A6F1DDDEB420034C3B6 /* InputValueEncodingTests.swift in Sources */,
+				865624C11FA1C3B400FD840E /* PromisedCancellableTests.swift in Sources */,
 				9FE1C6E71E634C8D00C02284 /* PromiseTests.swift in Sources */,
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,
 				9F8622FA1EC2117C00C38162 /* FragmentConstructionAndConversionTests.swift in Sources */,

--- a/Sources/Apollo/PromisedCancellable.swift
+++ b/Sources/Apollo/PromisedCancellable.swift
@@ -2,7 +2,7 @@
 /// Wraps a promised cancellable as a normal cancellable.
 public class PromisedCancellable: Cancellable {
   /// The cancellable promise.
-  private let promise: Promise<Cancellable>
+  internal let promise: Promise<Cancellable>
   
   /// Whether the promised cancellable has been cancelled.
   private var isCancelledValue: Bool = false

--- a/Sources/Apollo/PromisedCancellable.swift
+++ b/Sources/Apollo/PromisedCancellable.swift
@@ -1,0 +1,35 @@
+
+/// Wraps a promised cancellable as a normal cancellable.
+public class PromisedCancellable: Cancellable {
+  /// The cancellable promise.
+  private let promise: Promise<Cancellable>
+  
+  /// Whether the promised cancellable has been cancelled.
+  private var isCancelledValue: Bool = false
+  
+  /// Mutex to protect the access to `isCancelledValue`.
+  private var mutex = Mutex()
+  
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///   - promise: The cancellable promise to wrap.
+  public init(promise: Promise<Cancellable>) {
+    self.promise = promise
+  }
+  
+  /// Cancels the wrapped promise.
+  public func cancel() {
+    mutex.withLock {
+      isCancelledValue = true
+    }
+    promise.andThen { $0.cancel() }
+  }
+  
+  /// Whether the promised cancellable has been cancelled.
+  public var isCancelled: Bool {
+    get {
+      return mutex.withLock { isCancelledValue }
+    }
+  }
+}

--- a/Tests/ApolloTests/PromisedCancellableTests.swift
+++ b/Tests/ApolloTests/PromisedCancellableTests.swift
@@ -1,0 +1,64 @@
+//
+//  PromisedCancellableTests.swift
+//  ApolloTests
+//
+//  Created by Marc Haisenko on 26.10.17.
+//  Copyright © 2017 Apollo GraphQL. All rights reserved.
+//
+
+import XCTest
+@testable import Apollo
+
+// Progress is cancellable, add the protocol.
+extension Progress: Cancellable {
+}
+
+class PromisedCancellableTests: XCTestCase {
+
+  func testSynchronousCancel() {
+    let progress = Progress(totalUnitCount: 1)
+    let promise = Promise<Cancellable>(fulfilled: progress)
+    let cancellable = PromisedCancellable(promise: promise)
+    
+    XCTAssertFalse(progress.isCancelled)
+    XCTAssertFalse(cancellable.isCancelled)
+    
+    cancellable.cancel()
+    
+    XCTAssertTrue(progress.isCancelled)
+    XCTAssertTrue(cancellable.isCancelled)
+  }
+
+  func testAsynchronousFulfilledCancel() {
+    let expectation = self.expectation(description: "async")
+    
+    let progress = Progress(totalUnitCount: 1)
+    let promise = Promise<Cancellable> {
+      (fulfill, reject) in
+      
+      DispatchQueue.main.async {
+        fulfill(progress)
+        expectation.fulfill()
+      }
+    }
+    let cancellable = PromisedCancellable(promise: promise)
+    
+    XCTAssertFalse(progress.isCancelled)
+    XCTAssertFalse(cancellable.isCancelled)
+    
+    // This notes that the PromisedCancellable is cancelled, but since the promise is not yet
+    // fulfilled the Progress will not be cancelled yet.
+    cancellable.cancel()
+    
+    XCTAssertFalse(progress.isCancelled)
+    XCTAssertTrue(cancellable.isCancelled)
+    
+    // Wait for asynchronous operation. The Progress immediately gets cancelled when the promise
+    // is fulfilled.
+    waitForExpectations(timeout: 1)
+    
+    XCTAssertTrue(progress.isCancelled)
+    XCTAssertTrue(cancellable.isCancelled)
+  }
+
+}


### PR DESCRIPTION
This is a proposal to solve #37 by adding a closure that may be executed asynchronously to modify the request before it's actually sent.