### PR TITLE
Invalidate items in cache

### DIFF
--- a/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      disableMainThreadChecker = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference

--- a/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -247,7 +247,5 @@ public final class ApolloStore {
         self.updateChangedKeysFunc?(keys, nil)
       }.wait()
     }
-    
   }
-  
 }

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -241,5 +241,13 @@ public final class ApolloStore {
         }
       }.wait()
     }
+    
+    public func delete(withId key: CacheKey) {
+      cache.deleteRecord(forKey: key).andThen { keys in
+        self.updateChangedKeysFunc?(keys, nil)
+      }.wait()
+    }
+    
   }
+  
 }

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -1,13 +1,13 @@
 public final class InMemoryNormalizedCache: NormalizedCache {
-  public func deleteRecord(forKey key: CacheKey) -> Promise<Set<CacheKey>> {
-    let v = records.removeValue(forKey: key)
-    return Promise(fulfilled: v)
-  }
-    
   private var records: RecordSet
 
   public init(records: RecordSet = RecordSet()) {
     self.records = records
+  }
+  
+  public func deleteRecord(forKey key: CacheKey) -> Promise<Set<CacheKey>> {
+    let removed = records.removeValue(forKey: key)
+    return Promise(fulfilled: removed)
   }
 
   public func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -1,4 +1,9 @@
 public final class InMemoryNormalizedCache: NormalizedCache {
+  public func deleteRecord(forKey key: CacheKey) -> Promise<Set<CacheKey>> {
+    let v = records.removeValue(forKey: key)
+    return Promise(fulfilled: v)
+  }
+    
   private var records: RecordSet
 
   public init(records: RecordSet = RecordSet()) {

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -13,4 +13,9 @@ public protocol NormalizedCache {
 
   // Clears all records
   func clear() -> Promise<Void>
+    
+  // Removes data associated with a single key from the cache
+  /// - returns: A promise that fulfils with a set of keys corresponding to the fields that have
+  ///            changed, including the key passed in if it was removed.
+  func deleteRecord(forKey: CacheKey) -> Promise<Set<CacheKey>>
 }

--- a/Sources/Apollo/Record.swift
+++ b/Sources/Apollo/Record.swift
@@ -7,7 +7,7 @@ public struct Record {
   
   public typealias Value = Any
   public typealias Fields = [CacheKey: Value]
-  public private(set) var fields: Fields
+  public var fields: Fields
   
   public init(key: CacheKey, _ fields: Fields = [:]) {
     self.key = key

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -10,13 +10,8 @@ public enum SQLiteNormalizedCacheError: Error {
 }
 
 public final class SQLiteNormalizedCache: NormalizedCache {
-  
   public init(fileURL: URL) throws {
     db = try Connection(.uri(fileURL.absoluteString), readonly: false)
-    db.trace {
-        print($0)
-        
-    }
     try createTableIfNeeded()
   }
 

--- a/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
+++ b/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
@@ -67,7 +67,7 @@ class CachePersistenceTests: XCTestCase {
 
       let networkExpectation = self.expectation(description: "Fetching query from network")
       let emptyCacheExpectation = self.expectation(description: "Fetch query from empty cache")
-
+    
       client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
         defer { networkExpectation.fulfill() }
         guard let result = result else { XCTFail("No query result");  return }
@@ -86,4 +86,58 @@ class CachePersistenceTests: XCTestCase {
       self.waitForExpectations(timeout: 2, handler: nil)
     }
   }
+  
+  func testDeleteSingleWithKey() {
+    let query = HeroAndFriendsNamesWithIDsQuery()
+    let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+    
+    SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
+      let store = ApolloStore(cache: cache)
+      
+      let networkTransport = MockNetworkTransport(body: [
+        "data": [
+          "hero": [
+            "id": "2001",
+            "name": "R2-D2",
+            "__typename": "Droid",
+            "friends": [
+              ["id": "1000", "name": "Luke Skywalker", "__typename": "Human"],
+              ["id": "1002", "name": "Han Solo", "__typename": "Human"],
+              ["id": "1003", "name": "Leia Organa", "__typename": "Human"]
+            ]
+          ]
+        ]
+        ])
+      let client = ApolloClient(networkTransport: networkTransport, store: store)
+      client.cacheKeyForObject = { $0["id"] }
+      
+      let notifyWatcherExpectation = self.expectation(description: "Watcher notified of deleted item")
+
+      let watcher = GraphQLQueryWatcher<HeroAndFriendsNamesWithIDsQuery>(client: client, query: query, handlerQueue: DispatchQueue.main) { result, error in
+        guard let result = result else { XCTFail("No query result");  return }
+        XCTAssertEqual(result.data?.hero?.name, "R2-D2")
+        
+        
+        if let friendNames = result.data?.hero?.friends?.compactMap({ $0?.name }), !friendNames.contains { $0 == "Luke Skywalker" } {
+          notifyWatcherExpectation.fulfill()
+        }
+        
+        DispatchQueue.main.async {
+          do {
+            try client.store.withinReadWriteTransaction { transaction in
+              return transaction.delete(withId: "1000")
+              }.await()
+          } catch {
+            XCTAssertFalse(true, "delete threw expection")
+          }
+        }
+        
+      }
+      
+      watcher.fetch(cachePolicy: CachePolicy.fetchIgnoringCacheData)
+
+      self.waitForExpectations(timeout: 2, handler: nil)
+    }
+  }
+
 }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -4,15 +4,6 @@ import ApolloTestSupport
 import StarWarsAPI
 
 private final class MockBatchedNormalizedCache: NormalizedCache {
-  func deleteRecord(forKey key: CacheKey) -> Promise<Set<CacheKey>> {
-    return Promise { fulfill, reject in
-      DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
-        let records = self.records.removeValue(forKey: key)
-        fulfill(records)
-      }
-    }
-  }
-  
   private var records: RecordSet
   
   var numberOfBatchLoads: Int32 = 0
@@ -46,6 +37,15 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
       DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
         self.records.clear()
         fulfill(())
+      }
+    }
+  }
+
+  func deleteRecord(forKey key: CacheKey) -> Promise<Set<CacheKey>> {
+    return Promise { fulfill, reject in
+      DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
+        let records = self.records.removeValue(forKey: key)
+        fulfill(records)
       }
     }
   }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -4,6 +4,15 @@ import ApolloTestSupport
 import StarWarsAPI
 
 private final class MockBatchedNormalizedCache: NormalizedCache {
+  func deleteRecord(forKey key: CacheKey) -> Promise<Set<CacheKey>> {
+    return Promise { fulfill, reject in
+      DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
+        let records = self.records.removeValue(forKey: key)
+        fulfill(records)
+      }
+    }
+  }
+  
   private var records: RecordSet
   
   var numberOfBatchLoads: Int32 = 0


### PR DESCRIPTION
Define a delete cache function for ApolloCache and implement it for InMemoryNormalizedCache and SQLiteNormalizedCache, along with tests to ensure watchers are fired and items are removed from the cache and all places where they are referenced.



<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->