### PR TITLE
use lock in InMemoryNormalizedCache to avoid race conditions

### DIFF
--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
-  private let recordsLock = NSLock()
+  private let recordsLock = NSRecursiveLock()
 
   public init(records: RecordSet = RecordSet()) {
     self.records = records

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -383,4 +383,95 @@ class FetchQueryTests: XCTestCase {
       waitForExpectations(timeout: 5, handler: nil)
     }
   }
+  
+  func testThreadedCache() throws {
+    let cache = InMemoryNormalizedCache()
+    
+    let networkTransport1 = MockNetworkTransport(body: [
+      "data": [
+        "hero": [
+          "id": "1000",
+          "name": "Luke Skywalker",
+          "__typename": "Human",
+          "friends": [
+            ["__typename": "Human", "name": "Leia Organa", "id": "1003"],
+            ["__typename": "Human", "name": "Han Solo", "id": "1002"],
+          ]
+        ]
+      ]
+    ])
+    
+    let networkTransport2 = MockNetworkTransport(body: [
+      "data": [
+        "hero": [
+          "id": "1002",
+          "name": "Han Solo",
+          "__typename": "Human",
+          "friends": [
+            ["__typename": "Human", "name": "Leia Organa", "id": "1003"],
+            ["__typename": "Human", "name": "Luke Skywalker", "id": "1000"],
+          ]
+        ]
+      ]
+    ])
+    
+    let store = ApolloStore(cache: cache)
+    let store2 = ApolloStore(cache: cache)
+    
+    let client1 = ApolloClient(networkTransport: networkTransport1, store: store)
+    let client2 = ApolloClient(networkTransport: networkTransport2, store: store2)
+    
+    let group = DispatchGroup()
+    
+    let watcherQueue = DispatchQueue(label: "test watcher queue")
+    var watchers = [GraphQLQueryWatcher<HeroAndFriendsNamesWithIDsQuery>]()
+    
+    for _ in 0...1000 {
+      
+      group.enter()
+      DispatchQueue.global().async {
+        let watcher =
+          client1.watch(
+          query: HeroAndFriendsNamesWithIDsQuery(), cachePolicy: .returnCacheDataAndFetch) { result in
+            if result.value?.source == .some(.server) {
+              group.leave()
+            }
+        }
+        
+        watcherQueue.sync {
+          watchers.append(watcher)
+        }
+      }
+      
+      group.enter()
+      DispatchQueue.global().async {
+        let watcher =
+          client2.watch(
+          query: HeroAndFriendsNamesWithIDsQuery(), cachePolicy: .returnCacheDataAndFetch) { result in
+            if result.value?.source == .some(.server) {
+              group.leave()
+            }
+        }
+        
+        watcherQueue.sync {
+          watchers.append(watcher)
+        }
+      }
+      
+      group.enter()
+      DispatchQueue.global().async {
+        _ = client1.clearCache() { _ in
+          group.leave()
+        }
+      }
+      
+    }
+    
+    let expectation = self.expectation(description: "Fetching query")
+    group.notify(queue: .main) {
+      expectation.fulfill()
+    }
+    self.wait(for: [expectation], timeout: 10)
+    
+  }
 }


### PR DESCRIPTION
we see some crashes trying to access `RecordSet` while doing `.clear()` on `InMemoryNormalizedCache`

```
* thread #35, queue = 'com.apollographql.DataLoader', stop reason = EXC_BAD_ACCESS (code=1, address=0x10)
  frame #0: 0x00000001c71bf530 libobjc.A.dylib`objc_msgSend + 16
  frame #1: 0x00000001f60ee364 libswiftCore.dylib`Swift.Dictionary._Variant.subscript.getter : (A) -> Swift.Optional<B> + 148
  frame #2: 0x0000000106044da8 Apollo`RecordSet.subscript.getter(key="User_12", self=Apollo.RecordSet @ 0x00000001701b20d8) at RecordSet.swift:24:19
  frame #3: 0x000000010602fc64 Apollo`closure #1 in InMemoryNormalizedCache.loadRecords($0="User_12", self=0x0000000282b1ef60) at InMemoryNormalizedCache.swift:9:42
  frame #4: 0x000000010602fce8 Apollo`thunk for @callee_guaranteed (@guaranteed String) -> (@owned Record?, @error @owned Error) at <compiler-generated>:0
  frame #5: 0x000000010602fdcc Apollo`partial apply for thunk for @callee_guaranteed (@guaranteed String) -> (@owned Record?, @error @owned Error) at <compiler-generated>:0
  frame #6: 0x00000001f6074ef4 libswiftCore.dylib`(extension in Swift):Swift.Collection.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1> + 748
  frame #7: 0x000000010602fb1c Apollo`InMemoryNormalizedCache.loadRecords(keys=1 value, self=0x0000000282b1ef60) at InMemoryNormalizedCache.swift:9:24
  frame #8: 0x0000000106030228 Apollo`protocol witness for NormalizedCache.loadRecords(forKeys:) in conformance InMemoryNormalizedCache at <compiler-generated>:0
  frame #9: 0x0000000106001c20 Apollo`partial apply at <compiler-generated>:0
  frame #10: 0x00000001060099c4 Apollo`closure #1 in DataLoader.dispatch(self=0x00000002831abd00) at DataLoader.swift:53:12
  frame #11: 0x0000000105ff0d50 Apollo`thunk for @escaping @callee_guaranteed () -> () at <compiler-generated>:0
  frame #12: 0x00000001084176f0 libdispatch.dylib`_dispatch_call_block_and_release + 24
  frame #13: 0x0000000108418c74 libdispatch.dylib`_dispatch_client_callout + 16
  frame #14: 0x0000000108420bf4 libdispatch.dylib`_dispatch_lane_serial_drain + 712
  frame #15: 0x00000001084218b4 libdispatch.dylib`_dispatch_lane_invoke + 456
  frame #16: 0x000000010842b77c libdispatch.dylib`_dispatch_workloop_worker_thread + 1148
  frame #17: 0x00000001c7bed114 libsystem_pthread.dylib`_pthread_wqthread + 304
  frame #18: 0x00000001c7befcd4 libsystem_pthread.dylib`start_wqthread + 4
```

sentry.io log
<img width="839" alt="Screenshot 2019-07-29 at 13 18 32" src="https://user-images.githubusercontent.com/1027187/62047891-70e1c100-b203-11e9-84c4-d37faee466e9.png">


This PR wraps access to `InMemoryNormalizedCache.records` in internal queue to avoid race conditions.