### PR TITLE
Remove Public Promise

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		9B95EDC022CAA0B000702BB2 /* GETTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */; };
 		9BA1244A22D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1244922D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift */; };
 		9BA1245E22DE116B00BF1D24 /* Result+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1245D22DE116B00BF1D24 /* Result+Helpers.swift */; };
+		9BA3130E2302BEA5007B7FC5 /* DispatchQueue+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */; };
 		9BDE43D122C6655300FD7C7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43D022C6655200FD7C7F /* Cancellable.swift */; };
 		9BDE43DD22C6705300FD7C7F /* GraphQLHTTPResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */; };
 		9BDE43DF22C6708600FD7C7F /* GraphQLHTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */; };
@@ -270,6 +271,7 @@
 		9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GETTransformerTests.swift; sourceTree = "<group>"; };
 		9BA1244922D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONSerialziation+Sorting.swift"; sourceTree = "<group>"; };
 		9BA1245D22DE116B00BF1D24 /* Result+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Helpers.swift"; sourceTree = "<group>"; };
+		9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Optional.swift"; sourceTree = "<group>"; };
 		9BDE43D022C6655200FD7C7F /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponseError.swift; sourceTree = "<group>"; };
 		9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPRequestError.swift; sourceTree = "<group>"; };
@@ -711,6 +713,7 @@
 			children = (
 				9F578D8F1D8D2CB300C0EA36 /* Utilities.swift */,
 				9FCDFD221E33A0D8007519DC /* AsynchronousOperation.swift */,
+				9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */,
 				9FE941CF1E62C771007CDD89 /* Promise.swift */,
 				9BA1245D22DE116B00BF1D24 /* Result+Helpers.swift */,
 				9F19D8431EED568200C57247 /* ResultOrPromise.swift */,
@@ -1230,6 +1233,7 @@
 				9FE941D01E62C771007CDD89 /* Promise.swift in Sources */,
 				9BA1245E22DE116B00BF1D24 /* Result+Helpers.swift in Sources */,
 				9FC750631D2A59F600458D91 /* ApolloClient.swift in Sources */,
+				9BA3130E2302BEA5007B7FC5 /* DispatchQueue+Optional.swift in Sources */,
 				9F86B6901E65533D00B885FF /* GraphQLResponseGenerator.swift in Sources */,
 				9FC9A9C21E2D3CAF0023C4D5 /* GraphQLInputValue.swift in Sources */,
 			);

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -118,8 +118,8 @@ extension ApolloClient: ApolloClientProtocol {
     }
   }
   
-  public func clearCache() -> Promise<Void> {
-    return self.store.clearCache()
+  public func clearCache(callbackQueue: DispatchQueue = .main, completion: (() -> Void)? = nil) {
+    self.store.clearCache(completion: completion)
   }
   
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -118,7 +118,7 @@ extension ApolloClient: ApolloClientProtocol {
     }
   }
   
