### PR TITLE
Fix an issue that watcher doesn't notify specific change

### DIFF
--- a/Sources/Apollo/GraphQLDependencyTracker.swift
+++ b/Sources/Apollo/GraphQLDependencyTracker.swift
@@ -14,6 +14,7 @@ final class GraphQLDependencyTracker: GraphQLResultAccumulator {
   }
   
   func accept(fieldEntry: Void, info: GraphQLResolveInfo) {
+    dependentKeys.insert(joined(path: info.cachePath))
   }
   
   func accept(fieldEntries: [Void], info: GraphQLResolveInfo) {


### PR DESCRIPTION
# Agenda

Fix an issue that watcher doesn't notify specific change.

# Detail

`GraphQLQueryWatcher.dependentKeys` doesn't contain specific kind of key.
In a following query and `apolloClient.cacheKeyForObject = { $0["id"] }`, `<user_id>.company` is not contained in `GraphQLQueryWatcher.dependentKeys`.

```graphql
query GetUser($id: ID!) {
  getUser(id: $id) {
    id
    name
    company {
      id
      name
    }
  }
}
```

### Side effects

I don't think it has side effects, since `GraphQLQueryWatcher.dependentKeys` is `Set` so keys can't be duplicated.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
- [x] bug

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->