### PR TITLE
Add "operationName" to GraphQLOperation protocol

### DIFF
--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -8,6 +8,7 @@ public protocol GraphQLOperation: class {
   var operationType: GraphQLOperationType { get }
   
   var operationDefinition: String { get }
+  var operationName: String { get }
   var operationIdentifier: String? { get }
   
   var queryDocument: String { get }


### PR DESCRIPTION
Now that https://github.com/apollographql/apollo-tooling/pull/1386 is released, update `GraphQLOperation` to have an `operationName` var, so we can use it :)