-  public func clearCache(callbackQueue: DispatchQueue = .main, completion: (() -> Void)? = nil) {
+  public func clearCache(callbackQueue: DispatchQueue = .main, completion: ((Result<Void, Error>) -> Void)? = nil) {
     self.store.clearCache(completion: completion)
   }
   

--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -15,7 +15,7 @@ public protocol ApolloClientProtocol: class {
   /// - Parameters:
   ///   - callbackQueue: The queue to fall back on. Should default to the main queue.
   ///   - completion: [optional] A completion closure to execute when clearing has completed. Should default to nil.
-  func clearCache(callbackQueue: DispatchQueue, completion: (() -> Void)?)
+  func clearCache(callbackQueue: DispatchQueue, completion: ((Result<Void, Error>) -> Void)?)
   
   /// Fetches a query from the server or from the local cache, depending on the current contents of the cache and the specified cache policy.
   ///

--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -12,8 +12,10 @@ public protocol ApolloClientProtocol: class {
   /// Clears the underlying cache.
   /// Be aware: In more complex setups, the same underlying cache can be used across multiple instances, so if you call this on one instance, it'll clear that cache across all instances which share that cache.
   ///
-  /// - Returns: Promise which fulfills when clear is complete.
-  func clearCache() -> Promise<Void>
+  /// - Parameters:
+  ///   - callbackQueue: The queue to fall back on. Should default to the main queue.
+  ///   - completion: [optional] A completion closure to execute when clearing has completed. Should default to nil.
+  func clearCache(callbackQueue: DispatchQueue, completion: (() -> Void)?)
   
   /// Fetches a query from the server or from the local cache, depending on the current contents of the cache and the specified cache policy.
   ///

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -50,7 +50,7 @@ public final class ApolloStore {
   /// Clears the instance of the cache. Note that a cache can be shared across multiple `ApolloClient` objects, so clearing that underlying cache will clear it for all clients.
   ///
   /// - Returns: A promise which fulfills when the Cache is cleared.
-  public func clearCache(callbackQueue: DispatchQueue = .main, completion: (() -> Void)? = nil) {
+  public func clearCache(callbackQueue: DispatchQueue = .main, completion: ((Result<Void, Error>) -> Void)? = nil) {
     queue.async(flags: .barrier) {
       self.cacheLock.withWriteLock {
           self.cache.clearPromise()
@@ -59,7 +59,7 @@ public final class ApolloStore {
             return
           }
           callbackQueue.async {
-            completion()
+            completion(.success(()))
           }
       }
     }
@@ -90,7 +90,7 @@ public final class ApolloStore {
     }
   }
 
-  public func withinReadTransaction<T>(_ body: @escaping (ReadTransaction) throws -> Promise<T>) -> Promise<T> {
+  func withinReadTransaction<T>(_ body: @escaping (ReadTransaction) throws -> Promise<T>) -> Promise<T> {
     return Promise<ReadTransaction> { fulfill, reject in
       self.queue.async {
         self.cacheLock.lockForReading()
@@ -103,13 +103,13 @@ public final class ApolloStore {
     }
   }
 
-  public func withinReadTransaction<T>(_ body: @escaping (ReadTransaction) throws -> T) -> Promise<T> {
+  func withinReadTransaction<T>(_ body: @escaping (ReadTransaction) throws -> T) -> Promise<T> {
     return withinReadTransaction {
       Promise(fulfilled: try body($0))
     }
   }
 
-  public func withinReadWriteTransaction<T>(_ body: @escaping (ReadWriteTransaction) throws -> Promise<T>) -> Promise<T> {
+  func withinReadWriteTransaction<T>(_ body: @escaping (ReadWriteTransaction) throws -> Promise<T>) -> Promise<T> {
     return Promise<ReadWriteTransaction> { fulfill, reject in
       self.queue.async(flags: .barrier) {
         self.cacheLock.lockForWriting()
@@ -121,13 +121,13 @@ public final class ApolloStore {
     }
   }
 
-  public func withinReadWriteTransaction<T>(_ body: @escaping (ReadWriteTransaction) throws -> T) -> Promise<T> {
+  func withinReadWriteTransaction<T>(_ body: @escaping (ReadWriteTransaction) throws -> T) -> Promise<T> {
     return withinReadWriteTransaction {
       Promise(fulfilled: try body($0))
     }
   }
 
-  public func load<Query: GraphQLQuery>(query: Query) -> Promise<GraphQLResult<Query.Data>> {
+  func load<Query: GraphQLQuery>(query: Query) -> Promise<GraphQLResult<Query.Data>> {
     return withinReadTransaction { transaction in
       let mapper = GraphQLSelectionSetMapper<Query.Data>()
       let dependencyTracker = GraphQLDependencyTracker()

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -116,14 +116,14 @@ public final class ApolloStore {
         Promise(fulfilled: try body($0))
       }
       .andThen { object in
-        DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-          completion?(.success(object))
-        }
+        DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                       action: completion,
+                                                       result: .success(object))
       }
       .catch { error in
-        DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-          completion?(.failure(error))
-        }
+        DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                       action: completion,
+                                                       result: .failure(error))
     }
   }
 
@@ -152,15 +152,15 @@ public final class ApolloStore {
         Promise(fulfilled: try body($0))
       }
       .andThen { object in
-        DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-          completion?(.success(object))
-        }
+        DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                       action: completion,
+                                                       result: .success(object))
       }
       .catch { error in
-        DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-          completion?(.failure(error))
+        DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                       action: completion,
+                                                       result: .failure(error))
       }
-    }
   }
 
   func load<Query: GraphQLQuery>(query: Query) -> Promise<GraphQLResult<Query.Data>> {

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -55,12 +55,9 @@ public final class ApolloStore {
       self.cacheLock.withWriteLock {
           self.cache.clearPromise()
         }.andThen {
-          guard let completion = completion else {
-            return
-          }
-          callbackQueue.async {
-            completion(.success(()))
-          }
+          DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                         action: completion,
+                                                         result: .success(()))
       }
     }
   }

--- a/Sources/Apollo/DispatchQueue+Optional.swift
+++ b/Sources/Apollo/DispatchQueue+Optional.swift
@@ -1,0 +1,24 @@
+//
+//  DispatchQueue+Optional.swift
+//  Apollo
+//
+//  Created by Ellen Shapiro on 8/13/19.
+//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+
+extension DispatchQueue {
+  
+  static func performAsyncIfNeeded(on callbackQueue: DispatchQueue?, action: @escaping () -> Void) {
+    if let callbackQueue = callbackQueue {
+      // A callback queue was provided, perform the action on that queue
+      callbackQueue.async {
+        action()
+      }
+    } else {
+      // Perform the action on the current queue
+      action()
+    }
+  }
+}

--- a/Sources/Apollo/DispatchQueue+Optional.swift
+++ b/Sources/Apollo/DispatchQueue+Optional.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension DispatchQueue {
+public extension DispatchQueue {
   
-  static func performAsyncIfNeeded(on callbackQueue: DispatchQueue?, action: @escaping () -> Void) {
+  static func apollo_performAsyncIfNeeded(on callbackQueue: DispatchQueue?, action: @escaping () -> Void) {
     if let callbackQueue = callbackQueue {
       // A callback queue was provided, perform the action on that queue
       callbackQueue.async {

--- a/Sources/Apollo/DispatchQueue+Optional.swift
+++ b/Sources/Apollo/DispatchQueue+Optional.swift
@@ -21,4 +21,14 @@ public extension DispatchQueue {
       action()
     }
   }
+  
+  static func apollo_returnResultAsyncIfNeeded<T>(on callbackQueue: DispatchQueue?, action: ((Result<T, Error>) -> Void)?, result: Result<T, Error>) {
+    guard let action = action else {
+      return
+    }
+    
+    self.apollo_performAsyncIfNeeded(on: callbackQueue) {
+      action(result)
+    }
+  }
 }

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -4,18 +4,48 @@ public final class InMemoryNormalizedCache: NormalizedCache {
   public init(records: RecordSet = RecordSet()) {
     self.records = records
   }
-
-  public func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {
+  
+  public func loadRecords(forKeys keys: [CacheKey],
+                          callbackQueue: DispatchQueue?,
+                          completion: @escaping (Result<[Record?], Error>) -> Void) {
     let records = keys.map { self.records[$0] }
-    return Promise(fulfilled: records)
+    if let callbackQueue = callbackQueue {
+      callbackQueue.async {
+        completion(.success(records))
+      }
+    } else {
+      completion(.success(records))
+    }
+  }
+  
+  public func merge(records: RecordSet,
+                    callbackQueue: DispatchQueue?,
+                    completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
+    let cacheKeys = self.records.merge(records: records)
+    
+    if let callbackQueue = callbackQueue {
+      callbackQueue.async {
+        completion(.success(cacheKeys))
+      }
+    } else {
+      completion(.success(cacheKeys))
+    }
   }
 
-  public func merge(records: RecordSet) -> Promise<Set<CacheKey>> {
-    return Promise(fulfilled: self.records.merge(records: records))
-  }
-
-  public func clear() -> Promise<Void> {
-    records.clear()
-    return Promise(fulfilled: ())
+  public func clear(callbackQueue: DispatchQueue?,
+                    completion: ((Result<Void, Error>) -> Void)?) {
+    self.records.clear()
+    
+    guard let completion = completion else {
+      return
+    }
+    
+    if let callbackQueue = callbackQueue {
+      callbackQueue.async {
+        completion(.success(()))
+      }
+    } else {
+      completion(.success(()))
+    }
   }
 }

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -9,11 +9,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
                           callbackQueue: DispatchQueue?,
                           completion: @escaping (Result<[Record?], Error>) -> Void) {
     let records = keys.map { self.records[$0] }
-    if let callbackQueue = callbackQueue {
-      callbackQueue.async {
-        completion(.success(records))
-      }
-    } else {
+    DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
       completion(.success(records))
     }
   }
@@ -22,12 +18,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
                     callbackQueue: DispatchQueue?,
                     completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
     let cacheKeys = self.records.merge(records: records)
-    
-    if let callbackQueue = callbackQueue {
-      callbackQueue.async {
-        completion(.success(cacheKeys))
-      }
-    } else {
+    DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
       completion(.success(cacheKeys))
     }
   }
@@ -40,11 +31,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
       return
     }
     
-    if let callbackQueue = callbackQueue {
-      callbackQueue.async {
-        completion(.success(()))
-      }
-    } else {
+    DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
       completion(.success(()))
     }
   }

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -9,7 +9,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
                           callbackQueue: DispatchQueue?,
                           completion: @escaping (Result<[Record?], Error>) -> Void) {
     let records = keys.map { self.records[$0] }
-    DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+    DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
       completion(.success(records))
     }
   }
@@ -18,7 +18,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
                     callbackQueue: DispatchQueue?,
                     completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
     let cacheKeys = self.records.merge(records: records)
-    DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+    DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
       completion(.success(cacheKeys))
     }
   }
@@ -31,7 +31,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
       return
     }
     
-    DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+    DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
       completion(.success(()))
     }
   }

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -9,18 +9,18 @@ public final class InMemoryNormalizedCache: NormalizedCache {
                           callbackQueue: DispatchQueue?,
                           completion: @escaping (Result<[Record?], Error>) -> Void) {
     let records = keys.map { self.records[$0] }
-    DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-      completion(.success(records))
-    }
+    DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                   action: completion,
+                                                   result: .success(records))
   }
   
   public func merge(records: RecordSet,
                     callbackQueue: DispatchQueue?,
                     completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
     let cacheKeys = self.records.merge(records: records)
-    DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-      completion(.success(cacheKeys))
-    }
+    DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                   action: completion,
+                                                   result: .success(cacheKeys))
   }
 
   public func clear(callbackQueue: DispatchQueue?,
@@ -31,8 +31,8 @@ public final class InMemoryNormalizedCache: NormalizedCache {
       return
     }
     
-    DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-      completion(.success(()))
-    }
+    DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                   action: completion,
+                                                   result: .success(()))
   }
 }

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -1,16 +1,31 @@
 public protocol NormalizedCache {
-
+  
   /// Loads records corresponding to the given keys.
-  /// - returns: A promise that fulfills with an array, with each index containing either the
-  ///            record corresponding to the key at that index or nil if not found.
-  func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]>
-
+  ///
+  /// - Parameters:
+  ///   - keys: The cache keys to load data for
+  ///   - callbackQueue: [optional] An alternate queue to fire the completion closure on. If nil, will fire on the current queue.
+  ///   - completion: A completion closure to fire when the load has completed. If successful, will contain an array. Each index will contain either the record corresponding to the key at the same index in the passed-in array of cache keys, or nil if that record was not found.
+  func loadRecords(forKeys keys: [CacheKey],
+                   callbackQueue: DispatchQueue?,
+                   completion: @escaping (Result<[Record?], Error>) -> Void)
+  
   /// Merges a set of records into the cache.
