### PR TITLE
Send `operationName`

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		9BDE43D122C6655300FD7C7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43D022C6655200FD7C7F /* Cancellable.swift */; };
 		9BDE43DD22C6705300FD7C7F /* GraphQLHTTPResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */; };
 		9BDE43DF22C6708600FD7C7F /* GraphQLHTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */; };
+		9BEDC79E22E5D2CF00549BF6 /* RequestCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BEDC79D22E5D2CF00549BF6 /* RequestCreator.swift */; };
 		9BF1A94F22CA5784005292C2 /* HTTPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */; };
 		9BF1A95122CA6E71005292C2 /* GraphQLGETTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */; };
 		9F0CA4451EE7F9E90032DD39 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
@@ -267,6 +268,7 @@
 		9BDE43D022C6655200FD7C7F /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponseError.swift; sourceTree = "<group>"; };
 		9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPRequestError.swift; sourceTree = "<group>"; };
+		9BEDC79D22E5D2CF00549BF6 /* RequestCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestCreator.swift; sourceTree = "<group>"; };
 		9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTransportTests.swift; sourceTree = "<group>"; };
 		9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLGETTransformer.swift; sourceTree = "<group>"; };
 		9F10A51D1EC1BA0F0045E62B /* MockNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkTransport.swift; sourceTree = "<group>"; };
@@ -645,12 +647,13 @@
 				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
 				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
 				C377CCA822D798BD00572E03 /* GraphQLFile.swift */,
+				9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */,
 				5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */,
 				9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */,
 				9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
-				9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */,
 				C377CCAA22D7992E00572E03 /* MultipartFormData.swift */,
+				9BEDC79D22E5D2CF00549BF6 /* RequestCreator.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -1169,6 +1172,7 @@
 				9FADC84F1E6B865E00C677E6 /* DataLoader.swift in Sources */,
 				9FF90A611DDDEB100034C3B6 /* GraphQLResponse.swift in Sources */,
 				9F27D4641D40379500715680 /* JSONStandardTypeConversions.swift in Sources */,
