### PR TITLE
Move response parsing to DispatchQueue

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -152,21 +152,18 @@ public class ApolloClient {
         return
       }
       
-      handlerQueue.async {
-        
-        firstly {
-          try response.parseResult(cacheKeyForObject: self.cacheKeyForObject)
-          }.andThen { (result, records) in
-            notifyResultHandler(result: result, error: nil)
+      firstly(on: self.queue) {
+        try response.parseResult(cacheKeyForObject: self.cacheKeyForObject)
+      }.andThen { (result, records) in
+        notifyResultHandler(result: result, error: nil)
             
-            if let records = records {
-              self.store.publish(records: records, context: context).catch { error in
-                preconditionFailure(String(describing: error))
-              }
-            }
-          }.catch { error in
-            notifyResultHandler(result: nil, error: error)
+        if let records = records {
+          self.store.publish(records: records, context: context).catch { error in
+            preconditionFailure(String(describing: error))
+          }
         }
+      }.catch { error in
+        notifyResultHandler(result: nil, error: error)
       }
     }
   }

--- a/Sources/Apollo/Promise.swift
+++ b/Sources/Apollo/Promise.swift
@@ -28,6 +28,18 @@ public func firstly<T>(_ body: () throws -> Promise<T>) -> Promise<T> {
   }
 }
 
+public func firstly<T>(on queue: DispatchQueue, _ body: @escaping () throws -> Promise<T>) -> Promise<T> {
+  return Promise<T> { fulfill, reject in
+    queue.async {
+      do {
+        try body().andThen(fulfill).catch(reject)
+      } catch {
+        reject(error)
+      }
+    }
+  }
+}
+
 public final class Promise<Value> {
   private let lock = Mutex()
   private var state: State<Value>

--- a/Tests/ApolloTests/PromiseTests.swift
+++ b/Tests/ApolloTests/PromiseTests.swift
@@ -249,4 +249,100 @@ class PromiseTests: XCTestCase {
     
     waitForExpectations(timeout: 1)
   }
+  
+  func testFirstlyFulfills() {
+    let promise = Promise(fulfilled: "test")
+    
+    let expectation = self.expectation(description: "firstly andThen handler invoked")
+    
+    firstly {
+      promise
+    }.andThen { value in
+      XCTAssertEqual(value, "test")
+      
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testFirstlyRejects() {
+    let promise = Promise<Void>(rejected: TestError())
+    
+    let expectation = self.expectation(description: "firstly catch handler invoked")
+    
+    firstly {
+      promise
+    }.catch { error in
+      XCTAssert(error is TestError)
+      
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testFirstlyThrows() {
+    let expectation = self.expectation(description: "firstly catch handler invoked")
+    
+    firstly { () throws -> Promise<Void> in
+      throw TestError()
+    }.catch { error in
+      XCTAssert(error is TestError)
+      
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testFirstlyOnFulfills() {
+    let queue = DispatchQueue(label: "test queue")
+    let promise = Promise(fulfilled: "test")
+    
+    let expectation = self.expectation(description: "firstly(on:) andThen handler invoked")
+    
+    firstly(on: queue) { () throws -> Promise<String> in
+      return promise
+    }.andThen { value in
+      XCTAssertEqual(value, "test")
+      
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testFirstlyOnRejects() {
+    let queue = DispatchQueue(label: "test queue")
+    let promise = Promise<Void>(rejected: TestError())
+    
+    let expectation = self.expectation(description: "firstly(on:) catch handler invoked")
+    
+    firstly(on: queue) { () throws -> Promise<Void> in
+      return promise
+    }.catch { error in
+      XCTAssert(error is TestError)
+      
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testFirstlyOnThrows() {
+    let queue = DispatchQueue(label: "test queue")
+    
+    let expectation = self.expectation(description: "firstly(on:) catch handler invoked")
+    
+    firstly(on: queue) { () throws -> Promise<Void> in
+      throw TestError()
+    }.catch { error in
+      XCTAssert(error is TestError)
+      
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 1)
+  }
 }


### PR DESCRIPTION
This moves the response parsing onto a DispatchQueue. The queue was already there and looks like it was intended for this purpose. The queue stopped being used in this commit: https://github.com/apollographql/apollo-ios/commit/56f1674d065396ea978c2ec7b5d552ea9c03365a#diff-ceeef11df562c93c0080f63181a19188