-  /// - returns: A promise that fulfills with a set of keys corresponding to *fields* that have
-  ///            changed (i.e. QUERY_ROOT.Foo.myField). These are the same type of keys as are 
-  ///            returned by RecordSet.merge(records:).
-  func merge(records: RecordSet) -> Promise<Set<CacheKey>>
+  ///
+  /// - Parameters:
+  ///   - records: The set of records to merge.
+  ///   - callbackQueue: [optional] An alternate queue to fire the completion closure on. If nil, will fire on the current queue.
+  ///   - completion: A completion closure to fire when the merge has completed. If successful, will contain a set of keys corresponding to *fields* that have changed (i.e. QUERY_ROOT.Foo.myField). These are the same type of keys as are returned by RecordSet.merge(records:).
+  func merge(records: RecordSet,
+             callbackQueue: DispatchQueue?,
+             completion: @escaping (Result<Set<CacheKey>, Error>) -> Void)
 
   // Clears all records
-  func clear() -> Promise<Void>
+  ///
+  /// - Parameters:
+  ///   - callbackQueue: [optional] An alternate queue to fire the completion closure on. If nil, will fire on the current queue.
+  ///   - completion: [optional] A completion closure to fire when the clear function has completed.
+  func clear(callbackQueue: DispatchQueue?,
+             completion: ((Result<Void, Error>) -> Void)?)
 }
+

