### PR TITLE
Exposed a method to ping

### DIFF
--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -78,7 +78,11 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
   public func isConnected() -> Bool {
     return websocket.isConnected
   }
-  
+
+  public func ping(data: Data, completionHandler: (() -> Void)? = nil) {
+    return websocket.write(ping: data, completion: completionHandler)
+  }
+
   private func processMessage(socket: WebSocketClient, text: String) {
     OperationMessage(serialized: text).parse { (type, id, payload, error) in
       guard let type = type, let messageType = OperationMessage.Types(rawValue: type) else {


### PR DESCRIPTION
Our server-side Websocket implementation forces us to ping every 30seconds for the connection to stay alive.

This change just exposes a ping method on a `WebSocketTransport` instance.