### PR TITLE
Allow spaces in Project name

### DIFF
--- a/scripts/check-and-run-apollo-cli.sh
+++ b/scripts/check-and-run-apollo-cli.sh
@@ -10,7 +10,7 @@ REQUIRED_APOLLO_CLI_VERSION=1.2.0
 install_apollo_cli() {
   # Exit immediately if the command fails
   set -e
-  npm install --prefix $SRCROOT apollo@$REQUIRED_APOLLO_CLI_VERSION
+  npm install --prefix "$SRCROOT" apollo@$REQUIRED_APOLLO_CLI_VERSION
   set +e
 }
 


### PR DESCRIPTION
Fixes npm install with a project prefix that contains spaces.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
/label fix
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->