### PR TITLE
Fix for scripts being included in app bundle when using cocoapods

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'Sources/Apollo/*.swift'
-    ss.resources = ['scripts/check-and-run-apollo-cli.sh', 'scripts/check-and-run-apollo-codegen.sh']
+    ss.preserve_paths = ['scripts/check-and-run-apollo-cli.sh', 'scripts/check-and-run-apollo-codegen.sh']
   end
 
   # Apollo provides exactly one persistent cache out-of-the-box, as a reasonable default choice for


### PR DESCRIPTION
Using the `resources` field causes the scripts to be included in the app bundle. Instead `preserve_paths` makes sure the files aren't deleted by cocoapods, but doesn't include them in the app bundle. https://guides.cocoapods.org/syntax/podspec.html#preserve_paths