### PR TITLE
Generalize Xcode version and link (which was broken).

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -2,7 +2,7 @@
 title: Installation
 ---
 
-Apollo iOS requires Xcode 8, which you can install from the [Mac App Store](https://itunes.apple.com/en/app/xcode/id497799835?mt=12).
+Apollo iOS requires the latest Xcode, which can be installed from the [Mac App Store](http://appstore.com/mac/apple/xcode).
 
 Follow along with these steps (described in detail below) to use Apollo iOS in your app:
 


### PR DESCRIPTION
Apple almost always requires the latest Xcode, so this generalizes the version as well as the link (which was previously broken).

---

(Also, I used the "Edit on GitHub" button to fix this, thanks to https://github.com/apollographql/apollo-ios/pull/258 🌮 ).