### PR TITLE
Update for compatibility with Swift5

### DIFF
--- a/Sources/Apollo/Collections.swift
+++ b/Sources/Apollo/Collections.swift
@@ -44,7 +44,7 @@ extension GroupedSequence: Sequence {
 struct GroupedSequenceIterator<Key: Equatable, Value>: IteratorProtocol {
   private var base: GroupedSequence<Key, Value>
   
-  private var keyIterator: EnumeratedIterator<IndexingIterator<Array<Key>>>
+  private var keyIterator: EnumeratedSequence<Array<Key>>.Iterator
   
   init(base: GroupedSequence<Key, Value>) {
     self.base = base

--- a/Sources/Apollo/Collections.swift
+++ b/Sources/Apollo/Collections.swift
@@ -1,17 +1,3 @@
-extension Dictionary {
-  subscript(key: Key, withDefault value: @autoclosure () -> Value) -> Value {
-    mutating get {
-      if self[key] == nil {
-        self[key] = value()
-      }
-      return self[key]!
-    }
-    set {
-      self[key] = newValue
-    }
-  }
-}
-
 public extension Dictionary {
   static func += (lhs: inout Dictionary, rhs: Dictionary) {
     #if swift(>=3.2)


### PR DESCRIPTION
- Remove an unused subscript implementation on Dictionary that triggers a compiler crash
- Tweak the type of an iterator