### PR TITLE
Provide separate valid architectures for the iOS Simulator

### DIFF
--- a/Framework.xcconfig
+++ b/Framework.xcconfig
@@ -7,7 +7,8 @@ SKIP_INSTALL = YES
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator appletvsimulator appletvos watchsimulator watchos macosx
 
 SDKROOT[sdk=iphone*] = iphoneos
-VALID_ARCHS[sdk=iphone*] = arm64 armv7 armv7s
+VALID_ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
+VALID_ARCHS[sdk=iphonesimulator*] = x86_64 i386
 IPHONEOS_DEPLOYMENT_TARGET = 9.0
 TARGETED_DEVICE_FAMILY[sdk=iphone*]  = 1,2
 LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks


### PR DESCRIPTION
Presently Xcode says that it's had to map architectures for the simulator target:
<img width="426" alt="screen shot 2018-11-15 at 11 08 12 pm" src="https://user-images.githubusercontent.com/742696/48552107-aa9bc180-e92b-11e8-9a9b-e11adadf066f.png">