### PR TITLE
Send headers if possible

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -268,6 +268,12 @@ public class HTTPNetworkTransport: NetworkTransport {
       }
     }
     
+    request.setValue(operation.operationName, forHTTPHeaderField: "X-APOLLO-OPERATION-NAME")
+    
+    if let operationID = operation.operationIdentifier {
+      request.setValue(operationID, forHTTPHeaderField: "X-APOLLO-OPERATION-ID")
+    }
+    
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     
     // If there's a delegate, do a pre-flight check and allow modifications to the request.


### PR DESCRIPTION
While I'm mucking around with the `operationName`, I've addressed #375 and added `"X-APOLLO-OPERATION-NAME"` headers to all outgoing requests and `"X-APOLLO-OPERATION-ID"` headers to operations which have an ID. 