### PR TITLE
Added GraphQLContext - and used for response header parameters

### DIFF
--- a/Sources/Apollo/GraphQLResult.swift
+++ b/Sources/Apollo/GraphQLResult.swift
@@ -15,11 +15,15 @@ public struct GraphQLResult<Data> {
     
   let dependentKeys: Set<CacheKey>?
   
-  init(data: Data?, errors: [GraphQLError]?, source: Source, dependentKeys: Set<CacheKey>?) {
+  public let context : GraphQLContext?
+
+  init(data: Data?, errors: [GraphQLError]?, source: Source, dependentKeys: Set<CacheKey>?, context: GraphQLContext? = nil) {
     self.data = data
     self.errors = errors
     self.source = source
     self.dependentKeys = dependentKeys
+    self.context = context
   }
 }
 
+public typealias GraphQLContext = [AnyHashable: Any]

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -100,7 +100,7 @@ public class HTTPNetworkTransport: NetworkTransport {
         guard let body =  try self.serializationFormat.deserialize(data: data) as? JSONObject else {
           throw GraphQLHTTPResponseError(body: data, response: httpResponse, kind: .invalidResponse)
         }
-        let response = GraphQLResponse(operation: operation, body: body)
+        let response = GraphQLResponse(operation: operation, body: body, context: httpResponse.allHeaderFields)
         completionHandler(response, nil)
       } catch {
         completionHandler(nil, error)


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ X] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Proposed implementation for #223 based on the suggested use of Context. 

Context is added to GraphQLResponse and carried over to GraphQLResult and there available to the client. HTTPNetworkTransport insert the context directly when creating the GraphQLResponse entity.
