### PR TITLE
Add ApolloSQLite and ApolloWebSockets to Package.swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SQLite.swift",
+        "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
+          "version": "0.12.2"
+        }
+      },
+      {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/daltoniam/Starscream",
+        "state": {
+          "branch": null,
+          "revision": "9c03ef715d1bc9334b446c90df53586dd38cf849",
+          "version": "3.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,14 +9,27 @@ let package = Package(
         .library(
             name: "Apollo",
             targets: ["Apollo"]),
+		.library(
+			name: "ApolloSQLite",
+			targets: ["ApolloSQLite"]),
+		.library(
+			name: "ApolloWebSocket",
+			targets: ["ApolloWebSocket"]),
     ],
     dependencies: [
-
+		.package(url: "https://github.com/stephencelis/SQLite.swift.git", from: .init(0, 12, 2)),
+		.package(url: "https://github.com/daltoniam/Starscream", from: .init(3, 1, 0)),
     ],
     targets: [
         .target(
             name: "Apollo",
             dependencies: []),
+		.target(
+			name: "ApolloSQLite",
+			dependencies: ["Apollo", "SQLite"]),
+		.target(
+			name: "ApolloWebSocket",
+			dependencies: ["Starscream"]),
         .testTarget(
             name: "ApolloTestSupport",
             dependencies: ["Apollo"]),

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
 			targets: ["ApolloWebSocket"]),
     ],
     dependencies: [
-		.package(url: "https://github.com/stephencelis/SQLite.swift.git", from: .init(0, 12, 2)),
-		.package(url: "https://github.com/daltoniam/Starscream", from: .init(3, 1, 0)),
+		.package(url: "https://github.com/stephencelis/SQLite.swift.git", .exact("0.12.2")),
+		.package(url: "https://github.com/daltoniam/Starscream", .exact("3.1.0")),
     ],
     targets: [
         .target(

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SQLite
 #if !COCOAPODS
 import Apollo

--- a/Sources/ApolloSQLite/SQLiteSerialization.swift
+++ b/Sources/ApolloSQLite/SQLiteSerialization.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SQLite
 #if !COCOAPODS
 import Apollo


### PR DESCRIPTION
This exposes the ApolloSQLite and ApolloWebSockets sub-frameworks to clients.

This comes after I tried to set up disk-caching and realized `SQLiteNormalizedCache` wasn't available for use in SPM, although it was for Carthage and Cocoapods. I also included ApolloWebSockets since it seemed to be in the same situation.