### PR TITLE
Cache load errors cause deadlock in write transaction

### DIFF
--- a/Sources/Apollo/DataLoader.swift
+++ b/Sources/Apollo/DataLoader.swift
@@ -47,7 +47,9 @@ public final class DataLoader<Key: Hashable, Value> {
       
       let keys = loads.map { $0.key }
       
-      self.batchLoad(keys).andThen { values in
+      self.batchLoad(keys).catch { error in
+        loads.forEach { $0.reject(error) }
+      }.andThen { values in
         for (load, value) in zip(loads, values) {
           load.fulfill(value)
         }

--- a/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
@@ -210,6 +210,37 @@ class LoadQueryFromStoreTests: XCTestCase {
     }
   }
   
+  
+  func testLoadingWithBadCacheSerialization() throws {
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "2001")],
+      "2001": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+        "friends": [
+          Reference(key: "1000"),
+          Reference(key: "1002"),
+          Reference(key: "1003")
+        ]
+      ],
+      "1000": ["__typename": "Human", "name": "Luke Skywalker", "badField":
+        ["dictionary": "badValues", "nested bad val": ["subdictionary": "some value"] ]
+      ],
+      "1002": ["__typename": "Human", "name": "Han Solo"],
+      "1003": ["__typename": "Human", "name": "Leia Organa"],
+      ]
+    
+    withCache(initialRecords: initialRecords) { (cache) in
+      store = ApolloStore(cache: cache)
+      
+      let query = HeroAndFriendsNamesQuery()
+      load(query: query) { (result, error) in
+        XCTAssertNil(result)
+        XCTAssertNotNil(error)
+      }
+    }
+  }
+  
   // MARK: - Helpers
   
   private func load<Query: GraphQLQuery>(query: Query, resultHandler: @escaping OperationResultHandler<Query>) {
@@ -223,3 +254,12 @@ class LoadQueryFromStoreTests: XCTestCase {
     waitForExpectations(timeout: 5, handler: nil)
   }
 }
+
+//class JSON: JSONEncodable, JSONDecodable {
+//  var jsonValue: JSONValue {
+//    return ["asdf": "123"]
+//  }
+//  required init(jsonValue value: JSONValue) throws {
+//    return
+//  }
+//}

--- a/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
@@ -223,8 +223,7 @@ class LoadQueryFromStoreTests: XCTestCase {
           Reference(key: "1003")
         ]
       ],
-      "1000": ["__typename": "Human", "name": "Luke Skywalker", "badField":
-        ["dictionary": "badValues", "nested bad val": ["subdictionary": "some value"] ]
+      "1000": ["__typename": "Human", "name": ["dictionary": "badValues", "nested bad val": ["subdictionary": "some value"] ]
       ],
       "1002": ["__typename": "Human", "name": "Han Solo"],
       "1003": ["__typename": "Human", "name": "Leia Organa"],

--- a/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
@@ -254,12 +254,3 @@ class LoadQueryFromStoreTests: XCTestCase {
     waitForExpectations(timeout: 5, handler: nil)
   }
 }
-
-//class JSON: JSONEncodable, JSONDecodable {
-//  var jsonValue: JSONValue {
-//    return ["asdf": "123"]
-//  }
-//  required init(jsonValue value: JSONValue) throws {
-//    return
-//  }
-//}


### PR DESCRIPTION
Reject batch loader loads if a loader fails to allow exceptions to cascade through promise chain. Previous behavior (run test without code) causes the load to never complete, and more importantly, causes the store to hold a read lock indefinitely, causing a deadlock when a write is attempted later. In practice, this is every time a fetch occurs with default cache policy.

The root of the issue is a non-normalized dictionary which is stored in the cache. In our schema, we have some JSON blobs that come from an external service which are represented as a JSON custom scalar. Storing these in the cache worked fine, but fetching these types caused attempts to read from cache to never return, and other strange behavior due to writes also failing.

Solution was pretty simple, just needed to pass the failures in the batch loader to the individual load promises so they can be picked up and forwarded on the chain. Since these are wrapped in a `whenAll`, only the first `reject` matters.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->