### PR TITLE
Document and anal-retentively organize upload code

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -584,7 +584,6 @@
 			children = (
 				9FC750621D2A59F600458D91 /* ApolloClient.swift */,
 				9FC9A9D21E2FD48B0023C4D5 /* GraphQLError.swift */,
-				C377CCA822D798BD00572E03 /* GraphQLFile.swift */,
 				9FC750601D2A59C300458D91 /* GraphQLOperation.swift */,
 				9FCDFD281E33D0CE007519DC /* GraphQLQueryWatcher.swift */,
 				9FC9A9BE1E2C27FB0023C4D5 /* GraphQLResult.swift */,
@@ -645,6 +644,7 @@
 			children = (
 				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
 				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
+				C377CCA822D798BD00572E03 /* GraphQLFile.swift */,
 				5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */,
 				9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */,
 				9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -588,7 +588,6 @@
 				9FC750601D2A59C300458D91 /* GraphQLOperation.swift */,
 				9FCDFD281E33D0CE007519DC /* GraphQLQueryWatcher.swift */,
 				9FC9A9BE1E2C27FB0023C4D5 /* GraphQLResult.swift */,
-				C377CCAA22D7992E00572E03 /* MultipartFormData.swift */,
 				9F27D4601D40363A00715680 /* Execution */,
 				9FC4B9231D2BE4F00046A641 /* JSON */,
 				9FC9A9CE1E2FD0CC0023C4D5 /* Network */,
@@ -651,6 +650,7 @@
 				9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
 				9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */,
+				C377CCAA22D7992E00572E03 /* MultipartFormData.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";

--- a/Sources/Apollo/GraphQLFile.swift
+++ b/Sources/Apollo/GraphQLFile.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// A file which can be uploaded to a GraphQL server
 public struct GraphQLFile {
   let fieldName: String
   let originalName: String
@@ -7,11 +8,39 @@ public struct GraphQLFile {
   let inputStream: InputStream
   let contentLength: UInt64
   
-  public init(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", data: Data) {
-    self.init(fieldName: fieldName, originalName: originalName, mimeType: mimeType, inputStream: InputStream(data: data), contentLength: UInt64(data.count))
+  /// A convenience constant for declaring your mimetype is octet-stream.
+  public static let octetStreamMimeType = "application/octet-stream"
+  
+  /// Convenience initializer for raw data
+  ///
+  /// - Parameters:
+  ///   - fieldName: The name of the field this file is being sent for
+  ///   - originalName: The original name of the file
+  ///   - mimeType: The mime type of the file to send to the server. Defaults to `GraphQLFile.octetStreamMimeType`.
+  ///   - data: The raw data to send for the file.
+  public init(fieldName: String,
+              originalName: String,
+              mimeType: String = GraphQLFile.octetStreamMimeType,
+              data: Data) {
+    self.init(fieldName: fieldName,
+              originalName: originalName,
+              mimeType: mimeType,
+              inputStream: InputStream(data: data),
+              contentLength: UInt64(data.count))
   }
   
-  public init?(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", fileURL: URL) {
+  /// Failable convenience initializer for files in the filesystem
+  /// Will return `nil` if the file URL cannot be used to create an `InputStream`, or if the file's size could not be determined.
+  ///
+  /// - Parameters:
+  ///   - fieldName: The name of the field this file is being sent for
+  ///   - originalName: The original name of the file
+  ///   - mimeType: The mime type of the file to send to the server. Defaults to `GraphQLFile.octetStreamMimeType`.
+  ///   - fileURL: The URL of the file to upload.
+  public init?(fieldName: String,
+               originalName: String,
+               mimeType: String = GraphQLFile.octetStreamMimeType,
+               fileURL: URL) {
     guard let inputStream = InputStream(url: fileURL) else {
       return nil
     }
@@ -20,10 +49,26 @@ public struct GraphQLFile {
       return nil
     }
     
-    self.init(fieldName: fieldName, originalName: originalName, mimeType: mimeType, inputStream: inputStream, contentLength: contentLength)
+    self.init(fieldName: fieldName,
+              originalName: originalName,
+              mimeType: mimeType,
+              inputStream: inputStream,
+              contentLength: contentLength)
   }
   
-  public init(fieldName: String, originalName: String, mimeType: String = "application/octet-stream", inputStream: InputStream, contentLength: UInt64) {
+  /// Designated Initializer
+  ///
+  /// - Parameters:
+  ///   - fieldName: The name of the field this file is being sent for
+  ///   - originalName: The original name of the file
+  ///   - mimeType: The mime type of the file to send to the server. Defaults to `GraphQLFile.octetStreamMimeType`.
+  ///   - inputStream: An input stream to use to acccess data
+  ///   - contentLength: The length of the data being sent
+  public init(fieldName: String,
+              originalName: String,
+              mimeType: String = GraphQLFile.octetStreamMimeType,
+              inputStream: InputStream,
+              contentLength: UInt64) {
     self.fieldName = fieldName
     self.originalName = originalName
     self.mimeType = mimeType

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -104,10 +104,21 @@ public class HTTPNetworkTransport: NetworkTransport {
   ///   - error: An error that indicates why a request failed, or `nil` if the request was succesful.
   /// - Returns: An object that can be used to cancel an in progress request.
   public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
-    return upload(operation: operation, completionHandler: completionHandler)
+    return send(operation: operation, files: nil, completionHandler: completionHandler)
   }
   
-  public func upload<Operation>(operation: Operation, files: [GraphQLFile]? = nil, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
+  /// Uploads the given files with the given operation. 
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to send
+  ///   - files: An array of `GraphQLFile` objects to send.
+  ///   - completionHandler: The completion handler to execute when the request completes or errors
+  /// - Returns: An object that can be used to cancel an in progress request.
+  public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
+    return send(operation: operation, files: files, completionHandler: completionHandler)
+  }
+  
+  private func send<Operation>(operation: Operation, files: [GraphQLFile]?, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
     let request: URLRequest
     do {
       request = try self.createRequest(for: operation, files: files)

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -308,7 +308,11 @@ public class HTTPNetworkTransport: NetworkTransport {
     }
     
     files.forEach {
-      formData.appendPart(inputStream: $0.inputStream, contentLength: $0.contentLength, name: $0.fieldName, contentType: $0.mimeType, filename: $0.originalName)
+      formData.appendPart(inputStream: $0.inputStream,
+                          contentLength: $0.contentLength,
+                          name: $0.fieldName,
+                          contentType: $0.mimeType,
+                          filename: $0.originalName)
     }
     
     return formData

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -253,7 +253,7 @@ public class HTTPNetworkTransport: NetworkTransport {
         if let files = files, !files.isEmpty {
           let formData = try requestMultipartFormData(for: operation, files: files)
           request.setValue("multipart/form-data; boundary=\(formData.boundary)", forHTTPHeaderField: "Content-Type")
-          request.httpBody = formData.encode()
+          request.httpBody = try formData.encode()
         } else {
           request.httpBody = try serializationFormat.serialize(value: body)
         }
@@ -301,9 +301,9 @@ public class HTTPNetworkTransport: NetworkTransport {
         let data = try serializationFormat.serialize(value: data)
         formData.appendPart(data: data, name: name)
       } else if let data = data as? String {
-        formData.appendPart(string: data, name: name)
+        try formData.appendPart(string: data, name: name)
       } else {
-        formData.appendPart(string: data.debugDescription, name: name)
+        try formData.appendPart(string: data.debugDescription, name: name)
       }
     }
     

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -1,86 +1,100 @@
-class MultipartFormData {
+import Foundation
 
+/// A helper for building out multi-part form data for upload
+class MultipartFormData {
+  
+  enum FormDataError: Error, LocalizedError {
+    case encodingStringToDataFailed(_ string: String)
+    
+    var localizedDescription: String {
+      switch self {
+      case .encodingStringToDataFailed(let string):
+        return "Could not encode \"\(string)\" as .utf8 data."
+      }
+    }
+  }
+
+  /// A Carriage Return Line Feed character, which will be seen as a newline on both unix and Windows servers.
   static let CRLF = "\r\n"
 
   let boundary: String
 
   private var bodyParts: [BodyPart]
 
+  /// Designated initializer
+  ///
+  /// - Parameter boundary: The boundary to use between parts of the form.
   init(boundary: String) {
     self.boundary = boundary
     self.bodyParts = []
   }
-
+  
+  /// Convenience initializer which uses a pre-defined boundary
   convenience init() {
     self.init(boundary: "apollo-ios.boundary.\(UUID().uuidString)")
   }
 
-  struct BodyPart {
-    let name: String
-    let inputStream: InputStream
-    let contentLength: UInt64
-    let contentType: String?
-    let filename: String?
-
-    init(name: String, inputStream: InputStream, contentLength: UInt64, contentType: String?, filename: String?) {
-      self.name = name
-      self.inputStream = inputStream
-      self.contentLength = contentLength
-      self.contentType = contentType
-      self.filename = filename
-    }
-
-    func headers() -> String {
-      var headers = "Content-Disposition: form-data; name=\"\(self.name)\""
-      if let filename = self.filename {
-        headers += "; filename=\"\(filename)\""
-      }
-      headers += "\(MultipartFormData.CRLF)"
-
-      if let contentType = self.contentType {
-        headers += "Content-Type: \(contentType)\(MultipartFormData.CRLF)"
-      }
-
-      headers += "\(MultipartFormData.CRLF)"
-
-      return headers
-    }
+  func appendPart(string: String, name: String) throws {
+    self.appendPart(data: try self.encode(string: string),
+                    name: name,
+                    contentType: nil)
   }
-
-  func appendPart(string: String, name: String) {
-    self.appendPart(data: self.encode(string: string), name: name, contentType: nil)
-  }
-
-  func appendPart(data: Data, name: String, contentType: String? = nil, filename: String? = nil) {
+  
+  /// Appends the passed-in data as a part of the body.
+  ///
+  /// - Parameters:
+  ///   - data: The data to append
+  ///   - name: The name of the part to pass along to the server
+  ///   - contentType: [optional] The content type of this part. Defaults to nil.
+  ///   - filename: [optional] The name of the file for this part. Defaults to nil.
+  func appendPart(data: Data,
+                  name: String,
+                  contentType: String? = nil,
+                  filename: String? = nil) {
     let inputStream = InputStream(data: data)
     let contentLength = UInt64(data.count)
 
-    self.appendPart(inputStream: inputStream, contentLength: contentLength, name: name, contentType: contentType, filename: filename)
+    self.appendPart(inputStream: inputStream,
+                    contentLength: contentLength,
+                    name: name,
+                    contentType: contentType,
+                    filename: filename)
   }
 
-  func appendPart(inputStream: InputStream, contentLength: UInt64, name: String, contentType: String? = nil, filename: String? = nil) {
-    self.bodyParts.append(BodyPart(name: name, inputStream: inputStream, contentLength: contentLength, contentType: contentType, filename: filename))
+  func appendPart(inputStream: InputStream,
+                  contentLength: UInt64,
+                  name: String,
+                  contentType: String? = nil,
+                  filename: String? = nil) {
+    self.bodyParts.append(BodyPart(name: name,
+                                   inputStream: inputStream,
+                                   contentLength: contentLength,
+                                   contentType: contentType,
+                                   filename: filename))
   }
 
-  func encode() -> Data {
+  /// Encodes everything into the final form data to send to a server.
+  ///
+  /// - Returns: The final form data to send to a server.
+  func encode() throws -> Data {
     var data = Data()
 
     for p in self.bodyParts {
-      data.append(self.encode(bodyPart: p))
+      data.append(try self.encode(bodyPart: p))
     }
 
-    data.append(self.encode(string: "--".appending(self.boundary.appending("--"))))
+    data.append(try self.encode(string: "--".appending(self.boundary.appending("--"))))
 
     return data
   }
   
-  private func encode(bodyPart: BodyPart) -> Data {
+  private func encode(bodyPart: BodyPart) throws -> Data {
     var encoded = Data()
 
-    encoded.append(self.encode(string: "--\(self.boundary)\(MultipartFormData.CRLF)"))
-    encoded.append(self.encode(string: bodyPart.headers()))
+    encoded.append(try self.encode(string: "--\(self.boundary)\(MultipartFormData.CRLF)"))
+    encoded.append(try self.encode(string: bodyPart.headers()))
     encoded.append(self.encode(inputStream: bodyPart.inputStream, length: bodyPart.contentLength))
-    encoded.append(self.encode(string: "\(MultipartFormData.CRLF)"))
+    encoded.append(try self.encode(string: "\(MultipartFormData.CRLF)"))
 
     return encoded
   }
@@ -109,7 +123,50 @@ class MultipartFormData {
     return encoded
   }
 
-  private func encode(string: String) -> Data {
-    return string.data(using: .utf8, allowLossyConversion: false)!
+  private func encode(string: String) throws -> Data {
+    guard let encodedData = string.data(using: .utf8, allowLossyConversion: false) else {
+      throw FormDataError.encodingStringToDataFailed(string)
+    }
+    
+    return encodedData
+  }
+}
+
+/// MARK: - BodyPart
+
+/// A structure representing a single part of multi-part form data.
+fileprivate struct BodyPart {
+  let name: String
+  let inputStream: InputStream
+  let contentLength: UInt64
+  let contentType: String?
+  let filename: String?
+  
+  init(name: String,
+       inputStream: InputStream,
+       contentLength: UInt64,
+       contentType: String?,
+       filename: String?) {
+    self.name = name
+    self.inputStream = inputStream
+    self.contentLength = contentLength
+    self.contentType = contentType
+    self.filename = filename
+  }
+  
+  func headers() -> String {
+    var headers = "Content-Disposition: form-data; name=\"\(self.name)\""
+    if let filename = self.filename {
+      headers += "; filename=\"\(filename)\""
+    }
+    headers += "\(MultipartFormData.CRLF)"
+    
+    if let contentType = self.contentType {
+      headers += "Content-Type: \(contentType)\(MultipartFormData.CRLF)"
+    }
+    
+    headers += "\(MultipartFormData.CRLF)"
+    
+    return headers
   }
 }

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -11,14 +11,14 @@ import XCTest
 
 class MultipartFormDataTests: XCTestCase {
 
-    func testSingleFile() {
+    func testSingleFile() throws {
       let alphaFileUrl = Bundle(for: type(of: self)).url(forResource: "a", withExtension: "txt")!
 
       let alphaData = try! Data(contentsOf: alphaFileUrl)
 
       let formData = MultipartFormData(boundary: "------------------------cec8e8123c05ba25")
-      formData.appendPart(string: "{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }", name: "operations")
-      formData.appendPart(string: "{ \"0\": [\"variables.file\"] }", name: "map")
+      try formData.appendPart(string: "{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }", name: "operations")
+      try formData.appendPart(string: "{ \"0\": [\"variables.file\"] }", name: "map")
       formData.appendPart(data: alphaData, name: "0", contentType: "text/plain", filename: "a.txt")
       
       let expectation = """
@@ -40,10 +40,10 @@ class MultipartFormDataTests: XCTestCase {
                         """
 
       // Replacing CRLF with new line as string literals uses new lines
-      XCTAssertEqual(String(data: formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+      XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
     }
 
-  func testMultifileFile() {
+  func testMultifileFile() throws {
     let bravoFileUrl = Bundle(for: type(of: self)).url(forResource: "b", withExtension: "txt")!
     let charlieFileUrl = Bundle(for: type(of: self)).url(forResource: "c", withExtension: "txt")!
 
@@ -51,8 +51,8 @@ class MultipartFormDataTests: XCTestCase {
     let charlieData = try! Data(contentsOf: charlieFileUrl)
 
     let formData = MultipartFormData(boundary: "------------------------ec62457de6331cad")
-    formData.appendPart(string: "{ \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }", name: "operations")
-    formData.appendPart(string: "{ \"0\": [\"variables.files.0\"], \"1\": [\"variables.files.1\"] }", name: "map")
+    try formData.appendPart(string: "{ \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }", name: "operations")
+    try formData.appendPart(string: "{ \"0\": [\"variables.files.0\"], \"1\": [\"variables.files.1\"] }", name: "map")
     formData.appendPart(data: bravoData, name: "0", contentType: "text/plain", filename: "b.txt")
     formData.appendPart(data: charlieData, name: "1", contentType: "text/plain", filename: "c.txt")
 
@@ -81,10 +81,10 @@ class MultipartFormDataTests: XCTestCase {
                         """
 
     // Replacing CRLF with new line as string literals uses new lines
-    XCTAssertEqual(String(data: formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+    XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
   }
 
-  func testBatchFile() {
+  func testBatchFile() throws {
     let alphaFileUrl = Bundle(for: type(of: self)).url(forResource: "a", withExtension: "txt")!
     let bravoFileUrl = Bundle(for: type(of: self)).url(forResource: "b", withExtension: "txt")!
     let charlieFileUrl = Bundle(for: type(of: self)).url(forResource: "c", withExtension: "txt")!
@@ -94,8 +94,8 @@ class MultipartFormDataTests: XCTestCase {
     let charlieData = try! Data(contentsOf: charlieFileUrl)
 
     let formData = MultipartFormData(boundary: "------------------------627436eaefdbc285")
-    formData.appendPart(string: "[{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }, { \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }]", name: "operations")
-    formData.appendPart(string: "{ \"0\": [\"0.variables.file\"], \"1\": [\"1.variables.files.0\"], \"2\": [\"1.variables.files.1\"] }", name: "map")
+    try formData.appendPart(string: "[{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }, { \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }]", name: "operations")
+    try formData.appendPart(string: "{ \"0\": [\"0.variables.file\"], \"1\": [\"1.variables.files.0\"], \"2\": [\"1.variables.files.1\"] }", name: "map")
     formData.appendPart(data: alphaData, name: "0", contentType: "text/plain", filename: "a.txt")
     formData.appendPart(data: bravoData, name: "1", contentType: "text/plain", filename: "b.txt")
     formData.appendPart(data: charlieData, name: "2", contentType: "text/plain", filename: "c.txt")
@@ -131,6 +131,6 @@ class MultipartFormDataTests: XCTestCase {
                       """
 
     // Replacing CRLF with new line as string literals uses new lines
-    XCTAssertEqual(String(data: formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+    XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
   }
 }


### PR DESCRIPTION
Added a bunch of documentation for code merged from #626, and did a bit of organizational stuff. 

Only real functional change is to take a method to encode a string which was previously force-unwrapping and set it up to `throw` instead, since consumers of the SDK should be able to choose if they want to crash rather than just failing. Totally missed that in the earlier review 🤦‍♀️