### PR TITLE
Update ApolloSQLite project to Swift 4.0

### DIFF
--- a/ApolloSQLite.xcodeproj/project.pbxproj
+++ b/ApolloSQLite.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -612,7 +612,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";


### PR DESCRIPTION
I noticed that there was an update that enables support for Xcode 10.2 (with the Swift 5 compiler) but this did not work for Carthage because the project itself was still using Swift 3.0.

This PR updates the project to use Swift 4.0