### PR TITLE
make `-[ApolloStore clearCache]` public.

### DIFF
--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -44,7 +44,7 @@ public final class ApolloStore {
     }
   }
 
-  func clearCache() -> Promise<Void> {
+  public func clearCache() -> Promise<Void> {
     return Promise<Void> { fulfill, reject in
       queue.async(flags: .barrier) {
         self.cacheLock.withWriteLock {


### PR DESCRIPTION
make `-[ApolloStore clearCache]` public. At the moment there is no way to clear cache unless you have access to `ApolloClient`. Having `clearCache()` on `ApolloClient` is not exactly correct as multiple `ApolloClient` can share same cache.

Not in this PR (as it is more invasive https://github.com/apollographql/apollo-ios/pull/518) but IMO make more sense:
`ApolloClient.clearCache()` should be deprecated and `ApolloStore.clearCache()` made public.
Old code would need updating from `apolloClient.clearCache()` to `apolloClient.store.clearCache()` so developer would realise that he clearing cache of store not the client and store might be shared.