### PR TITLE
Disable bitcode in debug builds for physical iOS devices

### DIFF
--- a/Configuration/Shared/Workspace-Universal-Framework.xcconfig
+++ b/Configuration/Shared/Workspace-Universal-Framework.xcconfig
@@ -31,4 +31,5 @@ ENABLE_BITCODE[sdk=appletvos*] = YES
 // Source: https://github.com/realm/realm-cocoa/pull/2567
 BITCODE_GENERATION_MODE[sdk=watchos*] = bitcode
 BITCODE_GENERATION_MODE[sdk=iphoneos*] = bitcode
+BITCODE_GENERATION_MODE[sdk=iphoneos*][config=Debug] = marker
 BITCODE_GENERATION_MODE[sdk=appletvos*] = bitcode


### PR DESCRIPTION
A PR for the suggested change in issue #498 

The change in the configuration file is only for debug builds on iOS devices - tvOS and watchOS are not touched.