### PR TITLE
Remove manual targeted device setting in ApolloWebSocket project config

### DIFF
--- a/ApolloWebSocket.xcodeproj/project.pbxproj
+++ b/ApolloWebSocket.xcodeproj/project.pbxproj
@@ -472,7 +472,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
 		};
@@ -502,7 +501,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Removing the project's manual targeted device override so config will be inherited from the Framework.xcconfig