### PR TITLE
Add HTTPNetworkTransport.init to take URLSession instance to allow …

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -53,9 +53,20 @@ public class HTTPNetworkTransport: NetworkTransport {
   ///   - url: The URL of a GraphQL server to connect to.
   ///   - configuration: A session configuration used to configure the session. Defaults to `URLSessionConfiguration.default`.
   ///   - sendOperationIdentifiers: Whether to send operation identifiers rather than full operation text, for use with servers that support query persistence. Defaults to false.
-  public init(url: URL, configuration: URLSessionConfiguration = URLSessionConfiguration.default, sendOperationIdentifiers: Bool = false) {
+  public convenience init(url: URL, configuration: URLSessionConfiguration = URLSessionConfiguration.default, sendOperationIdentifiers: Bool = false) {
+    self.init(url: url, session: URLSession(configuration: configuration),
+              sendOperationIdentifiers: sendOperationIdentifiers)
+  }
+
+  /// Creates a network transport with the specified server URL and session.
+  ///
+  /// - Parameters:
+  ///   - url: The URL of a GraphQL server to connect to.
+  ///   - session: An URLSession instance to be used for ensuing operations.
+  ///   - sendOperationIdentifiers: Whether to send operation identifiers rather than full operation text, for use with servers that support query persistence. Defaults to false.
+  public init(url: URL, session: URLSession, sendOperationIdentifiers: Bool = false) {
     self.url = url
-    self.session = URLSession(configuration: configuration)
+    self.session = session
     self.sendOperationIdentifiers = sendOperationIdentifiers
   }
   


### PR DESCRIPTION
Add HTTPNetworkTransport.init to take URLSession instance to allow caller to handle exceptional cases by way of URLSessionDelegate.  The problem was that HTTPNetworkTransport was hiding and subsequently blocking access to existing functionality on URLSession.  

This change is to add an additional initializing that takes an URLSession instance from the caller, allowing said caller to first register a delegate handler.  By contrast, Alamofire handles this in arguably a more elegant method, by exposing optional closure methods to handle each of the three URLSessionDelegate methods.

The approach taken here is simpler to implement, but is less elegant for calling code.  It is more conventional though and will suffice until any higher level solution decision is warranted.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ x] feature
- [ x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->