### PR TITLE
Make `GraphQLResultError` public

### DIFF
--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -26,7 +26,7 @@ struct GraphQLResolveInfo {
 
 public struct GraphQLResultError: Error, LocalizedError {
   let path: ResponsePath
-  let underlying: Error
+  public let underlying: Error
   
   public var errorDescription: String? {
     return "Error at path \"\(path))\": \(underlying)"

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -24,7 +24,7 @@ struct GraphQLResolveInfo {
   }
 }
 
-struct GraphQLResultError: Error, LocalizedError {
+public struct GraphQLResultError: Error, LocalizedError {
   let path: ResponsePath
   let underlying: Error
   


### PR DESCRIPTION
## Motivation

Errors produced by Apollo SDK should be public so that clients can perform type safe error handling using pattern matching.