### PR TITLE
Prevent crash when invalid URL string supplied

### DIFF
--- a/Sources/Apollo/JSONStandardTypeConversions.swift
+++ b/Sources/Apollo/JSONStandardTypeConversions.swift
@@ -144,7 +144,12 @@ extension URL: JSONDecodable, JSONEncodable {
     guard let string = value as? String else {
       throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
     }
-    self.init(string: string)!
+    
+    if let url = URL(string: string) {
+        self = url
+    } else {
+        throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
+    }
   }
 
   public var jsonValue: JSONValue {


### PR DESCRIPTION
Currently, in a setup where the following occur:

- GraphQL server has a custom scalar named `URL`
- `--passthrough-custom-scalars` is true

Apollo will use `JSONStandardTypeConversions.swift` to manage converting `URL`.
It will not guard against the case where a valid `String` is provided but the `String` is not a valid `Foundation.URL`. The `self.init(string: string)!` will encounter `Optional` while unwrapping a nil. This crashes any app immediately.

This is really bad, because if even one URL in a GraphQLRequest comes back as invalid, the app will crash as soon as the request comes through. If caching is being used, this puts the app in a crash loop. The only solution is to delete the app and reinstall from scratch 😬 

My change resolves the issue by throwing if a URL cannot be created. Unfortunately, attempts to initialize optionally fail due to the swift error `A non-failable initializer cannot delegate to failable initializer 'init(string:)' written with 'init?'`. So short of editing `JSONDecodable` to allow an optional initializer everywhere, this is the only solution I could think of.