### PR TITLE
Cleanup & Fix data races in ApolloWebSocket

### DIFF
--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -63,6 +62,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference

--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -62,7 +63,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -16,10 +16,10 @@ public protocol ApolloWebSocketClient: WebSocketClient {
 public class WebSocketTransport {
   public static var provider : ApolloWebSocketClient.Type = ApolloWebSocket.self
   let serializationFormat = JSONSerializationFormat.self
+  var reconnect = false
 
   private let protocols = ["graphql-ws"]
   internal let websocket: WebSocketClient
-  private var reconnect = false
   private var acked = false
 
   private var messageQueue: [Int: String] = [:]
@@ -102,8 +102,7 @@ public class WebSocketTransport {
     print("WebSocketTransport::unprocessed event \(data)")
   }
 
-  public func initServer(reconnect: Bool = true) {
-    self.reconnect = reconnect
+  private func initServer() {
     self.acked = false
 
     if let str = OperationMessage(payload: self.connectingPayload, type: .connectionInit).rawMessage {

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -26,7 +26,7 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
   private var acked = false
 
   private var messageQueue: [Int: String] = [:]
-  private var connectingParams: [String: String]?
+  private var connectingPayload: GraphQLMap?
 
   private var subscribers = [String: (JSONObject?, Error?) -> Void]()
   private var subscriptions : [String: String] = [:]
@@ -35,8 +35,8 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
 
   public static var provider : ApolloWebSocketClient.Type = ApolloWebSocket.self
 
-  public init(url: URL, sendOperationIdentifiers: Bool = false, requestHeaders: [String: String] = [:], connectingParams: [String:String]? = [:]) {
-    self.connectingParams = connectingParams
+  public init(url: URL, sendOperationIdentifiers: Bool = false, requestHeaders: [String: String] = [:], connectingPayload: GraphQLMap? = [:]) {
+    self.connectingPayload = connectingPayload
     self.sendOperationIdentifiers = sendOperationIdentifiers
     var request = URLRequest(url: url)
     request.allHTTPHeaderFields = requestHeaders
@@ -46,8 +46,8 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
     self.websocket?.connect()
   }
 
-  public init(request: URLRequest? = nil, sendOperationIdentifiers: Bool = false,  requestHeaders: [String: String] = [:],  connectingParams: [String:String]? = [:]) {
-    self.connectingParams = connectingParams
+  public init(request: URLRequest? = nil, sendOperationIdentifiers: Bool = false,  requestHeaders: [String: String] = [:],  connectingPayload: GraphQLMap? = [:]) {
+    self.connectingPayload = connectingPayload
     self.sendOperationIdentifiers = sendOperationIdentifiers
     if var request = request {
       request.allHTTPHeaderFields = requestHeaders
@@ -186,7 +186,7 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
     self.reconnect = reconnect
     self.acked = false
 
-    if let str = OperationMessage(payload: self.connectingParams, type: .connectionInit).rawMessage {
+    if let str = OperationMessage(payload: self.connectingPayload, type: .connectionInit).rawMessage {
       write(str, force:true)
     }
   }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -32,16 +32,6 @@ public class WebSocketTransport {
   private var reconnected: Bool = false
   private var sequenceNumber: Int = 0
 
-  public init(url: URL, sendOperationIdentifiers: Bool = false, requestHeaders: [String: String] = [:], connectingPayload: GraphQLMap? = [:]) {
-    self.connectingPayload = connectingPayload
-    self.sendOperationIdentifiers = sendOperationIdentifiers
-    var request = URLRequest(url: url)
-    request.allHTTPHeaderFields = requestHeaders
-    self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
-    self.websocket.delegate = self
-    self.websocket.connect()
-  }
-
   public init(request: URLRequest, sendOperationIdentifiers: Bool = false,  connectingPayload: GraphQLMap? = [:]) {
     self.connectingPayload = connectingPayload
     self.sendOperationIdentifiers = sendOperationIdentifiers

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -26,7 +26,6 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
   private var acked = false
 
   private var messageQueue: [Int: String] = [:]
-  private var params: [String: String]?
   private var connectingParams: [String: String]?
 
   private var subscribers = [String: (JSONObject?, Error?) -> Void]()
@@ -36,28 +35,22 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
 
   public static var provider : ApolloWebSocketClient.Type = ApolloWebSocket.self
 
-  public init(url: URL, sendOperationIdentifiers: Bool = false, params: [String:String]? = nil, connectingParams: [String:String]? = [:]) {
-    self.params = params
+  public init(url: URL, sendOperationIdentifiers: Bool = false, requestHeaders: [String: String] = [:], connectingParams: [String:String]? = [:]) {
     self.connectingParams = connectingParams
     self.sendOperationIdentifiers = sendOperationIdentifiers
     var request = URLRequest(url: url)
-    if let params = self.params {
-      request.allHTTPHeaderFields = params
-    }
+    request.allHTTPHeaderFields = requestHeaders
     self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
 
     self.websocket?.delegate = self
     self.websocket?.connect()
   }
 
-  public init(request: URLRequest? = nil, sendOperationIdentifiers: Bool = false,  params: [String:String]? = nil,  connectingParams: [String:String]? = [:]) {
-    self.params = params
+  public init(request: URLRequest? = nil, sendOperationIdentifiers: Bool = false,  requestHeaders: [String: String] = [:],  connectingParams: [String:String]? = [:]) {
     self.connectingParams = connectingParams
     self.sendOperationIdentifiers = sendOperationIdentifiers
     if var request = request {
-      if let params = self.params {
-        request.allHTTPHeaderFields = params
-      }
+      request.allHTTPHeaderFields = requestHeaders
       self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
       self.websocket?.delegate = self
       self.websocket?.connect()

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -14,28 +14,28 @@ public protocol ApolloWebSocketClient: WebSocketClient {
 
 /// A network transport that uses web sockets requests to send GraphQL subscription operations to a server, and that uses the Starscream implementation of web sockets.
 public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
-  
-  final let PROTOCOLS = ["graphql-ws"]
-  
+
+  private let protocols = ["graphql-ws"]
+
   var websocket: WebSocketClient? = nil
-  var error : Error? = nil
-  
+  private(set) var error: Error? = nil
+
   let serializationFormat = JSONSerializationFormat.self
-  
-  var reconnect : Bool = false
-  var acked : Bool = false
-  
-  private var queue: [Int:String] = [:]
-  private var params: [String:String]?
-  private var connectingParams: [String:String]?
+
+  private var reconnect = false
+  private var acked = false
+
+  private var messageQueue: [Int: String] = [:]
+  private var params: [String: String]?
+  private var connectingParams: [String: String]?
 
   private var subscribers = [String: (JSONObject?, Error?) -> Void]()
   private var subscriptions : [String: String] = [:]
-  
+
   private let sendOperationIdentifiers: Bool
-  
+
   public static var provider : ApolloWebSocketClient.Type = ApolloWebSocket.self
-  
+
   public init(url: URL, sendOperationIdentifiers: Bool = false, params: [String:String]? = nil, connectingParams: [String:String]? = [:]) {
     self.params = params
     self.connectingParams = connectingParams
@@ -44,12 +44,12 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
     if let params = self.params {
       request.allHTTPHeaderFields = params
     }
-    self.websocket = WebSocketTransport.provider.init(request: request, protocols: PROTOCOLS)
-    
+    self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
+
     self.websocket?.delegate = self
     self.websocket?.connect()
   }
-  
+
   public init(request: URLRequest? = nil, sendOperationIdentifiers: Bool = false,  params: [String:String]? = nil,  connectingParams: [String:String]? = [:]) {
     self.params = params
     self.connectingParams = connectingParams
@@ -58,213 +58,206 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
       if let params = self.params {
         request.allHTTPHeaderFields = params
       }
-      // self.websocket = WebSocket(request: request, protocols: PROTOCOLS)
-      self.websocket = WebSocketTransport.provider.init(request: request, protocols: PROTOCOLS)
+      self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
       self.websocket?.delegate = self
       self.websocket?.connect()
     }
   }
-  
+
   public func connect(request: URLRequest) {
-    // self.websocket = WebSocket(request: request, protocols: PROTOCOLS)
-    self.websocket = WebSocketTransport.provider.init(request: request, protocols: PROTOCOLS)
+    self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
     self.websocket?.delegate = self
     self.websocket?.connect()
   }
-  
+
   public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
-    
     if let error = self.error {
-      completionHandler(nil,error)
+      completionHandler(nil, error)
     }
-    
-    return WebSocketTask(self,operation) { (body, error) in
+
+    return WebSocketTask(transport: self, operation: operation) { (body, error) in
       if let body = body {
         let response = GraphQLResponse(operation: operation, body: body)
-        completionHandler(response,error)
+        completionHandler(response, error)
       } else {
-        completionHandler(nil,error)
+        completionHandler(nil, error)
       }
     }
-    
+
   }
-  
+
   public func isConnected() -> Bool {
     return websocket?.isConnected ?? false
   }
-  
+
   private func processMessage(socket: WebSocketClient, text: String) {
-    
-    OperationMessage(serialized: text).parse { (type,id,payload,error) in
-      if let type = type {
-        switch(type) {
-        case OperationMessage.Types.DATA.rawValue,
-             OperationMessage.Types.ERROR.rawValue:
-          if let id = id, let responseHandler = subscribers[id] {
-            responseHandler(payload,error)
-          } else {
-            notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
-          }
-          
-        case OperationMessage.Types.COMPLETE.rawValue:
-          if let id = id {
-            // remove the callback if NOT a subscription
-            if subscriptions[id] == nil {
-              subscribers.removeValue(forKey: id)
-            }
-          } else {
-            notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
-          }
-          
-        case OperationMessage.Types.CONNECTION_ACK.rawValue,
-             OperationMessage.Types.CONNECTION_KEEP_ALIVE.rawValue:
-          
-          acked = (type == OperationMessage.Types.CONNECTION_ACK.rawValue)
-          writeQueue()
-          
-        default:
+    OperationMessage(serialized: text).parse { (type, id, payload, error) in
+      guard let type = type, let messageType = OperationMessage.Types(rawValue: type) else {
+        return notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
+      }
+
+      switch(messageType) {
+      case .data, .error:
+        if let id = id, let responseHandler = subscribers[id] {
+          responseHandler(payload,error)
+        } else {
           notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
         }
-      } else {
+
+      case .complete:
+        if let id = id {
+          // remove the callback if NOT a subscription
+          if subscriptions[id] == nil {
+            subscribers.removeValue(forKey: id)
+          }
+        } else {
+          notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
+        }
+
+      case .connectionAck:
+        acked = true
+        processWriteQueue()
+
+      case .connectionKeepAlive:
+        processWriteQueue()
+
+      case .connectionInit, .connectionTerminate, .start, .stop, .connectionError:
         notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
       }
     }
   }
-  
+
   func notifyErrorAllHandlers(_ error: Error) {
-    for (_,handler) in subscribers {
-      handler(nil,error)
+    for (_, handler) in subscribers {
+      handler(nil, error)
     }
   }
-  
-  private func writeQueue() {
-    if (!self.queue.isEmpty) {
-      let queue = self.queue.sorted(by: { $0.0 < $1.0 })
-      self.queue.removeAll()
-      for (id,msg) in queue {
-        self.write(msg,id: id)
-      }
+
+  private func processWriteQueue() {
+    guard !self.messageQueue.isEmpty else { return }
+
+    let queue = self.messageQueue.sorted(by: { $0.0 < $1.0 })
+    self.messageQueue.removeAll()
+    for (id, msg) in queue {
+      write(msg,id: id)
     }
   }
-  
+
   private func processMessage(socket: WebSocketClient, data: Data) {
     print("WebSocketTransport::unprocessed event \(data)")
   }
-  
-  fileprivate var reconnected : Bool = false
-  
+
+  fileprivate var reconnected: Bool = false
+
   public func websocketDidConnect(socket: WebSocketClient) {
     self.error = nil
+
     initServer()
     if reconnected {
       // re-send the subscriptions whenever we are re-connected
       // for the first connect, any subscriptions are already in queue
-      for (_,msg) in self.subscriptions {
+      for (_, msg) in self.subscriptions {
         write(msg)
       }
     }
     reconnected = true
   }
-  
+
   public func websocketDidDisconnect(socket: WebSocketClient, error: Error?) {
-    
     // report any error to all subscribers
     if let error = error {
       self.error = WebSocketError(payload: nil, error: error, kind: .networkError)
-      for (_,responseHandler) in subscribers {
-        responseHandler(nil,error)
+      for (_, responseHandler) in subscribers {
+        responseHandler(nil, error)
       }
     } else {
       self.error = nil
     }
-    
+
     acked = false // need new connect and ack before sending
-    
+
     if (reconnect) {
       websocket?.connect();
     }
-    
   }
-  
+
   public func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
     processMessage(socket: socket, text: text)
   }
-  
+
   public func websocketDidReceiveData(socket: WebSocketClient, data: Data) {
     processMessage(socket: socket, data: data)
   }
-  
+
   public func initServer(reconnect: Bool = true) {
     self.reconnect = reconnect
     self.acked = false
-    
-    if let str = OperationMessage(payload: self.connectingParams, type: .CONNECTION_INIT).rawValue {
+
+    if let str = OperationMessage(payload: self.connectingParams, type: .connectionInit).rawMessage {
       write(str, force:true)
     }
-    
   }
-  
+
   public func closeConnection() {
     self.reconnect = false
-    if let str = OperationMessage(type: .CONNECTION_TERMINATE).rawValue {
+    if let str = OperationMessage(type: .connectionTerminate).rawMessage {
       write(str)
     }
-    self.queue.removeAll()
+
+    self.messageQueue.removeAll()
     self.subscriptions.removeAll()
   }
-  
+
   private func write(_ str: String, force forced: Bool = false, id : Int? = nil) {
-    
-    if let websocket = websocket {
-      if websocket.isConnected && (acked || forced) {
-        websocket.write(string: str)
+    guard let websocket = websocket else { return }
+
+    if websocket.isConnected && (acked || forced) {
+      websocket.write(string: str)
+    } else {
+      // using sequence number to make sure that the queue is processed correctly
+      // either using the earlier assigned id or with the next higher key
+      if let id = id {
+        messageQueue[id] = str
+      } else if let id = messageQueue.keys.max() {
+        messageQueue[id+1] = str
       } else {
-        // using sequence number to make sure that the queue is processed correctly
-        // either using the earlier assigned id or with the next higher key
-        if let id = id {
-          queue[id] = str
-        } else if let id = queue.keys.max() {
-          queue[id+1] = str
-        } else {
-          queue[1] = str
-        }
+        messageQueue[1] = str
       }
     }
   }
-  
+
   deinit {
     websocket?.disconnect()
     websocket?.delegate = nil
   }
-  
-  fileprivate var sequenceNumber : Int = 0
-  
-  fileprivate func nextSeqNo() -> Int {
+
+  fileprivate var sequenceNumber: Int = 0
+
+  fileprivate func nextSequenceNumber() -> Int {
     sequenceNumber += 1
     return sequenceNumber
   }
-  
+
   fileprivate func sendHelper<Operation: GraphQLOperation>(operation: Operation, resultHandler: @escaping (_ response: JSONObject?, _ error: Error?) -> Void) -> String? {
-    
     let body = requestBody(for: operation)
-    
-    let seqNo = "\(nextSeqNo())"
-    
-    if let str = OperationMessage(payload: body, id: seqNo).rawValue {
+
+    let sequenceNumber = "\(nextSequenceNumber())"
+
+    if let str = OperationMessage(payload: body, id: sequenceNumber).rawMessage {
       write(str)
-      
-      subscribers[seqNo] = resultHandler
+
+      subscribers[sequenceNumber] = resultHandler
       if operation.operationType == .subscription {
-        subscriptions[seqNo] = str
+        subscriptions[sequenceNumber] = str
       }
-      
-      return seqNo
+
+      return sequenceNumber
     }
-    
+
     return nil
-    
+
   }
-  
+
   private func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
     if sendOperationIdentifiers {
       guard let operationIdentifier = operation.operationIdentifier else {
@@ -274,70 +267,61 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
     }
     return ["query": operation.queryDocument, "variables": operation.variables]
   }
-  
+
   public func unsubscribe(_ subscriptionId: String) {
-    if let str = OperationMessage(id: subscriptionId, type: .STOP).rawValue {
+    if let str = OperationMessage(id: subscriptionId, type: .stop).rawMessage {
       write(str)
     }
     subscribers.removeValue(forKey: subscriptionId)
     subscriptions.removeValue(forKey: subscriptionId)
   }
-  
-  fileprivate final class WebSocketTask<Operation: GraphQLOperation> : Cancellable {
-    
-    let seqNo : String?
-    let wst: WebSocketTransport
-    
-    init(_ ws: WebSocketTransport, _ operation: Operation, _ completionHandler: @escaping (_ response: JSONObject?, _ error: Error?) -> Void) {
-      
-      seqNo = ws.sendHelper(operation: operation, resultHandler: completionHandler)
-      wst = ws
+
+  fileprivate final class WebSocketTask<Operation: GraphQLOperation>: Cancellable {
+    let sequenceNumber: String?
+    let transport: WebSocketTransport
+
+    init(transport: WebSocketTransport, operation: Operation, completionHandler: @escaping (_ response: JSONObject?, _ error: Error?) -> Void) {
+      sequenceNumber = transport.sendHelper(operation: operation, resultHandler: completionHandler)
+      self.transport = transport
     }
-    
+
     public func cancel() {
-      if let seqNo = seqNo {
-        wst.unsubscribe(seqNo)
+      if let sequenceNumber = sequenceNumber {
+        transport.unsubscribe(sequenceNumber)
       }
     }
-    
+
     // unsubscribe same as cancel
     public func unsubscribe() {
       cancel()
     }
-    
   }
-  
+
   fileprivate final class OperationMessage {
-    
-    public enum Types : String {
-      case CONNECTION_INIT = "connection_init"            // Client -> Server
-      case CONNECTION_TERMINATE = "connection_terminate"  // Client -> Server
-      case START = "start"                                // Client -> Server
-      case STOP = "stop"                                  // Client -> Server
-      
-      case CONNECTION_ACK = "connection_ack"              // Server -> Client
-      case CONNECTION_ERROR = "connection_error"          // Server -> Client
-      case CONNECTION_KEEP_ALIVE = "ka"                   // Server -> Client
-      case DATA = "data"                                  // Server -> Client
-      case ERROR = "error"                                // Server -> Client
-      case COMPLETE = "complete"                          // Server -> Client
+
+    enum Types: String {
+      case connectionInit = "connection_init"           // Client -> Server
+      case connectionTerminate = "connection_terminate" // Client -> Server
+      case start = "start"                              // Client -> Server
+      case stop = "stop"                                // Client -> Server
+
+      case connectionAck = "connection_ack"             // Server -> Client
+      case connectionError = "connection_error"         // Server -> Client
+      case connectionKeepAlive = "ka"                   // Server -> Client
+      case data = "data"                                // Server -> Client
+      case error = "error"                              // Server -> Client
+      case complete = "complete"                        // Server -> Client
     }
-    
+
     let serializationFormat = JSONSerializationFormat.self
-    var message : GraphQLMap = [:]
-    
-    var rawValue : String? {
-      get {
-        let serialized = try! serializationFormat.serialize(value: message)
-        if let str = String(data: serialized, encoding: .utf8) {
-          return str
-        } else {
-          return nil
-        }
-      }
+    private var message: GraphQLMap = [:]
+
+    var rawMessage: String? {
+      let serialized = try! serializationFormat.serialize(value: message)
+      return String(data: serialized, encoding: .utf8)
     }
-    
-    init(payload: GraphQLMap? = nil, id: String? = nil, type: Types = .START) {
+
+    init(payload: GraphQLMap? = nil, id: String? = nil, type: Types = .start) {
       if let payload = payload {
         message += ["payload": payload]
       }
@@ -346,28 +330,28 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
       }
       message += ["type": type.rawValue]
     }
-    
-    var serialized : String?
-    
+
+    var serialized: String?
+
     init(serialized: String) {
       self.serialized = serialized
     }
-    
+
     func parse(handler: (_ type: String?, _ id: String?, _ payload: JSONObject?, _ error: Error?) -> Void) {
-      
-      var type : String?
-      var id : String?
-      var payload : JSONObject?
-      
+
+      var type: String?
+      var id: String?
+      var payload: JSONObject?
+
       if let serialized = self.serialized {
         if let data = self.serialized?.data(using: (.utf8) ) {
           do {
             let json = try JSONSerializationFormat.deserialize(data: data ) as? JSONObject
-            
+
             id = json?["id"] as? String
             type = json?["type"] as? String
             payload = json?["payload"] as? JSONObject
-            
+
             handler(type,id,payload,nil)
           }
           catch {
@@ -383,9 +367,9 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
                 WebSocketError(payload: payload, error: nil, kind: .serializedMessageError))
       }
     }
-    
+
   }
-  
+
 }
 
 public struct WebSocketError: Error, LocalizedError {
@@ -394,7 +378,7 @@ public struct WebSocketError: Error, LocalizedError {
     case networkError
     case unprocessedMessage(String)
     case serializedMessageError
-    
+
     var description: String {
       switch self {
       case .errorResponse:
@@ -408,7 +392,7 @@ public struct WebSocketError: Error, LocalizedError {
       }
     }
   }
-  
+
   /// The payload of the response.
   public let payload: JSONObject?
   public let error: Error?

--- a/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
@@ -20,7 +20,7 @@ class MockWebSocketTests: XCTestCase {
     super.setUp()
   
     WebSocketTransport.provider = MockWebSocket.self
-    networkTransport = WebSocketTransport(url: URL(string: "http://localhost/dummy_url")!)
+    networkTransport = WebSocketTransport(request: URLRequest(url: URL(string: "http://localhost/dummy_url")!))
     client = ApolloClient(networkTransport: networkTransport!)
   }
     

--- a/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
@@ -7,7 +7,7 @@ extension WebSocketTransport {
   func write(message: GraphQLMap) {
     let serialized = try! JSONSerializationFormat.serialize(value: message)
     if let str = String(data: serialized, encoding: .utf8) {
-      self.websocket?.write(string: str)
+      self.websocket.write(string: str)
     }
   }
 }

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -12,7 +12,7 @@ class StarWarsSubscriptionTests: XCTestCase {
   override func setUp() {
     super.setUp()
     
-    let networkTransport = WebSocketTransport(url: URL(string: SERVER)!)
+    let networkTransport = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
     client = ApolloClient(networkTransport: networkTransport)
   }
   

--- a/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
@@ -271,7 +271,7 @@ class StarWarsWebsSocketTests: XCTestCase {
   
   private func fetch<Query: GraphQLQuery>(query: Query, completionHandler: @escaping (_ data: Query.Data) -> Void) {
     withCache { (cache) in
-      let network = WebSocketTransport(url: URL(string: SERVER)!)
+      let network = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
       let store = ApolloStore(cache: cache)
       let client = ApolloClient(networkTransport: network, store: store)
 
@@ -298,7 +298,7 @@ class StarWarsWebsSocketTests: XCTestCase {
 
   private func perform<Mutation: GraphQLMutation>(mutation: Mutation, completionHandler: @escaping (_ data: Mutation.Data) -> Void) {
     withCache { (cache) in
-      let network = WebSocketTransport(url: URL(string: SERVER)!)
+      let network = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
       let store = ApolloStore(cache: cache)
       let client = ApolloClient(networkTransport: network, store: store)
 


### PR DESCRIPTION
This PR commits the ultimate sin of mixing several changes in the same PR, sorry not sorry.

The ApolloWebSocket had a vastly different coding style than the rest of the project, and diverged a bit from standard swift style as well, so since I'm a total snob I had to fix that before I could fix the actual problem:

Due to the fact that Starscream delivers its callbacks on the main queue by default (it can be configured to another DispatchQueue but we'd still have the same problem) and the `NetworkTransport`'s `send(....)` is operated from whatever queue the calling `AsynchronousOperation` gets assigned to, this can lead to race conditions on some of the state variables, as detected by the Thread Sanitizer. So this PR adds a lock around some of the state variables (mainly the acking of messages) as well as processing of starscream callbacks on a serial queue. 
I'm not too happy about the latter there as I feel there should be another design around coordinating thread access with the NetworkTransport implementations, what do you think?