### PR TITLE
docs: Fix broken "Edit on GitHub" buttons.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@ sidebar_categories:
   - watching-queries
   - mutations
 github_repo: apollographql/apollo-ios
-content_root: source
+content_root: docs/source
 
 url: https://www.apollographql.com/docs/ios/
 root: /docs/ios/


### PR DESCRIPTION
The `content_root` parameter for this particular repository's documentation `_config.yml` was pointing to the wrong documentation source path, which is meant to point to the path where the documentation lives within the Git repository, not relative to the `docs` directory.
