### PR TITLE
Fixed unnecessary imports of Apollo and SQLite in SQLiteNormalizedCache

### DIFF
--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -1,6 +1,3 @@
-import Apollo
-import SQLite
-
 public enum SQLiteNormalizedCacheError: Error {
   case invalidRecordEncoding(record: String)
   case invalidRecordShape(object: Any)

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -1,3 +1,5 @@
+import SQLite
+
 public enum SQLiteNormalizedCacheError: Error {
   case invalidRecordEncoding(record: String)
   case invalidRecordShape(object: Any)


### PR DESCRIPTION
Fixes a warning when using Apollo SQLite framework that says imports are already included in the framework.