### PR TITLE
export createRequest method for extending the transport

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -65,6 +65,14 @@ public class HTTPNetworkTransport: NetworkTransport {
     self.sendOperationIdentifiers = sendOperationIdentifiers
   }
   
+  /// Initializes a URLRequest object. Override this in your implementation to customize the request.
+  ///
+  /// - Parameters:
+  ///   - url: The URL of a GraphQL server to connect to.
+  public func createRequest(url: URL) -> URLRequest {
+    return URLRequest(url: url)
+  }
+  
   /// Send a GraphQL operation to a server and return a response.
   ///
   /// - Parameters:
@@ -74,7 +82,7 @@ public class HTTPNetworkTransport: NetworkTransport {
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
   public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
-    var request = URLRequest(url: url)
+    var request = createRequest(url: url)
     request.httpMethod = "POST"
     
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -69,6 +69,7 @@ public class HTTPNetworkTransport: NetworkTransport {
   ///
   /// - Parameters:
   ///   - url: The URL of a GraphQL server to connect to.
+  /// - Returns: A URLRequest
   public func createRequest(url: URL) -> URLRequest {
     return URLRequest(url: url)
   }


### PR DESCRIPTION
To make even the most trivial adjustment to the request, like being able to dynamically specify the headers, you have to copy the full implementation of the transport class.

By exposing the `createRequest` method, this would be possible by simply extending the existing transport, and only override the `createRequest` method.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->