### PR TITLE
[WIP] Add Apollo Link

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -8,6 +8,18 @@
 
 /* Begin PBXBuildFile section */
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
+		5DD6DA651FC21EA900199464 /* LinkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA641FC21EA900199464 /* LinkContext.swift */; };
+		5DD6DA671FC21ED100199464 /* ConcatLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA661FC21ED100199464 /* ConcatLink.swift */; };
+		5DD6DA691FC21F4F00199464 /* SplitLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA681FC21F4F00199464 /* SplitLink.swift */; };
+		5DD6DA6B1FC222A800199464 /* TerminatingLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA6A1FC222A800199464 /* TerminatingLink.swift */; };
+		5DD6DA6F1FC2284E00199464 /* NonTerminatingLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA6E1FC2284E00199464 /* NonTerminatingLink.swift */; };
+		5DD6DA711FC2287600199464 /* EmptyLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA701FC2287600199464 /* EmptyLink.swift */; };
+		5DD6DA731FC2289100199464 /* PassthroughLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA721FC2289100199464 /* PassthroughLink.swift */; };
+		5DD6DA751FC22E6D00199464 /* NetworkTransportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA741FC22E6D00199464 /* NetworkTransportLink.swift */; };
+		5DF5636E1FBA2FBE005C9165 /* ApolloLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF5636D1FBA2FBE005C9165 /* ApolloLink.swift */; };
+		5DF5FBBC1FBE2E2E009C5B8D /* CancelControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF5FBBB1FBE2E2E009C5B8D /* CancelControllerTests.swift */; };
+		5DF5FBBE1FBE48C6009C5B8D /* CancelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF5FBBD1FBE48C6009C5B8D /* CancelController.swift */; };
+		5DF5FBC01FBE49AD009C5B8D /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF5FBBF1FBE49AD009C5B8D /* LinkTests.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		9F0CA4461EE7F9E90032DD39 /* ApolloTestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F10A51E1EC1BA0F0045E62B /* MockNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */; };
@@ -228,6 +240,18 @@
 
 /* Begin PBXFileReference section */
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
+		5DD6DA641FC21EA900199464 /* LinkContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkContext.swift; sourceTree = "<group>"; };
+		5DD6DA661FC21ED100199464 /* ConcatLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcatLink.swift; sourceTree = "<group>"; };
+		5DD6DA681FC21F4F00199464 /* SplitLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitLink.swift; sourceTree = "<group>"; };
+		5DD6DA6A1FC222A800199464 /* TerminatingLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminatingLink.swift; sourceTree = "<group>"; };
+		5DD6DA6E1FC2284E00199464 /* NonTerminatingLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonTerminatingLink.swift; sourceTree = "<group>"; };
+		5DD6DA701FC2287600199464 /* EmptyLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyLink.swift; sourceTree = "<group>"; };
+		5DD6DA721FC2289100199464 /* PassthroughLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughLink.swift; sourceTree = "<group>"; };
+		5DD6DA741FC22E6D00199464 /* NetworkTransportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTransportLink.swift; sourceTree = "<group>"; };
+		5DF5636D1FBA2FBE005C9165 /* ApolloLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloLink.swift; sourceTree = "<group>"; };
+		5DF5FBBB1FBE2E2E009C5B8D /* CancelControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelControllerTests.swift; sourceTree = "<group>"; };
+		5DF5FBBD1FBE48C6009C5B8D /* CancelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelController.swift; sourceTree = "<group>"; };
+		5DF5FBBF1FBE49AD009C5B8D /* LinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkTests.swift; sourceTree = "<group>"; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
 		9F19D8431EED568200C57247 /* ResultOrPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromise.swift; sourceTree = "<group>"; };
 		9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromiseTests.swift; sourceTree = "<group>"; };
@@ -407,6 +431,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5DD6DA631FC21E6500199464 /* Link */ = {
+			isa = PBXGroup;
+			children = (
+				5DF5636D1FBA2FBE005C9165 /* ApolloLink.swift */,
+				5DD6DA641FC21EA900199464 /* LinkContext.swift */,
+				5DD6DA6A1FC222A800199464 /* TerminatingLink.swift */,
+				5DD6DA6E1FC2284E00199464 /* NonTerminatingLink.swift */,
+				5DD6DA701FC2287600199464 /* EmptyLink.swift */,
+				5DD6DA721FC2289100199464 /* PassthroughLink.swift */,
+				5DD6DA661FC21ED100199464 /* ConcatLink.swift */,
+				5DD6DA681FC21F4F00199464 /* SplitLink.swift */,
+			);
+			name = Link;
+			sourceTree = "<group>";
+		};
 		9F27D4601D40363A00715680 /* Execution */ = {
 			isa = PBXGroup;
 			children = (
@@ -531,6 +570,7 @@
 				9FC9A9BE1E2C27FB0023C4D5 /* GraphQLResult.swift */,
 				9FC9A9D21E2FD48B0023C4D5 /* GraphQLError.swift */,
 				9FCDFD281E33D0CE007519DC /* GraphQLQueryWatcher.swift */,
+				5DD6DA631FC21E6500199464 /* Link */,
 				9FC9A9CE1E2FD0CC0023C4D5 /* Network */,
 				9FC9A9CA1E2FD05C0023C4D5 /* Store */,
 				9F27D4601D40363A00715680 /* Execution */,
@@ -556,6 +596,8 @@
 				9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */,
 				9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */,
 				9FADC8531E6B86D900C677E6 /* DataLoaderTests.swift */,
+				5DF5FBBB1FBE2E2E009C5B8D /* CancelControllerTests.swift */,
+				5DF5FBBF1FBE49AD009C5B8D /* LinkTests.swift */,
 				9FC750551D2A532D00458D91 /* Info.plist */,
 			);
 			path = ApolloTests;
@@ -578,6 +620,7 @@
 			isa = PBXGroup;
 			children = (
 				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
+				5DD6DA741FC22E6D00199464 /* NetworkTransportLink.swift */,
 				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
 			);
@@ -594,6 +637,7 @@
 				9F19D8431EED568200C57247 /* ResultOrPromise.swift */,
 				9FEC15B31E681DAD00D461B4 /* Collections.swift */,
 				9FADC8491E6B0B2300C677E6 /* Locking.swift */,
+				5DF5FBBD1FBE48C6009C5B8D /* CancelController.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -1089,8 +1133,13 @@
 				9FC9A9BF1E2C27FB0023C4D5 /* GraphQLResult.swift in Sources */,
 				9FC9A9D31E2FD48B0023C4D5 /* GraphQLError.swift in Sources */,
 				9FEB050D1DB5732300DA3B44 /* JSONSerializationFormat.swift in Sources */,
+				5DF5FBBE1FBE48C6009C5B8D /* CancelController.swift in Sources */,
 				54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */,
 				9FC9A9C51E2D6CE70023C4D5 /* GraphQLSelectionSet.swift in Sources */,
+				5DD6DA6B1FC222A800199464 /* TerminatingLink.swift in Sources */,
+				5DD6DA651FC21EA900199464 /* LinkContext.swift in Sources */,
+				5DD6DA711FC2287600199464 /* EmptyLink.swift in Sources */,
+				5DF5636E1FBA2FBE005C9165 /* ApolloLink.swift in Sources */,
 				9FCDFD231E33A0D8007519DC /* AsynchronousOperation.swift in Sources */,
 				9FC9A9CC1E2FD0760023C4D5 /* Record.swift in Sources */,
 				9FC4B9201D2A6F8D0046A641 /* JSON.swift in Sources */,
@@ -1101,13 +1150,18 @@
 				9FADC84F1E6B865E00C677E6 /* DataLoader.swift in Sources */,
 				9FF90A611DDDEB100034C3B6 /* GraphQLResponse.swift in Sources */,
 				9F27D4641D40379500715680 /* JSONStandardTypeConversions.swift in Sources */,
+				5DD6DA731FC2289100199464 /* PassthroughLink.swift in Sources */,
+				5DD6DA6F1FC2284E00199464 /* NonTerminatingLink.swift in Sources */,
+				5DD6DA691FC21F4F00199464 /* SplitLink.swift in Sources */,
 				9FA6F3681E65DF4700BF8D73 /* GraphQLResultAccumulator.swift in Sources */,
 				9FF90A651DDDEB100034C3B6 /* GraphQLExecutor.swift in Sources */,
 				9FC750611D2A59C300458D91 /* GraphQLOperation.swift in Sources */,
 				9FE941D01E62C771007CDD89 /* Promise.swift in Sources */,
 				9FC750631D2A59F600458D91 /* ApolloClient.swift in Sources */,
+				5DD6DA671FC21ED100199464 /* ConcatLink.swift in Sources */,
 				9F86B6901E65533D00B885FF /* GraphQLResponseGenerator.swift in Sources */,
 				9FC9A9C21E2D3CAF0023C4D5 /* GraphQLInputValue.swift in Sources */,
+				5DD6DA751FC22E6D00199464 /* NetworkTransportLink.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1118,8 +1172,10 @@
 				9FC9A9C81E2EFE6E0023C4D5 /* CacheKeyForFieldTests.swift in Sources */,
 				9F91CF8F1F6C0DB2008DD0BE /* MutatingResultsTests.swift in Sources */,
 				9F19D8461EED8D3B00C57247 /* ResultOrPromiseTests.swift in Sources */,
+				5DF5FBBC1FBE2E2E009C5B8D /* CancelControllerTests.swift in Sources */,
 				9F533AB31E6C4A4200CBE097 /* BatchedLoadTests.swift in Sources */,
 				9FF90A6F1DDDEB420034C3B6 /* InputValueEncodingTests.swift in Sources */,
+				5DF5FBC01FBE49AD009C5B8D /* LinkTests.swift in Sources */,
 				9FE1C6E71E634C8D00C02284 /* PromiseTests.swift in Sources */,
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,
 				9F8622FA1EC2117C00C38162 /* FragmentConstructionAndConversionTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
+		5DD12DEB1FC4BCE80022E38B /* LimboLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD12DEA1FC4BCE80022E38B /* LimboLink.swift */; };
 		5DD6DA651FC21EA900199464 /* LinkContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA641FC21EA900199464 /* LinkContext.swift */; };
 		5DD6DA671FC21ED100199464 /* ConcatLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA661FC21ED100199464 /* ConcatLink.swift */; };
 		5DD6DA691FC21F4F00199464 /* SplitLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD6DA681FC21F4F00199464 /* SplitLink.swift */; };
