### PR TITLE
Make `field` and `alias` on *GraphQLField* public

### DIFF
--- a/Sources/Apollo/GraphQLSelectionSet.swift
+++ b/Sources/Apollo/GraphQLSelectionSet.swift
@@ -31,8 +31,8 @@ public protocol GraphQLSelection {
 }
 
 public struct GraphQLField: GraphQLSelection {
-  let name: String
-  let alias: String?
+  public let name: String
+  public let alias: String?
   let arguments: [String: GraphQLInputValue]?
   
   var responseKey: String {


### PR DESCRIPTION
I'd like to utilize these fields in order to facilitate automatic conversion back to an auto-generated structs JSON representation