### PR TITLE
Fix writing a query with variables to the store.

### DIFF
--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -143,9 +143,10 @@ public final class ApolloStore {
 
     fileprivate lazy var loader: DataLoader<CacheKey, Record?> = DataLoader(self.cache.loadRecords)
 
-    fileprivate func makeExecutor() -> GraphQLExecutor {
+    fileprivate func makeExecutor(keySelector: @escaping (GraphQLResolveInfo) -> String = { $0.cacheKeyForField }) -> GraphQLExecutor {
       let executor = GraphQLExecutor { object, info in
-        let value = object[info.cacheKeyForField]
+        let key = keySelector(info)
+        let value = object[key]
         return self.complete(value: value)
       }
 
@@ -206,8 +207,8 @@ public final class ApolloStore {
     fileprivate var updateChangedKeysFunc: DidChangeKeysFunc?
 
     init(cache: NormalizedCache, cacheKeyForObject: CacheKeyForObject?, updateChangedKeysFunc: @escaping DidChangeKeysFunc) {
-        self.updateChangedKeysFunc = updateChangedKeysFunc
-        super.init(cache: cache, cacheKeyForObject: cacheKeyForObject)
+      self.updateChangedKeysFunc = updateChangedKeysFunc
+      super.init(cache: cache, cacheKeyForObject: cacheKeyForObject)
     }
 
     public func update<Query: GraphQLQuery>(query: Query, _ body: (inout Query.Data) throws -> Void) throws {
@@ -232,18 +233,13 @@ public final class ApolloStore {
 
     private func write(object: JSONObject, forSelections selections: [GraphQLSelection], withKey key: CacheKey, variables: GraphQLMap?) throws {
       let normalizer = GraphQLResultNormalizer()
-      var objectWithCacheKeys = object
-      for selection in selections {
-        if let field = selection as? GraphQLField, let data = object[field.name], let cacheKey = try? field.cacheKey(with: variables) {
-          objectWithCacheKeys[cacheKey] = data
-        }
-      }
-      try self.makeExecutor().execute(selections: selections, on: objectWithCacheKeys, withKey: key, variables: variables, accumulator: normalizer)
+      let executor = makeExecutor { $0.responseKeyForField }
+      try executor.execute(selections: selections, on: object, withKey: key, variables: variables, accumulator: normalizer)
       .flatMap {
         self.cache.merge(records: $0)
       }.andThen { changedKeys in
         if let didChangeKeysFunc = self.updateChangedKeysFunc {
-            didChangeKeysFunc(changedKeys, nil)
+          didChangeKeysFunc(changedKeys, nil)
         }
       }.wait()
     }

--- a/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
@@ -160,7 +160,44 @@ class ReadWriteFromStoreTests: XCTestCase {
       XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
     }
   }
-  
+
+  func testUpdateHeroAndFriendsNamesQueryWithEpisode() throws {
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero(episode:NEWHOPE)": Reference(key: "2001")],
+      "2001": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+        "friends": [
+          Reference(key: "1000"),
+          Reference(key: "1002"),
+          Reference(key: "1003")
+        ]
+      ],
+      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
+      "1002": ["__typename": "Human", "name": "Han Solo"],
+      "1003": ["__typename": "Human", "name": "Leia Organa"],
+      ]
+
+    try withCache(initialRecords: initialRecords) { (cache) in
+      let store = ApolloStore(cache: cache)
+
+      let query = HeroAndFriendsNamesQuery(episode: Episode.newhope)
+
+      try await(store.withinReadWriteTransaction { transaction in
+        try transaction.update(query: query) { (data: inout HeroAndFriendsNamesQuery.Data) in
+          data.hero?.friends?.append(.makeDroid(name: "C-3PO"))
+        }
+      })
+
+      let result = try await(store.load(query: query))
+      guard let data = result.data else { XCTFail(); return }
+
+      XCTAssertEqual(data.hero?.name, "R2-D2")
+      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
+      XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
+    }
+  }
+
   func testReadHeroDetailsFragmentWithTypeSpecificProperty() throws {
     let initialRecords: RecordSet = [
       "2001": ["name": "R2-D2", "__typename": "Droid", "primaryFunction": "Protocol"]

--- a/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
@@ -43,7 +43,7 @@ class ReadWriteFromStoreTests: XCTestCase {
       })
     }
   }
-  
+
   func testReadHeroNameQueryWithMissingName() throws {
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
@@ -161,7 +161,7 @@ class ReadWriteFromStoreTests: XCTestCase {
     }
   }
 
-  func testUpdateHeroAndFriendsNamesQueryWithEpisode() throws {
+  func testUpdateHeroAndFriendsNamesQueryWithVariable() throws {
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero(episode:NEWHOPE)": Reference(key: "2001")],
       "2001": [


### PR DESCRIPTION
This issue is also discussed in https://github.com/apollographql/apollo-ios/issues/357

The ReadWriteTransaction's [resolver](https://github.com/apollographql/apollo-ios/blob/master/Sources/Apollo/ApolloStore.swift#L148) expects the cache key to be in the object data. When writing to the store, the data will not already have this. The existing tests for this didn't include a query with variables, which would cause the lookup to fail.

I'm not sure if the below is the best way to fix this. Seems like either the data needs to have the cache key added, or the write needs to use a different resolver that just uses the field name.

