### PR TITLE
Remove renovate config from docs/package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,10 +20,5 @@
     "build": "chexo apollo-hexo-config -- generate",
     "clean": "hexo clean",
     "test": "npm run clean; npm run build"
-  },
-  "renovate": {
-    "extends": [
-      "apollo-docs"
-    ]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,6 @@
 {
-  "packageFiles": ["docs/package.json"]
+  "packageFiles": ["docs/package.json"],
+  "extends": [
+    "apollo-docs"
+  ]
 }


### PR DESCRIPTION
Removes the (unsupported) Renovate configuration from `docs/package.json` and adds it to `package.json` instead.

Note: this preset would *not* have been being applied before however I'm sure you intended it to so the new behaviour should be welcomed.

Closes #247