### PR TITLE
`Result` ALL THE THINGS!!!

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -18,8 +18,7 @@ public enum CachePolicy {
 /// A handler for operation results.
 ///
 /// - Parameters:
-///   - result: The result of the performed operation, or `nil` if an error occurred.
-///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
+///   - result: The result of a performed operation. Will have a `GraphQLResult` with the data of the requested type on `success`, and an `Error` on `failure`.
 public typealias GraphQLResultHandler<Data> = (Result< GraphQLResult<Data>, Error>) -> Void
 
 /// The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
@@ -226,7 +225,7 @@ private final class FetchQueryOperation<Query: GraphQLQuery>: AsynchronousOperat
           self.resultHandler(result)
           self.state = .finished
           return
-        }  
+        }
       }
       
       self.fetchFromNetwork()

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -99,7 +99,6 @@ public class ApolloClient {
   ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
   ///   - resultHandler: An optional closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
-  
   public func watch<Query: GraphQLQuery>(query: Query, cachePolicy: CachePolicy = .returnCacheDataElseFetch, queue: DispatchQueue = DispatchQueue.main, resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self, query: query, resultHandler: wrapResultHandler(resultHandler, queue: queue))
     watcher.fetch(cachePolicy: cachePolicy)

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -19,7 +19,7 @@ public enum CachePolicy {
 ///
 /// - Parameters:
 ///   - result: The result of a performed operation. Will have a `GraphQLResult` with the data of the requested type on `success`, and an `Error` on `failure`.
-public typealias GraphQLResultHandler<Data> = (Result< GraphQLResult<Data>, Error>) -> Void
+public typealias GraphQLResultHandler<Data> = (Result<GraphQLResult<Data>, Error>) -> Void
 
 /// The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
 public class ApolloClient {

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -226,10 +226,10 @@ private final class FetchQueryOperation<Query: GraphQLQuery>: AsynchronousOperat
           self.resultHandler(result)
           self.state = .finished
           return
-        }
-        
-        self.fetchFromNetwork()
+        }  
       }
+      
+      self.fetchFromNetwork()
     }
   }
   

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -18,7 +18,7 @@ public enum CachePolicy {
 /// A handler for operation results.
 ///
 /// - Parameters:
-///   - result: The result of a performed operation. Will have a `GraphQLResult` with the data of the requested type on `success`, and an `Error` on `failure`.
+///   - result: The result of a performed operation. Will have a `GraphQLResult` with any parsed data and any GraphQL errors on `success`, and an `Error` on `failure`.
 public typealias GraphQLResultHandler<Data> = (Result<GraphQLResult<Data>, Error>) -> Void
 
 /// The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -22,9 +22,6 @@ public enum CachePolicy {
 ///   - error: An error that indicates why the mutation failed, or `nil` if the mutation was succesful.
 public typealias GraphQLResultHandler<Data> = (_ result: GraphQLResult<Data>?, _ error: Error?) -> Void
 
-@available(*, deprecated, renamed: "GraphQLResultHandler")
-public typealias OperationResultHandler<Operation: GraphQLOperation> = GraphQLResultHandler<Operation.Data>
-
 /// The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
 public class ApolloClient {
   let networkTransport: NetworkTransport

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -131,9 +131,9 @@ public final class ApolloStore {
 
   public func load<Query: GraphQLQuery>(query: Query, resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
     load(query: query).andThen { result in
-      resultHandler(result, nil)
+      resultHandler(.success(result))
     }.catch { error in
-      resultHandler(nil, error)
+      resultHandler(.failure(error))
     }
   }
 

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -26,17 +26,17 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
   
   func fetch(cachePolicy: CachePolicy) {
-    fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context) { [weak self] outerResult in
+    fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context) { [weak self] result in
       guard let `self` = self else { return }
       
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         self.dependentKeys = graphQLResult.dependentKeys
       case .failure:
         break
       }
       
-      self.resultHandler(outerResult)
+      self.resultHandler(result)
     }
   }
   

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -26,11 +26,17 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
   
   func fetch(cachePolicy: CachePolicy) {
-    fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context) { [weak self] (result, error) in
+    fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context) { [weak self] outerResult in
       guard let `self` = self else { return }
-        
-      self.dependentKeys = result?.dependentKeys
-      self.resultHandler(result, error)
+      
+      switch outerResult {
+      case .success(let graphQLResult):
+        self.dependentKeys = graphQLResult.dependentKeys
+      case .failure:
+        break
+      }
+      
+      self.resultHandler(outerResult)
     }
   }
   

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -68,7 +68,7 @@ public protocol HTTPNetworkTransportRetryDelegate: HTTPNetworkTransportDelegate 
 // MARK: -
 
 /// A network transport that uses HTTP POST requests to send GraphQL operations to a server, and that uses `URLSession` as the networking implementation.
