### PR TITLE
Fixed Build failure in tvOS, watchOS using Carthage

### DIFF
--- a/ApolloWebSocket.xcodeproj/project.pbxproj
+++ b/ApolloWebSocket.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
 		};
@@ -504,7 +504,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;
 		};
@@ -526,7 +526,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
 		};
@@ -548,7 +548,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
**Description**
tvOS builds failed as demonstrated in issue #330 when using Carthage during the `ApolloWebSocket` build phase.  Also noticed watchOS failed so I took the liberty of adding both tvOS and watchOS to the Targeted Device configuration in the `ApolloWebSocket` project file. 

**How I tested**
Created a new Project in Xcode 9.4.1, used carthage with this branch locally in Cartfile. Tested platform builds for tvOS & watchOS.