### PR TITLE
Header configuration + Fix GET with null parameter

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -9,10 +9,12 @@
 /* Begin PBXBuildFile section */
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */; };
+		9B95EDC022CAA0B000702BB2 /* GETTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */; };
 		9BDE43D122C6655300FD7C7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43D022C6655200FD7C7F /* Cancellable.swift */; };
 		9BDE43DD22C6705300FD7C7F /* GraphQLHTTPResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */; };
 		9BDE43DF22C6708600FD7C7F /* GraphQLHTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */; };
 		9BF1A94F22CA5784005292C2 /* HTTPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */; };
+		9BF1A95122CA6E71005292C2 /* GraphQLGETTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		9F0CA4461EE7F9E90032DD39 /* ApolloTestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F10A51E1EC1BA0F0045E62B /* MockNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */; };
@@ -249,10 +251,12 @@
 		90690D2322433C5900FC2E54 /* Apollo-Target-CacheDependentTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CacheDependentTests.xcconfig"; sourceTree = "<group>"; };
 		90690D2422433C8000FC2E54 /* Apollo-Target-PerformanceTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-PerformanceTests.xcconfig"; sourceTree = "<group>"; };
 		90690D2522433CAF00FC2E54 /* Apollo-Target-TestSupport.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-TestSupport.xcconfig"; sourceTree = "<group>"; };
+		9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GETTransformerTests.swift; sourceTree = "<group>"; };
 		9BDE43D022C6655200FD7C7F /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponseError.swift; sourceTree = "<group>"; };
 		9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPRequestError.swift; sourceTree = "<group>"; };
 		9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTransportTests.swift; sourceTree = "<group>"; };
+		9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLGETTransformer.swift; sourceTree = "<group>"; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
 		9F19D8431EED568200C57247 /* ResultOrPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromise.swift; sourceTree = "<group>"; };
 		9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromiseTests.swift; sourceTree = "<group>"; };
@@ -584,6 +588,7 @@
 				9FC9A9C71E2EFE6E0023C4D5 /* CacheKeyForFieldTests.swift */,
 				9FADC8531E6B86D900C677E6 /* DataLoaderTests.swift */,
 				9F8622F91EC2117C00C38162 /* FragmentConstructionAndConversionTests.swift */,
+				9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */,
 				9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */,
 				9FC750551D2A532D00458D91 /* Info.plist */,
 				9FF90A6A1DDDEB420034C3B6 /* InputValueEncodingTests.swift */,
@@ -621,6 +626,7 @@
 				9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */,
 				9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
+				9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -1118,6 +1124,7 @@
 				9F578D901D8D2CB300C0EA36 /* Utilities.swift in Sources */,
 				9F7BA89922927A3700999B3B /* ResponsePath.swift in Sources */,
 				9FC9A9BD1E2C271C0023C4D5 /* RecordSet.swift in Sources */,
+				9BF1A95122CA6E71005292C2 /* GraphQLGETTransformer.swift in Sources */,
 				9FEC15B91E6965E300D461B4 /* Result.swift in Sources */,
 				9FADC84F1E6B865E00C677E6 /* DataLoader.swift in Sources */,
 				9FF90A611DDDEB100034C3B6 /* GraphQLResponse.swift in Sources */,
@@ -1142,6 +1149,7 @@
 				9F91CF8F1F6C0DB2008DD0BE /* MutatingResultsTests.swift in Sources */,
 				9F19D8461EED8D3B00C57247 /* ResultOrPromiseTests.swift in Sources */,
 				9F533AB31E6C4A4200CBE097 /* BatchedLoadTests.swift in Sources */,
+				9B95EDC022CAA0B000702BB2 /* GETTransformerTests.swift in Sources */,
 				9FF90A6F1DDDEB420034C3B6 /* InputValueEncodingTests.swift in Sources */,
 				9FE1C6E71E634C8D00C02284 /* PromiseTests.swift in Sources */,
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		9BDE43D122C6655300FD7C7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43D022C6655200FD7C7F /* Cancellable.swift */; };
 		9BDE43DD22C6705300FD7C7F /* GraphQLHTTPResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */; };
 		9BDE43DF22C6708600FD7C7F /* GraphQLHTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */; };
