### PR TITLE
Dynamic configuration of http headers

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -46,7 +46,8 @@ public class HTTPNetworkTransport: NetworkTransport {
   let url: URL
   let session: URLSession
   let serializationFormat = JSONSerializationFormat.self
-  
+  var httpHeaders: [String: String]? = nil
+
   /// Creates a network transport with the specified server URL and session configuration.
   ///
   /// - Parameters:
@@ -57,6 +58,14 @@ public class HTTPNetworkTransport: NetworkTransport {
     self.url = url
     self.session = URLSession(configuration: configuration)
     self.sendOperationIdentifiers = sendOperationIdentifiers
+  }
+
+  /// Set HTTP Headers sent to GraphQL operations. Current headers will be overridden.
+  ///
+  /// - Parameters:
+  ///   - httpHeaders: A dictionary with the headers, or `nil` to remove the current ones.
+  public func set(httpHeaders: [String: String]?) {
+    self.httpHeaders = httpHeaders
   }
   
   /// Send a GraphQL operation to a server and return a response.
@@ -70,7 +79,11 @@ public class HTTPNetworkTransport: NetworkTransport {
   public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
-    
+
+    httpHeaders?.forEach { header in
+        request.addValue(header.value, forHTTPHeaderField: header.key)
+    }
+
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
     let body = requestBody(for: operation)

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -10,7 +10,7 @@ let apollo = ApolloClient(url: URL(string: "http://localhost:8080/graphql")!)
 
 <h2 id="adding-headers">Adding additional headers</h2>
 
-If you need to add additional headers to requests, to include authentication details for example, you need to create an instance of `HTTPNetworkTransport` and use `set(httpHeaders:)`. can be called at any time, just keep in mind that it will override any previously set headers.
+If you need to add additional headers to requests, to include authentication details for example, you need to create an instance of `HTTPNetworkTransport` and use `set(httpHeaders:)`. This function can be called at any time, just keep in mind that it will override any previously set headers.
 
 ```swift
 let url = URL(string: "http://localhost:8080/graphql")!

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -10,18 +10,13 @@ let apollo = ApolloClient(url: URL(string: "http://localhost:8080/graphql")!)
 
 <h2 id="adding-headers">Adding additional headers</h2>
 
-If you need to add additional headers to requests, to include authentication details for example, you can create your own `URLSessionConfiguration` and use this to configure an `HTTPNetworkTransport`. If you want to define the client as a global variable, you can use an immediately invoked closure here:
+If you need to add additional headers to requests, to include authentication details for example, you need to create an instance of `HTTPNetworkTransport` and use `set(httpHeaders:)`. can be called at any time, just keep in mind that it will override any previously set headers.
 
 ```swift
-let apollo: ApolloClient = {
-  let configuration = URLSessionConfiguration.default
-  // Add additional headers as needed
-  configuration.httpAdditionalHeaders = ["Authorization": "Bearer <token>"] // Replace `<token>`
+let url = URL(string: "http://localhost:8080/graphql")!
 
-  let url = URL(string: "http://localhost:8080/graphql")!
+let networkTransport = HTTPNetworkTransport(url: url)
+let apollo = ApolloClient(networkTransport: networkTransport)
 
-  return ApolloClient(networkTransport: HTTPNetworkTransport(url: url, configuration: configuration))
-}()
+networkTransport.set(httpHeaders: ["Authorization": "Bearer <token>"]) // Replace `<token>`
 ```
-
-> Right now, additional headers can only be specified when creating a client. We're working on a better solution for dynamic configuration of the network transport, including the ability to retry requests that failed after refreshing an access token. Please chime in on https://github.com/apollographql/apollo-ios/issues/37 to help shape the design of this feature or to contribute to it.


### PR DESCRIPTION
Allow http headers to be reconfigured through HTTPNetworkTransport.

This will probably resolve the following issues:

#37 
#140 
#131 (Never been merged)

---

/enhancement

- [x] feature
- [ ] blocking
- [ ] docs
