### PR TITLE
Use EnumeratedSequence.Iterator

### DIFF
--- a/Sources/Apollo/Collections.swift
+++ b/Sources/Apollo/Collections.swift
@@ -58,7 +58,7 @@ extension GroupedSequence: Sequence {
 struct GroupedSequenceIterator<Key: Equatable, Value>: IteratorProtocol {
   private var base: GroupedSequence<Key, Value>
   
-  private var keyIterator: EnumeratedIterator<IndexingIterator<Array<Key>>>
+  private var keyIterator: EnumeratedSequence<[Key]>.Iterator
   
   init(base: GroupedSequence<Key, Value>) {
     self.base = base


### PR DESCRIPTION
Use `EnumeratedSequence.Iterator` instead of `EnumeratedIterator<IndexingIterator>`, which causes build failures in Xcode 10.2 beta 1.

Fixes #444 

NOTE: Tests pass in both Xcode 10.1 and Xcode 10.2 beta 1.