### PR TITLE
Response parsing now done on the provided handlerQueue

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -150,18 +150,21 @@ public class ApolloClient {
         return
       }
       
-      firstly {
-        try response.parseResult(cacheKeyForObject: self.cacheKeyForObject)
-      }.andThen { (result, records) in
-        notifyResultHandler(result: result, error: nil)
+      handlerQueue.async {
         
-        if let records = records {
-          self.store.publish(records: records, context: context).catch { error in
-            preconditionFailure(String(describing: error))
-          }
+        firstly {
+          try response.parseResult(cacheKeyForObject: self.cacheKeyForObject)
+          }.andThen { (result, records) in
+            notifyResultHandler(result: result, error: nil)
+            
+            if let records = records {
+              self.store.publish(records: records, context: context).catch { error in
+                preconditionFailure(String(describing: error))
+              }
+            }
+          }.catch { error in
+            notifyResultHandler(result: nil, error: error)
         }
-      }.catch { error in
-        notifyResultHandler(result: nil, error: error)
       }
     }
   }


### PR DESCRIPTION
If the cache policy is `.fetchIgnoringCacheData`, the send method is executed on the caller queue/thread. ( see `_fetch` method) .   
It also means that the response parsing is done on the caller queue/thread which can be the main queue (and so, blocking it).   

This change executes the parsing on the provided handler queue every time.