+		9BF1A94F22CA5784005292C2 /* HTTPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		9F0CA4461EE7F9E90032DD39 /* ApolloTestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F10A51E1EC1BA0F0045E62B /* MockNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */; };
@@ -251,6 +252,7 @@
 		9BDE43D022C6655200FD7C7F /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponseError.swift; sourceTree = "<group>"; };
 		9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPRequestError.swift; sourceTree = "<group>"; };
+		9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTransportTests.swift; sourceTree = "<group>"; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
 		9F19D8431EED568200C57247 /* ResultOrPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromise.swift; sourceTree = "<group>"; };
 		9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultOrPromiseTests.swift; sourceTree = "<group>"; };
@@ -582,6 +584,7 @@
 				9FC9A9C71E2EFE6E0023C4D5 /* CacheKeyForFieldTests.swift */,
 				9FADC8531E6B86D900C677E6 /* DataLoaderTests.swift */,
 				9F8622F91EC2117C00C38162 /* FragmentConstructionAndConversionTests.swift */,
+				9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */,
 				9FC750551D2A532D00458D91 /* Info.plist */,
 				9FF90A6A1DDDEB420034C3B6 /* InputValueEncodingTests.swift */,
 				E86D8E03214B32DA0028EFE1 /* JSONTests.swift */,
@@ -1148,6 +1151,7 @@
 				9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */,
 				9F295E311E27534800A24949 /* NormalizeQueryResults.swift in Sources */,
 				9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */,
