### PR TITLE
[airbnb] Fix missing "Foundation" imports

### DIFF
--- a/Sources/Apollo/Decoding.swift
+++ b/Sources/Apollo/Decoding.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 private typealias GroupedFields = GroupedSequence<String, GraphQLField>
 
 func decode<SelectionSet: GraphQLSelectionSet>(selectionSet: SelectionSet.Type, from object: JSONObject, variables: GraphQLMap? = nil) throws -> SelectionSet {

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -1,4 +1,5 @@
 import Dispatch
+import Foundation
 
 /// A resolver is responsible for resolving a value for a field.
 typealias GraphQLResolver = (_ object: JSONObject, _ info: GraphQLResolveInfo) -> ResultOrPromise<JSONValue?>

--- a/Sources/Apollo/GraphQLHTTPRequestError.swift
+++ b/Sources/Apollo/GraphQLHTTPRequestError.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// An error which has occurred during the serialization of a request.
 public enum GraphQLHTTPRequestError: Error, LocalizedError {
   case cancelledByDelegate

--- a/Sources/Apollo/GraphQLHTTPResponseError.swift
+++ b/Sources/Apollo/GraphQLHTTPResponseError.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A transport-level, HTTP-specific error.
 public struct GraphQLHTTPResponseError: Error, LocalizedError {
   public enum ErrorKind {

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -2,6 +2,7 @@
 import Apollo
 #endif
 import Starscream
+import Foundation
 
 // To allow for alternative implementations supporting the same WebSocketClient protocol
 public class ApolloWebSocket: WebSocket, ApolloWebSocketClient {


### PR DESCRIPTION
I noticed when pulling in 0.11.0 to Airbnb that there were a bunch of failures related to certain types not being defined. This was happening due to missing `Foundation` imports.

This PR simply adds those imports where appropriate.