### PR TITLE
Mo' Better Uploading

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -977,7 +977,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = "Apollo GraphQL";
 				TargetAttributes = {
 					9F8A95771EC0FC1200304A2D = {

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloPerformanceTests.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloPerformanceTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -227,6 +227,9 @@ public class HTTPNetworkTransport {
     let body = RequestCreator.requestBody(for: operation, sendOperationIdentifiers: self.sendOperationIdentifiers)
     var request = URLRequest(url: self.url)
     
+    // We default to json, but this can be changed below if needed.
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
     if self.useGETForQueries && operation.operationType == .query {
       let transformer = GraphQLGETTransformer(body: body, url: self.url)
       if let urlForGet = transformer.createGetURL() {
@@ -261,8 +264,6 @@ public class HTTPNetworkTransport {
     if let operationID = operation.operationIdentifier {
       request.setValue(operationID, forHTTPHeaderField: "X-APOLLO-OPERATION-ID")
     }
-    
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     
     // If there's a delegate, do a pre-flight check and allow modifications to the request.
     if

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -95,18 +95,7 @@ public class HTTPNetworkTransport {
     self.useGETForQueries = useGETForQueries
     self.delegate = delegate
   }
-  
-  /// Uploads the given files with the given operation. 
-  ///
-  /// - Parameters:
-  ///   - operation: The operation to send
-  ///   - files: An array of `GraphQLFile` objects to send.
-  ///   - completionHandler: The completion handler to execute when the request completes or errors
-  /// - Returns: An object that can be used to cancel an in progress request.
-  public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
-    return send(operation: operation, files: files, completionHandler: completionHandler)
-  }
-  
+
   private func send<Operation>(operation: Operation, files: [GraphQLFile]?, completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     let request: URLRequest
     do {
@@ -286,6 +275,15 @@ extension HTTPNetworkTransport: NetworkTransport {
   
   public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     return send(operation: operation, files: nil, completionHandler: completionHandler)
+  }
+}
+
+// MARK: - UploadingNetworkTransport conformance
+
+extension HTTPNetworkTransport: UploadingNetworkTransport {
+  
+  public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+    return send(operation: operation, files: files, completionHandler: completionHandler)
   }
 }
 

--- a/Sources/Apollo/JSONSerializationFormat.swift
+++ b/Sources/Apollo/JSONSerializationFormat.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class JSONSerializationFormat {
   public class func serialize(value: JSONEncodable) throws -> Data {
-    return try JSONSerialization.data(withJSONObject: value.jsonValue, options: [])
+    return try JSONSerialization.dataSortedIfPossible(withJSONObject: value.jsonValue)
   }
   
   public class func deserialize(data: Data) throws -> JSONValue {

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -9,3 +9,16 @@ public protocol NetworkTransport {
   /// - Returns: An object that can be used to cancel an in progress request.
   func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
 }
+
+/// A network transport which can also handle uploads of files.
+public protocol UploadingNetworkTransport: NetworkTransport {
+  
+  /// Uploads the given files with the given operation.
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to send
+  ///   - files: An array of `GraphQLFile` objects to send.
+  ///   - completionHandler: The completion handler to execute when the request completes or errors
+  /// - Returns: An object that can be used to cancel an in progress request.
+  func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+}

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -51,7 +51,16 @@ public struct RequestCreator {
       formData = MultipartFormData()
     }
     
-    let fields = requestBody(for: operation, sendOperationIdentifiers: sendOperationIdentifiers)
+    // Make sure all fields for files are set to null, or the server won't look
+    // for the files in the rest of the form data
+    let fieldsForFiles = Set(files.map { $0.fieldName })
+    var fields = requestBody(for: operation, sendOperationIdentifiers: sendOperationIdentifiers)
+    var variables = fields["variables"] as? GraphQLMap ?? GraphQLMap()
+    for fieldName in fieldsForFiles {
+      variables.updateValue(nil, forKey: fieldName)
+    }
+    fields["variables"] = variables
+    
     let operationData = try serializationFormat.serialize(value: fields)
     formData.appendPart(data: operationData, name: "operations")
     

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -67,22 +67,22 @@ public struct RequestCreator {
     var map = [String: [String]]()
     if files.count == 1 {
       let firstFile = files.first!
-      map[firstFile.originalName] = ["variables.\(firstFile.fieldName)"]
+      map["0"] = ["variables.\(firstFile.fieldName)"]
     } else {
       for (index, file) in files.enumerated() {
-        map[file.originalName] = ["variables.\(file.fieldName).\(index)"]
+        map["\(index)"] = ["variables.\(file.fieldName).\(index)"]
       }
     }
     
     let mapData = try serializationFormat.serialize(value: map)
     formData.appendPart(data: mapData, name: "map")
-      
-    files.forEach {
-      formData.appendPart(inputStream: $0.inputStream,
-                          contentLength: $0.contentLength,
-                          name: $0.fieldName,
-                          contentType: $0.mimeType,
-                          filename: $0.originalName)
+    
+    for (index, file) in files.enumerated() {
+      formData.appendPart(inputStream: file.inputStream,
+                          contentLength: file.contentLength,
+                          name: "\(index)",
+                          contentType: file.mimeType,
+                          filename: file.originalName)
     }
     
     return formData

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -28,21 +28,46 @@ public struct RequestCreator {
     return body
   }
   
-  static func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation, files: [GraphQLFile], sendOperationIdentifiers: Bool, serializationFormat: JSONSerializationFormat.Type) throws -> MultipartFormData {
-    let formData = MultipartFormData()
+  /// Creates multi-part form data to send with a request
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to create the data for.
+  ///   - files: An array of files to use.
+  ///   - sendOperationIdentifiers: True if operation identifiers should be sent, false if not.
+  ///   - serializationFormat: The format to use to serialize data.
+  ///   - manualBoundary: [optional] A manual boundary to pass in. A default boundary will be used otherwise.
+  /// - Returns: The created form data
+  /// - Throws: Errors creating or loading the form  data
+  static func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
+                                                                    files: [GraphQLFile],
+                                                                    sendOperationIdentifiers: Bool,
+                                                                    serializationFormat: JSONSerializationFormat.Type,
+                                                                    manualBoundary: String? = nil) throws -> MultipartFormData {
+    let formData: MultipartFormData
+
+    if let boundary = manualBoundary {
+      formData = MultipartFormData(boundary: boundary)
+    } else {
+      formData = MultipartFormData()
+    }
     
     let fields = requestBody(for: operation, sendOperationIdentifiers: sendOperationIdentifiers)
-    for (name, data) in fields {
-      if let data = data as? GraphQLMap {
-        let data = try serializationFormat.serialize(value: data)
-        formData.appendPart(data: data, name: name)
-      } else if let data = data as? String {
-        try formData.appendPart(string: data, name: name)
-      } else {
-        try formData.appendPart(string: data.debugDescription, name: name)
+    let operationData = try serializationFormat.serialize(value: fields)
+    formData.appendPart(data: operationData, name: "operations")
+    
+    var map = [String: String]()
+    if files.count == 1 {
+      let firstFile = files.first!
+      map[firstFile.originalName] = "[variables.\(firstFile.fieldName)]"
+    } else {
+      for (index, file) in files.enumerated() {
+        map[file.originalName] = "[variables.\(file.fieldName).\(index)]"
       }
     }
     
+    let mapData = try serializationFormat.serialize(value: map)
+    formData.appendPart(data: mapData, name: "map")
+      
     files.forEach {
       formData.appendPart(inputStream: $0.inputStream,
                           contentLength: $0.contentLength,

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -55,13 +55,13 @@ public struct RequestCreator {
     let operationData = try serializationFormat.serialize(value: fields)
     formData.appendPart(data: operationData, name: "operations")
     
-    var map = [String: String]()
+    var map = [String: [String]]()
     if files.count == 1 {
       let firstFile = files.first!
-      map[firstFile.originalName] = "[variables.\(firstFile.fieldName)]"
+      map[firstFile.originalName] = ["variables.\(firstFile.fieldName)"]
     } else {
       for (index, file) in files.enumerated() {
-        map[file.originalName] = "[variables.\(file.fieldName).\(index)]"
+        map[file.originalName] = ["variables.\(file.fieldName).\(index)"]
       }
     }
     

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -57,7 +57,14 @@ public struct RequestCreator {
     var fields = requestBody(for: operation, sendOperationIdentifiers: sendOperationIdentifiers)
     var variables = fields["variables"] as? GraphQLMap ?? GraphQLMap()
     for fieldName in fieldsForFiles {
-      variables.updateValue(nil, forKey: fieldName)
+      if
+        let value = variables[fieldName],
+        let arrayValue = value as? [JSONEncodable] {
+        let updatedArray: [JSONEncodable?] = arrayValue.map { _ in nil }
+          variables.updateValue(updatedArray, forKey: fieldName)
+      } else {
+        variables.updateValue(nil, forKey: fieldName)
+      }
     }
     fields["variables"] = variables
     

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -4,15 +4,15 @@ import Apollo
 
 /// A network transport that sends subscriptions using one `NetworkTransport` and other requests using another `NetworkTransport`. Ideal for sending subscriptions via a web socket but everything else via HTTP. 
 public class SplitNetworkTransport {
-  private let httpNetworkTransport: NetworkTransport
+  private let httpNetworkTransport: UploadingNetworkTransport
   private let webSocketNetworkTransport: NetworkTransport
   
   /// Designated initializer
   ///
   /// - Parameters:
-  ///   - httpNetworkTransport: A `NetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
+  ///   - httpNetworkTransport: An `UploadingNetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
   ///   - webSocketNetworkTransport: A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar.
-  public init(httpNetworkTransport: NetworkTransport, webSocketNetworkTransport: NetworkTransport) {
+  public init(httpNetworkTransport: UploadingNetworkTransport, webSocketNetworkTransport: NetworkTransport) {
     self.httpNetworkTransport = httpNetworkTransport
     self.webSocketNetworkTransport = webSocketNetworkTransport
   }
@@ -28,5 +28,14 @@ extension SplitNetworkTransport: NetworkTransport {
     } else {
       return httpNetworkTransport.send(operation: operation, completionHandler: completionHandler)
     }
+  }
+}
+
+// MARK: - UploadingNetworkTransport conformance
+
+extension SplitNetworkTransport: UploadingNetworkTransport {
+  
+  public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+    return httpNetworkTransport.upload(operation: operation, files: files, completionHandler: completionHandler)
   }
 }

--- a/Tests/ApolloPerformanceTests/NormalizedCachingTests.swift
+++ b/Tests/ApolloPerformanceTests/NormalizedCachingTests.swift
@@ -65,8 +65,14 @@ class NormalizedCachingTests: XCTestCase {
       (1...100).forEach { number in
         let expectation = self.expectation(description: "Loading query #\(number) from store")
         
-        store.load(query: query) { (result, error) in
-          XCTAssertEqual(result?.data?.hero?.name, "R2-D2")
+        store.load(query: query) { result in
+          switch result {
+          case .success(let graphQLResult):
+            XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          case .failure(let error):
+            XCTFail("Unexpected error: \(error)")
+          }
+          
           expectation.fulfill()
         }
       }
@@ -111,8 +117,14 @@ class NormalizedCachingTests: XCTestCase {
         (1...10).forEach { _ in
           let expectation = self.expectation(description: "Loading query #\(number) from store")
           
-          store.load(query: query) { (result, error) in
-            XCTAssertEqual(result?.data?.hero?.friends?.first??.name, "Droid #\(number)")
+          store.load(query: query) { result in
+            switch result {
+            case .success(let graphQLResult):
+              XCTAssertEqual(graphQLResult.data?.hero?.friends?.first??.name, "Droid #\(number)")
+            case .failure(let error):
+              XCTFail("Unexpected error: \(error)")
+            }
+            
             expectation.fulfill()
           }
         }

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -184,9 +184,9 @@ Content-Disposition: form-data; name="operations"
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
-{"a.txt":["variables.upload"]}
+{"0":["variables.upload"]}
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="upload"; filename="a.txt"
+Content-Disposition: form-data; name="0"; filename="a.txt"
 Content-Type: text/plain
 
 Alpha file content.
@@ -200,9 +200,9 @@ Alpha file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
-{"a.txt":["variables.upload"]}
+{"0":["variables.upload"]}
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="upload"; filename="a.txt"
+Content-Disposition: form-data; name="0"; filename="a.txt"
 Content-Type: text/plain
 
 Alpha file content.
@@ -246,15 +246,15 @@ Content-Disposition: form-data; name="operations"
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
-{"a.txt":["variables.uploads.0"],"b.txt":["variables.uploads.1"]}
+{"0":["variables.uploads.0"],"1":["variables.uploads.1"]}
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="uploads"; filename="a.txt"
+Content-Disposition: form-data; name="0"; filename="a.txt"
 Content-Type: text/plain
 
 Alpha file content.
 
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="uploads"; filename="b.txt"
+Content-Disposition: form-data; name="1"; filename="b.txt"
 Content-Type: text/plain
 
 Bravo file content.
@@ -266,13 +266,13 @@ Bravo file content.
       // Query and operation parameters may be in weird order, so let's at least check that the files got encoded properly.
       let endString = """
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="uploads"; filename="a.txt"
+Content-Disposition: form-data; name="0"; filename="a.txt"
 Content-Type: text/plain
 
 Alpha file content.
 
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="uploads"; filename="b.txt"
+Content-Disposition: form-data; name="1"; filename="b.txt"
 Content-Type: text/plain
 
 Bravo file content.

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -8,46 +8,71 @@
 
 import XCTest
 @testable import Apollo
+import StarWarsAPI
 
 class MultipartFormDataTests: XCTestCase {
+  
+  private func checkString(_ string: String,
+                           includes expectedString: String,
+                           file: StaticString = #file,
+                           line: UInt = #line) {
+    XCTAssertTrue(string.contains(expectedString),
+                  "Expected string:\n\n\(expectedString)\n\ndid not appear in string\n\n\(string)",
+      file: file,
+      line: line)
+  }
+  
+  private func string(from formData: MultipartFormData) throws -> String {
+    let encodedData = try formData.encode()
+    let string = String(bytes: encodedData, encoding: .utf8)!
+  
+    // Replacing CRLF with new line as string literals uses new lines
+    return string.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n")
+  }
+  
+  private func fileURLForFile(named name: String, extension fileExtension: String) -> URL {
+    return Bundle(for: type(of: self)).url(forResource: name, withExtension: fileExtension)!
+  }
+  
+  // MARK: - Tests
+  
   func testSingleFile() throws {
-    let alphaFileUrl = Bundle(for: type(of: self)).url(forResource: "a", withExtension: "txt")!
-    
-    let alphaData = try! Data(contentsOf: alphaFileUrl)
+    let alphaFileUrl = self.fileURLForFile(named: "a", extension: "txt")
+    let alphaData = try Data(contentsOf: alphaFileUrl)
     
     let formData = MultipartFormData(boundary: "------------------------cec8e8123c05ba25")
     try formData.appendPart(string: "{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }", name: "operations")
     try formData.appendPart(string: "{ \"0\": [\"variables.file\"] }", name: "map")
     formData.appendPart(data: alphaData, name: "0", contentType: "text/plain", filename: "a.txt")
     
-    let expectation = """
-                        --------------------------cec8e8123c05ba25
-                        Content-Disposition: form-data; name="operations"
+    let expectedString = """
+--------------------------cec8e8123c05ba25
+Content-Disposition: form-data; name="operations"
 
-                        { "query": "mutation ($file: Upload!) { singleUpload(file: $file) { id } }", "variables": { "file": null } }
-                        --------------------------cec8e8123c05ba25
-                        Content-Disposition: form-data; name="map"
+{ "query": "mutation ($file: Upload!) { singleUpload(file: $file) { id } }", "variables": { "file": null } }
+--------------------------cec8e8123c05ba25
+Content-Disposition: form-data; name="map"
 
-                        { "0": ["variables.file"] }
-                        --------------------------cec8e8123c05ba25
-                        Content-Disposition: form-data; name="0"; filename="a.txt"
-                        Content-Type: text/plain
+{ "0": ["variables.file"] }
+--------------------------cec8e8123c05ba25
+Content-Disposition: form-data; name="0"; filename="a.txt"
+Content-Type: text/plain
 
-                        Alpha file content.
+Alpha file content.
 
-                        --------------------------cec8e8123c05ba25--
-                        """
-    
-    // Replacing CRLF with new line as string literals uses new lines
-    XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+--------------------------cec8e8123c05ba25--
+"""
+
+    let stringToCompare = try self.string(from: formData)
+    XCTAssertEqual(stringToCompare, expectedString)
   }
   
   func testMultifileFile() throws {
-    let bravoFileUrl = Bundle(for: type(of: self)).url(forResource: "b", withExtension: "txt")!
-    let charlieFileUrl = Bundle(for: type(of: self)).url(forResource: "c", withExtension: "txt")!
+    let bravoFileUrl = self.fileURLForFile(named: "b", extension: "txt")
+    let charlieFileUrl = self.fileURLForFile(named: "c", extension: "txt")
     
-    let bravoData = try! Data(contentsOf: bravoFileUrl)
-    let charlieData = try! Data(contentsOf: charlieFileUrl)
+    let bravoData = try Data(contentsOf: bravoFileUrl)
+    let charlieData = try Data(contentsOf: charlieFileUrl)
     
     let formData = MultipartFormData(boundary: "------------------------ec62457de6331cad")
     try formData.appendPart(string: "{ \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }", name: "operations")
@@ -55,32 +80,31 @@ class MultipartFormDataTests: XCTestCase {
     formData.appendPart(data: bravoData, name: "0", contentType: "text/plain", filename: "b.txt")
     formData.appendPart(data: charlieData, name: "1", contentType: "text/plain", filename: "c.txt")
     
-    let expectation = """
-                        --------------------------ec62457de6331cad
-                        Content-Disposition: form-data; name="operations"
+    let expectedString = """
+--------------------------ec62457de6331cad
+Content-Disposition: form-data; name="operations"
 
-                        { "query": "mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }", "variables": { "files": [null, null] } }
-                        --------------------------ec62457de6331cad
-                        Content-Disposition: form-data; name="map"
+{ "query": "mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }", "variables": { "files": [null, null] } }
+--------------------------ec62457de6331cad
+Content-Disposition: form-data; name="map"
 
-                        { "0": ["variables.files.0"], "1": ["variables.files.1"] }
-                        --------------------------ec62457de6331cad
-                        Content-Disposition: form-data; name="0"; filename="b.txt"
-                        Content-Type: text/plain
+{ "0": ["variables.files.0"], "1": ["variables.files.1"] }
+--------------------------ec62457de6331cad
+Content-Disposition: form-data; name="0"; filename="b.txt"
+Content-Type: text/plain
 
-                        Bravo file content.
+Bravo file content.
 
-                        --------------------------ec62457de6331cad
-                        Content-Disposition: form-data; name="1"; filename="c.txt"
-                        Content-Type: text/plain
+--------------------------ec62457de6331cad
+Content-Disposition: form-data; name="1"; filename="c.txt"
+Content-Type: text/plain
 
-                        Charlie file content.
+Charlie file content.
 
-                        --------------------------ec62457de6331cad--
-                        """
-    
-    // Replacing CRLF with new line as string literals uses new lines
-    XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+--------------------------ec62457de6331cad--
+"""
+    let stringToCompare = try self.string(from: formData)
+    XCTAssertEqual(stringToCompare, expectedString)
   }
   
   func testBatchFile() throws {
@@ -88,9 +112,9 @@ class MultipartFormDataTests: XCTestCase {
     let bravoFileUrl = Bundle(for: type(of: self)).url(forResource: "b", withExtension: "txt")!
     let charlieFileUrl = Bundle(for: type(of: self)).url(forResource: "c", withExtension: "txt")!
     
-    let alphaData = try! Data(contentsOf: alphaFileUrl)
-    let bravoData = try! Data(contentsOf: bravoFileUrl)
-    let charlieData = try! Data(contentsOf: charlieFileUrl)
+    let alphaData = try Data(contentsOf: alphaFileUrl)
+    let bravoData = try Data(contentsOf: bravoFileUrl)
+    let charlieData = try Data(contentsOf: charlieFileUrl)
     
     let formData = MultipartFormData(boundary: "------------------------627436eaefdbc285")
     try formData.appendPart(string: "[{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }, { \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }]", name: "operations")
@@ -99,37 +123,163 @@ class MultipartFormDataTests: XCTestCase {
     formData.appendPart(data: bravoData, name: "1", contentType: "text/plain", filename: "b.txt")
     formData.appendPart(data: charlieData, name: "2", contentType: "text/plain", filename: "c.txt")
     
-    let expectation = """
-                      --------------------------627436eaefdbc285
-                      Content-Disposition: form-data; name="operations"
+    let expectedString = """
+--------------------------627436eaefdbc285
+Content-Disposition: form-data; name="operations"
 
-                      [{ "query": "mutation ($file: Upload!) { singleUpload(file: $file) { id } }", "variables": { "file": null } }, { "query": "mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }", "variables": { "files": [null, null] } }]
-                      --------------------------627436eaefdbc285
-                      Content-Disposition: form-data; name="map"
+[{ "query": "mutation ($file: Upload!) { singleUpload(file: $file) { id } }", "variables": { "file": null } }, { "query": "mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }", "variables": { "files": [null, null] } }]
+--------------------------627436eaefdbc285
+Content-Disposition: form-data; name="map"
 
-                      { "0": ["0.variables.file"], "1": ["1.variables.files.0"], "2": ["1.variables.files.1"] }
-                      --------------------------627436eaefdbc285
-                      Content-Disposition: form-data; name="0"; filename="a.txt"
-                      Content-Type: text/plain
+{ "0": ["0.variables.file"], "1": ["1.variables.files.0"], "2": ["1.variables.files.1"] }
+--------------------------627436eaefdbc285
+Content-Disposition: form-data; name="0"; filename="a.txt"
+Content-Type: text/plain
 
-                      Alpha file content.
+Alpha file content.
 
-                      --------------------------627436eaefdbc285
-                      Content-Disposition: form-data; name="1"; filename="b.txt"
-                      Content-Type: text/plain
+--------------------------627436eaefdbc285
+Content-Disposition: form-data; name="1"; filename="b.txt"
+Content-Type: text/plain
 
-                      Bravo file content.
+Bravo file content.
 
-                      --------------------------627436eaefdbc285
-                      Content-Disposition: form-data; name="2"; filename="c.txt"
-                      Content-Type: text/plain
+--------------------------627436eaefdbc285
+Content-Disposition: form-data; name="2"; filename="c.txt"
+Content-Type: text/plain
 
-                      Charlie file content.
+Charlie file content.
 
-                      --------------------------627436eaefdbc285--
-                      """
+--------------------------627436eaefdbc285--
+"""
+
+    let stringToCompare = try self.string(from: formData)
+    XCTAssertEqual(stringToCompare, expectedString)
+  }
+  
+  func testSingleFileWithRequestCreator() throws {
+    let alphaFileUrl = self.fileURLForFile(named: "a", extension: "txt")
     
-    // Replacing CRLF with new line as string literals uses new lines
-    XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+    let alphaFile = GraphQLFile(fieldName: "upload",
+                                originalName: "a.txt",
+                                mimeType: "text/plain",
+                                fileURL: alphaFileUrl)
+    
+    let data = try RequestCreator.requestMultipartFormData(
+      for: HeroNameQuery(),
+      files: [alphaFile!],
+      sendOperationIdentifiers: false,
+      serializationFormat: JSONSerializationFormat.self,
+      manualBoundary: "TEST.BOUNDARY"
+    )
+    
+    let stringToCompare = try self.string(from: data)
+    
+    if #available(iOS 11, macOS 13, tvOS 11, watchOS 4, *) {
+      let expectedString = """
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="operations"
+
+{"operationName":"HeroName","query":"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }","variables":{"episode":null}}
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="map"
+
+{"a.txt":"[variables.upload]"}
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="upload"; filename="a.txt"
+Content-Type: text/plain
+
+Alpha file content.
+
+--TEST.BOUNDARY--
+"""
+      XCTAssertEqual(stringToCompare, expectedString)
+    } else {
+      // Operation parameters may be in weird order, so let's at least check that the files and single parameter got encoded properly.
+      let expectedEndString = """
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="map"
+
+{"a.txt":"[variables.upload]"}
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="upload"; filename="a.txt"
+Content-Type: text/plain
+
+Alpha file content.
+
+--TEST.BOUNDARY--
+"""
+      self.checkString(stringToCompare, includes: expectedEndString)
+    }
+  }
+  
+  func testMultipleFilesWithRequestCreator() throws {
+    let alphaFileURL = self.fileURLForFile(named: "a", extension: "txt")
+    let alphaFile = GraphQLFile(fieldName: "uploads",
+                                originalName: "a.txt",
+                                mimeType: "text/plain",
+                                fileURL: alphaFileURL)!
+    
+    let betaFileURL = self.fileURLForFile(named: "b", extension: "txt")
+    let betaFile = GraphQLFile(fieldName: "uploads",
+                               originalName: "b.txt",
+                               mimeType: "text/plain",
+                               fileURL: betaFileURL)!
+    
+    
+    let data = try RequestCreator.requestMultipartFormData(
+      for: HeroNameQuery(),
+      files: [alphaFile, betaFile],
+      sendOperationIdentifiers: false,
+      serializationFormat: JSONSerializationFormat.self,
+      manualBoundary: "TEST.BOUNDARY"
+    )
+    
+    let stringToCompare = try self.string(from: data)
+    
+    if #available(iOS 11, macOS 13, tvOS 11, watchOS 4, *) {
+      let expectedString = """
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="operations"
+
+{"operationName":"HeroName","query":"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }","variables":{"episode":null}}
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="map"
+
+{"a.txt":"[variables.uploads.0]","b.txt":"[variables.uploads.1]"}
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="uploads"; filename="a.txt"
+Content-Type: text/plain
+
+Alpha file content.
+
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="uploads"; filename="b.txt"
+Content-Type: text/plain
+
+Bravo file content.
+
+--TEST.BOUNDARY--
+"""
+      XCTAssertEqual(stringToCompare, expectedString)
+    } else {
+      // Query and operation parameters may be in weird order, so let's at least check that the files got encoded properly.
+      let endString = """
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="uploads"; filename="a.txt"
+Content-Type: text/plain
+
+Alpha file content.
+
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="uploads"; filename="b.txt"
+Content-Type: text/plain
+
+Bravo file content.
+
+--TEST.BOUNDARY--
+"""
+      self.checkString(stringToCompare, includes: endString)
+    }
   }
 }

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -10,18 +10,17 @@ import XCTest
 @testable import Apollo
 
 class MultipartFormDataTests: XCTestCase {
-
-    func testSingleFile() throws {
-      let alphaFileUrl = Bundle(for: type(of: self)).url(forResource: "a", withExtension: "txt")!
-
-      let alphaData = try! Data(contentsOf: alphaFileUrl)
-
-      let formData = MultipartFormData(boundary: "------------------------cec8e8123c05ba25")
-      try formData.appendPart(string: "{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }", name: "operations")
-      try formData.appendPart(string: "{ \"0\": [\"variables.file\"] }", name: "map")
-      formData.appendPart(data: alphaData, name: "0", contentType: "text/plain", filename: "a.txt")
-      
-      let expectation = """
+  func testSingleFile() throws {
+    let alphaFileUrl = Bundle(for: type(of: self)).url(forResource: "a", withExtension: "txt")!
+    
+    let alphaData = try! Data(contentsOf: alphaFileUrl)
+    
+    let formData = MultipartFormData(boundary: "------------------------cec8e8123c05ba25")
+    try formData.appendPart(string: "{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }", name: "operations")
+    try formData.appendPart(string: "{ \"0\": [\"variables.file\"] }", name: "map")
+    formData.appendPart(data: alphaData, name: "0", contentType: "text/plain", filename: "a.txt")
+    
+    let expectation = """
                         --------------------------cec8e8123c05ba25
                         Content-Disposition: form-data; name="operations"
 
@@ -38,24 +37,24 @@ class MultipartFormDataTests: XCTestCase {
 
                         --------------------------cec8e8123c05ba25--
                         """
-
-      // Replacing CRLF with new line as string literals uses new lines
-      XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
-    }
-
+    
+    // Replacing CRLF with new line as string literals uses new lines
+    XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
+  }
+  
   func testMultifileFile() throws {
     let bravoFileUrl = Bundle(for: type(of: self)).url(forResource: "b", withExtension: "txt")!
     let charlieFileUrl = Bundle(for: type(of: self)).url(forResource: "c", withExtension: "txt")!
-
+    
     let bravoData = try! Data(contentsOf: bravoFileUrl)
     let charlieData = try! Data(contentsOf: charlieFileUrl)
-
+    
     let formData = MultipartFormData(boundary: "------------------------ec62457de6331cad")
     try formData.appendPart(string: "{ \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }", name: "operations")
     try formData.appendPart(string: "{ \"0\": [\"variables.files.0\"], \"1\": [\"variables.files.1\"] }", name: "map")
     formData.appendPart(data: bravoData, name: "0", contentType: "text/plain", filename: "b.txt")
     formData.appendPart(data: charlieData, name: "1", contentType: "text/plain", filename: "c.txt")
-
+    
     let expectation = """
                         --------------------------ec62457de6331cad
                         Content-Disposition: form-data; name="operations"
@@ -79,27 +78,27 @@ class MultipartFormDataTests: XCTestCase {
 
                         --------------------------ec62457de6331cad--
                         """
-
+    
     // Replacing CRLF with new line as string literals uses new lines
     XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
   }
-
+  
   func testBatchFile() throws {
     let alphaFileUrl = Bundle(for: type(of: self)).url(forResource: "a", withExtension: "txt")!
     let bravoFileUrl = Bundle(for: type(of: self)).url(forResource: "b", withExtension: "txt")!
     let charlieFileUrl = Bundle(for: type(of: self)).url(forResource: "c", withExtension: "txt")!
-
+    
     let alphaData = try! Data(contentsOf: alphaFileUrl)
     let bravoData = try! Data(contentsOf: bravoFileUrl)
     let charlieData = try! Data(contentsOf: charlieFileUrl)
-
+    
     let formData = MultipartFormData(boundary: "------------------------627436eaefdbc285")
     try formData.appendPart(string: "[{ \"query\": \"mutation ($file: Upload!) { singleUpload(file: $file) { id } }\", \"variables\": { \"file\": null } }, { \"query\": \"mutation($files: [Upload!]!) { multipleUpload(files: $files) { id } }\", \"variables\": { \"files\": [null, null] } }]", name: "operations")
     try formData.appendPart(string: "{ \"0\": [\"0.variables.file\"], \"1\": [\"1.variables.files.0\"], \"2\": [\"1.variables.files.1\"] }", name: "map")
     formData.appendPart(data: alphaData, name: "0", contentType: "text/plain", filename: "a.txt")
     formData.appendPart(data: bravoData, name: "1", contentType: "text/plain", filename: "b.txt")
     formData.appendPart(data: charlieData, name: "2", contentType: "text/plain", filename: "c.txt")
-
+    
     let expectation = """
                       --------------------------627436eaefdbc285
                       Content-Disposition: form-data; name="operations"
@@ -129,7 +128,7 @@ class MultipartFormDataTests: XCTestCase {
 
                       --------------------------627436eaefdbc285--
                       """
-
+    
     // Replacing CRLF with new line as string literals uses new lines
     XCTAssertEqual(String(data: try formData.encode(), encoding: .utf8)!.replacingOccurrences(of: MultipartFormData.CRLF, with: "\n"), expectation)
   }

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -184,7 +184,7 @@ Content-Disposition: form-data; name="operations"
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
-{"a.txt":"[variables.upload]"}
+{"a.txt":["variables.upload"]}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="upload"; filename="a.txt"
 Content-Type: text/plain
@@ -200,7 +200,7 @@ Alpha file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
-{"a.txt":"[variables.upload]"}
+{"a.txt":["variables.upload"]}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="upload"; filename="a.txt"
 Content-Type: text/plain
@@ -246,7 +246,7 @@ Content-Disposition: form-data; name="operations"
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
-{"a.txt":"[variables.uploads.0]","b.txt":"[variables.uploads.1]"}
+{"a.txt":["variables.uploads.0"],"b.txt":["variables.uploads.1"]}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="uploads"; filename="a.txt"
 Content-Type: text/plain

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -180,7 +180,7 @@ Charlie file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"operationName":"HeroName","query":"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }","variables":{"episode":null}}
+{"operationName":"HeroName","query":"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }","variables":{"episode":null,\"upload\":null}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
@@ -242,7 +242,7 @@ Alpha file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"operationName":"HeroName","query":"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }","variables":{"episode":null}}
+{"operationName":"HeroName","query":"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }","variables":{"episode":null,\"uploads\":null}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 

--- a/docs/source/mutations.md
+++ b/docs/source/mutations.md
@@ -84,3 +84,53 @@ When people talk about GraphQL, they often focus on the data fetching side of th
 In GraphQL, mutations can return any type, and that type can be queried just like a regular GraphQL query. So the question is - what type should a particular mutation return?
 
 In most cases, the data available from a mutation result should be the server developer's best guess of the data a client would need to understand what happened on the server. For example, a mutation that creates a new comment on a blog post might return the comment itself. A mutation that reorders an array might need to return the whole array.
+
+## Uploading files
+
+The iOS SDK supports the [GraphQL Multipart Request Specification](https://github.com/jaydenseric/graphql-multipart-request-spec#multipart-form-field-structure) for uploading files. 
+
+>**Note**: At the moment, we only support uploads for a single operation, not for batch operations. You can upload multiple files for a single operation if your server supports it, though.
+
+To upload a file, you will need: 
+
+- A `NetworkTransport` which also supports the `UploadingNetworkTransport` protocol on your `ApolloClient` instance. If you're using `HTTPNetworkTransport` (which is set up by default), this protocol is already supported. 
+- The correct `MIME` type for the data you're uploading. The default value is `application/octet-stream`. 
+- Either the data or the file URL of the data you want to upload. 
+- A mutation which takes an `Upload` as a parameter. Note that this must be supported by your server. 
+
+Here is an example of a GraphQL query for a mutation that accepts a single upload, and then returns the `id` for that upload:
+
+```graphql
+mutation UploadFile($upload:Upload!) {
+    singleUpload(file:$upload) {
+        id
+    }
+}
+```
+
+If you wanted to use this to upload a file called `a.txt`, it would look something like this: 
+
+```swift
+// Create the file to upload
+guard
+  let fileURL = Bundle.main.url(forResource: "a", 
+                                withExtension: "txt"),
+  let file = GraphQLFile(fieldName: "upload",   
+                         originalName: "a.txt", 
+                         mimeType: "text/plain", // <-defaults to "application/octet-stream"
+                         fileURL: fileURL) else {
+    // Either the file URL couldn't be created or the file couldn't be created.
+    return 
+}
+
+// Actually upload the file
+client.upload(operation: UploadFileMutation(uploads: ["a"]),
+              files: [file]) { result in 
+  switch result {
+  case .success(let graphQLResult):
+    print("ID: \(graphQLResult.data?.singleUpload.id)")
+  case .failure(let error):
+    print("error: \(error)")
+  }
+}
+```


### PR DESCRIPTION
I started trying to get some real documentation together for uploading and noticed a few holes in the implementation. This PR tries to address what I found. 

In this PR: 
- Fixed an issue where we were setting the default `Content-Type` late enough that it was hammering the form data upload type which is set when there's form data.
- Add an `UploadingNetworkTransport` sub-protocol of `NetworkTransport` to capture that not all network transports handle uploads.
- Make `HTTPNetworkTransport` and `SplitNetworkTransport` conform to this protocol. 
- Add `upload` support to the main `ApolloClient` class so you don't need a direct reference to the network transport anymore. Note that this will hit an `assertionFailure` during development and return an `Error` in production if you attempt to use it with a `NetworkTransport` which does not also conform to `UploadingNetworkTransport`. 
- Added tests to make sure `RequestCreator` is properly creating multipart requests. 
- Actually added the documentation I came to add in the first place 🙃