### PR TITLE
Update SQLiteNormalizedCache for Swift 5

### DIFF
--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -24,7 +24,7 @@ public final class SQLiteNormalizedCache: NormalizedCache {
     return Promise {
       let records = try selectRecords(forKeys: keys)
       let recordsOrNil: [Record?] = keys.map { key in
-        if let recordIndex = records.index(where: { $0.key == key }) {
+        if let recordIndex = records.firstIndex(where: { $0.key == key }) {
           return records[recordIndex]
         }
         return nil


### PR DESCRIPTION
I just realized everything in `master` works fine with Swift 5 except `SQLiteNormalizedCache`.
Let's replace deprecated `index(of:)` with `firstIndex(of:)` so that Xcode 10.2 doesn't have to offer an upgrade any more.