### PR TITLE
Update downloading-schema.md

### DIFF
--- a/docs/source/downloading-schema.md
+++ b/docs/source/downloading-schema.md
@@ -13,5 +13,5 @@ apollo schema:download --endpoint=http://localhost:8080/graphql schema.json
 If needed, you can use the `header` option to add additional HTTP headers to the request. For example, to include an authentication token, use `--header "Authorization: Bearer <token>"`:
 
 ```sh
-apollo schema:download --endpoint=http://localhost:8080/graphql --header="Authorization: Bearer <token>" schema.json
+apollo schema:download --endpoint=http://localhost:8080/graphql --header="Authorization: Bearer <token>"
 ```


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Passing the `schema.json` argument to Apollo CLI results in this error:
```
TypeError: Cannot read property 'trim' of undefined
    at Object.parse (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/lib/commands/schema/download.js:52:57)
    at Parser._flags (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/node_modules/@oclif/parser/lib/parse.js:149:49)
    at Parser.parse (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/node_modules/@oclif/parser/lib/parse.js:112:28)
    at Object.parse (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/node_modules/@oclif/parser/lib/index.js:25:27)
    at SchemaDownload.parse (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/node_modules/@oclif/command/lib/command.js:68:41)
    at SchemaDownload.run (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/lib/commands/schema/download.js:13:38)
    at SchemaDownload._run (~/.nvm/versions/node/v8.11.2/lib/node_modules/apollo/node_modules/@oclif/command/lib/command.js:29:31)
```