-public class HTTPNetworkTransport: NetworkTransport {
+public class HTTPNetworkTransport {
   let url: URL
   let session: URLSession
   let serializationFormat = JSONSerializationFormat.self
@@ -94,18 +94,6 @@ public class HTTPNetworkTransport: NetworkTransport {
     self.sendOperationIdentifiers = sendOperationIdentifiers
     self.useGETForQueries = useGETForQueries
     self.delegate = delegate
-  }
-  
-  /// Send a GraphQL operation to a server and return a response.
-  ///
-  /// - Parameters:
-  ///   - operation: The operation to send.
-  ///   - completionHandler: A closure to call when a request completes.
-  ///   - response: The response received from the server, or `nil` if an error occurred.
-  ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
-  /// - Returns: An object that can be used to cancel an in progress request.
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
-    return send(operation: operation, files: nil, completionHandler: completionHandler)
   }
   
   /// Uploads the given files with the given operation. 
@@ -282,5 +270,14 @@ public class HTTPNetworkTransport: NetworkTransport {
     }
     
     return request
+  }
+}
+
+// MARK: - NetworkTransport conformance
+
+extension HTTPNetworkTransport: NetworkTransport {
+  
+  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+    return send(operation: operation, files: nil, completionHandler: completionHandler)
   }
 }

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -8,5 +8,5 @@ public protocol NetworkTransport {
   ///   - response: The response received from the server, or `nil` if an error occurred.
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
-  func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable
+  func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
 }

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -1,12 +1,11 @@
 /// A network transport is responsible for sending GraphQL operations to a server.
 public protocol NetworkTransport {
+  
   /// Send a GraphQL operation to a server and return a response.
   ///
   /// - Parameters:
   ///   - operation: The operation to send.
-  ///   - completionHandler: A closure to call when a request completes.
-  ///   - response: The response received from the server, or `nil` if an error occurred.
-  ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
+  ///   - completionHandler: A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred.
   /// - Returns: An object that can be used to cancel an in progress request.
   func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
 }

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -12,7 +12,7 @@ public class SplitNetworkTransport: NetworkTransport {
     self.webSocketNetworkTransport = webSocketNetworkTransport
   }
   
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+  public func send<Operation>(operation: Operation, completionHandler: @escaping (Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     if operation.operationType == .subscription {
         return webSocketNetworkTransport.send(operation: operation, completionHandler: completionHandler)
     } else {

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -2,7 +2,7 @@
 import Apollo
 #endif
 
-/// A network transport that sends subscriptions using one network transport and other requests using another `NetworkTransport`.
+/// A network transport that sends subscriptions using one `NetworkTransport` and other requests using another `NetworkTransport`. Ideal for sending subscriptions via a web socket but everything else via HTTP. 
 public class SplitNetworkTransport {
   private let httpNetworkTransport: NetworkTransport
   private let webSocketNetworkTransport: NetworkTransport

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -2,21 +2,31 @@
 import Apollo
 #endif
 
-
-public class SplitNetworkTransport: NetworkTransport {
+/// A network transport that sends subscriptions using one network transport and other requests using another `NetworkTransport`.
+public class SplitNetworkTransport {
   private let httpNetworkTransport: NetworkTransport
   private let webSocketNetworkTransport: NetworkTransport
   
+  /// Designated initializer
+  ///
+  /// - Parameters:
+  ///   - httpNetworkTransport: A `NetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
+  ///   - webSocketNetworkTransport: A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar.
   public init(httpNetworkTransport: NetworkTransport, webSocketNetworkTransport: NetworkTransport) {
     self.httpNetworkTransport = httpNetworkTransport
     self.webSocketNetworkTransport = webSocketNetworkTransport
   }
+}
+
+// MARK: - NetworkTransport conformance
+
+extension SplitNetworkTransport: NetworkTransport {
   
   public func send<Operation>(operation: Operation, completionHandler: @escaping (Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     if operation.operationType == .subscription {
-        return webSocketNetworkTransport.send(operation: operation, completionHandler: completionHandler)
+      return webSocketNetworkTransport.send(operation: operation, completionHandler: completionHandler)
     } else {
-        return httpNetworkTransport.send(operation: operation, completionHandler: completionHandler)
+      return httpNetworkTransport.send(operation: operation, completionHandler: completionHandler)
     }
   }
 }

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -77,8 +77,7 @@ class FetchQueryTests: XCTestCase {
         
         switch result {
         case .success(let queryResult):
-          #warning("Fix failure")
-          if queryResult.data?.hero?.name != "R2-D2" {
+          if queryResult.data?.hero?.name == "R2-D2" {
             // ignore first result assuming from cache, and wait for second callback with fetched result
             return
           } else {

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -121,10 +121,10 @@ class FetchQueryTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { outerResult in
+      client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { result in
         defer { expectation.fulfill() }
 
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
         case .failure(let error):
@@ -162,10 +162,10 @@ class FetchQueryTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { outerResult in
+      client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { result in
         defer { expectation.fulfill() }
 
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
         case .failure(let error):
@@ -204,10 +204,10 @@ class FetchQueryTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { outerResult in
+      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
         defer { expectation.fulfill() }
         
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
         case .failure(let error):
@@ -246,10 +246,10 @@ class FetchQueryTests: XCTestCase {
 
         let expectation = self.expectation(description: "Fetching query")
 
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { outerResult in
+        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
           defer { expectation.fulfill() }
           
-          switch outerResult {
+          switch result {
           case .success(let graphQLResult):
             XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
           case .failure(let error):
@@ -264,9 +264,9 @@ class FetchQueryTests: XCTestCase {
 
         let expectation2 = self.expectation(description: "Fetching query")
 
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { outerResult in
+        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
           defer { expectation2.fulfill() }
-          switch outerResult {
+          switch result {
           case .success:
             XCTFail("This should have returned an error")
           case .failure(let error):
@@ -314,9 +314,9 @@ class FetchQueryTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { outerResult in
+      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
         defer { expectation.fulfill() }
-        switch outerResult {
+        switch result {
         case .success:
           XCTFail("This should have returned an error!")
         case .failure(let error):

--- a/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
@@ -194,8 +194,6 @@ class LoadQueryFromStoreTests: XCTestCase {
         case .failure(let error):
           XCTFail("Unexpected error: \(error)")
         }
-        
-        
       }
     }
   }

--- a/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/LoadQueryFromStoreTests.swift
@@ -17,8 +17,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery()
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
@@ -40,8 +40,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery(episode: .jedi)
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
@@ -63,8 +63,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery()
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success:
           XCTFail("This should not have succeeded!")
         case .failure(let error):
@@ -90,8 +90,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery()
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success:
           XCTFail("This should not have succeeded!")
         case .failure(let error):
@@ -128,8 +128,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroAndFriendsNamesQuery(episode: .jedi)
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           
@@ -174,8 +174,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroAndFriendsNamesQuery()
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           
@@ -213,8 +213,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroAndFriendsNamesQuery()
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           
@@ -243,8 +243,8 @@ class LoadQueryFromStoreTests: XCTestCase {
 
       let query = HeroAndFriendsNamesQuery()
 
-      load(query: query) { outerResult in
-        switch outerResult {
+      load(query: query) { result in
+        switch result {
         case .success:
           XCTFail("This should not have succeeded!")
         case .failure(let error):

--- a/Tests/ApolloCacheDependentTests/StarWarsServerCachingRoundtripTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerCachingRoundtripTests.swift
@@ -46,24 +46,39 @@ class StarWarsServerCachingRoundtripTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query) { (result, error) in
-        if let error = error { XCTFail("Error while fetching query: \(error.localizedDescription)");  return }
-        guard let result = result else { XCTFail("No query result");  return }
-
-        if let errors = result.errors {
-          XCTFail("Errors in query result: \(errors)")
-        }
-
-        guard result.data != nil else { XCTFail("No query result data");  return }
-
-        client.store.load(query: query) { (result, error) in
-          defer { expectation.fulfill() }
-
-          if let error = error { XCTFail("Error while loading query from store: \(error.localizedDescription)");  return }
-
-          guard let data = result?.data else { XCTFail("No query result data");  return }
-
-          completionHandler(data)
+      client.fetch(query: query) { outerResult in
+        switch outerResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with fetch: \(error)")
+          expectation.fulfill()
+          return
+        case .success(let fetchGraphQLResult):
+          if let errors = fetchGraphQLResult.errors {
+            // We aren't expecting errors, so fail the test, but don't kill the rest of the checks.
+            XCTFail("Errors in query result: \(errors)")
+          }
+          
+          guard fetchGraphQLResult.data != nil else {
+            XCTFail("No query result data from fetching!")
+            expectation.fulfill()
+            return
+          }
+          
+          client.store.load(query: query) { innerResult in
+            defer { expectation.fulfill() }
+            
+            switch innerResult {
+            case .success(let loadGraphQLResult):
+              guard let data = loadGraphQLResult.data else {
+                XCTFail("No query result data from loading!")
+                return
+              }
+              
+              completionHandler(data)
+            case .failure(let error):
+              XCTFail("Error while loading query from store: \(error.localizedDescription)")
+            }
+          }
         }
       }
 

--- a/Tests/ApolloCacheDependentTests/StarWarsServerCachingRoundtripTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerCachingRoundtripTests.swift
@@ -53,10 +53,7 @@ class StarWarsServerCachingRoundtripTests: XCTestCase {
           expectation.fulfill()
           return
         case .success(let fetchGraphQLResult):
-          if let errors = fetchGraphQLResult.errors {
-            // We aren't expecting errors, so fail the test, but don't kill the rest of the checks.
-            XCTFail("Errors in query result: \(errors)")
-          }
+          XCTAssertNil(fetchGraphQLResult.errors)
           
           guard fetchGraphQLResult.data != nil else {
             XCTFail("No query result data from fetching!")

--- a/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
@@ -272,19 +272,21 @@ class StarWarsServerTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query) { (result, error) in
+      client.fetch(query: query) { outerResult in
         defer { expectation.fulfill() }
-
-        if let error = error { XCTFail("Error while fetching query: \(error.localizedDescription)");  return }
-        guard let result = result else { XCTFail("No query result");  return }
-
-        if let errors = result.errors {
-          XCTFail("Errors in query result: \(errors)")
+      
+        switch outerResult {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          guard let data = graphQLResult.data else {
+            XCTFail("No query result data")
+            return
+          }
+          
+          completionHandler(data)
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
         }
-
-        guard let data = result.data else { XCTFail("No query result data");  return }
-
-        completionHandler(data)
       }
       
       waitForExpectations(timeout: 5, handler: nil)
@@ -299,19 +301,22 @@ class StarWarsServerTests: XCTestCase {
 
       let expectation = self.expectation(description: "Performing mutation")
 
-      client.perform(mutation: mutation) { (result, error) in
+      client.perform(mutation: mutation) { outerResult in
         defer { expectation.fulfill() }
-
-        if let error = error { XCTFail("Error while performing mutation: \(error.localizedDescription)");  return }
-        guard let result = result else { XCTFail("No mutation result");  return }
-
-        if let errors = result.errors {
-          XCTFail("Errors in mutation result: \(errors)")
+        
+        switch outerResult {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          
+          guard let data = graphQLResult.data else {
+            XCTFail("No mutation result data")
+            return
+          }
+          
+          completionHandler(data)
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
         }
-
-        guard let data = result.data else { XCTFail("No mutation result data");  return }
-
-        completionHandler(data)
       }
       
       waitForExpectations(timeout: 5, handler: nil)

--- a/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
@@ -272,10 +272,10 @@ class StarWarsServerTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query) { outerResult in
+      client.fetch(query: query) { result in
         defer { expectation.fulfill() }
       
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           guard let data = graphQLResult.data else {
@@ -301,10 +301,10 @@ class StarWarsServerTests: XCTestCase {
 
       let expectation = self.expectation(description: "Performing mutation")
 
-      client.perform(mutation: mutation) { outerResult in
+      client.perform(mutation: mutation) { result in
         defer { expectation.fulfill() }
         
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           

--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -30,8 +30,8 @@ class WatchQueryTests: XCTestCase {
 
       var verifyResult: GraphQLResultHandler<HeroNameQuery.Data>
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
@@ -49,8 +49,8 @@ class WatchQueryTests: XCTestCase {
 
       waitForExpectations(timeout: 5, handler: nil)
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           XCTAssertEqual(graphQLResult.data?.hero?.name, "Artoo")
@@ -100,8 +100,8 @@ class WatchQueryTests: XCTestCase {
 
       var verifyResult: GraphQLResultHandler<HeroAndFriendsNamesQuery.Data>
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           guard let data = graphQLResult.data else {
@@ -126,8 +126,8 @@ class WatchQueryTests: XCTestCase {
 
       waitForExpectations(timeout: 5, handler: nil)
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           guard let data = graphQLResult.data else {
@@ -188,7 +188,7 @@ class WatchQueryTests: XCTestCase {
       let fetching = self.expectation(description: "Fetching query")
       var refetching: XCTestExpectation?
       
-      let _ = client.watch(query: query) { outerResult in
+      let _ = client.watch(query: query) { result in
         guard refetching == nil else {
           return refetching!.fulfill()
         }
@@ -197,7 +197,7 @@ class WatchQueryTests: XCTestCase {
           fetching.fulfill()
         }
         
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           
@@ -259,8 +259,8 @@ class WatchQueryTests: XCTestCase {
 
       var verifyResult: GraphQLResultHandler<HeroNameWithIdQuery.Data>
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
@@ -278,8 +278,8 @@ class WatchQueryTests: XCTestCase {
 
       waitForExpectations(timeout: 5, handler: nil)
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
@@ -321,8 +321,8 @@ class WatchQueryTests: XCTestCase {
 
       var verifyResult: GraphQLResultHandler<HeroAndFriendsNamesQuery.Data>
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
 
@@ -362,8 +362,8 @@ class WatchQueryTests: XCTestCase {
         }
       })
 
-      verifyResult = { outerResult in
-        switch outerResult {
+      verifyResult = { result in
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           guard let data = graphQLResult.data else {

--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -341,9 +341,6 @@ class WatchQueryTests: XCTestCase {
         case .failure(let error):
           XCTFail("Unexpected error: \(error)")
         }
-
-
-        
       }
 
       var expectation = self.expectation(description: "Fetching query")

--- a/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
+++ b/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
@@ -26,25 +26,35 @@ class CachePersistenceTests: XCTestCase {
       let networkExpectation = self.expectation(description: "Fetching query from network")
       let newCacheExpectation = self.expectation(description: "Fetch query from new cache")
 
-      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
         defer { networkExpectation.fulfill() }
-        guard let result = result else { XCTFail("No query result");  return }
-        XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
-
-        // Do another fetch from cache to ensure that data is cached before creating new cache
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
-          SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
-            let newStore = ApolloStore(cache: cache)
-            let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
-            newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
-              defer { newCacheExpectation.fulfill() }
-              guard let result = result else { XCTFail("No query result");  return }
-              XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
-              _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
+        
+        switch outerResult {
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
+          return
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          // Do another fetch from cache to ensure that data is cached before creating new cache
+          client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
+            SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { cache in
+              let newStore = ApolloStore(cache: cache)
+              let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
+              newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { newClientResult in
+                defer { newCacheExpectation.fulfill() }
+                switch newClientResult {
+                case .success(let newClientGraphQLResult):
+                  XCTAssertEqual(newClientGraphQLResult.data?.hero?.name, "Luke Skywalker")
+                case .failure(let error):
+                  XCTFail("Unexpected error with new client: \(error)")
+                }
+                _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
+              }
             }
           }
         }
       }
+      
       self.waitForExpectations(timeout: 2, handler: nil)
     }
   }
@@ -68,18 +78,43 @@ class CachePersistenceTests: XCTestCase {
       let networkExpectation = self.expectation(description: "Fetching query from network")
       let emptyCacheExpectation = self.expectation(description: "Fetch query from empty cache")
 
-      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
         defer { networkExpectation.fulfill() }
-        guard let result = result else { XCTFail("No query result");  return }
-        XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
+        
+        switch outerResult {
+        case .failure(let error):
+          XCTFail("Unexpected faillure: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+        }
 
-        do { try client.clearCache().await() }
-        catch { XCTFail() }
+        do {
+          try client.clearCache().await()
+        } catch {
+          XCTFail("Error Clearing cache: \(error)")
+          emptyCacheExpectation.fulfill()
+          return
+        }
 
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
           defer { emptyCacheExpectation.fulfill() }
-          XCTAssertNil(result)
-          XCTAssertNil(error)
+          
+          switch innerResult {
+          case .success:
+            XCTFail("This should have returned an error")
+          case .failure(let error):
+            if let resultError = error as? JSONDecodingError {
+              switch resultError {
+              case .missingValue:
+                // Correct error!
+                break
+              default:
+                XCTFail("Unexpected JSON error: \(error)")
+              }
+            } else {
+              XCTFail("Unexpected error: \(error)")
+            }
+          }
         }
       }
 

--- a/Tests/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Tests/ApolloTestSupport/MockNetworkTransport.swift
@@ -8,9 +8,9 @@ public final class MockNetworkTransport: NetworkTransport {
     self.body = body
   }
 
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
+  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     DispatchQueue.global(qos: .default).async {
-      completionHandler(GraphQLResponse(operation: operation, body: self.body), nil)
+      completionHandler(.success(GraphQLResponse(operation: operation, body: self.body)))
     }
     return MockTask()
   }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -64,12 +64,12 @@ class BatchedLoadTests: XCTestCase {
     
     let expectation = self.expectation(description: "Loading query from store")
     
-    store.load(query: query) { outerResult in
+    store.load(query: query) { result in
       defer {
         expectation.fulfill()
       }
       
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         
@@ -115,12 +115,12 @@ class BatchedLoadTests: XCTestCase {
     (1...10).forEach { number in
       let expectation = self.expectation(description: "Loading query #\(number) from store")
       
-      store.load(query: query) { outerResult in
+      store.load(query: query) { result in
         defer {
           expectation.fulfill()
         }
         
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           

--- a/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
@@ -33,14 +33,14 @@ class MockWebSocketTests: XCTestCase {
   func testLocalSingleSubscription() throws {
     let expectation = self.expectation(description: "Single subscription")
     
-    client.subscribe(subscription: ReviewAddedSubscription()) { (result, error) in
+    client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
       defer { expectation.fulfill() }
-    
-      if error != nil { XCTFail("Error response");  return }
-      
-      guard let result = result else { XCTFail("No subscription result");  return }
-      
-      XCTAssertEqual(result.data?.reviewAdded?.stars, 5)
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertEqual(graphQLResult.data?.reviewAdded?.stars, 5)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
     }
         
     let message : GraphQLMap = [
@@ -67,7 +67,7 @@ class MockWebSocketTests: XCTestCase {
     let expectation = self.expectation(description: "Missing subscription")
     expectation.isInverted = true
 
-    client.subscribe(subscription: ReviewAddedSubscription()) { (result, error) in
+    client.subscribe(subscription: ReviewAddedSubscription()) { _ in
       expectation.fulfill()
     }
     
@@ -77,12 +77,25 @@ class MockWebSocketTests: XCTestCase {
   func testLocalErrorUnknownId() throws {
     let expectation = self.expectation(description: "Unknown id for subscription")
     
-    client.subscribe(subscription: ReviewAddedSubscription()) { (result, error) in
+    client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
       defer { expectation.fulfill() }
       
-      // Expecting error and no result
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
+      switch outerResult {
+      case .success:
+        XCTFail("This should have caused an error!")
+      case .failure(let error):
+        if let webSocketError = error as? WebSocketError {
+          switch webSocketError.kind {
+          case .unprocessedMessage:
+            // Correct!
+            break
+          default:
+            XCTFail("Unexpected websocket error: \(error)")
+          }
+        } else {
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
     }
     
     let message : GraphQLMap = [

--- a/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
@@ -33,9 +33,9 @@ class MockWebSocketTests: XCTestCase {
   func testLocalSingleSubscription() throws {
     let expectation = self.expectation(description: "Single subscription")
     
-    client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
+    client.subscribe(subscription: ReviewAddedSubscription()) { result in
       defer { expectation.fulfill() }
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         XCTAssertEqual(graphQLResult.data?.reviewAdded?.stars, 5)
       case .failure(let error):
@@ -77,10 +77,10 @@ class MockWebSocketTests: XCTestCase {
   func testLocalErrorUnknownId() throws {
     let expectation = self.expectation(description: "Unknown id for subscription")
     
-    client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
+    client.subscribe(subscription: ReviewAddedSubscription()) { result in
       defer { expectation.fulfill() }
       
-      switch outerResult {
+      switch result {
       case .success:
         XCTFail("This should have caused an error!")
       case .failure(let error):

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -21,14 +21,25 @@ class StarWarsSubscriptionTests: XCTestCase {
   func testSubscribeReviewJediEpisode() {
     let expectation = self.expectation(description: "Subscribe single review")
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { (result, error) in
-      guard let data = result?.data else { XCTFail("No subscription result data");  return }
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { outerResult in
+      defer {
+        expectation.fulfill()
+      }
       
-      XCTAssertEqual(data.reviewAdded?.episode, .jedi)
-      XCTAssertEqual(data.reviewAdded?.stars, 6)
-      XCTAssertEqual(data.reviewAdded?.commentary, "This is the greatest movie!")
-      
-      expectation.fulfill()
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        guard let data = graphQLResult.data else {
+          XCTFail("No subscription result data")
+          return
+        }
+        
+        XCTAssertEqual(data.reviewAdded?.episode, .jedi)
+        XCTAssertEqual(data.reviewAdded?.stars, 6)
+        XCTAssertEqual(data.reviewAdded?.commentary, "This is the greatest movie!")
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
     }
     
     client.perform(mutation: CreateReviewForEpisodeMutation(episode: .jedi, review: ReviewInput(stars: 6, commentary: "This is the greatest movie!")))
@@ -40,13 +51,24 @@ class StarWarsSubscriptionTests: XCTestCase {
   func testSubscribeReviewAnyEpisode() {
     let expectation = self.expectation(description: "Subscribe any episode")
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription()) { (result, error) in
-      guard let data = result?.data else { XCTFail("No subscription result data");  return }
+    let sub = client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
+      defer {
+        expectation.fulfill()
+      }
       
-      XCTAssertEqual(data.reviewAdded?.stars, 13)
-      XCTAssertEqual(data.reviewAdded?.commentary, "This is an even greater movie!")
-      
-      expectation.fulfill()
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        guard let data = graphQLResult.data else {
+          XCTFail("No subscription result data")
+          return
+        }
+        
+        XCTAssertEqual(data.reviewAdded?.stars, 13)
+        XCTAssertEqual(data.reviewAdded?.commentary, "This is an even greater movie!")
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
     }
     
     client.perform(mutation: CreateReviewForEpisodeMutation(episode: .empire, review: ReviewInput(stars: 13, commentary: "This is an even greater movie!")))
@@ -59,12 +81,23 @@ class StarWarsSubscriptionTests: XCTestCase {
     let expectation = self.expectation(description: "Subscription to specific episode - expecting timeout")
     expectation.isInverted = true
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { (result, error) in
-      guard let data = result?.data else { XCTFail("No subscription result data");  return }
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { outerResult in
+      defer {
+        expectation.fulfill()
+      }
       
-      XCTAssertNotEqual(data.reviewAdded?.episode, .jedi)
-      
-      expectation.fulfill()
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        guard let data = graphQLResult.data else {
+          XCTFail("No subscription result data")
+          return
+        }
+        
+        XCTAssertNotEqual(data.reviewAdded?.episode, .jedi)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
     }
     
     client.perform(mutation: CreateReviewForEpisodeMutation(episode: .empire, review: ReviewInput(stars: 10, commentary: "This is an even greater movie!")))
@@ -77,7 +110,7 @@ class StarWarsSubscriptionTests: XCTestCase {
     let expectation = self.expectation(description: "Subscription then cancel - expecting timeput")
     expectation.isInverted = true
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { (result, error) in
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { _ in
       XCTFail("Received subscription after cancel")
     }
     
@@ -93,18 +126,23 @@ class StarWarsSubscriptionTests: XCTestCase {
     let expectation = self.expectation(description: "Multiple reviews")
     expectation.expectedFulfillmentCount = count
 
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { (result, error) in
-      if let error = error { XCTFail("Error while performing subscription: \(error.localizedDescription)");  return }
-      guard let result = result else { XCTFail("No subscription result");  return }
-
-      if let errors = result.errors {
-        XCTFail("Errors in subscription result: \(errors)")
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { outerResult in
+      defer {
+        expectation.fulfill()
       }
-
-      guard let data = result.data else { XCTFail("No subscription result data");  return }
-
-      XCTAssertEqual(data.reviewAdded?.episode, .empire)
-      expectation.fulfill()
+      
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        guard let data = graphQLResult.data else {
+          XCTFail("No subscription result data")
+          return
+        }
+        
+        XCTAssertEqual(data.reviewAdded?.episode, .empire)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
     }
 
     for i in 1...count {
@@ -123,25 +161,53 @@ class StarWarsSubscriptionTests: XCTestCase {
     let count = 20
     
     let expectation = self.expectation(description: "Multiple reviews")
-    expectation.expectedFulfillmentCount = count*2
+    expectation.expectedFulfillmentCount = count * 2
     
-    let subAll = client.subscribe(subscription: ReviewAddedSubscription()) { (result, error) in
-      guard let _ = result?.data else { XCTFail("No subscription result data");  return }
+    let subAll = client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        XCTAssertNotNil(graphQLResult.data)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
+      
       expectation.fulfill()
     }
     
-    let subEmpire = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { (result, error) in
-      guard let _ = result?.data else { XCTFail("No subscription result data");  return }
+    let subEmpire = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { outerResult in
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        XCTAssertNotNil(graphQLResult.data)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
+
       expectation.fulfill()
     }
     
-    let subJedi = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { (result, error) in
-      guard let _ = result?.data else { XCTFail("No subscription result data");  return }
+    let subJedi = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { outerResult in
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        XCTAssertNotNil(graphQLResult.data)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
+
       expectation.fulfill()
     }
     
-    let subNewHope = client.subscribe(subscription: ReviewAddedSubscription(episode: .newhope)) { (result, error) in
-      guard let _ = result?.data else { XCTFail("No subscription result data");  return }
+    let subNewHope = client.subscribe(subscription: ReviewAddedSubscription(episode: .newhope)) { outerResult in
+      switch outerResult {
+      case .success(let graphQLResult):
+        XCTAssertNil(graphQLResult.errors)
+        XCTAssertNotNil(graphQLResult.data)
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
+
       expectation.fulfill()
     }
     

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -21,12 +21,12 @@ class StarWarsSubscriptionTests: XCTestCase {
   func testSubscribeReviewJediEpisode() {
     let expectation = self.expectation(description: "Subscribe single review")
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { outerResult in
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { result in
       defer {
         expectation.fulfill()
       }
       
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         guard let data = graphQLResult.data else {
@@ -51,12 +51,12 @@ class StarWarsSubscriptionTests: XCTestCase {
   func testSubscribeReviewAnyEpisode() {
     let expectation = self.expectation(description: "Subscribe any episode")
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
+    let sub = client.subscribe(subscription: ReviewAddedSubscription()) { result in
       defer {
         expectation.fulfill()
       }
       
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         guard let data = graphQLResult.data else {
@@ -81,12 +81,12 @@ class StarWarsSubscriptionTests: XCTestCase {
     let expectation = self.expectation(description: "Subscription to specific episode - expecting timeout")
     expectation.isInverted = true
     
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { outerResult in
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { result in
       defer {
         expectation.fulfill()
       }
       
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         guard let data = graphQLResult.data else {
@@ -126,12 +126,12 @@ class StarWarsSubscriptionTests: XCTestCase {
     let expectation = self.expectation(description: "Multiple reviews")
     expectation.expectedFulfillmentCount = count
 
-    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { outerResult in
+    let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { result in
       defer {
         expectation.fulfill()
       }
       
-      switch outerResult {
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         guard let data = graphQLResult.data else {
@@ -163,8 +163,8 @@ class StarWarsSubscriptionTests: XCTestCase {
     let expectation = self.expectation(description: "Multiple reviews")
     expectation.expectedFulfillmentCount = count * 2
     
-    let subAll = client.subscribe(subscription: ReviewAddedSubscription()) { outerResult in
-      switch outerResult {
+    let subAll = client.subscribe(subscription: ReviewAddedSubscription()) { result in
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         XCTAssertNotNil(graphQLResult.data)
@@ -175,8 +175,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       expectation.fulfill()
     }
     
-    let subEmpire = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { outerResult in
-      switch outerResult {
+    let subEmpire = client.subscribe(subscription: ReviewAddedSubscription(episode: .empire)) { result in
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         XCTAssertNotNil(graphQLResult.data)
@@ -187,8 +187,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       expectation.fulfill()
     }
     
-    let subJedi = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { outerResult in
-      switch outerResult {
+    let subJedi = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { result in
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         XCTAssertNotNil(graphQLResult.data)
@@ -199,8 +199,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       expectation.fulfill()
     }
     
-    let subNewHope = client.subscribe(subscription: ReviewAddedSubscription(episode: .newhope)) { outerResult in
-      switch outerResult {
+    let subNewHope = client.subscribe(subscription: ReviewAddedSubscription(episode: .newhope)) { result in
+      switch result {
       case .success(let graphQLResult):
         XCTAssertNil(graphQLResult.errors)
         XCTAssertNotNil(graphQLResult.data)

--- a/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
@@ -277,10 +277,10 @@ class StarWarsWebSocketTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query) { outerResult in
+      client.fetch(query: query) { result in
         defer { expectation.fulfill() }
 
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           guard let data = graphQLResult.data else {
@@ -306,10 +306,10 @@ class StarWarsWebSocketTests: XCTestCase {
 
       let expectation = self.expectation(description: "Performing mutation")
 
-      client.perform(mutation: mutation) { outerResult in
+      client.perform(mutation: mutation) { result in
         defer { expectation.fulfill() }
         
-        switch outerResult {
+        switch result {
         case .success(let graphQLResult):
           XCTAssertNil(graphQLResult.errors)
           guard let data = graphQLResult.data else {

--- a/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
@@ -6,7 +6,7 @@ import StarWarsAPI
 
 // import StarWarsAPI
 
-class StarWarsWebsSocketTests: XCTestCase {
+class StarWarsWebSocketTests: XCTestCase {
   let SERVER = "http://localhost:8080/websocket"
 
   // MARK: Queries

--- a/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsWebSocketTests.swift
@@ -277,19 +277,21 @@ class StarWarsWebSocketTests: XCTestCase {
 
       let expectation = self.expectation(description: "Fetching query")
 
-      client.fetch(query: query) { (result, error) in
+      client.fetch(query: query) { outerResult in
         defer { expectation.fulfill() }
 
-        if let error = error { XCTFail("Error while fetching query: \(error.localizedDescription)");  return }
-        guard let result = result else { XCTFail("No query result");  return }
-
-        if let errors = result.errors {
-          XCTFail("Errors in query result: \(errors)")
+        switch outerResult {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          guard let data = graphQLResult.data else {
+            XCTFail("No query result data")
+            return
+          }
+          
+          completionHandler(data)
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
         }
-
-        guard let data = result.data else { XCTFail("No query result data");  return }
-
-        completionHandler(data)
       }
       
       waitForExpectations(timeout: 5, handler: nil)
@@ -304,19 +306,21 @@ class StarWarsWebSocketTests: XCTestCase {
 
       let expectation = self.expectation(description: "Performing mutation")
 
-      client.perform(mutation: mutation) { (result, error) in
+      client.perform(mutation: mutation) { outerResult in
         defer { expectation.fulfill() }
-
-        if let error = error { XCTFail("Error while performing mutation: \(error.localizedDescription)");  return }
-        guard let result = result else { XCTFail("No mutation result");  return }
-
-        if let errors = result.errors {
-          XCTFail("Errors in mutation result: \(errors)")
+        
+        switch outerResult {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          guard let data = graphQLResult.data else {
+            XCTFail("No mutation result data")
+            return
+          }
+          
+          completionHandler(data)
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
         }
-
-        guard let data = result.data else { XCTFail("No mutation result data");  return }
-
-        completionHandler(data)
       }
       
       waitForExpectations(timeout: 5, handler: nil)


### PR DESCRIPTION
This PR changes pretty much all of our completion closures to take advantage of Swift 5's built-in `Result` type. This is going to be a **SUPER-BREAKING CHANGE™**, though I believe it will help significantly in disambiguating whether a particular request has succeeded or failed, which is why I've done it in the first place. 

If you have reasons you think I should abandon this path, I'd love to hear them - please let me know in the comments!

In this PR: 
- Changed basically anything which had the following signature:
   ```swift
   completionHandler: ((Object?, Error?) -> Void)
  ```
  to use this signature instead: 
  ```swift
  completionHandler: ((Result<Object, Error>) -> Void)
  ```
  This takes advantage of Swift's built in `Result` type to make it WAY easier to tell when a request has failed prior to parsing. This does cause a couple of significant changes: 
  - Previously, there were cases where we would return neither a result nor an error. These cases will now always return a result.
  - This leads to some extra-fun and inscrutable compiler errors when you're going through and updating everything: 

    <img width="291" alt="Screen Shot 2019-07-16 at 6 25 28 PM" src="https://user-images.githubusercontent.com/1976498/61383101-511ad680-a8ae-11e9-802e-77789c2e6a3e.png">

    What this error is attemping to tell you is that you need to change the two-parameter completion closure into a single-parameter one. It's telling you that in a very, very opaque fashion, though. I plan to document this in the release notes as well. 
- Updated all tests - I'll flag the ones which are significant changes in comments. 
- Removed deprecated method `OperationResultHandler` typealias since I'm already breaking the crap out of everything