### PR TITLE
Allow setting the delegate property on transport

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -73,7 +73,7 @@ public class HTTPNetworkTransport {
   let session: URLSession
   let serializationFormat = JSONSerializationFormat.self
   let useGETForQueries: Bool
-  let delegate: HTTPNetworkTransportDelegate?
+  public weak var delegate: HTTPNetworkTransportDelegate?
   private let sendOperationIdentifiers: Bool
   
   /// Creates a network transport with the specified server URL and session configuration.


### PR DESCRIPTION
In addition to passing the delegate as an argument to `HTTPNetworkTransport`, it's practical to be able to set it as a property as well.

For example; we use a wrapper class for the client, which looks something like this:

```swift
class GraphQLClient {
    static var shared = GraphQLClient(url: Config.API.graphQLURL)
    private let client: ApolloClient
    init(url: URL) {
        let transport = HTTPNetworkTransport(url: url,
                                             configuration: URLSessionConfiguration.default,
                                             sendOperationIdentifiers: false,
                                             delegate: self)

        self.client = ApolloClient(networkTransport: transport)
    }
}
```

But passing `self` to `HTTPNetworkTransport` as delegate doesn't work, because that gives the compile time error:

    Constant 'self.client' used before being initialized

From inspecting the code it should be totally safe to make the `delegate` property public and assignable, which would allow the delegate to be set after `self.client` is initialized;

```swift
class GraphQLClient {
    static var shared = GraphQLClient(url: Config.API.graphQLURL)
    private let client: ApolloClient
    init(url: URL) {
        let transport = HTTPNetworkTransport(url: url,
                                             configuration: URLSessionConfiguration.default,
                                             sendOperationIdentifiers: false)

        self.client = ApolloClient(networkTransport: transport)

        transport.delegate = self
    }
}
```