### PR TITLE
Make operationDefinition on GraphQLOperation static.

### DIFF
--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -7,7 +7,7 @@ public enum GraphQLOperationType {
 public protocol GraphQLOperation: class {
   var operationType: GraphQLOperationType { get }
   
-  var operationDefinition: String { get }
+  static var operationDefinition: String { get }
   var operationIdentifier: String? { get }
   
   var queryDocument: String { get }

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -19,7 +19,7 @@ public protocol GraphQLOperation: class {
 
 public extension GraphQLOperation {
   var queryDocument: String {
-    return operationDefinition
+    return type(of: self).operationDefinition
   }
 
   var operationIdentifier: String? {


### PR DESCRIPTION
# What

This makes `operationDefinition` on `GraphQLOperation` `static`. 

# Why

Since it is already a constant, there are a couple reasons why making it `static` is nice.

1. It's not allocated each time the class is instantiated.
1. It allows accessing the string outside of the context of an instance.

The latter is the main reason I'm making this PR. We were previously using `requestString` from the older `apollo-codegen` to detect changes in the query in order to invalidate local caches. Ignoring the fact that we could have a better way of determining that, I think this property _should_ be `static` anyway. 

# Problems

This requires a change in apollo-cli as well. Here's my PR -- https://github.com/apollographql/apollo-cli/pull/579