### PR TITLE
Add operation id in header

### DIFF
--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -79,11 +79,12 @@ public class HTTPNetworkTransport: NetworkTransport {
     
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+    let body = requestBody(for: operation)
+
     if sendOperationIdentifiers, let operationIdentifier = operation.operationIdentifier {
         request.setValue(operationIdentifier, forHTTPHeaderField: "x-Apollo-Operation-Id")
     }
 
-    let body = requestBody(for: operation)
     request.httpBody = try! serializationFormat.serialize(value: body)
     
     let task = session.dataTask(with: request) { (data: Data?, response: URLResponse?, error: Error?) in

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -80,7 +80,7 @@ public class HTTPNetworkTransport: NetworkTransport {
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
     if sendOperationIdentifiers, let operationIdentifier = operation.operationIdentifier {
-        request.setValue(operationIdentifier, forHTTPHeaderField: "Apollo-Operation-Id")
+        request.setValue(operationIdentifier, forHTTPHeaderField: "x-Apollo-Operation-Id")
     }
 
     let body = requestBody(for: operation)

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -79,6 +79,10 @@ public class HTTPNetworkTransport: NetworkTransport {
     
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+    if sendOperationIdentifiers, let operationIdentifier = operation.operationIdentifier {
+        request.setValue(operationIdentifier, forHTTPHeaderField: "Apollo-Operation-Id")
+    }
+
     let body = requestBody(for: operation)
     request.httpBody = try! serializationFormat.serialize(value: body)
     


### PR DESCRIPTION
/label feature

In our team we have a use case, when we need to send operationID in header with every query request. Because  we can set up headers only during the `ApolloClient` init, we can't send operationID header dynamically. With my pr I've added operationID (if exists) in header for every request. The same logic is currently implemented in Android client.

