### PR TITLE
make `-[ApolloStore clearCache]` public

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -68,6 +68,7 @@ public class ApolloClient {
   /// Clears apollo cache
   ///
   /// - Returns: Promise
+  @available(*, deprecated, message: "No longer supported. User .store.clearCache() instead.")
   public func clearCache() -> Promise<Void> {
     return store.clearCache()
   }

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -68,7 +68,6 @@ public class ApolloClient {
   /// Clears apollo cache
   ///
   /// - Returns: Promise
-  @available(*, deprecated, message: "No longer supported. User .store.clearCache() instead.")
   public func clearCache() -> Promise<Void> {
     return store.clearCache()
   }

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -44,7 +44,7 @@ public final class ApolloStore {
     }
   }
 
-  func clearCache() -> Promise<Void> {
+  public func clearCache() -> Promise<Void> {
     return Promise<Void> { fulfill, reject in
       queue.async(flags: .barrier) {
         self.cacheLock.withWriteLock {


### PR DESCRIPTION
followup to https://github.com/apollographql/apollo-ios/pull/517

make `-[ApolloStore clearCache]` public. 

At the moment there is no way to clear cache unless you have access to `ApolloClient`. Having `clearCache()` on `ApolloClient` is not exactly correct as multiple `ApolloClient` can share same cache.