### PR TITLE
Pin To Exact Versions of Dependencies

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -30,14 +30,14 @@ Pod::Spec.new do |s|
   s.subspec 'SQLite' do |ss|
     ss.source_files = 'Sources/ApolloSQLite/*.swift'
     ss.dependency 'Apollo/Core'
-    ss.dependency 'SQLite.swift', '~> 0.12.2'
+    ss.dependency 'SQLite.swift', '0.12.2'
   end
 
   # Websocket and subscription support based on Starscream
   s.subspec 'WebSocket' do |ss|
     ss.source_files = 'Sources/ApolloWebSocket/*.swift'
     ss.dependency 'Apollo/Core'
-    ss.dependency 'Starscream', '~> 3.1.0'
+    ss.dependency 'Starscream', '3.1.0'
   end
 
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "stephencelis/SQLite.swift" ~> 0.12.0
-github "daltoniam/Starscream" ~> 3.1.0
+github "stephencelis/SQLite.swift" == 0.12.2
+github "daltoniam/Starscream" == 3.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "daltoniam/Starscream" "3.1.0"
-github "stephencelis/SQLite.swift" "0.12.0"
+github "stephencelis/SQLite.swift" "0.12.2"


### PR DESCRIPTION
In this PR: 

- Corrected Carthage version of `SQLite.swift` to be the same as the CocoaPods one.
- Pinned both package managers to exact versions so we can validate that new patch versions don't break anything. (Suggested in #537).