@@ -240,6 +241,7 @@
 
 /* Begin PBXFileReference section */
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
+		5DD12DEA1FC4BCE80022E38B /* LimboLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LimboLink.swift; sourceTree = "<group>"; };
 		5DD6DA641FC21EA900199464 /* LinkContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkContext.swift; sourceTree = "<group>"; };
 		5DD6DA661FC21ED100199464 /* ConcatLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcatLink.swift; sourceTree = "<group>"; };
 		5DD6DA681FC21F4F00199464 /* SplitLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitLink.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 				5DD6DA721FC2289100199464 /* PassthroughLink.swift */,
 				5DD6DA661FC21ED100199464 /* ConcatLink.swift */,
 				5DD6DA681FC21F4F00199464 /* SplitLink.swift */,
+				5DD12DEA1FC4BCE80022E38B /* LimboLink.swift */,
 			);
 			name = Link;
 			sourceTree = "<group>";
@@ -1161,6 +1164,7 @@
 				5DD6DA671FC21ED100199464 /* ConcatLink.swift in Sources */,
 				9F86B6901E65533D00B885FF /* GraphQLResponseGenerator.swift in Sources */,
 				9FC9A9C21E2D3CAF0023C4D5 /* GraphQLInputValue.swift in Sources */,
+				5DD12DEB1FC4BCE80022E38B /* LimboLink.swift in Sources */,
 				5DD6DA751FC22E6D00199464 /* NetworkTransportLink.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Apollo/ApolloLink.swift
+++ b/Sources/Apollo/ApolloLink.swift
@@ -1,0 +1,1 @@
+public typealias NextLink<Operation: GraphQLOperation> = (Operation, LinkContext) -> Promise<GraphQLResponse<Operation>>

--- a/Sources/Apollo/CancelController.swift
+++ b/Sources/Apollo/CancelController.swift
@@ -1,0 +1,37 @@
+public final class CancelController: Cancellable {
+  public let signal = CancelSignal()
+  
+  public func cancel() {
+    signal.cancel()
+  }
+}
+
+public final class CancelSignal {
+  private let promise: Promise<Void>
+  private let fulfill: (() -> Void)
+  
+  fileprivate init() {
+    var _fulfill: (() -> Void)!
+    promise = Promise { (fulfill, _) in
+      _fulfill = fulfill
+    }
+    
+    fulfill = _fulfill
+  }
+  
+  fileprivate func cancel() {
+    fulfill()
+  }
+  
+  public var isCancelled: Bool {
+    return !promise.isPending
+  }
+  
+  public func onCancel(_ whenCancelled: @escaping () -> Void) {
+    promise.andThen(whenCancelled)
+  }
+}
+
+public struct CancelError: Error {
+}
+

--- a/Sources/Apollo/ConcatLink.swift
+++ b/Sources/Apollo/ConcatLink.swift
@@ -1,0 +1,41 @@
+extension NonTerminatingLink {
+  public func concat(_ next: NonTerminatingLink) -> NonTerminatingLink {
+    return NonTerminatingConcatLink(first: self, second: next)
+  }
+  
+  public func concat(_ next: TerminatingLink) -> TerminatingLink {
+    return TerminatingConcatLink(first: self, second: next)
+  }
+}
+
+fileprivate class NonTerminatingConcatLink: NonTerminatingLink {
+  private var first: NonTerminatingLink
+  private var second: NonTerminatingLink
+  
+  init(first: NonTerminatingLink, second: NonTerminatingLink) {
+    self.first = first
+    self.second = second
+  }
+  
+  func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>> {
+    return first.request(operation: operation, context: context) {
+      return self.second.request(operation: $0, context: $1, forward: forward)
+    }
+  }
+}
+
+fileprivate class TerminatingConcatLink: TerminatingLink {
+  private var first: NonTerminatingLink
+  private var second: TerminatingLink
+  
+  init(first: NonTerminatingLink, second: TerminatingLink) {
+    self.first = first
+    self.second = second
+  }
+  
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    return first.request(operation: operation, context: context) {
+      return self.second.request(operation: $0, context: $1)
+    }
+  }
+}

--- a/Sources/Apollo/ConcatLink.swift
+++ b/Sources/Apollo/ConcatLink.swift
@@ -8,7 +8,7 @@ extension NonTerminatingLink {
   }
 }
 
-fileprivate class NonTerminatingConcatLink: NonTerminatingLink {
+fileprivate final class NonTerminatingConcatLink: NonTerminatingLink {
   private var first: NonTerminatingLink
   private var second: NonTerminatingLink
   
@@ -24,7 +24,7 @@ fileprivate class NonTerminatingConcatLink: NonTerminatingLink {
   }
 }
 
-fileprivate class TerminatingConcatLink: TerminatingLink {
+fileprivate final class TerminatingConcatLink: TerminatingLink {
   private var first: NonTerminatingLink
   private var second: TerminatingLink
   

--- a/Sources/Apollo/EmptyLink.swift
+++ b/Sources/Apollo/EmptyLink.swift
@@ -1,0 +1,7 @@
+fileprivate final class EmptyLink: TerminatingLink {
+  public func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    return Promise(fulfilled: GraphQLResponse(operation: operation, body: [:]))
+  }
+}
+
+public let emptyLink: TerminatingLink = EmptyLink()

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -1,4 +1,4 @@
-public protocol GraphQLOperation: class {
+public protocol GraphQLOperationBase {
   static var rootCacheKey: String { get }
   
   static var operationString: String { get }
@@ -6,7 +6,9 @@ public protocol GraphQLOperation: class {
   static var operationIdentifier: String? { get }
   
   var variables: GraphQLMap? { get }
-  
+}
+
+public protocol GraphQLOperation: class, GraphQLOperationBase {
   associatedtype Data: GraphQLSelectionSet
 }
 

--- a/Sources/Apollo/LimboLink.swift
+++ b/Sources/Apollo/LimboLink.swift
@@ -1,0 +1,25 @@
+extension NonTerminatingLink {
+  public func makeTerminating(file: StaticString = #file, line: UInt = #line) -> TerminatingLink {
+    return concat(LimboLink(previousLink: self, file: file, line: line))
+  }
+}
+
+fileprivate final class LimboLink: TerminatingLink {
+  weak private var previousLink: NonTerminatingLink?
+  private let file: StaticString
+  private let line: UInt
+  
+  init(previousLink: NonTerminatingLink, file: StaticString, line: UInt) {
+    self.previousLink = previousLink
+    self.file = file
+    self.line = line
+  }
+  
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    guard let link = previousLink else {
+      fatalError("Link did not terminate", file: file, line: line)
+    }
+    
+    fatalError("\(link) did not terminate", file: file, line: line)
+  }
+}

--- a/Sources/Apollo/LinkContext.swift
+++ b/Sources/Apollo/LinkContext.swift
@@ -1,0 +1,23 @@
+public struct LinkContext {
+  private var data = [AnyHashable: Any]()
+  
+  public subscript(_ key: AnyHashable) -> Any? {
+    get {
+      return data[key]
+    }
+    set {
+      data[key] = newValue
+    }
+  }
+  
+  public subscript<T>(_ key: AnyHashable, default defaultValue: T) -> T {
+    get {
+      return data[key, default: defaultValue] as! T
+    }
+    set {
+      data[key] = newValue
+    }
+  }
+  
+  public var signal = CancelController().signal
+}

--- a/Sources/Apollo/NetworkTransportLink.swift
+++ b/Sources/Apollo/NetworkTransportLink.swift
@@ -1,0 +1,31 @@
+final class NetworkTransportLink: TerminatingLink {
+  let networkTransport: NetworkTransport
+  
+  init(networkTransport: NetworkTransport) {
+    self.networkTransport = networkTransport
+  }
+  
+  public func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    return Promise({ (fulfill, reject) in
+      guard !context.signal.isCancelled else {
+        throw CancelError()
+      }
+      
+      let request = networkTransport.send(operation: operation, completionHandler: { (response, error) in
+        if let error = error {
+          reject(error)
+          return
+        }
+        
+        if let response = response {
+          fulfill(response)
+          return
+        }
+      })
+      
+      context.signal.onCancel {
+        request.cancel()
+      }
+    })
+  }
+}

--- a/Sources/Apollo/NonTerminatingLink.swift
+++ b/Sources/Apollo/NonTerminatingLink.swift
@@ -1,0 +1,3 @@
+public protocol NonTerminatingLink {
+  func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>>
+}

--- a/Sources/Apollo/NonTerminatingLink.swift
+++ b/Sources/Apollo/NonTerminatingLink.swift
@@ -1,3 +1,21 @@
-public protocol NonTerminatingLink {
+public protocol NonTerminatingLink: class {
   func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>>
+}
+
+public func link(from links: [NonTerminatingLink]) -> NonTerminatingLink {
+  guard let firstLink = links.first else {
+    return passthroughLink
+  }
+  
+  return links[1...].reduce(firstLink, { (chain, nextLink) in
+    chain.concat(nextLink)
+  })
+}
+
+public func link(from links: [NonTerminatingLink], file: StaticString = #file, line: UInt = #line) -> TerminatingLink {
+  return link(from: links).makeTerminating(file: file, line: line)
+}
+
+public func link(from links: [NonTerminatingLink], terminating terminatingLink: TerminatingLink) -> TerminatingLink {
+  return link(from: links).concat(terminatingLink)
 }

--- a/Sources/Apollo/PassthroughLink.swift
+++ b/Sources/Apollo/PassthroughLink.swift
@@ -1,0 +1,7 @@
+fileprivate final class PassthroughLink: NonTerminatingLink {
+  public func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>> {
+    return forward(operation, context)
+  }
+}
+
+public let passthroughLink: NonTerminatingLink = PassthroughLink()

--- a/Sources/Apollo/SplitLink.swift
+++ b/Sources/Apollo/SplitLink.swift
@@ -1,9 +1,9 @@
 extension NonTerminatingLink {
-  public func split(first: TerminatingLink, second: TerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) -> TerminatingLink {
+  public func split(first: TerminatingLink, second: TerminatingLink, test: @escaping (GraphQLOperationBase, LinkContext) -> Bool) -> TerminatingLink {
     return concat(TerminatingSplitLink(first: first, second: second, test: test))
   }
   
-  public func split(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) -> NonTerminatingLink {
+  public func split(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (GraphQLOperationBase, LinkContext) -> Bool) -> NonTerminatingLink {
     return concat(NonTerminatingSplitLink(first: first, second: second, test: test))
   }
 }
@@ -11,16 +11,16 @@ extension NonTerminatingLink {
 fileprivate final class TerminatingSplitLink: TerminatingLink {
   private var first: TerminatingLink
   private var second: TerminatingLink
-  private var test: (GraphQLOperationBase) -> Bool
+  private var test: (GraphQLOperationBase, LinkContext) -> Bool
   
-  init(first: TerminatingLink, second: TerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) {
+  init(first: TerminatingLink, second: TerminatingLink, test: @escaping (GraphQLOperationBase, LinkContext) -> Bool) {
     self.first = first
     self.second = second
     self.test = test
   }
   
   func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
-    if test(operation) {
+    if test(operation, context) {
       return first.request(operation: operation, context: context)
     }
     else {
@@ -32,16 +32,16 @@ fileprivate final class TerminatingSplitLink: TerminatingLink {
 fileprivate final class NonTerminatingSplitLink: NonTerminatingLink {
   private var first: NonTerminatingLink
   private var second: NonTerminatingLink
-  private var test: (GraphQLOperationBase) -> Bool
+  private var test: (GraphQLOperationBase, LinkContext) -> Bool
   
-  init(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) {
+  init(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (GraphQLOperationBase, LinkContext) -> Bool) {
     self.first = first
     self.second = second
     self.test = test
   }
   
   func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>> {
-    if test(operation) {
+    if test(operation, context) {
       return first.request(operation: operation, context: context, forward: forward)
     }
     else {

--- a/Sources/Apollo/SplitLink.swift
+++ b/Sources/Apollo/SplitLink.swift
@@ -8,7 +8,7 @@ extension NonTerminatingLink {
   }
 }
 
-fileprivate class TerminatingSplitLink: TerminatingLink {
+fileprivate final class TerminatingSplitLink: TerminatingLink {
   private var first: TerminatingLink
   private var second: TerminatingLink
   private var test: (GraphQLOperationBase) -> Bool
@@ -29,7 +29,7 @@ fileprivate class TerminatingSplitLink: TerminatingLink {
   }
 }
 
-fileprivate class NonTerminatingSplitLink: NonTerminatingLink {
+fileprivate final class NonTerminatingSplitLink: NonTerminatingLink {
   private var first: NonTerminatingLink
   private var second: NonTerminatingLink
   private var test: (GraphQLOperationBase) -> Bool

--- a/Sources/Apollo/SplitLink.swift
+++ b/Sources/Apollo/SplitLink.swift
@@ -1,46 +1,26 @@
 extension NonTerminatingLink {
-  public func split(first: TerminatingLink, second: TerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) -> TerminatingLink {
+  public func split(first: TerminatingLink, second: TerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) -> TerminatingLink {
     return concat(TerminatingSplitLink(first: first, second: second, test: test))
   }
   
-  public func split(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) -> NonTerminatingLink {
+  public func split(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) -> NonTerminatingLink {
     return concat(NonTerminatingSplitLink(first: first, second: second, test: test))
-  }
-}
-
-public struct LinkOperationDescriptor {
-  let rootCacheKey: String
-  let operationString: String
-  let requestString: String
-  let operationIdentifier: String?
-  let variables: GraphQLMap?
-  let context: LinkContext
-  
-  fileprivate init<Operation: GraphQLOperation>(operation: Operation, context: LinkContext) {
-    rootCacheKey = Operation.rootCacheKey
-    operationString = Operation.operationString
-    requestString = Operation.requestString
-    operationIdentifier = Operation.operationIdentifier
-    variables = operation.variables
-    self.context = context
   }
 }
 
 fileprivate class TerminatingSplitLink: TerminatingLink {
   private var first: TerminatingLink
   private var second: TerminatingLink
-  private var test: (LinkOperationDescriptor) -> Bool
+  private var test: (GraphQLOperationBase) -> Bool
   
-  init(first: TerminatingLink, second: TerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) {
+  init(first: TerminatingLink, second: TerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) {
     self.first = first
     self.second = second
     self.test = test
   }
   
   func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
-    let descriptor = LinkOperationDescriptor(operation: operation, context: context)
-    
-    if test(descriptor) {
+    if test(operation) {
       return first.request(operation: operation, context: context)
     }
     else {
@@ -52,18 +32,16 @@ fileprivate class TerminatingSplitLink: TerminatingLink {
 fileprivate class NonTerminatingSplitLink: NonTerminatingLink {
   private var first: NonTerminatingLink
   private var second: NonTerminatingLink
-  private var test: (LinkOperationDescriptor) -> Bool
+  private var test: (GraphQLOperationBase) -> Bool
   
-  init(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) {
+  init(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (GraphQLOperationBase) -> Bool) {
     self.first = first
     self.second = second
     self.test = test
   }
   
   func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>> {
-    let descriptor = LinkOperationDescriptor(operation: operation, context: context)
-    
-    if test(descriptor) {
+    if test(operation) {
       return first.request(operation: operation, context: context, forward: forward)
     }
     else {

--- a/Sources/Apollo/SplitLink.swift
+++ b/Sources/Apollo/SplitLink.swift
@@ -1,0 +1,73 @@
+extension NonTerminatingLink {
+  public func split(first: TerminatingLink, second: TerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) -> TerminatingLink {
+    return concat(TerminatingSplitLink(first: first, second: second, test: test))
+  }
+  
+  public func split(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) -> NonTerminatingLink {
+    return concat(NonTerminatingSplitLink(first: first, second: second, test: test))
+  }
+}
+
+public struct LinkOperationDescriptor {
+  let rootCacheKey: String
+  let operationString: String
+  let requestString: String
+  let operationIdentifier: String?
+  let variables: GraphQLMap?
+  let context: LinkContext
+  
+  fileprivate init<Operation: GraphQLOperation>(operation: Operation, context: LinkContext) {
+    rootCacheKey = Operation.rootCacheKey
+    operationString = Operation.operationString
+    requestString = Operation.requestString
+    operationIdentifier = Operation.operationIdentifier
+    variables = operation.variables
+    self.context = context
+  }
+}
+
+fileprivate class TerminatingSplitLink: TerminatingLink {
+  private var first: TerminatingLink
+  private var second: TerminatingLink
+  private var test: (LinkOperationDescriptor) -> Bool
+  
+  init(first: TerminatingLink, second: TerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) {
+    self.first = first
+    self.second = second
+    self.test = test
+  }
+  
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    let descriptor = LinkOperationDescriptor(operation: operation, context: context)
+    
+    if test(descriptor) {
+      return first.request(operation: operation, context: context)
+    }
+    else {
+      return second.request(operation: operation, context: context)
+    }
+  }
+}
+
+fileprivate class NonTerminatingSplitLink: NonTerminatingLink {
+  private var first: NonTerminatingLink
+  private var second: NonTerminatingLink
+  private var test: (LinkOperationDescriptor) -> Bool
+  
+  init(first: NonTerminatingLink, second: NonTerminatingLink, test: @escaping (LinkOperationDescriptor) -> Bool) {
+    self.first = first
+    self.second = second
+    self.test = test
+  }
+  
+  func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>> {
+    let descriptor = LinkOperationDescriptor(operation: operation, context: context)
+    
+    if test(descriptor) {
+      return first.request(operation: operation, context: context, forward: forward)
+    }
+    else {
+      return second.request(operation: operation, context: context, forward: forward)
+    }
+  }
+}

--- a/Sources/Apollo/TerminatingLink.swift
+++ b/Sources/Apollo/TerminatingLink.swift
@@ -1,4 +1,4 @@
-public protocol TerminatingLink {
+public protocol TerminatingLink: class {
   func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>>
 }
 

--- a/Sources/Apollo/TerminatingLink.swift
+++ b/Sources/Apollo/TerminatingLink.swift
@@ -1,0 +1,9 @@
+public protocol TerminatingLink {
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>>
+}
+
+extension TerminatingLink {
+  public func execute<Operation>(operation: Operation, context: LinkContext? = nil) -> Promise<GraphQLResponse<Operation>> {
+    return request(operation: operation, context: context ?? LinkContext())
+  }
+}

--- a/Tests/ApolloTests/CancelControllerTests.swift
+++ b/Tests/ApolloTests/CancelControllerTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Apollo
+
+class CancelControllerTests: XCTestCase {
+  func testSignalIsNotCancelledInitially() {
+    let controller = CancelController()
+    
+    XCTAssertFalse(controller.signal.isCancelled)
+  }
+  
+  func testSignalIsCancelledAfterCancel() {
+    let controller = CancelController()
+    controller.cancel()
+    
+    XCTAssert(controller.signal.isCancelled)
+  }
+  
+  func testCallsOnCancelHandlerWhenCancelled() {
+    let controller = CancelController()
+    controller.cancel()
+
+    let expectation = self.expectation(description: "onCancel handler invoked")
+
+    controller.signal.onCancel {
+      expectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testCallsOnCancelHandlerAfterCancel() {
+    let controller = CancelController()
+    
+    let expectation = self.expectation(description: "onCancel handler invoked")
+    
+    controller.signal.onCancel {
+      expectation.fulfill()
+    }
+    
+    controller.cancel()
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testCallsAllOnCancelHandler() {
+    let controller = CancelController()
+    
+    let expectations = (1..<5).map { _ -> XCTestExpectation in
+      let expectation = self.expectation(description: "onCancel handler invoked")
+      
+      controller.signal.onCancel {
+        expectation.fulfill()
+      }
+      
+      return expectation
+    }
+    
+    controller.cancel()
+    
+    wait(for: expectations, timeout: 0.1)
+  }
+}

--- a/Tests/ApolloTests/LinkTests.swift
+++ b/Tests/ApolloTests/LinkTests.swift
@@ -275,7 +275,7 @@ class LinkTests: XCTestCase {
     let queryLink = SetContextLink.incrementCounter(by: 1)
     let mutationLink = SetContextLink.incrementCounter(by: -1)
     
-    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op, _  in
       type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
@@ -295,7 +295,7 @@ class LinkTests: XCTestCase {
     let queryLink = SetContextLink.incrementCounter(by: 1)
     let mutationLink = SetContextLink.incrementCounter(by: -1)
     
-    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op, _ in
       type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
@@ -315,7 +315,7 @@ class LinkTests: XCTestCase {
     let queryLink = SetContextLink.incrementCounter(by: 1).concat(SyncLink())
     let mutationLink = SetContextLink.incrementCounter(by: -1).concat(SyncLink())
     
-    let link = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+    let link = passthroughLink.split(first: queryLink, second: mutationLink) { op, _ in
       type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
@@ -333,7 +333,7 @@ class LinkTests: XCTestCase {
     let queryLink = SetContextLink.incrementCounter(by: 1)
     let mutationLink = SetContextLink.incrementCounter(by: -1)
     
-    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op, _ in
       type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     

--- a/Tests/ApolloTests/LinkTests.swift
+++ b/Tests/ApolloTests/LinkTests.swift
@@ -1,0 +1,360 @@
+import XCTest
+@testable import Apollo
+import StarWarsAPI
+
+fileprivate extension LinkContext {
+  var counter: Int {
+    get {
+      return self["counter", default: 0]
+    }
+    set {
+      self["counter"] = newValue
+    }
+  }
+}
+
+fileprivate class SetContextLink: NonTerminatingLink {
+  let setContext: (LinkContext) -> LinkContext
+  
+  init(_ setContext: @escaping (LinkContext) -> LinkContext) {
+    self.setContext = setContext
+  }
+  
+  func request<Operation>(operation: Operation, context: LinkContext, forward: @escaping NextLink<Operation>) -> Promise<GraphQLResponse<Operation>> {
+    return forward(operation, setContext(context))
+  }
+  
+  static func incrementCounter(by value: Int) -> NonTerminatingLink {
+    return SetContextLink { context in
+      var newContext = context
+      newContext.counter += value
+      return newContext
+    }
+  }
+  
+  static func with(cancelController: CancelController) -> NonTerminatingLink {
+    return SetContextLink { context in
+      var newContext = context
+      newContext.signal = cancelController.signal
+      return newContext
+    }
+  }
+}
+
+fileprivate class SyncLink: TerminatingLink {
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    if context.signal.isCancelled {
+      return Promise(rejected: CancelError())
+    }
+    
+    let body: JSONObject = ["counter": context.counter]
+    let response = GraphQLResponse(operation: operation, body: body)
+    
+    return Promise(fulfilled: response)
+  }
+}
+
+fileprivate class AsyncLink: TerminatingLink {
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    if context.signal.isCancelled {
+      return Promise(rejected: CancelError())
+    }
+    
+    return Promise({ (fulfill, reject) in
+      DispatchQueue.global().async {
+        guard !context.signal.isCancelled else {
+          reject(CancelError())
+          return
+        }
+        
+        let body: JSONObject = ["counter": context.counter]
+        let response = GraphQLResponse(operation: operation, body: body)
+        
+        fulfill(response)
+      }
+    })
+  }
+}
+
+fileprivate class InfiniteLink: TerminatingLink {
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    var swiftIsHappy = true
+    return Promise { (fulfill, reject) in
+      DispatchQueue.global().async {
+        while swiftIsHappy {
+          // infinite loop
+        }
+        
+        fulfill(GraphQLResponse(operation: operation, body: [:]))
+      }
+      
+      context.signal.onCancel {
+        reject(CancelError())
+      }
+      
+      }.finally {
+        swiftIsHappy = false
+    }
+  }
+}
+
+fileprivate class SemaLink: TerminatingLink {
+  func request<Operation>(operation: Operation, context: LinkContext) -> Promise<GraphQLResponse<Operation>> {
+    return Promise { (fulfill, reject) in
+      let sema = DispatchSemaphore(value: 0)
+      DispatchQueue.global().async {
+        sema.wait()
+        
+        fulfill(GraphQLResponse(operation: operation, body: [:]))
+      }
+      
+      context.signal.onCancel {
+        reject(CancelError())
+      }
+    }
+  }
+}
+
+let query = HeroNameQuery()
+let mutation = CreateAwesomeReviewMutation()
+
+class LinkTests: XCTestCase {
+  func testExecuteLink() {
+    let link = SyncLink()
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 0)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testExecuteLinkWithContext() {
+    let link = SyncLink()
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    var context = LinkContext()
+    context.counter = 10
+    
+    link.execute(operation: query, context: context).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 10)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testExecuteEmptyLink() {
+    let expectation = self.expectation(description: "link executed")
+    
+    emptyLink.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body.count, 0)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testExecutePassthroughLink() {
+    let link = passthroughLink.concat(emptyLink)
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body.count, 0)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testConcatLink() {
+    let link = SetContextLink.incrementCounter(by: 1).concat(SyncLink())
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 1)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testConcatMultipleLinks() {
+    let link = SetContextLink.incrementCounter(by: 1).concat(SetContextLink.incrementCounter(by: 2)).concat(SyncLink())
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 3)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testSplitNonTerminatingLinkFirst() {
+    let queryLink = SetContextLink.incrementCounter(by: 1)
+    let mutationLink = SetContextLink.incrementCounter(by: -1)
+    
+    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+      op.rootCacheKey == "QUERY_ROOT"
+    }
+    
+    let link = splitLink.concat(SyncLink())
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 1)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testSplitNonTerminatingLinkSecond() {
+    let queryLink = SetContextLink.incrementCounter(by: 1)
+    let mutationLink = SetContextLink.incrementCounter(by: -1)
+    
+    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+      op.rootCacheKey == "QUERY_ROOT"
+    }
+    
+    let link = splitLink.concat(SyncLink())
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: mutation).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, -1)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testSplitTerminatingLinkFirst() {
+    let queryLink = SetContextLink.incrementCounter(by: 1).concat(SyncLink())
+    let mutationLink = SetContextLink.incrementCounter(by: -1).concat(SyncLink())
+    
+    let link = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+      op.rootCacheKey == "QUERY_ROOT"
+    }
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 1)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testSplitTerminatingLinkSecond() {
+    let queryLink = SetContextLink.incrementCounter(by: 1)
+    let mutationLink = SetContextLink.incrementCounter(by: -1)
+    
+    let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
+      op.rootCacheKey == "QUERY_ROOT"
+    }
+    
+    let link = splitLink.concat(SyncLink())
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: mutation).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, -1)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testExecuteAsyncLink() {
+    let link = AsyncLink()
+    
+    let expectation = self.expectation(description: "link executed")
+    
+    link.execute(operation: query).andThen { response in
+      XCTAssertEqual(response.body["counter"] as? Int, 0)
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testCancelLink() {
+    let controller = CancelController()
+    
+    let link = SetContextLink.with(cancelController: controller).concat(SyncLink())
+    
+    controller.cancel()
+    
+    let expectation = self.expectation(description: "link cancelled")
+    
+    link.execute(operation: query).catch { error in
+      expectation.fulfill()
+      XCTAssert(error is CancelError)
+    }
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testCancelAsyncLink() {
+    let controller = CancelController()
+    
+    let link = SetContextLink.with(cancelController: controller).concat(AsyncLink())
+    
+    controller.cancel()
+    
+    let expectation = self.expectation(description: "link cancelled")
+    
+    link.execute(operation: query).catch { error in
+      expectation.fulfill()
+      XCTAssert(error is CancelError)
+    }
+    
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testCancelInfiniteLink() {
+    let controller = CancelController()
+    
+    let link = SetContextLink.with(cancelController: controller).concat(InfiniteLink())
+    
+    let expectation = self.expectation(description: "link cancelled")
+    
+    link.execute(operation: query).catch { error in
+      expectation.fulfill()
+      XCTAssert(error is CancelError)
+    }
+    
+    controller.cancel()
+    
+    waitForExpectations(timeout: 0.1)
+  }
+  
+  func testCancelSemaLink() {
+    let controller = CancelController()
+    
+    let link = SetContextLink.with(cancelController: controller).concat(SemaLink())
+    
+    let expectation = self.expectation(description: "link cancelled")
+    
+    link.execute(operation: query).catch { error in
+      expectation.fulfill()
+      XCTAssert(error is CancelError)
+    }
+    
+    controller.cancel()
+    
+    waitForExpectations(timeout: 0.1)
+  }
+}

--- a/Tests/ApolloTests/LinkTests.swift
+++ b/Tests/ApolloTests/LinkTests.swift
@@ -203,7 +203,7 @@ class LinkTests: XCTestCase {
     let mutationLink = SetContextLink.incrementCounter(by: -1)
     
     let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
-      op.rootCacheKey == "QUERY_ROOT"
+      type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
     let link = splitLink.concat(SyncLink())
@@ -223,7 +223,7 @@ class LinkTests: XCTestCase {
     let mutationLink = SetContextLink.incrementCounter(by: -1)
     
     let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
-      op.rootCacheKey == "QUERY_ROOT"
+      type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
     let link = splitLink.concat(SyncLink())
@@ -243,7 +243,7 @@ class LinkTests: XCTestCase {
     let mutationLink = SetContextLink.incrementCounter(by: -1).concat(SyncLink())
     
     let link = passthroughLink.split(first: queryLink, second: mutationLink) { op in
-      op.rootCacheKey == "QUERY_ROOT"
+      type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
     let expectation = self.expectation(description: "link executed")
@@ -261,7 +261,7 @@ class LinkTests: XCTestCase {
     let mutationLink = SetContextLink.incrementCounter(by: -1)
     
     let splitLink = passthroughLink.split(first: queryLink, second: mutationLink) { op in
-      op.rootCacheKey == "QUERY_ROOT"
+      type(of: op).rootCacheKey == "QUERY_ROOT"
     }
     
     let link = splitLink.concat(SyncLink())


### PR DESCRIPTION
Also see the discussion in #173.

# Terminating vs. Non-Terminating Links

ApolloLink has a concept of terminating and non-terminating links. In the Javascript implementation, the link type is determined at runtime.
I thought we could de better and determine it at compile time by using two distinct types TerminatingLink and NonTerminatingLink. This eliminates some compile time checks. For example, concat is only defined on NonTerminatingLink and returns a terminating or non-terminating link, depending on the type of the second link.
However, it makes it difficult to define a split of a terminating and a non-terminating link or vice-versa, because what should the return type be? SchrödingersLink?

# Cancellation

Requests need to be cancellable, that means links need to be cancellable. I considered three options to achieve that:

Using Observables. Observables are inherently cancellable, but non-trivial to implement.
Adding a Cancelled state to Promise.
Using a cancellable object, that us to register onCancel handlers. This was inspired by an experimental Javascript feature, AbortController.
I chose the first third option and created an CancelController and CancelSignal similar to AbortController/AbortSignal in Javascript. The signal is passed in the context.
It seemed to be the less invasive solution and I actually really like the design.

# Caveats

The current design has a few caveats. Most notably, links can only return one result, which renders them unsuitable for subscriptions.

# Next steps

As a next step, I would like to implement an HTTPLink that pulls configuration from the context and makes a network request.
Then, I'd like to see how we could implement a RetryLink.