### PR TITLE
use firstIndex(where:)

### DIFF
--- a/Sources/Apollo/Collections.swift
+++ b/Sources/Apollo/Collections.swift
@@ -24,7 +24,7 @@ struct GroupedSequence<Key: Equatable, Value> {
   fileprivate var groupsForKeys: [[Value]] = []
   
   mutating func append(value: Value, forKey key: Key) -> (Int, Int) {
-    if let index = keys.index(where: { $0 == key }) {
+    if let index = keys.firstIndex(where: { $0 == key }) {
       groupsForKeys[index].append(value)
       return (index, groupsForKeys[index].endIndex - 1)
     } else {


### PR DESCRIPTION
- use `firstIndex(where:)` , because `index(where:)` will be deprecated in Swift 4.2 before being removed in Swift 5.

> In addition, the index(of:) and index(where:) methods will be renamed to firstIndex(of:) and firstIndex(where:), respectively. This change is beneficial for two reasons. First, it groups the first... and last... methods into two symmetric analogous groups, and second, it leaves the index... methods as solely responsible for index manipulation.

> The name changes to index(of:) and index(where:) are easily migratable, and will be deprecated in Swift 4.2 before being removed in Swift 5.

> ref: https://github.com/apple/swift-evolution/blob/master/proposals/0204-add-last-methods.md#detailed-design

Xcode10.2 Swift Conversion | After converting to swift5, Generating preview |
:-: | :-: | 
<img src=https://user-images.githubusercontent.com/6649643/56259581-80367600-610e-11e9-9685-0610a53f4502.png width=640/> | <img src=https://user-images.githubusercontent.com/6649643/56260346-dc4ec980-6111-11e9-980e-d57c13d7504b.png width=640/> |
