### PR TITLE
Add ApolloClientProtocol

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */; };
+		9B708AAD2305884500604A11 /* ApolloClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B708AAC2305884500604A11 /* ApolloClientProtocol.swift */; };
 		9B95EDC022CAA0B000702BB2 /* GETTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */; };
 		9BA1244A22D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1244922D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift */; };
 		9BA1245E22DE116B00BF1D24 /* Result+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1245D22DE116B00BF1D24 /* Result+Helpers.swift */; };
@@ -262,6 +263,7 @@
 		90690D2322433C5900FC2E54 /* Apollo-Target-CacheDependentTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CacheDependentTests.xcconfig"; sourceTree = "<group>"; };
 		90690D2422433C8000FC2E54 /* Apollo-Target-PerformanceTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-PerformanceTests.xcconfig"; sourceTree = "<group>"; };
 		90690D2522433CAF00FC2E54 /* Apollo-Target-TestSupport.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-TestSupport.xcconfig"; sourceTree = "<group>"; };
+		9B708AAC2305884500604A11 /* ApolloClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloClientProtocol.swift; sourceTree = "<group>"; };
 		9B8D864E22E7A846001F6D50 /* RepoURL.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = RepoURL.graphql; sourceTree = "<group>"; };
 		9B95EDBF22CAA0AF00702BB2 /* GETTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GETTransformerTests.swift; sourceTree = "<group>"; };
 		9BA1244922D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONSerialziation+Sorting.swift"; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 			isa = PBXGroup;
 			children = (
 				9FC750621D2A59F600458D91 /* ApolloClient.swift */,
+				9B708AAC2305884500604A11 /* ApolloClientProtocol.swift */,
 				9FC9A9D21E2FD48B0023C4D5 /* GraphQLError.swift */,
 				9FC750601D2A59C300458D91 /* GraphQLOperation.swift */,
 				9FCDFD281E33D0CE007519DC /* GraphQLQueryWatcher.swift */,
@@ -1203,6 +1206,7 @@
 				9BDE43DD22C6705300FD7C7F /* GraphQLHTTPResponseError.swift in Sources */,
 				9FCDFD231E33A0D8007519DC /* AsynchronousOperation.swift in Sources */,
 				9BA1244A22D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift in Sources */,
+				9B708AAD2305884500604A11 /* ApolloClientProtocol.swift in Sources */,
 				C377CCA922D798BD00572E03 /* GraphQLFile.swift in Sources */,
 				9FC9A9CC1E2FD0760023C4D5 /* Record.swift in Sources */,
 				9FC4B9201D2A6F8D0046A641 /* JSON.swift in Sources */,

