### PR TITLE
Add HTTPNetworkTransportDelegate and HTTPNetworkTransportInterception

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -41,11 +41,24 @@ public struct GraphQLHTTPResponseError: Error, LocalizedError {
   }
 }
 
+/// Used to intercept the http requests/errors/responses. This allows modifying url requests dynamically without recreating transports
+public protocol HTTPNetworkTransportDelegate: class {
+  func intercept() -> HTTPNetworkTransportInterception
+}
+
+/// An encapsulation of state for a single request (response/error) pair. If any method returns non-null it will be used in the http pipeline
+public protocol HTTPNetworkTransportInterception {
+  func willSend(request: URLRequest) -> URLRequest?
+  func didRecieve(error: Error) -> Error?
+  func didRecieve(response: HTTPURLResponse) -> HTTPURLResponse?
+}
+
 /// A network transport that uses HTTP POST requests to send GraphQL operations to a server, and that uses `URLSession` as the networking implementation.
 public class HTTPNetworkTransport: NetworkTransport {
   let url: URL
   let session: URLSession
   let serializationFormat = JSONSerializationFormat.self
+  public weak var delegate: HTTPNetworkTransportDelegate?
   
   /// Creates a network transport with the specified server URL and session configuration.
   ///
@@ -75,15 +88,25 @@ public class HTTPNetworkTransport: NetworkTransport {
 
     let body = requestBody(for: operation)
     request.httpBody = try! serializationFormat.serialize(value: body)
-    
+    let interception = delegate?.intercept()
+    if let interceptedRequest = interception?.willSend(request: request) {
+        request = interceptedRequest
+    }
     let task = session.dataTask(with: request) { (data: Data?, response: URLResponse?, error: Error?) in
-      if error != nil {
+      if var error = error {
+        if let interceptedError = interception?.didRecieve(error: error) {
+          error = interceptedError
+        }
         completionHandler(nil, error)
         return
       }
       
-      guard let httpResponse = response as? HTTPURLResponse else {
+      guard var httpResponse = response as? HTTPURLResponse else {
         fatalError("Response should be an HTTPURLResponse")
+      }
+
+      if let interceptedResponse = interception?.didRecieve(response: httpResponse) {
+        httpResponse = interceptedResponse
       }
       
       if (!httpResponse.isSuccessful) {


### PR DESCRIPTION
Add HTTPNetworkTransportDelegate and HTTPNetworkTransportInterception

So that mutating headers and other inspection can be done by the delegate. This
means being able to change headers without recreating clients or logging
request/response timing at a high level by instrumenting the calls to the
interception. Functionality this should give callers adequate control over the
http pipeline.

By using an `Interception` to encapsulate state it would be easy to implement a
timer for a request/response pair. By flattening it into the delegate itself
that information would be lost without using a unique id to tie them together.

Alternatively one could implement http chaining like seen in okhttp which would
give a cleaner contract in terms of showing that only one call to
`Chain.proceed` can perform an interception but is ultimately more complicated.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->