### PR TITLE
Fixes #435 Invoking Query.Data(jsonObject:) fails for queries with params …

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */; };
 		9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */; };
 		E86D8E05214B32FD0028EFE1 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86D8E03214B32DA0028EFE1 /* JSONTests.swift */; };
+		F16D083C21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -333,6 +334,7 @@
 		9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadFieldValueTests.swift; sourceTree = "<group>"; };
 		9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseQueryResponseTests.swift; sourceTree = "<group>"; };
 		E86D8E03214B32DA0028EFE1 /* JSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
+		F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryFromJSONBuildingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -560,6 +562,7 @@
 				9F295E301E27534800A24949 /* NormalizeQueryResults.swift */,
 				9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */,
 				9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */,
+				F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */,
 				9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */,
 				9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */,
 			);
@@ -1128,6 +1131,7 @@
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,
 				E86D8E05214B32FD0028EFE1 /* JSONTests.swift in Sources */,
 				9F8622FA1EC2117C00C38162 /* FragmentConstructionAndConversionTests.swift in Sources */,
+				F16D083C21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift in Sources */,
 				9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */,
 				9F295E311E27534800A24949 /* NormalizeQueryResults.swift in Sources */,
 				9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */,

--- a/Sources/Apollo/GraphQLSelectionSet.swift
+++ b/Sources/Apollo/GraphQLSelectionSet.swift
@@ -8,12 +8,12 @@ public protocol GraphQLSelectionSet {
 }
 
 public extension GraphQLSelectionSet {
-  init(jsonObject: JSONObject) throws {
+  init(jsonObject: JSONObject, variables: GraphQLMap? = nil) throws {
     let executor = GraphQLExecutor { object, info in
       .result(.success(object[info.responseKeyForField]))
     }
     executor.shouldComputeCachePath = false
-    self = try executor.execute(selections: Self.selections, on: jsonObject, accumulator: GraphQLSelectionSetMapper<Self>()).await()
+    self = try executor.execute(selections: Self.selections, on: jsonObject, variables: variables, accumulator: GraphQLSelectionSetMapper<Self>()).await()
   }
   
   var jsonObject: JSONObject {

--- a/Tests/ApolloTests/QueryFromJSONBuildingTests.swift
+++ b/Tests/ApolloTests/QueryFromJSONBuildingTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Apollo
+import ApolloTestSupport
+import StarWarsAPI
+
+class QueryFromJSONBuildingTests: XCTestCase {
+  func testHeroDetailsWithFragmentQueryHuman() throws {
+    let jsonObject = [
+        "hero": ["__typename": "Human", "name": "Luke Skywalker", "height": 1.72]
+    ]
+
+    let data = try HeroDetailsWithFragmentQuery.Data(jsonObject: jsonObject)
+
+    guard let human = data.hero?.fragments.heroDetails.asHuman else {
+      XCTFail("Wrong type")
+      return
+    }
+    
+    XCTAssertEqual(human.height, 1.72)
+  }
+
+  func testConditionalInclusionQuery() throws {
+    let jsonObject = [
+      "hero": [
+        "__typename": "Hero",
+        "name": "R2-D2"
+      ]
+    ]
+
+    let nameData = try HeroNameConditionalInclusionQuery.Data(jsonObject: jsonObject, variables: ["includeName" : true])
+    XCTAssertEqual(nameData.hero?.name, "R2-D2")
+
+    let noNameData = try HeroNameConditionalInclusionQuery.Data(jsonObject: jsonObject, variables: ["includeName" : false])
+    XCTAssertNil(noNameData.hero?.name)
+  }
+
+  func testConditionalInclusionQueryWithoutVariables() throws {
+    let jsonObject = [
+      "hero": [
+        "__typename": "Hero",
+        "name": "R2-D2"
+      ]
+    ]
+
+    XCTAssertThrowsError(try HeroNameConditionalInclusionQuery.Data(jsonObject: jsonObject)) { error in
+      if case let error as GraphQLResultError = error {
+        XCTAssertEqual(error.path, ["hero"])
+      } else {
+        XCTFail("Unexpected error: \(error)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/apollographql/apollo-ios/issues/435

Adds an optional 'variables' parameter to pass to the executor