### PR TITLE
Don't use global installation of Apollo CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ playground.xcworkspace
 # Carthage/Checkouts
 
 Carthage/Build
+
+# Local Node Modules for Apollo CLI
+node_modules/
+package-lock.json

--- a/scripts/check-and-run-apollo-cli.sh
+++ b/scripts/check-and-run-apollo-cli.sh
@@ -10,7 +10,7 @@ REQUIRED_APOLLO_CLI_VERSION=1.2.0
 install_apollo_cli() {
   # Exit immediately if the command fails
   set -e
-  npm install -g apollo@$REQUIRED_APOLLO_CLI_VERSION
+  npm install --prefix $SRCROOT apollo@$REQUIRED_APOLLO_CLI_VERSION
   set +e
 }
 
@@ -20,7 +20,7 @@ are_versions_compatible() {
 }
 
 get_installed_version() {
-  version=$(apollo -v)
+  version=$($SRCROOT/node_modules/.bin/apollo -v)
   if [[ $? -eq 0 ]]; then
     echo "$version"
   else
@@ -51,14 +51,6 @@ if [[ -s "$SRCROOT/node_modules/.bin/apollo" ]]; then
   # If it's installed locally, use version build instead
   set -x
 
-  exec "$SRCROOT/node_modules/.bin/apollo" "$@"
-else
-  # Otherwise use a global install
-  if ! type "apollo" >/dev/null 2>&1; then
-    echo "Can't find Apollo CLI. Installing..."
-    install_apollo_cli
-  fi
-
   INSTALLED_APOLLO_CLI_VERSION="$(get_installed_version)"
 
   if ! are_versions_compatible $INSTALLED_APOLLO_CLI_VERSION $REQUIRED_APOLLO_CLI_VERSION; then
@@ -67,8 +59,14 @@ else
     install_apollo_cli
   fi
 
+  exec "$SRCROOT/node_modules/.bin/apollo" "$@"
+else
+  # Otherwise install locally
+  echo "Can't find Apollo CLI. Installing..."
+  install_apollo_cli
+
   # Print commands before executing them (useful for troubleshooting)
   set -x
 
-  exec apollo "$@"
+  exec "$SRCROOT/node_modules/.bin/apollo" "$@"
 fi


### PR DESCRIPTION
Now the CLI is installed in local `node_modules` to prevent version conflicts with a globally installed Apollo CLI.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->