### PR TITLE
Equatable conformance for HTTPNetworkTransport

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -287,3 +287,15 @@ extension HTTPNetworkTransport: NetworkTransport {
     return send(operation: operation, files: nil, completionHandler: completionHandler)
   }
 }
+
+// MARK: - Equatable conformance
+
+extension HTTPNetworkTransport: Equatable {
+  
+  public static func ==(lhs: HTTPNetworkTransport, rhs: HTTPNetworkTransport) -> Bool {
+    return lhs.url == rhs.url
+      && lhs.session == rhs.session
+      && lhs.sendOperationIdentifiers == rhs.sendOperationIdentifiers
+      && lhs.useGETForQueries == rhs.useGETForQueries
+  }
+}

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -182,6 +182,17 @@ class HTTPTransportTests: XCTestCase {
     
     self.wait(for: [expectation], timeout: 10)
   }
+  
+  func testEquality() {
+    let identicalTransport = HTTPNetworkTransport(url: self.url,
+                                                  useGETForQueries: true,
+                                                  delegate: self)
+    XCTAssertEqual(self.networkTransport, identicalTransport)
+    
+    let nonIdenticalTransport = HTTPNetworkTransport(url: self.url,
+                                                     delegate: self)
+    XCTAssertNotEqual(self.networkTransport, nonIdenticalTransport)
+  }
 }
 
 // MARK: - HTTPNetworkTransportPreflightDelegate


### PR DESCRIPTION
Addresses #713, and broadly allows better comparison of multiple `HTTPNetworkTransport` instances.