### PR TITLE
Fix Apollo Build Step script because it fails when Schemes have space in their names

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -82,7 +82,7 @@ for macOS Project
 FIXED_FRAMEWORK_SEARCH_PATHS=\"$(echo $FRAMEWORK_SEARCH_PATHS | tr -d '"' | sed -e 's/ \//" "\//g')\"
 IFS=$'\n'
 APOLLO_FRAMEWORK_PATH="$(eval find $FIXED_FRAMEWORK_SEARCH_PATHS -name "Apollo.framework" -maxdepth 1)"
-if [ -z "$APOLLO_FRAMEWORK_PATH" ]; then
+if [ -z "{$APOLLO_FRAMEWORK_PATH}" ]; then
 echo "error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project."
 exit 1
 fi

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -65,9 +65,11 @@ In order to invoke `apollo` as part of the Xcode build process, create a build s
 
 for iOS Project
 ```sh
-APOLLO_FRAMEWORK_PATH="$(eval find $FRAMEWORK_SEARCH_PATHS -name "Apollo.framework" -maxdepth 1)"
+FIXED_FRAMEWORK_SEARCH_PATHS=\"$(echo $FRAMEWORK_SEARCH_PATHS | tr -d '"' | sed -e 's/ \//" "\//g')\"
+IFS=$'\n'
+APOLLO_FRAMEWORK_PATH="$(eval find $FIXED_FRAMEWORK_SEARCH_PATHS -name "Apollo.framework" -maxdepth 1)"
 
-if [ -z "$APOLLO_FRAMEWORK_PATH" ]; then
+if [ -z "${APOLLO_FRAMEWORK_PATH}" ]; then
   echo "error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project."
   exit 1
 fi
@@ -77,8 +79,9 @@ $APOLLO_FRAMEWORK_PATH/check-and-run-apollo-cli.sh codegen:generate --queries="$
 ```
 for macOS Project
 ```sh
-APOLLO_FRAMEWORK_PATH="$(eval find $FRAMEWORK_SEARCH_PATHS -name "Apollo.framework" -maxdepth 1)"
-
+FIXED_FRAMEWORK_SEARCH_PATHS=\"$(echo $FRAMEWORK_SEARCH_PATHS | tr -d '"' | sed -e 's/ \//" "\//g')\"
+IFS=$'\n'
+APOLLO_FRAMEWORK_PATH="$(eval find $FIXED_FRAMEWORK_SEARCH_PATHS -name "Apollo.framework" -maxdepth 1)"
 if [ -z "$APOLLO_FRAMEWORK_PATH" ]; then
 echo "error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project."
 exit 1


### PR DESCRIPTION

When there is spaces in any path of the FRAMEWORK_SEARCH_PATHS, the `find` command fails.
Having a scheme with a space in its name will cause FRAMEWORK_SEARCH_PATHS to have spaces in each path.

This edit changes the `find` separation character to `\n` from ` ` through `IFS` and fixes the FRAMEWORK_SEARCH_PATHS to include double quotes on its first path (which is without double quotes even if it has a space in the path). Not adding the double quotes also breaks `find` when it reads a path with a space if `IFS` is set

- [x] blocking
- [x] docs