--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// The `ApolloClientProtocol` provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
+public protocol ApolloClientProtocol: class {
+  
+  ///  A store used as a local cache.
+  var store: ApolloStore { get }
+  
+  /// A function that returns a cache key for a particular result object. If it returns `nil`, a default cache key based on the field path will be used.
+  var cacheKeyForObject: CacheKeyForObject? { get set }
+  
+  /// Clears the underlying cache.
+  /// Be aware: In more complex setups, the same underlying cache can be used across multiple instances, so if you call this on one instance, it'll clear that cache across all instances which share that cache.
+  ///
+  /// - Returns: Promise which fulfills when clear is complete.
+  func clearCache() -> Promise<Void>
+  
+  /// Fetches a query from the server or from the local cache, depending on the current contents of the cache and the specified cache policy.
+  ///
+  /// - Parameters:
+  ///   - query: The query to fetch.
+  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache.
+  ///   - context: [optional] A context to use for the cache to work with results. Should default to nil.
+  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
+  /// - Returns: An object that can be used to cancel an in progress fetch.
+  func fetch<Query: GraphQLQuery>(query: Query,
+                                  cachePolicy: CachePolicy,
+                                  context: UnsafeMutableRawPointer?,
+                                  queue: DispatchQueue,
+                                  resultHandler: GraphQLResultHandler<Query.Data>?) -> Cancellable
+  
+  /// Watches a query by first fetching an initial result from the server or from the local cache, depending on the current contents of the cache and the specified cache policy. After the initial fetch, the returned query watcher object will get notified whenever any of the data the query result depends on changes in the local cache, and calls the result handler again with the new result.
+  ///
+  /// - Parameters:
+  ///   - query: The query to fetch.
+  ///   - fetchHTTPMethod: The HTTP Method to be used.
+  ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
+  ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
+  ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
+  /// - Returns: A query watcher object that can be used to control the watching behavior.
+  func watch<Query: GraphQLQuery>(query: Query,
+                                  cachePolicy: CachePolicy,
+                                  queue: DispatchQueue,
+                                  resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>
+  
+  /// Performs a mutation by sending it to the server.
+  ///
+  /// - Parameters:
+  ///   - mutation: The mutation to perform.
+  ///   - context: [optional] A context to use for the cache to work with results. Should default to nil.
+  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
+  /// - Returns: An object that can be used to cancel an in progress mutation.
+  func perform<Mutation: GraphQLMutation>(mutation: Mutation,
+                                          context: UnsafeMutableRawPointer?,
+                                          queue: DispatchQueue,
+                                          resultHandler: GraphQLResultHandler<Mutation.Data>?) -> Cancellable
+  
+  /// Uploads the given files with the given operation.
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to send
+  ///   - context: [optional] A context to use for the cache to work with results. Should default to nil.
+  ///   - files: An array of `GraphQLFile` objects to send.
+  ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
+  ///   - completionHandler: The completion handler to execute when the request completes or errors
+  /// - Returns: An object that can be used to cancel an in progress request.
+  /// - Throws: If your `networkTransport` does not also conform to `UploadingNetworkTransport`.
+  func upload<Operation: GraphQLOperation>(operation: Operation,
+                                           context: UnsafeMutableRawPointer?,
+                                           files: [GraphQLFile],
+                                           queue: DispatchQueue,
+                                           resultHandler: GraphQLResultHandler<Operation.Data>?) -> Cancellable
+  
+  /// Subscribe to a subscription
+  ///
+  /// - Parameters:
+  ///   - subscription: The subscription to subscribe to.
+  ///   - fetchHTTPMethod: The HTTP Method to be used.
+  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
+  /// - Returns: An object that can be used to cancel an in progress subscription.
+  func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,
+                                                    queue: DispatchQueue,
+                                                    resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable
+}

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -2,7 +2,7 @@ import Dispatch
 
 /// A `GraphQLQueryWatcher` is responsible for watching the store, and calling the result handler with a new result whenever any of the data the previous result depends on changes.
 public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, ApolloStoreSubscriber {
-  weak var client: ApolloClient?
+  weak var client: ApolloClientProtocol?
   let query: Query
   let resultHandler: GraphQLResultHandler<Query.Data>
   
@@ -12,7 +12,15 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   
   private var dependentKeys: Set<CacheKey>?
   
-  init(client: ApolloClient, query: Query,  resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
+  /// Designated initializer
+  ///
+  /// - Parameters:
+  ///   - client: The client protocol to pass in
+  ///   - query: The query to watch
+  ///   - resultHandler: The result handler to call with changes.
+  init(client: ApolloClientProtocol,
+       query: Query,
+       resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
     self.client = client
     self.query = query
     self.resultHandler = resultHandler
@@ -26,7 +34,7 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
   
   func fetch(cachePolicy: CachePolicy) {
-    fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context) { [weak self] result in
+    fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context, queue: .main) { [weak self] result in
       guard let `self` = self else { return }
       
       switch result {

--- a/docs/source/api/Apollo/README.md
+++ b/docs/source/api/Apollo/README.md
@@ -1,5 +1,6 @@
 ## Protocols
 
+-   [ApolloClientProtocol](../protocols/ApolloClientProtocol/)
 -   [Cancellable](../protocols/Cancellable/)
 -   [GraphQLFragment](../protocols/GraphQLFragment/)
 -   [GraphQLInputValue](../protocols/GraphQLInputValue/)
@@ -19,6 +20,7 @@
 -   [Matchable](../protocols/Matchable/)
 -   [NetworkTransport](../protocols/NetworkTransport/)
 -   [NormalizedCache](../protocols/NormalizedCache/)
+-   [UploadingNetworkTransport](../protocols/UploadingNetworkTransport/)
 
 ## Structs
 
@@ -55,6 +57,7 @@
 
 ## Enums
 
+-   [ApolloClientError](../enums/ApolloClientError/)
 -   [CachePolicy](../enums/CachePolicy/)
 -   [ErrorKind](../enums/ErrorKind/)
 -   [GraphQLHTTPRequestError](../enums/GraphQLHTTPRequestError/)
@@ -66,6 +69,7 @@
 
 ## Extensions
 
+-   [ApolloClient](../extensions/ApolloClient/)
 -   [Array](../extensions/Array/)
 -   [Bool](../extensions/Bool/)
 -   [Dictionary](../extensions/Dictionary/)

--- a/docs/source/api/Apollo/classes/ApolloClient.md
+++ b/docs/source/api/Apollo/classes/ApolloClient.md
@@ -6,19 +6,13 @@
 public class ApolloClient
 ```
 
-> The `ApolloClient` class provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
+> The `ApolloClient` class implements the core API for Apollo by conforming to `ApolloClientProtocol`.
 
 ## Properties
 ### `store`
 
 ```swift
-public let store: ApolloStore
-```
-
-### `cacheKeyForObject`
-
-```swift
-public var cacheKeyForObject: CacheKeyForObject?
+public let store: ApolloStore // <- conformance to ApolloClientProtocol
 ```
 
 ## Methods
@@ -32,14 +26,14 @@ public init(networkTransport: NetworkTransport, store: ApolloStore = ApolloStore
 >
 > - Parameters:
 >   - networkTransport: A network transport used to send operations to a server.
->   - store: A store used as a local cache. Defaults to an empty store backed by an in memory cache.
+>   - store: A store used as a local cache. Should default to an empty store backed by an in-memory cache.
 
 #### Parameters
 
 | Name | Description |
 | ---- | ----------- |
 | networkTransport | A network transport used to send operations to a server. |
-| store | A store used as a local cache. Defaults to an empty store backed by an in memory cache. |
+| store | A store used as a local cache. Should default to an empty store backed by an in-memory cache. |
 
 ### `init(url:)`
 
@@ -56,112 +50,3 @@ public convenience init(url: URL)
 | Name | Description |
 | ---- | ----------- |
 | url | The URL of a GraphQL server to connect to. |
-
-### `clearCache()`
-
-```swift
-public func clearCache() -> Promise<Void>
-```
-
-> Clears the underlying cache.
-> Be aware: In more complex setups, the same underlying cache can be used across multiple instances, so if you call this on one instance, it'll clear that cache across all instances which share that cache.
->
-> - Returns: Promise which fulfills when clear is complete.
-
-### `fetch(query:cachePolicy:context:queue:resultHandler:)`
-
-```swift
-@discardableResult public func fetch<Query: GraphQLQuery>(query: Query, cachePolicy: CachePolicy = .returnCacheDataElseFetch, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue = DispatchQueue.main, resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable
-```
-
-> Fetches a query from the server or from the local cache, depending on the current contents of the cache and the specified cache policy.
->
-> - Parameters:
->   - query: The query to fetch.
->   - cachePolicy: A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache.
->   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
->   - resultHandler: An optional closure that is called when query results are available or when an error occurs.
-> - Returns: An object that can be used to cancel an in progress fetch.
-
-#### Parameters
-
-| Name | Description |
-| ---- | ----------- |
-| query | The query to fetch. |
-| cachePolicy | A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache. |
-| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
-| resultHandler | An optional closure that is called when query results are available or when an error occurs. |
-
-### `watch(query:cachePolicy:queue:resultHandler:)`
-
-```swift
-public func watch<Query: GraphQLQuery>(query: Query, cachePolicy: CachePolicy = .returnCacheDataElseFetch, queue: DispatchQueue = DispatchQueue.main, resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>
-```
-
-> Watches a query by first fetching an initial result from the server or from the local cache, depending on the current contents of the cache and the specified cache policy. After the initial fetch, the returned query watcher object will get notified whenever any of the data the query result depends on changes in the local cache, and calls the result handler again with the new result.
->
-> - Parameters:
->   - query: The query to fetch.
->   - fetchHTTPMethod: The HTTP Method to be used.
->   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
->   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
->   - resultHandler: An optional closure that is called when query results are available or when an error occurs.
-> - Returns: A query watcher object that can be used to control the watching behavior.
-
-#### Parameters
-
-| Name | Description |
-| ---- | ----------- |
-| query | The query to fetch. |
-| fetchHTTPMethod | The HTTP Method to be used. |
-| cachePolicy | A cache policy that specifies when results should be fetched from the server or from the local cache. |
-| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
-| resultHandler | An optional closure that is called when query results are available or when an error occurs. |
-
-### `perform(mutation:context:queue:resultHandler:)`
-
-```swift
-@discardableResult public func perform<Mutation: GraphQLMutation>(mutation: Mutation, context: UnsafeMutableRawPointer? = nil, queue: DispatchQueue = DispatchQueue.main, resultHandler: GraphQLResultHandler<Mutation.Data>? = nil) -> Cancellable
-```
-
-> Performs a mutation by sending it to the server.
->
-> - Parameters:
->   - mutation: The mutation to perform.
->   - fetchHTTPMethod: The HTTP Method to be used.
->   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
->   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
-> - Returns: An object that can be used to cancel an in progress mutation.
-
-#### Parameters
-
-| Name | Description |
-| ---- | ----------- |
-| mutation | The mutation to perform. |
-| fetchHTTPMethod | The HTTP Method to be used. |
-| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
-| resultHandler | An optional closure that is called when mutation results are available or when an error occurs. |
-
-### `subscribe(subscription:queue:resultHandler:)`
-
-```swift
-@discardableResult public func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription, queue: DispatchQueue = DispatchQueue.main, resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable
-```
-
-> Subscribe to a subscription
->
-> - Parameters:
->   - subscription: The subscription to subscribe to.
->   - fetchHTTPMethod: The HTTP Method to be used.
->   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
->   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
-> - Returns: An object that can be used to cancel an in progress subscription.
-
-#### Parameters
-
-| Name | Description |
-| ---- | ----------- |
-| subscription | The subscription to subscribe to. |
-| fetchHTTPMethod | The HTTP Method to be used. |
-| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
-| resultHandler | An optional closure that is called when mutation results are available or when an error occurs. |

--- a/docs/source/api/Apollo/classes/HTTPNetworkTransport.md
+++ b/docs/source/api/Apollo/classes/HTTPNetworkTransport.md
@@ -9,11 +9,11 @@ public class HTTPNetworkTransport
 > A network transport that uses HTTP POST requests to send GraphQL operations to a server, and that uses `URLSession` as the networking implementation.
 
 ## Methods
-### `init(url:configuration:sendOperationIdentifiers:useGETForQueries:delegate:)`
+### `init(url:session:sendOperationIdentifiers:useGETForQueries:delegate:)`
 
 ```swift
 public init(url: URL,
-            configuration: URLSessionConfiguration = .default,
+            session: URLSession = .shared,
             sendOperationIdentifiers: Bool = false,
             useGETForQueries: Bool = false,
             delegate: HTTPNetworkTransportDelegate? = nil)
@@ -23,7 +23,7 @@ public init(url: URL,
 >
 > - Parameters:
 >   - url: The URL of a GraphQL server to connect to.
->   - configuration: A session configuration used to configure the session. Defaults to `URLSessionConfiguration.default`.
+>   - session: The URLSession to use. Defaults to `URLSession.shared`,
 >   - sendOperationIdentifiers: Whether to send operation identifiers rather than full operation text, for use with servers that support query persistence. Defaults to false.
 >   - useGETForQueries: If query operation should be sent using GET instead of POST. Defaults to false.
 >   - delegate: [Optional] A delegate which can conform to any or all of `HTTPNetworkTransportPreflightDelegate`, `HTTPNetworkTransportTaskCompletedDelegate`, and `HTTPNetworkTransportRetryDelegate`. Defaults to nil.
@@ -33,29 +33,7 @@ public init(url: URL,
 | Name | Description |
 | ---- | ----------- |
 | url | The URL of a GraphQL server to connect to. |
-| configuration | A session configuration used to configure the session. Defaults to `URLSessionConfiguration.default`. |
+| session | The URLSession to use. Defaults to `URLSession.shared`, |
 | sendOperationIdentifiers | Whether to send operation identifiers rather than full operation text, for use with servers that support query persistence. Defaults to false. |
 | useGETForQueries | If query operation should be sent using GET instead of POST. Defaults to false. |
 | delegate | [Optional] A delegate which can conform to any or all of `HTTPNetworkTransportPreflightDelegate`, `HTTPNetworkTransportTaskCompletedDelegate`, and `HTTPNetworkTransportRetryDelegate`. Defaults to nil. |
-
-### `upload(operation:files:completionHandler:)`
-
-```swift
-public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
-```
-
-> Uploads the given files with the given operation.
->
-> - Parameters:
->   - operation: The operation to send
->   - files: An array of `GraphQLFile` objects to send.
->   - completionHandler: The completion handler to execute when the request completes or errors
-> - Returns: An object that can be used to cancel an in progress request.
-
-#### Parameters
-
-| Name | Description |
-| ---- | ----------- |
-| operation | The operation to send |
-| files | An array of `GraphQLFile` objects to send. |
-| completionHandler | The completion handler to execute when the request completes or errors |

--- a/docs/source/api/Apollo/enums/ApolloClientError.md
+++ b/docs/source/api/Apollo/enums/ApolloClientError.md
@@ -1,0 +1,21 @@
+**ENUM**
+
+# `ApolloClientError`
+
+```swift
+public enum ApolloClientError: Error, LocalizedError
+```
+
+## Cases
+### `noUploadTransport`
+
+```swift
+case noUploadTransport
+```
+
+## Properties
+### `localizedDescription`
+
+```swift
+public var localizedDescription: String
+```

--- a/docs/source/api/Apollo/extensions/ApolloClient.md
+++ b/docs/source/api/Apollo/extensions/ApolloClient.md
@@ -1,0 +1,111 @@
+**EXTENSION**
+
+# `ApolloClient`
+
+## Properties
+### `cacheKeyForObject`
+
+```swift
+public var cacheKeyForObject: CacheKeyForObject?
+```
+
+## Methods
+### `clearCache()`
+
+```swift
+public func clearCache() -> Promise<Void>
+```
+
+### `fetch(query:cachePolicy:context:queue:resultHandler:)`
+
+```swift
+@discardableResult public func fetch<Query: GraphQLQuery>(query: Query,
+                                                          cachePolicy: CachePolicy = .returnCacheDataElseFetch,
+                                                          context: UnsafeMutableRawPointer? = nil,
+                                                          queue: DispatchQueue = DispatchQueue.main,
+                                                          resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| query | The query to fetch. |
+| cachePolicy | A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache. |
+| context | [optional] A context to use for the cache to work with results. Should default to nil. |
+| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
+| resultHandler | [optional] A closure that is called when query results are available or when an error occurs. |
+
+### `watch(query:cachePolicy:queue:resultHandler:)`
+
+```swift
+public func watch<Query: GraphQLQuery>(query: Query,
+                                       cachePolicy: CachePolicy = .returnCacheDataElseFetch,
+                                       queue: DispatchQueue = .main,
+                                       resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| query | The query to fetch. |
+| fetchHTTPMethod | The HTTP Method to be used. |
+| cachePolicy | A cache policy that specifies when results should be fetched from the server or from the local cache. |
+| queue | A dispatch queue on which the result handler will be called. Should default to the main queue. |
+| resultHandler | [optional] A closure that is called when query results are available or when an error occurs. |
+
+### `perform(mutation:context:queue:resultHandler:)`
+
+```swift
+public func perform<Mutation: GraphQLMutation>(mutation: Mutation,
+                                               context: UnsafeMutableRawPointer? = nil,
+                                               queue: DispatchQueue = DispatchQueue.main,
+                                               resultHandler: GraphQLResultHandler<Mutation.Data>? = nil) -> Cancellable
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| mutation | The mutation to perform. |
+| context | [optional] A context to use for the cache to work with results. Should default to nil. |
+| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
+| resultHandler | An optional closure that is called when mutation results are available or when an error occurs. |
+
+### `upload(operation:context:files:queue:resultHandler:)`
+
+```swift
+public func upload<Operation: GraphQLOperation>(operation: Operation,
+                                                context: UnsafeMutableRawPointer? = nil,
+                                                files: [GraphQLFile],
+                                                queue: DispatchQueue = .main,
+                                                resultHandler: GraphQLResultHandler<Operation.Data>? = nil) -> Cancellable
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| operation | The operation to send |
+| context | [optional] A context to use for the cache to work with results. Should default to nil. |
+| files | An array of `GraphQLFile` objects to send. |
+| queue | A dispatch queue on which the result handler will be called. Should default to the main queue. |
+| completionHandler | The completion handler to execute when the request completes or errors |
+
+### `subscribe(subscription:queue:resultHandler:)`
+
+```swift
+public func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,
+                                                         queue: DispatchQueue = .main,
+                                                         resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| subscription | The subscription to subscribe to. |
+| fetchHTTPMethod | The HTTP Method to be used. |
+| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
+| resultHandler | An optional closure that is called when mutation results are available or when an error occurs. |

--- a/docs/source/api/Apollo/extensions/HTTPNetworkTransport.md
+++ b/docs/source/api/Apollo/extensions/HTTPNetworkTransport.md
@@ -15,3 +15,30 @@ public func send<Operation>(operation: Operation, completionHandler: @escaping (
 | ---- | ----------- |
 | operation | The operation to send. |
 | completionHandler | A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred. |
+
+### `upload(operation:files:completionHandler:)`
+
+```swift
+public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| operation | The operation to send |
+| files | An array of `GraphQLFile` objects to send. |
+| completionHandler | The completion handler to execute when the request completes or errors |
+
+### `==(_:_:)`
+
+```swift
+public static func ==(lhs: HTTPNetworkTransport, rhs: HTTPNetworkTransport) -> Bool
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| lhs | A value to compare. |
+| rhs | Another value to compare. |

--- a/docs/source/api/Apollo/protocols/ApolloClientProtocol.md
+++ b/docs/source/api/Apollo/protocols/ApolloClientProtocol.md
@@ -1,0 +1,165 @@
+**PROTOCOL**
+
+# `ApolloClientProtocol`
+
+```swift
+public protocol ApolloClientProtocol: class
+```
+
+> The `ApolloClientProtocol` provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
+
+## Properties
+### `store`
+
+```swift
+var store: ApolloStore
+```
+
+> A store used as a local cache.
+
+### `cacheKeyForObject`
+
+```swift
+var cacheKeyForObject: CacheKeyForObject?
+```
+
+> A function that returns a cache key for a particular result object. If it returns `nil`, a default cache key based on the field path will be used.
+
+## Methods
+### `clearCache()`
+
+```swift
+func clearCache() -> Promise<Void>
+```
+
+> Clears the underlying cache.
+> Be aware: In more complex setups, the same underlying cache can be used across multiple instances, so if you call this on one instance, it'll clear that cache across all instances which share that cache.
+>
+> - Returns: Promise which fulfills when clear is complete.
+
+### `fetch(query:cachePolicy:context:queue:resultHandler:)`
+
+```swift
+func fetch<Query: GraphQLQuery>(query: Query,
+```
+
+> Fetches a query from the server or from the local cache, depending on the current contents of the cache and the specified cache policy.
+>
+> - Parameters:
+>   - query: The query to fetch.
+>   - cachePolicy: A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache.
+>   - context: [optional] A context to use for the cache to work with results. Should default to nil.
+>   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+>   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
+> - Returns: An object that can be used to cancel an in progress fetch.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| query | The query to fetch. |
+| cachePolicy | A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache. |
+| context | [optional] A context to use for the cache to work with results. Should default to nil. |
+| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
+| resultHandler | [optional] A closure that is called when query results are available or when an error occurs. |
+
+### `watch(query:cachePolicy:queue:resultHandler:)`
+
+```swift
+func watch<Query: GraphQLQuery>(query: Query,
+```
+
+> Watches a query by first fetching an initial result from the server or from the local cache, depending on the current contents of the cache and the specified cache policy. After the initial fetch, the returned query watcher object will get notified whenever any of the data the query result depends on changes in the local cache, and calls the result handler again with the new result.
+>
+> - Parameters:
+>   - query: The query to fetch.
+>   - fetchHTTPMethod: The HTTP Method to be used.
+>   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
+>   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
+>   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
+> - Returns: A query watcher object that can be used to control the watching behavior.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| query | The query to fetch. |
+| fetchHTTPMethod | The HTTP Method to be used. |
+| cachePolicy | A cache policy that specifies when results should be fetched from the server or from the local cache. |
+| queue | A dispatch queue on which the result handler will be called. Should default to the main queue. |
+| resultHandler | [optional] A closure that is called when query results are available or when an error occurs. |
+
+### `perform(mutation:context:queue:resultHandler:)`
+
+```swift
+func perform<Mutation: GraphQLMutation>(mutation: Mutation,
+```
+
+> Performs a mutation by sending it to the server.
+>
+> - Parameters:
+>   - mutation: The mutation to perform.
+>   - context: [optional] A context to use for the cache to work with results. Should default to nil.
+>   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+>   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
+> - Returns: An object that can be used to cancel an in progress mutation.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| mutation | The mutation to perform. |
+| context | [optional] A context to use for the cache to work with results. Should default to nil. |
+| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
+| resultHandler | An optional closure that is called when mutation results are available or when an error occurs. |
+
+### `upload(operation:context:files:queue:resultHandler:)`
+
+```swift
+func upload<Operation: GraphQLOperation>(operation: Operation,
+```
+
+> Uploads the given files with the given operation.
+>
+> - Parameters:
+>   - operation: The operation to send
+>   - context: [optional] A context to use for the cache to work with results. Should default to nil.
+>   - files: An array of `GraphQLFile` objects to send.
+>   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
+>   - completionHandler: The completion handler to execute when the request completes or errors
+> - Returns: An object that can be used to cancel an in progress request.
+> - Throws: If your `networkTransport` does not also conform to `UploadingNetworkTransport`.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| operation | The operation to send |
+| context | [optional] A context to use for the cache to work with results. Should default to nil. |
+| files | An array of `GraphQLFile` objects to send. |
+| queue | A dispatch queue on which the result handler will be called. Should default to the main queue. |
+| completionHandler | The completion handler to execute when the request completes or errors |
+
+### `subscribe(subscription:queue:resultHandler:)`
+
+```swift
+func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,
+```
+
+> Subscribe to a subscription
+>
+> - Parameters:
+>   - subscription: The subscription to subscribe to.
+>   - fetchHTTPMethod: The HTTP Method to be used.
+>   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+>   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
+> - Returns: An object that can be used to cancel an in progress subscription.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| subscription | The subscription to subscribe to. |
+| fetchHTTPMethod | The HTTP Method to be used. |
+| queue | A dispatch queue on which the result handler will be called. Defaults to the main queue. |
+| resultHandler | An optional closure that is called when mutation results are available or when an error occurs. |

--- a/docs/source/api/Apollo/protocols/UploadingNetworkTransport.md
+++ b/docs/source/api/Apollo/protocols/UploadingNetworkTransport.md
@@ -1,0 +1,32 @@
+**PROTOCOL**
+
+# `UploadingNetworkTransport`
+
+```swift
+public protocol UploadingNetworkTransport: NetworkTransport
+```
+
+> A network transport which can also handle uploads of files.
+
+## Methods
+### `upload(operation:files:completionHandler:)`
+
+```swift
+func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+```
+
+> Uploads the given files with the given operation.
+>
+> - Parameters:
+>   - operation: The operation to send
+>   - files: An array of `GraphQLFile` objects to send.
+>   - completionHandler: The completion handler to execute when the request completes or errors
+> - Returns: An object that can be used to cancel an in progress request.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| operation | The operation to send |
+| files | An array of `GraphQLFile` objects to send. |
+| completionHandler | The completion handler to execute when the request completes or errors |

--- a/docs/source/api/ApolloWebSocket/classes/SplitNetworkTransport.md
+++ b/docs/source/api/ApolloWebSocket/classes/SplitNetworkTransport.md
@@ -12,18 +12,18 @@ public class SplitNetworkTransport
 ### `init(httpNetworkTransport:webSocketNetworkTransport:)`
 
 ```swift
-public init(httpNetworkTransport: NetworkTransport, webSocketNetworkTransport: NetworkTransport)
+public init(httpNetworkTransport: UploadingNetworkTransport, webSocketNetworkTransport: NetworkTransport)
 ```
 
 > Designated initializer
 >
 > - Parameters:
->   - httpNetworkTransport: A `NetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
+>   - httpNetworkTransport: An `UploadingNetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
 >   - webSocketNetworkTransport: A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar.
 
 #### Parameters
 
 | Name | Description |
 | ---- | ----------- |
-| httpNetworkTransport | A `NetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar. |
+| httpNetworkTransport | An `UploadingNetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar. |
 | webSocketNetworkTransport | A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar. |

--- a/docs/source/api/ApolloWebSocket/extensions/SplitNetworkTransport.md
+++ b/docs/source/api/ApolloWebSocket/extensions/SplitNetworkTransport.md
@@ -15,3 +15,17 @@ public func send<Operation>(operation: Operation, completionHandler: @escaping (
 | ---- | ----------- |
 | operation | The operation to send. |
 | completionHandler | A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred. |
+
+### `upload(operation:files:completionHandler:)`
+
+```swift
+public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+```
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| operation | The operation to send |
+| files | An array of `GraphQLFile` objects to send. |
+| completionHandler | The completion handler to execute when the request completes or errors |


### PR DESCRIPTION
Building off the work of #693, this PR creates a protocol for `ApolloClient` to allow for easier mocking of results. Also cleaned up some documentation when moving everything to a protocol. 