+				9BEDC79E22E5D2CF00549BF6 /* RequestCreator.swift in Sources */,
 				9FA6F3681E65DF4700BF8D73 /* GraphQLResultAccumulator.swift in Sources */,
 				9FF90A651DDDEB100034C3B6 /* GraphQLExecutor.swift in Sources */,
 				9FC750611D2A59C300458D91 /* GraphQLOperation.swift in Sources */,

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -9,6 +9,7 @@ public protocol GraphQLOperation: class {
   
   var operationDefinition: String { get }
   var operationIdentifier: String? { get }
+  var operationName: String { get }
   
   var queryDocument: String { get }
   

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -74,6 +74,7 @@ public class HTTPNetworkTransport: NetworkTransport {
   let serializationFormat = JSONSerializationFormat.self
   let useGETForQueries: Bool
   let delegate: HTTPNetworkTransportDelegate?
+  private let sendOperationIdentifiers: Bool
   
   /// Creates a network transport with the specified server URL and session configuration.
   ///
@@ -189,8 +190,6 @@ public class HTTPNetworkTransport: NetworkTransport {
     
     return task
   }
-  
-  private let sendOperationIdentifiers: Bool
   
   private func handleErrorOrRetry<Operation>(operation: Operation,
                                              error: Error,

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -237,7 +237,7 @@ public class HTTPNetworkTransport: NetworkTransport {
   }
   
   private func createRequest<Operation: GraphQLOperation>(for operation: Operation, files: [GraphQLFile]?) throws -> URLRequest {
-    let body = requestBody(for: operation)
+    let body = RequestCreator.requestBody(for: operation, sendOperationIdentifiers: self.sendOperationIdentifiers)
     var request = URLRequest(url: self.url)
     
     if self.useGETForQueries && operation.operationType == .query {
@@ -251,7 +251,12 @@ public class HTTPNetworkTransport: NetworkTransport {
     } else {
       do {
         if let files = files, !files.isEmpty {
-          let formData = try requestMultipartFormData(for: operation, files: files)
+          let formData = try RequestCreator.requestMultipartFormData(
+            for: operation,
+            files: files,
+            sendOperationIdentifiers: self.sendOperationIdentifiers,
+            serializationFormat: self.serializationFormat)
+          
           request.setValue("multipart/form-data; boundary=\(formData.boundary)", forHTTPHeaderField: "Content-Type")
           request.httpBody = try formData.encode()
         } else {
@@ -278,50 +283,5 @@ public class HTTPNetworkTransport: NetworkTransport {
     }
     
     return request
-  }
-  
-  func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
-    var body: GraphQLMap = [
-      "variables": operation.variables,
-      "operationName": operation.operationName,
-    ]
-    
-    if sendOperationIdentifiers {
-      guard let operationIdentifier = operation.operationIdentifier else {
-        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
-      }
-      
-      body["id"] = operationIdentifier
-    } else {
-      body["query"] = operation.queryDocument
-    }
-    
-    return body
-  }
-  
-  private func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation, files: [GraphQLFile]) throws -> MultipartFormData {
-    let formData = MultipartFormData()
-    
-    let fields = requestBody(for: operation)
-    for (name, data) in fields {
-      if let data = data as? GraphQLMap {
-        let data = try serializationFormat.serialize(value: data)
-        formData.appendPart(data: data, name: name)
-      } else if let data = data as? String {
-        try formData.appendPart(string: data, name: name)
-      } else {
-        try formData.appendPart(string: data.debugDescription, name: name)
-      }
-    }
-    
-    files.forEach {
-      formData.appendPart(inputStream: $0.inputStream,
-                          contentLength: $0.contentLength,
-                          name: $0.fieldName,
-                          contentType: $0.mimeType,
-                          filename: $0.originalName)
-    }
-    
-    return formData
   }
 }

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -280,16 +280,23 @@ public class HTTPNetworkTransport: NetworkTransport {
     return request
   }
   
-  private func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
+  func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
+    var body: GraphQLMap = [
+      "variables": operation.variables,
+      "operationName": operation.operationName,
+    ]
+    
     if sendOperationIdentifiers {
       guard let operationIdentifier = operation.operationIdentifier else {
         preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
       }
       
-      return ["id": operationIdentifier, "variables": operation.variables]
+      body["id"] = operationIdentifier
+    } else {
+      body["query"] = operation.queryDocument
     }
     
-    return ["query": operation.queryDocument, "variables": operation.variables]
+    return body
   }
   
   private func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation, files: [GraphQLFile]) throws -> MultipartFormData {

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+// Helper struct to create requests independently of HTTP operations.
+struct RequestCreator {
+  
+  static func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
+    var body: GraphQLMap = [
+      "variables": operation.variables,
+      "operationName": operation.operationName,
+    ]
+    
+    if sendOperationIdentifiers {
+      guard let operationIdentifier = operation.operationIdentifier else {
+        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
+      }
+      
+      body["id"] = operationIdentifier
+    } else {
+      body["query"] = operation.queryDocument
+    }
+    
+    return body
+  }
+  
+  static func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation, files: [GraphQLFile], sendOperationIdentifiers: Bool, serializationFormat: JSONSerializationFormat.Type) throws -> MultipartFormData {
+    let formData = MultipartFormData()
+    
+    let fields = requestBody(for: operation, sendOperationIdentifiers: sendOperationIdentifiers)
+    for (name, data) in fields {
+      if let data = data as? GraphQLMap {
+        let data = try serializationFormat.serialize(value: data)
+        formData.appendPart(data: data, name: name)
+      } else if let data = data as? String {
+        try formData.appendPart(string: data, name: name)
+      } else {
+        try formData.appendPart(string: data.debugDescription, name: name)
+      }
+    }
+    
+    files.forEach {
+      formData.appendPart(inputStream: $0.inputStream,
+                          contentLength: $0.contentLength,
+                          name: $0.fieldName,
+                          contentType: $0.mimeType,
+                          filename: $0.originalName)
+    }
+    
+    return formData
+  }
+}

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -1,9 +1,15 @@
 import Foundation
 
 // Helper struct to create requests independently of HTTP operations.
-struct RequestCreator {
+public struct RequestCreator {
   
-  static func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
+  /// Creates a `GraphQLMap` out of the passed-in operation
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to use
+  ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
+  /// - Returns: The created `GraphQLMap`
+  public static func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
     var body: GraphQLMap = [
       "variables": operation.variables,
       "operationName": operation.operationName,

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -239,7 +239,7 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
   }
   
   fileprivate func sendHelper<Operation: GraphQLOperation>(operation: Operation, resultHandler: @escaping (_ response: JSONObject?, _ error: Error?) -> Void) -> String? {
-    let body = requestBody(for: operation)
+    let body = RequestCreator.requestBody(for: operation, sendOperationIdentifiers: self.sendOperationIdentifiers)
     let sequenceNumber = "\(nextSequenceNumber())"
     
     guard let message = OperationMessage(payload: body, id: sequenceNumber).rawMessage else {
@@ -254,16 +254,6 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
     }
 
     return sequenceNumber
-  }
-  
-  private func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
-    if sendOperationIdentifiers {
-      guard let operationIdentifier = operation.operationIdentifier else {
-        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
-      }
-      return ["id": operationIdentifier, "variables": operation.variables]
-    }
-    return ["query": operation.queryDocument, "variables": operation.variables]
   }
   
   public func unsubscribe(_ subscriptionId: String) {

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -13,11 +13,10 @@ import StarWarsAPI
 class GETTransformerTests: XCTestCase {
   
   private lazy var url = URL(string: "http://localhost:8080/graphql")!
-  private lazy var transport = HTTPNetworkTransport(url: self.url)
   
   func testEncodingQueryWithSingleParameter() {
     let operation = HeroNameQuery(episode: .empire)
-    let body = self.transport.requestBody(for: operation)
+    let body = RequestCreator.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -28,7 +27,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() {
     let operation = HeroNameTypeSpecificConditionalInclusionQuery(episode: .jedi, includeName: true)
-    let body = self.transport.requestBody(for: operation)
+    let body = RequestCreator.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -91,7 +90,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithNullDefaultParameter() {
     let operation = HeroNameQuery()
-    let body = self.transport.requestBody(for: operation)
+    let body = RequestCreator.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -99,16 +99,4 @@ class GETTransformerTests: XCTestCase {
     
     XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D")
   }
-  
-  func testMissingQueryParameterInBodyReturnsNil() {
-    let operation = HeroNameQuery(episode: .empire)
-    let body: GraphQLMap = [
-      "variables": operation.variables,
-    ]
-    
-    let transformer = GraphQLGETTransformer(body: body, url: self.url)
-    
-    let url = transformer.createGetURL()
-    XCTAssertNil(url)
-  }
 }

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -13,27 +13,22 @@ import StarWarsAPI
 class GETTransformerTests: XCTestCase {
   
   private lazy var url = URL(string: "http://localhost:8080/graphql")!
+  private lazy var transport = HTTPNetworkTransport(url: self.url)
   
   func testEncodingQueryWithSingleParameter() {
     let operation = HeroNameQuery(episode: .empire)
-    let body: GraphQLMap = [
-      "query": operation.queryDocument,
-      "variables": operation.variables,
-    ]
+    let body = self.transport.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
     let url = transformer.createGetURL()
     
-    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22EMPIRE%22%7D")
+    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroName&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22EMPIRE%22%7D")
   }
   
   func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() {
     let operation = HeroNameTypeSpecificConditionalInclusionQuery(episode: .jedi, includeName: true)
-    let body: GraphQLMap = [
-      "query": operation.queryDocument,
-      "variables": operation.variables,
-    ]
+    let body = self.transport.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -42,7 +37,7 @@ class GETTransformerTests: XCTestCase {
     if #available(iOS 11, macOS 13, tvOS 11, watchOS 4, *) {
       // Here, we know that everything should be encoded in a stable order,
       // and we can check the encoded URL string directly.
-          XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?query=query%20HeroNameTypeSpecificConditionalInclusion($episode:%20Episode,%20$includeName:%20Boolean!)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%20@include(if:%20$includeName)%0A%20%20%20%20...%20on%20Droid%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22JEDI%22,%22includeName%22:true%7D")
+          XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroNameTypeSpecificConditionalInclusion&query=query%20HeroNameTypeSpecificConditionalInclusion($episode:%20Episode,%20$includeName:%20Boolean!)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%20@include(if:%20$includeName)%0A%20%20%20%20...%20on%20Droid%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22JEDI%22,%22includeName%22:true%7D")
     } else {
       // We can't guarantee order of encoding, so we need to pull the JSON back
       // out and check that it has the correct and correctly typed properties.
@@ -61,6 +56,14 @@ class GETTransformerTests: XCTestCase {
         return
       }
       
+      guard
+        let operationNameItem = queryItems.first(where: { $0.name == "operationName" }),
+        let operationName = operationNameItem.value else {
+          XCTFail("Query items did not contain operation name!")
+          return
+      }
+      
+      XCTAssertEqual(operationName, "HeroNameTypeSpecificConditionalInclusion")
       
       guard
         let variablesQueryItem = queryItems.first(where: { $0.name == "variables" }),
@@ -88,15 +91,12 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithNullDefaultParameter() {
     let operation = HeroNameQuery()
-    let body: GraphQLMap = [
-      "query": operation.queryDocument,
-      "variables": operation.variables,
-    ]
+    let body = self.transport.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
     let url = transformer.createGetURL()
     
-    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D")
+    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroName&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D")
   }
 }


### PR DESCRIPTION
Now that we're having folks use a new version of the codegen, we can send `operationName` along with all our requests. Mostly taken from #496, but since I'd like to get this out ASAP and Johan's out of town, I took it over. 

Also made a couple other changes: 

- Swiped some changes from #608 to make sure all keys and values for the body were getting added properly to `GET` requests (Thanks @codebear98!)
- Pulled out code for generating request so it could be shared across HTTP and websocket
- Updated tests