### PR TITLE
Wrap argument for Apollo CLI version check in quotes

### DIFF
--- a/scripts/check-and-run-apollo-cli.sh
+++ b/scripts/check-and-run-apollo-cli.sh
@@ -53,7 +53,7 @@ if [[ -s "$SRCROOT/node_modules/.bin/apollo" ]]; then
 
   INSTALLED_APOLLO_CLI_VERSION="$(get_installed_version)"
 
-  if ! are_versions_compatible $INSTALLED_APOLLO_CLI_VERSION $REQUIRED_APOLLO_CLI_VERSION; then
+  if ! are_versions_compatible "$INSTALLED_APOLLO_CLI_VERSION" $REQUIRED_APOLLO_CLI_VERSION; then
     echo "The version of Apollo.framework in your project requires Apollo CLI $REQUIRED_APOLLO_CLI_VERSION, \
   but $INSTALLED_APOLLO_CLI_VERSION seems to be installed. Installing..."
     install_apollo_cli


### PR DESCRIPTION
INSTALLED_APOLLO_CLI_VERSION may contain white spaces, which causes the version check in the script to fail since it treats the individual components of the apollo version as the arguments rather than comparing the INSTALLED_APOLLO_CLI_VERSION to REQUIRED_APOLLO_CLI_VERSION.  Wrapping the shell variable in quotes resolves the issue.

