### PR TITLE
Send operationName for GraphQLOperations

### DIFF
--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -6,14 +6,15 @@ public enum GraphQLOperationType {
 
 public protocol GraphQLOperation: class {
   var operationType: GraphQLOperationType { get }
-  
+
   var operationDefinition: String { get }
   var operationIdentifier: String? { get }
-  
+  var operationName: String? { get }
+
   var queryDocument: String { get }
-  
+
   var variables: GraphQLMap? { get }
-  
+
   associatedtype Data: GraphQLSelectionSet
 }
 
@@ -23,6 +24,10 @@ public extension GraphQLOperation {
   }
 
   var operationIdentifier: String? {
+    return nil
+  }
+
+  var operationName: String? {
     return nil
   }
 

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -121,12 +121,17 @@ public class HTTPNetworkTransport: NetworkTransport {
   private let sendOperationIdentifiers: Bool
 
   private func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
+    var body: GraphQLMap = ["variables": operation.variables, "operationName": operation.operationName]
+
     if sendOperationIdentifiers {
       guard let operationIdentifier = operation.operationIdentifier else {
         preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
       }
-      return ["id": operationIdentifier, "variables": operation.variables]
+      body["id"] = operationIdentifier
+    } else {
+      body["query"] = operation.queryDocument
     }
-    return ["query": operation.queryDocument, "variables": operation.variables]
+
+    return body
   }
 }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -249,13 +249,18 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
   }
   
   private func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
+    var body: GraphQLMap = ["variables": operation.variables, "operationName": operation.operationName]
+
     if sendOperationIdentifiers {
       guard let operationIdentifier = operation.operationIdentifier else {
         preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
       }
-      return ["id": operationIdentifier, "variables": operation.variables]
+      body["id"] = operationIdentifier
+    } else {
+      body["query"] = operation.queryDocument
     }
-    return ["query": operation.queryDocument, "variables": operation.variables]
+
+    return body
   }
   
   public func unsubscribe(_ subscriptionId: String) {


### PR DESCRIPTION
This PR adds `operationName` to the request payload. operationName is not really required per the graphql spec unless you send multiple operations in the same request. But it is _very_ useful for have when mapping up performance metrics and such so I'd like to have Apollo always send it. 

This PR indirectly relies on [changes](https://github.com/js/apollo-tooling/commit/637907e049c1b648939bd3cebc52f73cec214f85) to the apollo codegen, but I'm currently blocked there due to some silly npm tooling issues before I can verify that the `apollo codegen:generate` part actually works as intended. 

Current behaviour (not sending operationName) will be kept until the generator is updated.

The changes suggested in issue #294 only works if you name your operation definition (? what are these actually called) the same as the graphql operation you're calling, eg this is valid graphQL:
```
query nudgeUser($id: ID!) {
  pingUser(id: $id) { ... }
}
```
but would give an `operationName` of "nudgeUser" instead of the actual operation name "pingUser"



