### PR TITLE
Update podspec for SQLite.swift

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec 'SQLite' do |ss|
     ss.source_files = 'Sources/ApolloSQLite/*.swift'
     ss.dependency 'Apollo/Core'
-    ss.dependency 'SQLite.swift', '~> 0.11.4'
+    ss.dependency 'SQLite.swift', '~> 0.12.2'
   end
 
   # Websocket and subscription support based on Starscream


### PR DESCRIPTION
Having tried the latest version, I realized that SQLite.swift version remained old one which doesn't support Swift 5. Let's update it.