### PR TITLE
ApolloWebSockets code style, 

### DIFF
--- a/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
@@ -7,7 +7,7 @@ extension WebSocketTransport {
   func write(message: GraphQLMap) {
     let serialized = try! JSONSerializationFormat.serialize(value: message)
     if let str = String(data: serialized, encoding: .utf8) {
-      self.websocket?.write(string: str)
+      self.websocket.write(string: str)
     }
   }
 }
@@ -20,7 +20,7 @@ class MockWebSocketTests: XCTestCase {
     super.setUp()
   
     WebSocketTransport.provider = MockWebSocket.self
-    networkTransport = WebSocketTransport(url: URL(string: "http://localhost/dummy_url")!)
+    networkTransport = WebSocketTransport(request: URLRequest(url: URL(string: "http://localhost/dummy_url")!))
     client = ApolloClient(networkTransport: networkTransport!)
   }
     

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -12,7 +12,7 @@ class StarWarsSubscriptionTests: XCTestCase {
   override func setUp() {
     super.setUp()
     
-    let networkTransport = WebSocketTransport(url: URL(string: SERVER)!)
+    let networkTransport = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
     client = ApolloClient(networkTransport: networkTransport)
   }
   

--- a/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
@@ -271,7 +271,7 @@ class StarWarsWebsSocketTests: XCTestCase {
   
   private func fetch<Query: GraphQLQuery>(query: Query, completionHandler: @escaping (_ data: Query.Data) -> Void) {
     withCache { (cache) in
-      let network = WebSocketTransport(url: URL(string: SERVER)!)
+      let network = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
       let store = ApolloStore(cache: cache)
       let client = ApolloClient(networkTransport: network, store: store)
 
@@ -298,7 +298,7 @@ class StarWarsWebsSocketTests: XCTestCase {
 
   private func perform<Mutation: GraphQLMutation>(mutation: Mutation, completionHandler: @escaping (_ data: Mutation.Data) -> Void) {
     withCache { (cache) in
-      let network = WebSocketTransport(url: URL(string: SERVER)!)
+      let network = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
       let store = ApolloStore(cache: cache)
       let client = ApolloClient(networkTransport: network, store: store)
 


### PR DESCRIPTION
Since #307 is a bit unwieldy here's one with the stylistic and initializer changes, so they can be bikeshedded separately.

Stylistic changes:
 - Consistent use of spacing around variable type declarations
 - Switch on enum cases instead of their raw value
 - Avoid heavy indentation by using guard

I found the Optionality of the websocket property really odd, when would we ever want a nil websocket on a websocket transport class?
I removed the `connect(request:)` since a better API would be to supply a new WebSocketTransport if you need to call another endpoint, instead of mutating the underlying request potentially mid-flight. 

One thing it did provide was the option to "initialize now, but connect later" and I briefly considered not calling `websocket.connect()` in the initializer, in favour of requiring the caller to issue a `connect()` later, but since 99% will probably either call connect() immediately after initialising or forgetting it all-together I decided to just always immediately connect, side-effects be damned

Header configurations (confusingly named `params` in the removed initializers) has been removed, since the caller should instead pass in an URLRequest configured to their needs. That's not our job.