### PR TITLE
Swap out session configuration for URLSession

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ cache:
     - ../starwars-server
 
 before_install:
-  - nvm install 8
-  - nvm alias default 8
+  - nvm install 10
+  - nvm alias default 10
   - (./scripts/install-or-update-starwars-server.sh)
   - (cd ../starwars-server && npm start) &
   - npm install -g apollo

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -80,17 +80,17 @@ public class HTTPNetworkTransport {
   ///
   /// - Parameters:
   ///   - url: The URL of a GraphQL server to connect to.
-  ///   - configuration: A session configuration used to configure the session. Defaults to `URLSessionConfiguration.default`.
+  ///   - session: The URLSession to use. Defaults to `URLSession.shared`,
   ///   - sendOperationIdentifiers: Whether to send operation identifiers rather than full operation text, for use with servers that support query persistence. Defaults to false.
   ///   - useGETForQueries: If query operation should be sent using GET instead of POST. Defaults to false.
   ///   - delegate: [Optional] A delegate which can conform to any or all of `HTTPNetworkTransportPreflightDelegate`, `HTTPNetworkTransportTaskCompletedDelegate`, and `HTTPNetworkTransportRetryDelegate`. Defaults to nil.
   public init(url: URL,
-              configuration: URLSessionConfiguration = .default,
+              session: URLSession = .shared,
               sendOperationIdentifiers: Bool = false,
               useGETForQueries: Bool = false,
               delegate: HTTPNetworkTransportDelegate? = nil) {
     self.url = url
-    self.session = URLSession(configuration: configuration)
+    self.session = session
     self.sendOperationIdentifiers = sendOperationIdentifiers
     self.useGETForQueries = useGETForQueries
     self.delegate = delegate

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -35,7 +35,7 @@ The available implementations are:
 
 The initializer for `HTTPNetworkTransport` has several properties which can allow you to get better information and finer-grained control of your HTTP requests and responses:
 
-- `configuration` allows you to pass in a custom `URLSessionConfiguration` to set up anything which needs to be done for every single request without alteration. This defaults to `URLSessionConfiguration.default`. 
+- `session` allows you to pass in a custom `URLSession` to set up anything which needs to be done for every single request without alteration. This defaults to `URLSession.shared`. 
 - `sendOperationIdentifiers` allows you send operation identifiers along with your requests. **NOTE:** To send operation identifiers, Apollo types must be generated with `operationIdentifier`s or sending data will crash. Due to this restriction, this option defaults to `false`.
 - `useGETForQueries` sends all requests of `query` type using `GET` instead of `POST`. This defaults to `false` to preserve existing behavior in older versions of the client. 
 - `delegate` Can conform to one or many of several sub-protocols for `HTTPNetworkTransportDelegate`, detailed below.

--- a/scripts/install-or-update-starwars-server.sh
+++ b/scripts/install-or-update-starwars-server.sh
@@ -2,7 +2,7 @@
 
 cd $(dirname "$0")/../..
 
-git -C starwars-server pull || git clone https://github.com/apollostack/starwars-server
+git -C starwars-server pull || git clone https://github.com/apollographql/starwars-server
 
 cd starwars-server
 


### PR DESCRIPTION
The code changes here are pretty minimal: Swapping out a `URLSessionConfiguration` for the actual `URLSession`. However, by being able to pass in a `URLSession` that you control the `delegate` of, you can more easily support a number of things: 

- Certificate pinning
- Self-signed certificates
- Authentication challenge responses
- Metrics inspection

Note that this is going to be a breaking change if you were previously passing in a session configuration to the `HTTPNetworkTransport` - you'll need to hand that configuration to a `URLSession` yourself first. 