+				9BF1A94F22CA5784005292C2 /* HTTPTransportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -1,0 +1,63 @@
+//
+//  GraphQLGETTransformer.swift
+//  Apollo
+//
+//  Created by Ellen Shapiro on 7/1/19.
+//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+
+struct GraphQLGETTransformer {
+  
+  let body: GraphQLMap
+  let url: URL
+  
+  private let variablesKey = "variables"
+  private let queryKey = "query"
+  
+  /// A helper for transforming a GraphQLMap that can be sent with a `POST` request into a URL with query parameters for a `GET` request.
+  ///
+  /// - Parameters:
+  ///   - body: The GraphQLMap to transform from the body of a `POST` request
+  ///   - url: The base url to append the query to.
+  init(body: GraphQLMap,
+       url: URL) {
+    self.body = body
+    self.url = url
+  }
+  
+  /// Creates the get URL.
+  ///
+  /// - Returns: [optional] The created get URL or nil if the provided information couldn't be used to access the appropriate parameters.
+  func createGetURL() -> URL? {
+    guard var components = URLComponents(string: self.url.absoluteString) else {
+      return nil
+    }
+    
+    guard let query = self.body.jsonObject[self.queryKey] as? String else {
+      return nil
+    }
+    
+    var queryItems = components.queryItems ?? [URLQueryItem]()
+
+    queryItems.append(URLQueryItem(name: self.queryKey, value: query))
+    components.queryItems = queryItems
+    
+    guard let variables = self.body.jsonObject[self.variablesKey] as? [String: AnyHashable] else {
+      return components.url
+    }
+    
+    guard
+      let serializedData = try? JSONSerialization.data(withJSONObject: variables),
+      let jsonString = String(bytes: serializedData, encoding: .utf8) else {
+        return components.url
+    }
+    
+    queryItems.append(URLQueryItem(name: self.variablesKey, value: jsonString))
+    components.queryItems = queryItems
+    
+    return components.url
+  }
+}
+

--- a/Sources/Apollo/GraphQLHTTPRequestError.swift
+++ b/Sources/Apollo/GraphQLHTTPRequestError.swift
@@ -7,7 +7,7 @@ public enum GraphQLHTTPRequestError: Error, LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .cancelledByDeveloper:
-      return "The request was cancelled by the developer using the HTTPNetworkTransportDelegate."
+      return "The request was cancelled by the developer using the HTTPNetworkTransportPreflightDelegate."
     case .serializedBodyMessageError:
       return "JSONSerialization error: Error while serializing request's body"
     case .serializedQueryParamsMessageError:

--- a/Sources/Apollo/GraphQLHTTPRequestError.swift
+++ b/Sources/Apollo/GraphQLHTTPRequestError.swift
@@ -7,7 +7,7 @@ public enum GraphQLHTTPRequestError: Error, LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .cancelledByDeveloper:
-      return "The request was cancelled by the developer using the HTTPNetworkTransportPreflightDelegate."
+      return "The request was cancelled by the HTTPNetworkTransportPreflightDelegate."
     case .serializedBodyMessageError:
       return "JSONSerialization error: Error while serializing request's body"
     case .serializedQueryParamsMessageError:

--- a/Sources/Apollo/GraphQLHTTPRequestError.swift
+++ b/Sources/Apollo/GraphQLHTTPRequestError.swift
@@ -1,10 +1,13 @@
 /// An error which has occurred during the serialization of a request.
 public enum GraphQLHTTPRequestError: Error, LocalizedError {
+  case cancelledByDeveloper
   case serializedBodyMessageError
   case serializedQueryParamsMessageError
   
   public var errorDescription: String? {
     switch self {
+    case .cancelledByDeveloper:
+      return "The request was cancelled by the developer using the HTTPNetworkTransportDelegate."
     case .serializedBodyMessageError:
       return "JSONSerialization error: Error while serializing request's body"
     case .serializedQueryParamsMessageError:

--- a/Sources/Apollo/GraphQLHTTPRequestError.swift
+++ b/Sources/Apollo/GraphQLHTTPRequestError.swift
@@ -1,12 +1,12 @@
 /// An error which has occurred during the serialization of a request.
 public enum GraphQLHTTPRequestError: Error, LocalizedError {
-  case cancelledByDeveloper
+  case cancelledByDelegate
   case serializedBodyMessageError
   case serializedQueryParamsMessageError
   
   public var errorDescription: String? {
     switch self {
-    case .cancelledByDeveloper:
+    case .cancelledByDelegate:
       return "The request was cancelled by the HTTPNetworkTransportPreflightDelegate."
     case .serializedBodyMessageError:
       return "JSONSerialization error: Error while serializing request's body"

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -106,23 +106,23 @@ public class HTTPNetworkTransport: NetworkTransport {
     
   private func mountUrlWithQueryParamsIfNeeded(body: GraphQLMap) -> URL? {
     guard let query = body.jsonObject["query"], var queryParam = queryString(withItems:  [URLQueryItem(name: "query", value: "\(query)")]) else {
-        return self.url
+      return self.url
     }
     if areThereVariables(in: body) {
-        guard let serializedVariables = try? serializationFormat.serialize(value: body.jsonObject["variables"]) else {
-            return URL(string: "\(self.url.absoluteString)?\(queryParam)")
-        }
-        queryParam += getVariablesEncodedString(of: serializedVariables)
+      guard let serializedVariables = try? serializationFormat.serialize(value: body.jsonObject["variables"]) else {
+        return URL(string: "\(self.url.absoluteString)?\(queryParam)")
+      }
+      queryParam += getVariablesEncodedString(of: serializedVariables)
     }
     guard let urlForGet = URL(string: "\(self.url.absoluteString)?\(queryParam)") else {
-        return URL(string: "\(self.url.absoluteString)?\(queryParam)")
+      return URL(string: "\(self.url.absoluteString)?\(queryParam)")
     }
     return urlForGet
   }
 
   private func areThereVariables(in map: GraphQLMap) -> Bool {
     if let variables = map.jsonObject["variables"], "\(variables)" != "<null>" {
-        return true
+      return true
     }
     return false
   }
@@ -141,7 +141,7 @@ public class HTTPNetworkTransport: NetworkTransport {
     let queryString = percentEncoded ? url.percentEncodedQuery : url.query
     
     if let queryString = queryString {
-        return "\(queryString)"
+      return "\(queryString)"
     }
     return nil
   }

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -56,7 +56,7 @@ public protocol HTTPNetworkTransportRetryDelegate: class {
   ///   - response: [Optional] Any response received when the error was generated
   ///   - retryHandler: A closure indicating whether the operation should be retried. Asyncrhonous to allow for re-authentication or other async operations to complete.
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
-                        receievedError error: Error,
+                        receivedError error: Error,
                         for request: URLRequest,
                         response: URLResponse?,
                         retryHandler: @escaping (_ shouldRetry: Bool) -> Void)
@@ -193,7 +193,7 @@ public class HTTPNetworkTransport: NetworkTransport {
     
     retrier.networkTransport(
       self,
-      receievedError: error,
+      receivedError: error,
       for: request,
       response: response,
       retryHandler: { [weak self] shouldRetry in

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -140,50 +140,7 @@ public class HTTPNetworkTransport: NetworkTransport {
   }
     
   private func mountUrlWithQueryParamsIfNeeded(body: GraphQLMap) -> URL? {
-    guard let query = body.jsonObject["query"], var queryParam = queryString(withItems:  [URLQueryItem(name: "query", value: "\(query)")]) else {
-      return self.url
-    }
-    
-    if areThereVariables(in: body) {
-      guard let serializedVariables = try? serializationFormat.serialize(value: body.jsonObject["variables"]) else {
-        return URL(string: "\(self.url.absoluteString)?\(queryParam)")
-      }
-      queryParam += getVariablesEncodedString(of: serializedVariables)
-    }
-    
-    guard let urlForGet = URL(string: "\(self.url.absoluteString)?\(queryParam)") else {
-      return URL(string: "\(self.url.absoluteString)?\(queryParam)")
-    }
-    
-    return urlForGet
-  }
-
-  private func areThereVariables(in map: GraphQLMap) -> Bool {
-    if let variables = map.jsonObject["variables"], "\(variables)" != "<null>" {
-      return true
-    }
-    
-    return false
-  }
-
-  private func getVariablesEncodedString(of data: Data) -> String {
-    var dataString = String(data: data, encoding: String.Encoding.utf8) ?? ""
-    dataString = dataString.replacingOccurrences(of: ";", with: ",")
-    dataString = dataString.replacingOccurrences(of: "=", with: ":")
-    guard let variablesEncoded = queryString(withItems:  [URLQueryItem(name: "variables", value: "\(dataString)")]) else { return "" }
-    
-    return "&\(variablesEncoded)"
-  }
-
-  private func queryString(withItems items: [URLQueryItem], percentEncoded: Bool = true) -> String? {
-    let url = NSURLComponents()
-    url.queryItems = items
-    let queryString = percentEncoded ? url.percentEncodedQuery : url.query
-    
-    if let queryString = queryString {
-      return "\(queryString)"
-    }
-    
-    return nil
+    let transformer = GraphQLGETTransformer(body: body, url: self.url)
+    return transformer.mountUrlWithQueryParamsIfNeeded()
   }
 }

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -36,7 +36,7 @@ public protocol HTTPNetworkTransportTaskCompletedDelegate {
   ///   - response: [optional] Any response received. Passed through from `URLSession`.
   ///   - error: [optional] Any error received. Passed through from `URLSession`.
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
-                        completedRawTaskForRequest request: URLRequest,
+                        didCompleteRawTaskForRequest request: URLRequest,
                         withData data: Data?,
                         response: URLResponse?,
                         error: Error?)
@@ -215,7 +215,7 @@ public class HTTPNetworkTransport: NetworkTransport {
     }
     
     taskDelegate.networkTransport(self,
-                                  completedRawTaskForRequest: request,
+                                  didCompleteRawTaskForRequest: request,
                                   withData: data,
                                   response: response,
                                   error: error)

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -1,0 +1,56 @@
+//
+//  GETTransformerTests.swift
+//  ApolloTests
+//
+//  Created by Ellen Shapiro on 7/1/19.
+//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//
+
+import XCTest
+@testable import Apollo
+import StarWarsAPI
+
+class GETTransformerTests: XCTestCase {
+  
+  private lazy var url = URL(string: "http://localhost:8080/graphql")!
+  
+  func testEncodingQueryWithSingleParameter() {
+    let operation = HeroNameQuery(episode: .empire)
+    let body: GraphQLMap = [
+      "query": operation.queryDocument,
+      "variables": operation.variables,
+    ]
+    
+    let transformer = GraphQLGETTransformer(body: body, url: self.url)
+    
+    let url = transformer.createGetURL()
+    
+    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22EMPIRE%22%7D")
+  }
+  
+  func testEncodingQueryWithNullDefaultParameter() {
+    let operation = HeroNameQuery()
+    let body: GraphQLMap = [
+      "query": operation.queryDocument,
+      "variables": operation.variables,
+    ]
+    
+    let transformer = GraphQLGETTransformer(body: body, url: self.url)
+    
+    let url = transformer.createGetURL()
+    
+    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D")
+  }
+  
+  func testMissingQueryParameterInBodyReturnsNil() {
+    let operation = HeroNameQuery(episode: .empire)
+    let body: GraphQLMap = [
+      "variables": operation.variables,
+    ]
+    
+    let transformer = GraphQLGETTransformer(body: body, url: self.url)
+    
+    let url = transformer.createGetURL()
+    XCTAssertNil(url)
+  }
+}

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -241,7 +241,7 @@ extension HTTPTransportTests: HTTPNetworkTransportTaskCompletedDelegate {
 extension HTTPTransportTests: HTTPNetworkTransportRetryDelegate {
   
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
-                        receievedError error: Error,
+                        receivedError error: Error,
                         for request: URLRequest,
                         response: URLResponse?,
                         retryHandler: @escaping (Bool) -> Void) {

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -1,0 +1,126 @@
+//
+//  HTTPTransportTests.swift
+//  ApolloTests
+//
+//  Created by Ellen Shapiro on 7/1/19.
+//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//
+
+import XCTest
+@testable import Apollo
+import StarWarsAPI
+
+class HTTPTransportTests: XCTestCase {
+  
+  private var updatedHeaders: [String: String]?
+  private var shouldSend = true
+
+  private lazy var url = URL(string: "http://localhost:8080/")!
+  private lazy var networkTransport = HTTPNetworkTransport(url: self.url,
+                                                           delegate: self)
+  
+  func testDelegateTellingRequestNotToSend() {
+    self.shouldSend = false
+    
+    let expectation = self.expectation(description: "Send operation completed")
+    let cancellable = self.networkTransport.send(operation: HeroNameQuery()) { response, error in
+      
+      defer {
+        expectation.fulfill()
+      }
+      
+      guard let error = error else {
+        XCTFail("Expected error not received when telling delegate not to send!")
+        return
+      }
+      
+      switch error {
+      case GraphQLHTTPRequestError.cancelledByDeveloper:
+        // Correct!
+        break
+      default:
+        XCTFail("Expected `cancelledByDeveloper`, got \(error)")
+      }
+    }
+    
+    guard (cancellable as? ErrorCancellable) != nil else {
+      XCTFail("Wrong cancellable type returned!")
+      cancellable.cancel()
+      expectation.fulfill()
+      return
+    }
+    
+    // This should fail without hitting the network.
+    self.wait(for: [expectation], timeout: 1)
+  }
+  
+  func testDelgateModifyingRequest() {
+    self.updatedHeaders = ["Authorization": "Bearer HelloApollo"]
+
+    let expectation = self.expectation(description: "Send operation completed")
+    let cancellable = self.networkTransport.send(operation: HeroNameQuery()) { (response, error) in
+      
+      defer {
+        expectation.fulfill()
+      }
+      
+      if let responseError = error as? GraphQLHTTPResponseError {
+        print(responseError.bodyDescription)
+        XCTFail("Error!")
+        return
+      }
+      
+      guard let queryResponse = response else {
+        XCTFail("No response!")
+        return
+      }
+      
+      guard
+        let dictionary = queryResponse.body as? [String: AnyHashable],
+        let dataDict = dictionary["data"] as? [String: AnyHashable],
+        let heroDict = dataDict["hero"] as? [String: AnyHashable],
+        let name = heroDict["name"] as? String else {
+          XCTFail("No hero for you!")
+          return
+      }
+      
+      XCTAssertEqual(name, "R2-D2")
+    }
+    
+    guard
+      let task = cancellable as? URLSessionTask,
+      let url = task.currentRequest?.url,
+      let headers = task.currentRequest?.allHTTPHeaderFields else {
+        cancellable.cancel()
+        expectation.fulfill()
+        return
+    }
+    
+    XCTAssertEqual(url.absoluteString, "http://localhost:8080/graphql")
+    XCTAssertEqual(headers["Authorization"], "Bearer HelloApollo")
+    
+    // This will come through after hitting the network.
+    self.wait(for: [expectation], timeout: 10)
+  }
+}
+
+extension HTTPTransportTests: HTTPNetworkTransportDelegate {
+  func networkTransport(_ networkTransport: HTTPNetworkTransport, shouldSend request: URLRequest) -> Bool {
+    return self.shouldSend
+  }
+  
+  func networkTransport(_ networkTransport: HTTPNetworkTransport, willSend request: inout URLRequest) {
+    guard let headers = self.updatedHeaders else {
+      // Don't modify anything
+      return
+    }
+    
+    request.url = URL(string: "http://localhost:8080/graphql")!
+    headers.forEach { tuple in
+      let (key, value) = tuple
+      var headers = request.allHTTPHeaderFields ?? [String: String]()
+      headers[key] = value
+      request.allHTTPHeaderFields = headers
+    }
+  }
+}

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -225,7 +225,7 @@ extension HTTPTransportTests: HTTPNetworkTransportPreflightDelegate {
 extension HTTPTransportTests: HTTPNetworkTransportTaskCompletedDelegate {
   
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
-                        completedRawTaskForRequest request: URLRequest,
+                        didCompleteRawTaskForRequest request: URLRequest,
                         withData data: Data?,
                         response: URLResponse?,
                         error: Error?) {

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -26,9 +26,7 @@ class HTTPTransportTests: XCTestCase {
   private lazy var url = URL(string: "http://localhost:8080/graphql")!
   private lazy var networkTransport = HTTPNetworkTransport(url: self.url,
                                                            useGETForQueries: true,
-                                                           preflightDelegate: self,
-                                                           taskCompletedDelegate: self,
-                                                           retryDelegate: self)
+                                                           delegate: self)
   
   private func validateHeroNameQueryResponse<Operation: GraphQLOperation>(response: GraphQLResponse<Operation>?,
                                                                           error: Error?,

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -86,7 +86,7 @@ class HTTPTransportTests: XCTestCase {
       }
       
       switch error {
-      case GraphQLHTTPRequestError.cancelledByDeveloper:
+      case GraphQLHTTPRequestError.cancelledByDelegate:
         // Correct!
         break
       default:


### PR DESCRIPTION
I know this has been a request [for some time](https://github.com/apollographql/apollo-ios/issues/37), but this PR contains the ability to change parameters on the URL request before it gets sent out, the ability to have the raw `Data?`/`URLResponse`/`Error?` response from a `URLSessionTask` so you can grab headers and/or log things as you want, and the ability to retry asynchronously (for example, after re-authenticating). 

This work also uncovered some weirdness with sending GET requests with null parameters for optional variables, so I broke out the GET url constructor, simplified it, and tested it. 