--- a/Sources/Apollo/Promise.swift
+++ b/Sources/Apollo/Promise.swift
@@ -1,6 +1,6 @@
 import Dispatch
 
-public func whenAll<Value>(_ promises: [Promise<Value>], notifyOn queue: DispatchQueue = .global()) -> Promise<[Value]> {
+func whenAll<Value>(_ promises: [Promise<Value>], notifyOn queue: DispatchQueue = .global()) -> Promise<[Value]> {
   return Promise { (fulfill, reject) in
     let group = DispatchGroup()
     
@@ -20,7 +20,7 @@ public func whenAll<Value>(_ promises: [Promise<Value>], notifyOn queue: Dispatc
   }
 }
 
-public func firstly<T>(_ body: () throws -> Promise<T>) -> Promise<T> {
+func firstly<T>(_ body: () throws -> Promise<T>) -> Promise<T> {
   do {
     return try body()
   } catch {
@@ -28,26 +28,26 @@ public func firstly<T>(_ body: () throws -> Promise<T>) -> Promise<T> {
   }
 }
 
-public final class Promise<Value> {
+final class Promise<Value> {
   private let lock = Mutex()
   private var state: State<Value>
   
   private typealias ResultHandler<Value> = (Result<Value, Error>) -> Void
   private var resultHandlers: [ResultHandler<Value>] = []
   
-  public init(resolved result: Result<Value, Error>) {
+  init(resolved result: Result<Value, Error>) {
     state = .resolved(result)
   }
   
-  public init(fulfilled value: Value) {
+  init(fulfilled value: Value) {
     state = .resolved(.success(value))
   }
   
-  public init(rejected error: Error) {
+  init(rejected error: Error) {
     state = .resolved(.failure(error))
   }
   
-  public init(_ body: () throws -> Value) {
+  init(_ body: () throws -> Value) {
     do {
       let value = try body()
       state = .resolved(.success(value))
@@ -56,7 +56,7 @@ public final class Promise<Value> {
     }
   }
   
-  public init(_ body: (_ fulfill: @escaping (Value) -> Void, _ reject: @escaping (Error) -> Void) throws -> Void) {
+  init(_ body: (_ fulfill: @escaping (Value) -> Void, _ reject: @escaping (Error) -> Void) throws -> Void) {
     state = .pending
     
     do {
@@ -66,13 +66,13 @@ public final class Promise<Value> {
     }
   }
   
-  public var isPending: Bool {
+  var isPending: Bool {
     return lock.withLock {
       state.isPending
     }
   }
   
-  public var result: Result<Value, Error>? {
+  var result: Result<Value, Error>? {
     return lock.withLock {
       switch state {
       case .pending:
@@ -83,7 +83,7 @@ public final class Promise<Value> {
     }
   }
   
-  public func wait() {
+  func wait() {
     let semaphore = DispatchSemaphore(value: 0)
     
     whenResolved { result in
@@ -93,7 +93,7 @@ public final class Promise<Value> {
     semaphore.wait()
   }
   
-  public func await() throws -> Value {
+  func await() throws -> Value {
     let semaphore = DispatchSemaphore(value: 0)
     
     var result: Result<Value, Error>? = nil
@@ -108,7 +108,7 @@ public final class Promise<Value> {
     return try result!.get()
   }
   
-  @discardableResult public func andThen(_ whenFulfilled: @escaping (Value) throws -> Void) -> Promise<Value> {
+  @discardableResult func andThen(_ whenFulfilled: @escaping (Value) throws -> Void) -> Promise<Value> {
     return Promise<Value> { fulfill, reject in
       whenResolved { result in
         switch result {
@@ -126,7 +126,7 @@ public final class Promise<Value> {
     }
   }
   
-  @discardableResult public func `catch`(_ whenRejected: @escaping (Error) throws -> Void) -> Promise<Value> {
+  @discardableResult func `catch`(_ whenRejected: @escaping (Error) throws -> Void) -> Promise<Value> {
     return Promise<Value> { fulfill, reject in
       whenResolved { result in
         switch result {
@@ -144,12 +144,12 @@ public final class Promise<Value> {
     }
   }
   
-  @discardableResult public func finally(_ whenResolved: @escaping () -> Void) -> Promise<Value> {
+  @discardableResult func finally(_ whenResolved: @escaping () -> Void) -> Promise<Value> {
     self.whenResolved { _ in whenResolved() }
     return self
   }
 
-  public func map<T>(_ transform: @escaping (Value) throws -> T) -> Promise<T> {
+  func map<T>(_ transform: @escaping (Value) throws -> T) -> Promise<T> {
     return Promise<T> { fulfill, reject in
       whenResolved { result in
         switch result {
@@ -166,7 +166,7 @@ public final class Promise<Value> {
     }
   }
   
-  public func flatMap<T>(_ transform: @escaping (Value) throws -> Promise<T>) -> Promise<T> {
+  func flatMap<T>(_ transform: @escaping (Value) throws -> Promise<T>) -> Promise<T> {
     return Promise<T> { fulfill, reject in
       whenResolved { result in
         switch result {
@@ -183,7 +183,7 @@ public final class Promise<Value> {
     }
   }
   
-  public func on(queue: DispatchQueue) -> Promise<Value> {
+  func on(queue: DispatchQueue) -> Promise<Value> {
     return Promise<Value> { fulfill, reject in
       whenResolved { result in
         switch result {

--- a/Sources/Apollo/ResultOrPromise.swift
+++ b/Sources/Apollo/ResultOrPromise.swift
@@ -1,6 +1,6 @@
 import Dispatch
 
-public func whenAll<Value>(_ resultsOrPromises: [ResultOrPromise<Value>], notifyOn queue: DispatchQueue = .global()) -> ResultOrPromise<[Value]> {
+func whenAll<Value>(_ resultsOrPromises: [ResultOrPromise<Value>], notifyOn queue: DispatchQueue = .global()) -> ResultOrPromise<[Value]> {
   onlyResults: do {
     var results: [Result<Value, Error>] = []
     for resultOrPromise in resultsOrPromises {
@@ -36,11 +36,11 @@ public func whenAll<Value>(_ resultsOrPromises: [ResultOrPromise<Value>], notify
   })
 }
 
-public enum ResultOrPromise<Value> {
+enum ResultOrPromise<Value> {
   case result(Result<Value, Error>)
   case promise(Promise<Value>)
   
-  public init(_ body: () throws -> Value) {
+  init(_ body: () throws -> Value) {
     do {
       let value = try body()
       self = .result(.success(value))
@@ -49,7 +49,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  public var result: Result<Value, Error>? {
+  var result: Result<Value, Error>? {
     switch self {
     case .result(let result):
       return result
@@ -58,7 +58,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  public func await() throws -> Value {
+  func await() throws -> Value {
     switch self {
     case .result(let result):
       return try result.get()
@@ -76,7 +76,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  @discardableResult public func andThen(_ whenFulfilled: @escaping (Value) throws -> Void) -> ResultOrPromise<Value> {
+  @discardableResult func andThen(_ whenFulfilled: @escaping (Value) throws -> Void) -> ResultOrPromise<Value> {
     switch self {
     case .result(.success(let value)):
       do {
@@ -92,7 +92,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  @discardableResult public func `catch`(_ whenRejected: @escaping (Error) throws -> Void) -> ResultOrPromise<Value> {
+  @discardableResult func `catch`(_ whenRejected: @escaping (Error) throws -> Void) -> ResultOrPromise<Value> {
     switch self {
     case .result(.success(let value)):
       return .result(.success(value))
@@ -108,7 +108,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  public func map<T>(_ transform: @escaping (Value) throws -> T) -> ResultOrPromise<T> {
+  func map<T>(_ transform: @escaping (Value) throws -> T) -> ResultOrPromise<T> {
     switch self {
     case .result(.success(let value)):
       do {
@@ -125,7 +125,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  public func flatMap<T>(_ transform: @escaping (Value) throws -> ResultOrPromise<T>) -> ResultOrPromise<T> {
+ func flatMap<T>(_ transform: @escaping (Value) throws -> ResultOrPromise<T>) -> ResultOrPromise<T> {
     switch self {
     case .result(.success(let value)):
       do {
@@ -142,7 +142,7 @@ public enum ResultOrPromise<Value> {
     }
   }
   
-  public func on(queue: DispatchQueue) -> ResultOrPromise<Value> {
+  func on(queue: DispatchQueue) -> ResultOrPromise<Value> {
     if case .promise(let promise) = self {
       return .promise(promise.on(queue: queue))
     } else {

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -97,21 +97,23 @@ extension SQLiteNormalizedCache: NormalizedCache {
   public func merge(records: RecordSet,
                     callbackQueue: DispatchQueue?,
                     completion: @escaping (Swift.Result<Set<CacheKey>, Error>) -> Void) {
+    let result: Swift.Result<Set<CacheKey>, Error>
     do {
       let records = try self.mergeRecords(records: records)
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion(.success(records))
-      }
+      result = .success(records)
     } catch {
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion(.failure(error))
-      }
+      result = .failure(error)
     }
+    
+    DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                   action: completion,
+                                                   result: result)
   }
   
   public func loadRecords(forKeys keys: [CacheKey],
                           callbackQueue: DispatchQueue?,
                           completion: @escaping (Swift.Result<[Record?], Error>) -> Void) {
+    let result: Swift.Result<[Record?], Error>
     do {
       let records = try self.selectRecords(forKeys: keys)
       let recordsOrNil: [Record?] = keys.map { key in
@@ -121,26 +123,27 @@ extension SQLiteNormalizedCache: NormalizedCache {
         return nil
       }
       
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion(.success(recordsOrNil))
-      }
+      result = .success(recordsOrNil)
     } catch {
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion(.failure(error))
-      }
+      result = .failure(error)
     }
+    
+    DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                   action: completion,
+                                                   result: result)
   }
   
   public func clear(callbackQueue: DispatchQueue?, completion: ((Swift.Result<Void, Error>) -> Void)?) {
+    let result: Swift.Result<Void, Error>
     do {
       try self.clearRecords()
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion?(.success(()))
-      }
+      result = .success(())
     } catch {
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion?(.failure(error))
-      }
+      result = .failure(error)
     }
+    
+    DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                   action: completion,
+                                                   result: result)
   }
 }

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -6,7 +6,7 @@ import StarWarsAPI
 class FetchQueryTests: XCTestCase {
   func testFetchIgnoringCacheData() throws {
     let query = HeroNameQuery()
-
+    
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
       "hero": [
@@ -14,10 +14,10 @@ class FetchQueryTests: XCTestCase {
         "__typename": "Droid",
       ]
     ]
-
+    
     withCache(initialRecords: initialRecords) { cache in
       let store = ApolloStore(cache: cache)
-
+      
       let networkTransport = MockNetworkTransport(body: [
         "data": [
           "hero": [
@@ -26,14 +26,14 @@ class FetchQueryTests: XCTestCase {
           ]
         ]
         ])
-
+      
       let client = ApolloClient(networkTransport: networkTransport, store: store)
-
+      
       let expectation = self.expectation(description: "Fetching query")
-
+      
       client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { result in
         defer { expectation.fulfill() }
-
+        
         switch result {
         case .success(let queryResult):
           XCTAssertEqual(queryResult.data?.hero?.name, "Luke Skywalker")
@@ -41,7 +41,7 @@ class FetchQueryTests: XCTestCase {
           XCTFail("Error: \(error)")
         }
       }
-
+      
       self.waitForExpectations(timeout: 5, handler: nil)
     }
   }
@@ -96,7 +96,7 @@ class FetchQueryTests: XCTestCase {
   
   func testReturnCacheDataElseFetchWithCachedData() throws {
     let query = HeroNameQuery()
-
+    
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "QUERY_ROOT.hero")],
       "QUERY_ROOT.hero": [
@@ -104,10 +104,10 @@ class FetchQueryTests: XCTestCase {
         "__typename": "Droid",
       ]
     ]
-
+    
     withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
-
+      
       let networkTransport = MockNetworkTransport(body: [
         "data": [
           "hero": [
@@ -116,14 +116,14 @@ class FetchQueryTests: XCTestCase {
           ]
         ]
         ])
-
+      
       let client = ApolloClient(networkTransport: networkTransport, store: store)
-
+      
       let expectation = self.expectation(description: "Fetching query")
-
+      
       client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { result in
         defer { expectation.fulfill() }
-
+        
         switch result {
         case .success(let graphQLResult):
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
@@ -131,24 +131,24 @@ class FetchQueryTests: XCTestCase {
           XCTFail("Unexpected error: \(error)")
         }
       }
-
+      
       self.waitForExpectations(timeout: 5, handler: nil)
     }
   }
   
   func testReturnCacheDataElseFetchWithMissingData() throws {
     let query = HeroNameQuery()
-
+    
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
       "hero": [
         "name": "R2-D2",
       ]
     ]
-
+    
     withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
-
+      
       let networkTransport = MockNetworkTransport(body: [
         "data": [
           "hero": [
@@ -157,14 +157,14 @@ class FetchQueryTests: XCTestCase {
           ]
         ]
         ])
-
+      
       let client = ApolloClient(networkTransport: networkTransport, store: store)
-
+      
       let expectation = self.expectation(description: "Fetching query")
-
+      
       client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { result in
         defer { expectation.fulfill() }
-
+        
         switch result {
         case .success(let graphQLResult):
           XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
@@ -172,14 +172,14 @@ class FetchQueryTests: XCTestCase {
           XCTFail("Unexpected error: \(error)")
         }
       }
-
+      
       self.waitForExpectations(timeout: 5, handler: nil)
     }
   }
   
   func testReturnCacheDataDontFetchWithCachedData() throws {
     let query = HeroNameQuery()
-
+    
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
       "hero": [
@@ -187,10 +187,10 @@ class FetchQueryTests: XCTestCase {
         "__typename": "Droid",
       ]
     ]
-
+    
     withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
-
+      
       let networkTransport = MockNetworkTransport(body: [
         "data": [
           "hero": [
@@ -199,11 +199,11 @@ class FetchQueryTests: XCTestCase {
           ]
         ]
         ])
-
+      
       let client = ApolloClient(networkTransport: networkTransport, store: store)
-
+      
       let expectation = self.expectation(description: "Fetching query")
-
+      
       client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
         defer { expectation.fulfill() }
         
@@ -214,14 +214,14 @@ class FetchQueryTests: XCTestCase {
           XCTFail("Unexpected error: \(error)")
         }
       }
-
+      
       self.waitForExpectations(timeout: 5, handler: nil)
     }
   }
-
+  
   func testClearCache() throws {
     let query = HeroNameQuery()
-
+    
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
       "hero": [
@@ -229,78 +229,10 @@ class FetchQueryTests: XCTestCase {
         "__typename": "Droid",
       ]
     ]
-
-    withCache(initialRecords: initialRecords) { (cache) in
-        let store = ApolloStore(cache: cache)
-
-        let networkTransport = MockNetworkTransport(body: [
-          "data": [
-            "hero": [
-              "name": "Luke Skywalker",
-              "__typename": "Human"
-            ]
-          ]
-        ])
-
-        let client = ApolloClient(networkTransport: networkTransport, store: store)
-
-        let expectation = self.expectation(description: "Fetching query")
-
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
-          defer { expectation.fulfill() }
-          
-          switch result {
-          case .success(let graphQLResult):
-            XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
-          case .failure(let error):
-            XCTFail("Unexpected error: \(error)")
-          }          
-        }
-
-        self.waitForExpectations(timeout: 5, handler: nil)
-
-        do { try client.clearCache().await() }
-        catch { XCTFail() }
-
-        let expectation2 = self.expectation(description: "Fetching query")
-
-        client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
-          defer { expectation2.fulfill() }
-          switch result {
-          case .success:
-            XCTFail("This should have returned an error")
-          case .failure(let error):
-            if let resultError = error as? JSONDecodingError {
-              switch resultError {
-              case .missingValue:
-                // Correct error!
-                break
-              default:
-                XCTFail("Unexpected JSON error: \(error)")
-              }
-            } else {
-              XCTFail("Unexpected error: \(error)")
-            }
-          }
-        }
-
-        self.waitForExpectations(timeout: 5, handler: nil)
-      }
-  }
-  
-  func testReturnCacheDataDontFetchWithMissingData() throws {
-    let query = HeroNameQuery()
-
-    let initialRecords: RecordSet = [
-      "QUERY_ROOT": ["hero": Reference(key: "hero")],
-      "hero": [
-        "name": "R2-D2",
-      ]
-    ]
-
+    
     withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
-
+      
       let networkTransport = MockNetworkTransport(body: [
         "data": [
           "hero": [
@@ -308,12 +240,80 @@ class FetchQueryTests: XCTestCase {
             "__typename": "Human"
           ]
         ]
-      ])
-
+        ])
+      
       let client = ApolloClient(networkTransport: networkTransport, store: store)
-
+      
       let expectation = self.expectation(description: "Fetching query")
-
+      
+      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
+        defer { expectation.fulfill() }
+        
+        switch result {
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
+        }          
+      }
+      
+      self.waitForExpectations(timeout: 5, handler: nil)
+      
+      do { try client.clearCache().await() }
+      catch { XCTFail() }
+      
+      let expectation2 = self.expectation(description: "Fetching query")
+      
+      client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
+        defer { expectation2.fulfill() }
+        switch result {
+        case .success:
+          XCTFail("This should have returned an error")
+        case .failure(let error):
+          if let resultError = error as? JSONDecodingError {
+            switch resultError {
+            case .missingValue:
+              // Correct error!
+              break
+            default:
+              XCTFail("Unexpected JSON error: \(error)")
+            }
+          } else {
+            XCTFail("Unexpected error: \(error)")
+          }
+        }
+      }
+      
+      self.waitForExpectations(timeout: 5, handler: nil)
+    }
+  }
+  
+  func testReturnCacheDataDontFetchWithMissingData() throws {
+    let query = HeroNameQuery()
+    
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": [
+        "name": "R2-D2",
+      ]
+    ]
+    
+    withCache(initialRecords: initialRecords) { (cache) in
+      let store = ApolloStore(cache: cache)
+      
+      let networkTransport = MockNetworkTransport(body: [
+        "data": [
+          "hero": [
+            "name": "Luke Skywalker",
+            "__typename": "Human"
+          ]
+        ]
+        ])
+      
+      let client = ApolloClient(networkTransport: networkTransport, store: store)
+      
+      let expectation = self.expectation(description: "Fetching query")
+      
       client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
         defer { expectation.fulfill() }
         switch result {
@@ -323,23 +323,23 @@ class FetchQueryTests: XCTestCase {
           if
             let resultError = error as? GraphQLResultError,
             let underlyingError = resultError.underlying as? JSONDecodingError {
-              switch underlyingError {
-              case .missingValue:
-                // Correct error!
-                break
-              default:
-                XCTFail("Unexpected JSON error: \(error)")
-              }
+            switch underlyingError {
+            case .missingValue:
+              // Correct error!
+              break
+            default:
+              XCTFail("Unexpected JSON error: \(error)")
+            }
           } else {
             XCTFail("Unexpected error: \(error)")
           }
         }
       }
-
+      
       self.waitForExpectations(timeout: 5, handler: nil)
     }
   }
-    
+  
   func testCompletionHandlerIsCalledOnTheSpecifiedQueue() {
     let queue = DispatchQueue(label: "label")
     
@@ -349,27 +349,27 @@ class FetchQueryTests: XCTestCase {
     let query = HeroNameQuery()
     
     let networkTransport = MockNetworkTransport(body: [
-        "data": [
-            "hero": [
-                "name": "Luke Skywalker",
-                "__typename": "Human"
-            ]
+      "data": [
+        "hero": [
+          "name": "Luke Skywalker",
+          "__typename": "Human"
         ]
-        ])
+      ]
+      ])
     
     withCache { (cache) in
-        let store = ApolloStore(cache: cache)
-        let client = ApolloClient(networkTransport: networkTransport, store: store)
+      let store = ApolloStore(cache: cache)
+      let client = ApolloClient(networkTransport: networkTransport, store: store)
+      
+      let expectation = self.expectation(description: "Fetching query")
+      
+      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData, queue: queue) { _ in
+        defer { expectation.fulfill() }
         
-        let expectation = self.expectation(description: "Fetching query")
-        
-        client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData, queue: queue) { _ in
-            defer { expectation.fulfill() }
-            
-            XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
-        }
-        
-        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
+      }
+      
+      waitForExpectations(timeout: 5, handler: nil)
     }
   }
 }

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -254,13 +254,24 @@ class FetchQueryTests: XCTestCase {
           XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
         case .failure(let error):
           XCTFail("Unexpected error: \(error)")
-        }          
+        }
       }
       
       self.waitForExpectations(timeout: 5, handler: nil)
       
-      do { try client.clearCache().await() }
-      catch { XCTFail() }
+      let clearCacheExpectation = self.expectation(description: "cache cleared")
+      client.clearCache(completion: { result in
+        switch result {
+        case .success:
+          break
+        case .failure(let error):
+          XCTFail("Error clearing cache: \(error)")
+        }
+        
+        clearCacheExpectation.fulfill()
+      })
+      
+      self.waitForExpectations(timeout: 1, handler: nil)
       
       let expectation2 = self.expectation(description: "Fetching query")
       

--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -312,7 +312,7 @@ class WatchQueryTests: XCTestCase {
             "QUERY_ROOT.hero.friends.1": ["__typename": "Human", "name": "Han Solo"],
             "QUERY_ROOT.hero.friends.2": ["__typename": "Human", "name": "Leia Organa"],
             ]
-    try withCache(initialRecords: initialRecords) { (cache) in
+    withCache(initialRecords: initialRecords) { (cache) in
       let networkTransport = MockNetworkTransport(body: [:])
 
       let store = ApolloStore(cache: cache)
@@ -353,11 +353,14 @@ class WatchQueryTests: XCTestCase {
       waitForExpectations(timeout: 5, handler: nil)
 
       let nameQuery = HeroNameQuery()
-      try await(store.withinReadWriteTransaction { transaction in
+      expectation = self.expectation(description: "transaction'd")
+      store.withinReadWriteTransaction({ transaction in
         try transaction.update(query: nameQuery) { (data: inout HeroNameQuery.Data) in
           data.hero?.name = "Artoo"
         }
+        expectation.fulfill()
       })
+      self.waitForExpectations(timeout: 1, handler: nil)
 
       verifyResult = { result in
         switch result {

--- a/Tests/ApolloSQLiteTestSupport/TestCacheProvider.swift
+++ b/Tests/ApolloSQLiteTestSupport/TestCacheProvider.swift
@@ -13,7 +13,9 @@ public class SQLiteTestCacheProvider: TestCacheProvider {
     let fileURL = fileURL ?? temporarySQLiteFileURL()
     let cache = try! SQLiteNormalizedCache(fileURL: fileURL)
     if let initialRecords = initialRecords {
-      _ = cache.merge(records: initialRecords) // This is synchronous
+      cache.merge(records: initialRecords, callbackQueue: nil, completion: { _ in
+        // Theoretically, this should be syncrhonous
+      }) // This is synchronous
     }
     try test(cache)
   }

--- a/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
+++ b/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
@@ -77,6 +77,7 @@ class CachePersistenceTests: XCTestCase {
 
       let networkExpectation = self.expectation(description: "Fetching query from network")
       let emptyCacheExpectation = self.expectation(description: "Fetch query from empty cache")
+      let cacheClearExpectation = self.expectation(description: "cache cleared")
 
       client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { outerResult in
         defer { networkExpectation.fulfill() }
@@ -88,7 +89,6 @@ class CachePersistenceTests: XCTestCase {
           XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
         }
         
-        let cacheClearExpectation = self.expectation(description: "cache cleared")
         client.clearCache(completion: { result in
           switch result {
           case .success:
@@ -98,8 +98,6 @@ class CachePersistenceTests: XCTestCase {
           }
           cacheClearExpectation.fulfill()
         })
-
-        self.waitForExpectations(timeout: 1, handler: nil)
 
         client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
           defer { emptyCacheExpectation.fulfill() }

--- a/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
+++ b/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
@@ -87,14 +87,19 @@ class CachePersistenceTests: XCTestCase {
         case .success(let graphQLResult):
           XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
         }
+        
+        let cacheClearExpectation = self.expectation(description: "cache cleared")
+        client.clearCache(completion: { result in
+          switch result {
+          case .success:
+            break
+          case .failure(let error):
+            XCTFail("Error clearing cache: \(error)")
+          }
+          cacheClearExpectation.fulfill()
+        })
 
-        do {
-          try client.clearCache().await()
-        } catch {
-          XCTFail("Error Clearing cache: \(error)")
-          emptyCacheExpectation.fulfill()
-          return
-        }
+        self.waitForExpectations(timeout: 1, handler: nil)
 
         client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { innerResult in
           defer { emptyCacheExpectation.fulfill() }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -12,31 +12,35 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     self.records = records
   }
   
-  func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {
+  func loadRecords(forKeys keys: [CacheKey],
+                   callbackQueue: DispatchQueue?,
+                   completion: @escaping (Result<[Record?], Error>) -> Void) {
     OSAtomicIncrement32(&numberOfBatchLoads)
     
-    return Promise { fulfill, reject in
-      DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
-        let records = keys.map { self.records[$0] }
-        fulfill(records)
+    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
+      let records = keys.map { self.records[$0] }
+      DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+        completion(.success(records))
       }
     }
   }
   
-  func merge(records: RecordSet) -> Promise<Set<CacheKey>> {
-    return Promise { fulfill, reject in
-      DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
-        let changedKeys = self.records.merge(records: records)
-        fulfill(changedKeys)
+  func merge(records: RecordSet,
+             callbackQueue: DispatchQueue?,
+             completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
+    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
+      let changedKeys = self.records.merge(records: records)
+      DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+        completion(.success(changedKeys))
       }
     }
   }
-	
-  func clear() -> Promise<Void> {
-    return Promise { fulfill, reject in
-      DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
-        self.records.clear()
-        fulfill(())
+  
+  func clear(callbackQueue: DispatchQueue?, completion: ((Result<Void, Error>) -> Void)?) {
+    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
+      self.records.clear()
+      DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+        completion?(.success(()))
       }
     }
   }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -19,7 +19,7 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       let records = keys.map { self.records[$0] }
-      DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
         completion(.success(records))
       }
     }
@@ -30,7 +30,7 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
              completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       let changedKeys = self.records.merge(records: records)
-      DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
         completion(.success(changedKeys))
       }
     }
@@ -39,7 +39,7 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
   func clear(callbackQueue: DispatchQueue?, completion: ((Result<Void, Error>) -> Void)?) {
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       self.records.clear()
-      DispatchQueue.performAsyncIfNeeded(on: callbackQueue) {
+      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
         completion?(.success(()))
       }
     }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -19,9 +19,9 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       let records = keys.map { self.records[$0] }
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion(.success(records))
-      }
+      DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                     action: completion,
+                                                     result: .success(records))
     }
   }
   
@@ -30,18 +30,18 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
              completion: @escaping (Result<Set<CacheKey>, Error>) -> Void) {
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       let changedKeys = self.records.merge(records: records)
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion(.success(changedKeys))
-      }
+      DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                     action: completion,
+                                                     result: .success(changedKeys))
     }
   }
   
   func clear(callbackQueue: DispatchQueue?, completion: ((Result<Void, Error>) -> Void)?) {
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       self.records.clear()
-      DispatchQueue.apollo_performAsyncIfNeeded(on: callbackQueue) {
-        completion?(.success(()))
-      }
+      DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
+                                                     action: completion,
+                                                     result: .success(()))
     }
   }
 }


### PR DESCRIPTION
_NOTE: Leaving this as a draft because I'd like @martijnwalraven to take a look at this when he's back from vacation, and I'd love to hear any other feedback in the meantime._

This PR addresses #382. The promises Martijn created were originally intended to only be for framework-internal consumption, not for use by outside apps or SDKs. This is why we're using a custom `Promise` type rather than existing `Promise` libraries.

However, our `Promise` type conflicts with those existing libraries and can cause all sorts of weirdness and confusion when it's exposed publicly, and it also somewhat hamstrings future implementation choices (including removing Promises under the hood entirely). 

For this PR, we're only removing the "public" aspect of promises and continuing to use them under the hood. This should give us more flexibility in the future, and make it easier to wrap these methods in their preferred promise library. 

Note that this is going to be a BREAKING CHANGE!