### PR TITLE
Update dataloader dispatch to propagate errors

### DIFF
--- a/Sources/Apollo/DataLoader.swift
+++ b/Sources/Apollo/DataLoader.swift
@@ -47,10 +47,16 @@ public final class DataLoader<Key: Hashable, Value> {
       
       let keys = loads.map { $0.key }
       
-      self.batchLoad(keys).andThen { values in
-        for (load, value) in zip(loads, values) {
-          load.fulfill(value)
+      self.batchLoad(keys)
+        .andThen { values in
+          for (load, value) in zip(loads, values) {
+            load.fulfill(value)
+          }
         }
+        .catch { error in
+          for load in loads {
+            load.reject(error)
+          }
       }
     }
   }

--- a/Tests/ApolloTests/DataLoaderTests.swift
+++ b/Tests/ApolloTests/DataLoaderTests.swift
@@ -3,6 +3,8 @@ import XCTest
 import ApolloTestSupport
 import StarWarsAPI
 
+private struct TestError: Error {}
+
 class DataLoaderTests: XCTestCase {
   func testSingleLoad() {
     let loader = DataLoader<Int, Int> { keys in
@@ -18,6 +20,24 @@ class DataLoaderTests: XCTestCase {
     
     loader.dispatch()
     
+    waitForExpectations(timeout: 1)
+  }
+
+
+  func testDispatchError() {
+    let loader = DataLoader<Int, Int> { keys in
+      return Promise(rejected: TestError())
+    }
+
+    let expectation = self.expectation(description: "Waiting for error")
+
+    loader[1].catch { error in
+      XCTAssert(error is TestError)
+      expectation.fulfill()
+    }
+
+    loader.dispatch()
+
     waitForExpectations(timeout: 1)
   }
   


### PR DESCRIPTION
Seeing some SQLiteNormalizedCacheErrors that get swallowed in DataLoader and no-op without recovery. Add handling for rejected promises so they get propagated up to the ApolloStore and can fall back to network fetch.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->