### PR TITLE
Adding swift_version to the podspec

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -10,6 +10,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/apollographql/apollo-ios.git', :tag => s.version }
 
   s.requires_arc = true
+  
+  s.swift_version = '4.0'
 
   s.default_subspecs = 'Core'
 


### PR DESCRIPTION
When trying to package a library that's dependent on Apollo using cocoapods-packager, the script fails saying it doesn't specify a SWIFT_VERSION. I reckon it's proper behaviour in general to specify the version in the podspec.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->