### PR TITLE
add output files path to sample project script

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -1010,10 +1010,11 @@
 			files = (
 			);
 			inputPaths = (
+				"$TEMP_DIR/apollo-lastrun",
 			);
 			name = "Generate Apollo Client API";
 			outputPaths = (
-				"$(SRCROOT)/Tests/GitHubAPI/API.swift",
+				$SRCROOT/Tests/GitHubAPI/API.swift,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1025,10 +1026,11 @@
 			files = (
 			);
 			inputPaths = (
+				"$TEMP_DIR/apollo-lastrun",
 			);
 			name = "Generate Apollo Client API";
 			outputPaths = (
-				"$(SRCROOT)/Tests/StarWarsAPI/API.swift",
+				$SRCROOT/Tests/StarWarsAPI/API.swift,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -x";

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -1010,7 +1010,6 @@
 			files = (
 			);
 			inputPaths = (
-				"$TEMP_DIR/apollo-lastrun",
 			);
 			name = "Generate Apollo Client API";
 			outputPaths = (
@@ -1026,7 +1025,6 @@
 			files = (
 			);
 			inputPaths = (
-				"$TEMP_DIR/apollo-lastrun",
 			);
 			name = "Generate Apollo Client API";
 			outputPaths = (

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -1013,10 +1013,11 @@
 			);
 			name = "Generate Apollo Client API";
 			outputPaths = (
+				"$(SRCROOT)/Tests/GitHubAPI/API.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "APOLLO_FRAMEWORK_PATH=$(eval find $FRAMEWORK_SEARCH_PATHS -name \"Apollo.framework\" -maxdepth 1)\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd ${SRCROOT}/Tests/GitHubAPI\n$(find $APOLLO_FRAMEWORK_PATH/ -name 'check-and-run-apollo-cli.sh') codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=schema.json --mergeInFieldsFromFragmentSpreads API.swift";
+			shellScript = "APOLLO_FRAMEWORK_PATH=$(eval find $FRAMEWORK_SEARCH_PATHS -name \"Apollo.framework\" -maxdepth 1)\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd ${SRCROOT}/Tests/GitHubAPI\n$(find $APOLLO_FRAMEWORK_PATH/ -name 'check-and-run-apollo-cli.sh') codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=schema.json --mergeInFieldsFromFragmentSpreads API.swift\n";
 		};
 		9FCE2D061E6C251100E34457 /* Generate Apollo Client API */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1027,10 +1028,11 @@
 			);
 			name = "Generate Apollo Client API";
 			outputPaths = (
+				"$(SRCROOT)/Tests/StarWarsAPI/API.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -x";
-			shellScript = "APOLLO_FRAMEWORK_PATH=$(eval find $FRAMEWORK_SEARCH_PATHS -name \"Apollo.framework\" -maxdepth 1)\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd ${SRCROOT}/Tests/StarWarsAPI\n$(find $APOLLO_FRAMEWORK_PATH/ -name 'check-and-run-apollo-cli.sh') codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=schema.json --mergeInFieldsFromFragmentSpreads API.swift";
+			shellScript = "APOLLO_FRAMEWORK_PATH=$(eval find $FRAMEWORK_SEARCH_PATHS -name \"Apollo.framework\" -maxdepth 1)\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd ${SRCROOT}/Tests/StarWarsAPI\n$(find $APOLLO_FRAMEWORK_PATH/ -name 'check-and-run-apollo-cli.sh') codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=schema.json --mergeInFieldsFromFragmentSpreads API.swift\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloCacheDependentTests.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloCacheDependentTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9FA6ABBB1EC0A988000017BE"
+               BuildableName = "ApolloCacheDependentTests.xctest"
+               BlueprintName = "ApolloCacheDependentTests"
+               ReferencedContainer = "container:Apollo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloTests.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9FC7504D1D2A532D00458D91"
+               BuildableName = "ApolloTests.xctest"
+               BlueprintName = "ApolloTests"
+               ReferencedContainer = "container:Apollo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/GitHubAPI/API.swift
+++ b/Tests/GitHubAPI/API.swift
@@ -3,7 +3,7 @@
 import Apollo
 
 public final class RepositoryQuery: GraphQLQuery {
-  public static let operationString =
+  public let operationDefinition =
     "query Repository {\n  repository(owner: \"apollographql\", name: \"apollo-ios\") {\n    __typename\n    issueOrPullRequest(number: 13) {\n      __typename\n      ... on Issue {\n        body\n        ... on UniformResourceLocatable {\n          url\n        }\n        author {\n          __typename\n          avatarUrl\n        }\n      }\n      ... on Reactable {\n        viewerCanReact\n        ... on Comment {\n          author {\n            __typename\n            login\n          }\n        }\n      }\n    }\n  }\n}"
 
   public init() {
@@ -16,23 +16,23 @@ public final class RepositoryQuery: GraphQLQuery {
       GraphQLField("repository", arguments: ["owner": "apollographql", "name": "apollo-ios"], type: .object(Repository.selections)),
     ]
 
-    public var snapshot: Snapshot
+    public private(set) var resultMap: ResultMap
 
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
     }
 
     public init(repository: Repository? = nil) {
-      self.init(snapshot: ["__typename": "Query", "repository": repository.flatMap { $0.snapshot }])
+      self.init(unsafeResultMap: ["__typename": "Query", "repository": repository.flatMap { (value: Repository) -> ResultMap in value.resultMap }])
     }
 
     /// Lookup a given repository by the owner and repository name.
     public var repository: Repository? {
       get {
-        return (snapshot["repository"] as! Snapshot?).flatMap { Repository(snapshot: $0) }
+        return (resultMap["repository"] as? ResultMap).flatMap { Repository(unsafeResultMap: $0) }
       }
       set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "repository")
+        resultMap.updateValue(newValue?.resultMap, forKey: "repository")
       }
     }
 
@@ -44,32 +44,32 @@ public final class RepositoryQuery: GraphQLQuery {
         GraphQLField("issueOrPullRequest", arguments: ["number": 13], type: .object(IssueOrPullRequest.selections)),
       ]
 
-      public var snapshot: Snapshot
+      public private(set) var resultMap: ResultMap
 
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
       }
 
       public init(issueOrPullRequest: IssueOrPullRequest? = nil) {
-        self.init(snapshot: ["__typename": "Repository", "issueOrPullRequest": issueOrPullRequest.flatMap { $0.snapshot }])
+        self.init(unsafeResultMap: ["__typename": "Repository", "issueOrPullRequest": issueOrPullRequest.flatMap { (value: IssueOrPullRequest) -> ResultMap in value.resultMap }])
       }
 
       public var __typename: String {
         get {
-          return snapshot["__typename"]! as! String
+          return resultMap["__typename"]! as! String
         }
         set {
-          snapshot.updateValue(newValue, forKey: "__typename")
+          resultMap.updateValue(newValue, forKey: "__typename")
         }
       }
 
       /// Returns a single issue-like object from the current repository by number.
       public var issueOrPullRequest: IssueOrPullRequest? {
         get {
-          return (snapshot["issueOrPullRequest"] as! Snapshot?).flatMap { IssueOrPullRequest(snapshot: $0) }
+          return (resultMap["issueOrPullRequest"] as? ResultMap).flatMap { IssueOrPullRequest(unsafeResultMap: $0) }
         }
         set {
-          snapshot.updateValue(newValue?.snapshot, forKey: "issueOrPullRequest")
+          resultMap.updateValue(newValue?.resultMap, forKey: "issueOrPullRequest")
         }
       }
 
@@ -87,46 +87,46 @@ public final class RepositoryQuery: GraphQLQuery {
           )
         ]
 
-        public var snapshot: Snapshot
+        public private(set) var resultMap: ResultMap
 
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
         }
 
         public static func makePullRequest(viewerCanReact: Bool, author: Author? = nil) -> IssueOrPullRequest {
-          return IssueOrPullRequest(snapshot: ["__typename": "PullRequest", "viewerCanReact": viewerCanReact, "author": author.flatMap { $0.snapshot }])
+          return IssueOrPullRequest(unsafeResultMap: ["__typename": "PullRequest", "viewerCanReact": viewerCanReact, "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }])
         }
 
         public static func makeIssue(body: String, url: String, author: AsIssue.Author? = nil, viewerCanReact: Bool) -> IssueOrPullRequest {
-          return IssueOrPullRequest(snapshot: ["__typename": "Issue", "body": body, "url": url, "author": author.flatMap { $0.snapshot }, "viewerCanReact": viewerCanReact])
+          return IssueOrPullRequest(unsafeResultMap: ["__typename": "Issue", "body": body, "url": url, "author": author.flatMap { (value: AsIssue.Author) -> ResultMap in value.resultMap }, "viewerCanReact": viewerCanReact])
         }
 
         public var __typename: String {
           get {
-            return snapshot["__typename"]! as! String
+            return resultMap["__typename"]! as! String
           }
           set {
-            snapshot.updateValue(newValue, forKey: "__typename")
+            resultMap.updateValue(newValue, forKey: "__typename")
           }
         }
 
         /// Can user react to this subject
         public var viewerCanReact: Bool {
           get {
-            return snapshot["viewerCanReact"]! as! Bool
+            return resultMap["viewerCanReact"]! as! Bool
           }
           set {
-            snapshot.updateValue(newValue, forKey: "viewerCanReact")
+            resultMap.updateValue(newValue, forKey: "viewerCanReact")
           }
         }
 
         /// The actor who authored the comment.
         public var author: Author? {
           get {
-            return (snapshot["author"] as! Snapshot?).flatMap { Author(snapshot: $0) }
+            return (resultMap["author"] as? ResultMap).flatMap { Author(unsafeResultMap: $0) }
           }
           set {
-            snapshot.updateValue(newValue?.snapshot, forKey: "author")
+            resultMap.updateValue(newValue?.resultMap, forKey: "author")
           }
         }
 
@@ -138,40 +138,40 @@ public final class RepositoryQuery: GraphQLQuery {
             GraphQLField("login", type: .nonNull(.scalar(String.self))),
           ]
 
-          public var snapshot: Snapshot
+          public private(set) var resultMap: ResultMap
 
-          public init(snapshot: Snapshot) {
-            self.snapshot = snapshot
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
           }
 
           public static func makeOrganization(login: String) -> Author {
-            return Author(snapshot: ["__typename": "Organization", "login": login])
+            return Author(unsafeResultMap: ["__typename": "Organization", "login": login])
           }
 
           public static func makeUser(login: String) -> Author {
-            return Author(snapshot: ["__typename": "User", "login": login])
+            return Author(unsafeResultMap: ["__typename": "User", "login": login])
           }
 
           public static func makeBot(login: String) -> Author {
-            return Author(snapshot: ["__typename": "Bot", "login": login])
+            return Author(unsafeResultMap: ["__typename": "Bot", "login": login])
           }
 
           public var __typename: String {
             get {
-              return snapshot["__typename"]! as! String
+              return resultMap["__typename"]! as! String
             }
             set {
-              snapshot.updateValue(newValue, forKey: "__typename")
+              resultMap.updateValue(newValue, forKey: "__typename")
             }
           }
 
           /// The username of the actor.
           public var login: String {
             get {
-              return snapshot["login"]! as! String
+              return resultMap["login"]! as! String
             }
             set {
-              snapshot.updateValue(newValue, forKey: "login")
+              resultMap.updateValue(newValue, forKey: "login")
             }
           }
         }
@@ -179,11 +179,11 @@ public final class RepositoryQuery: GraphQLQuery {
         public var asIssue: AsIssue? {
           get {
             if !AsIssue.possibleTypes.contains(__typename) { return nil }
-            return AsIssue(snapshot: snapshot)
+            return AsIssue(unsafeResultMap: resultMap)
           }
           set {
             guard let newValue = newValue else { return }
-            snapshot = newValue.snapshot
+            resultMap = newValue.resultMap
           }
         }
 
@@ -199,62 +199,62 @@ public final class RepositoryQuery: GraphQLQuery {
             GraphQLField("author", type: .object(Author.selections)),
           ]
 
-          public var snapshot: Snapshot
+          public private(set) var resultMap: ResultMap
 
-          public init(snapshot: Snapshot) {
-            self.snapshot = snapshot
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
           }
 
           public init(body: String, url: String, author: Author? = nil, viewerCanReact: Bool) {
-            self.init(snapshot: ["__typename": "Issue", "body": body, "url": url, "author": author.flatMap { $0.snapshot }, "viewerCanReact": viewerCanReact])
+            self.init(unsafeResultMap: ["__typename": "Issue", "body": body, "url": url, "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }, "viewerCanReact": viewerCanReact])
           }
 
           public var __typename: String {
             get {
-              return snapshot["__typename"]! as! String
+              return resultMap["__typename"]! as! String
             }
             set {
-              snapshot.updateValue(newValue, forKey: "__typename")
+              resultMap.updateValue(newValue, forKey: "__typename")
             }
           }
 
           /// Identifies the body of the issue.
           public var body: String {
             get {
-              return snapshot["body"]! as! String
+              return resultMap["body"]! as! String
             }
             set {
-              snapshot.updateValue(newValue, forKey: "body")
+              resultMap.updateValue(newValue, forKey: "body")
             }
           }
 
           /// The HTTP URL for this issue
           public var url: String {
             get {
-              return snapshot["url"]! as! String
+              return resultMap["url"]! as! String
             }
             set {
-              snapshot.updateValue(newValue, forKey: "url")
+              resultMap.updateValue(newValue, forKey: "url")
             }
           }
 
           /// The actor who authored the comment.
           public var author: Author? {
             get {
-              return (snapshot["author"] as! Snapshot?).flatMap { Author(snapshot: $0) }
+              return (resultMap["author"] as? ResultMap).flatMap { Author(unsafeResultMap: $0) }
             }
             set {
-              snapshot.updateValue(newValue?.snapshot, forKey: "author")
+              resultMap.updateValue(newValue?.resultMap, forKey: "author")
             }
           }
 
           /// Can user react to this subject
           public var viewerCanReact: Bool {
             get {
-              return snapshot["viewerCanReact"]! as! Bool
+              return resultMap["viewerCanReact"]! as! Bool
             }
             set {
-              snapshot.updateValue(newValue, forKey: "viewerCanReact")
+              resultMap.updateValue(newValue, forKey: "viewerCanReact")
             }
           }
 
@@ -268,50 +268,50 @@ public final class RepositoryQuery: GraphQLQuery {
               GraphQLField("login", type: .nonNull(.scalar(String.self))),
             ]
 
-            public var snapshot: Snapshot
+            public private(set) var resultMap: ResultMap
 
-            public init(snapshot: Snapshot) {
-              self.snapshot = snapshot
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
             }
 
             public static func makeOrganization(avatarUrl: String, login: String) -> Author {
-              return Author(snapshot: ["__typename": "Organization", "avatarUrl": avatarUrl, "login": login])
+              return Author(unsafeResultMap: ["__typename": "Organization", "avatarUrl": avatarUrl, "login": login])
             }
 
             public static func makeUser(avatarUrl: String, login: String) -> Author {
-              return Author(snapshot: ["__typename": "User", "avatarUrl": avatarUrl, "login": login])
+              return Author(unsafeResultMap: ["__typename": "User", "avatarUrl": avatarUrl, "login": login])
             }
 
             public static func makeBot(avatarUrl: String, login: String) -> Author {
-              return Author(snapshot: ["__typename": "Bot", "avatarUrl": avatarUrl, "login": login])
+              return Author(unsafeResultMap: ["__typename": "Bot", "avatarUrl": avatarUrl, "login": login])
             }
 
             public var __typename: String {
               get {
-                return snapshot["__typename"]! as! String
+                return resultMap["__typename"]! as! String
               }
               set {
-                snapshot.updateValue(newValue, forKey: "__typename")
+                resultMap.updateValue(newValue, forKey: "__typename")
               }
             }
 
             /// A URL pointing to the actor's public avatar.
             public var avatarUrl: String {
               get {
-                return snapshot["avatarUrl"]! as! String
+                return resultMap["avatarUrl"]! as! String
               }
               set {
-                snapshot.updateValue(newValue, forKey: "avatarUrl")
+                resultMap.updateValue(newValue, forKey: "avatarUrl")
               }
             }
 
             /// The username of the actor.
             public var login: String {
               get {
-                return snapshot["login"]! as! String
+                return resultMap["login"]! as! String
               }
               set {
-                snapshot.updateValue(newValue, forKey: "login")
+                resultMap.updateValue(newValue, forKey: "login")
               }
             }
           }


### PR DESCRIPTION
# Agenda
add output files path to sample project script. it is needed for executing a script before compile sources.
because Xcode10 new build system is Parallelize build.

# Detail
another library fixed this issue like this.
https://github.com/mac-cain13/R.swift/issues/456

and this is apple document.(but this is old)

> Tasks that contain inputs that are the outputs of other tasks or outputs that are the inputs of other tasks are ordered tasks. These are tasks that are executed in the order determined by their inputs and outputs.

https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/XcodeBuildSystem/200-Build_Phases/bs_build_phases.html#//apple_ref/doc/uid/TP40002690-BBCCFEDJ

maybe this is related to these issues.
https://github.com/apollographql/apollo-ios/issues/423
https://github.com/apollographql/apollo-ios/issues/383