### PR TITLE
Public init for GraphQLError

### DIFF
--- a/Sources/Apollo/GraphQLError.swift
+++ b/Sources/Apollo/GraphQLError.swift
@@ -5,7 +5,7 @@ import Foundation
 ///  - SeeAlso: [The Response Format section in the GraphQL specification](https://facebook.github.io/graphql/#sec-Response-Format)
 public struct GraphQLError: Error {
   private let object: JSONObject
-
+  
   public init(_ object: JSONObject) {
     self.object = object
   }


### PR DESCRIPTION
Adding public init to GraphQLError to allow for creation in other projects. Means they can be created in tests to check expected actions when certain errors are received.