### PR TITLE
Fix Codegen fail for MacPorts users

### DIFF
--- a/scripts/check-and-run-apollo-cli.sh
+++ b/scripts/check-and-run-apollo-cli.sh
@@ -17,6 +17,10 @@ if [[ -z "$CONFIGURATION" ]]; then
   exit 1
 fi
 
+if [[ -x /opt/local/bin/port ]]; then
+    PATH="$PATH:/opt/local/bin"
+fi
+
 use_correct_node_via_nvm() {
   nvm version $REQUIRED_NODE_VERSION > /dev/null
   if [[ $? -eq 0 ]]; then

--- a/scripts/check-and-run-apollo-cli.sh
+++ b/scripts/check-and-run-apollo-cli.sh
@@ -17,6 +17,7 @@ if [[ -z "$CONFIGURATION" ]]; then
   exit 1
 fi
 
+# Add MacPorts default bin path if the user has `port` command.
 if [[ -x /opt/local/bin/port ]]; then
     PATH="$PATH:/opt/local/bin"
 fi


### PR DESCRIPTION
## Problem

I installed `node` and `npm` from MacPorts and don't use Homebrew.
When I build my project, it says `node` is not found.

```
... /Pods/Apollo/scripts/check-and-run-apollo-cli.sh: line 45: node: command not found
error: Apollo CLI requires Node 8 or higher to be installed.
```

But actually `node` and `npm` are installed under `/opt/local/bin`, that is default MacPorts' executable path.

## Cause

Xcode doesn't consider MacPorts default path `/opt/local/bin` and doesn't respect .bashrc.

## Solution

Added default MacPorts bin path to codegen script.