### PR TITLE
Fix header typo in initialization doc

### DIFF
--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -112,7 +112,7 @@ extension Apollo: HTTPNetworkTransportPreflightDelegate {
     var headers = request.allHTTPHeaderFields ?? [String: String]()
 
     // Add any new headers you need
-    headers["Authentication"] = "Bearer \(UserManager.shared.currentAuthToken)"
+    headers["Authorization"] = "Bearer \(UserManager.shared.currentAuthToken)"
   
     // Re-assign the updated headers to the request.
     request.allHTTPHeaderFields = headers


### PR DESCRIPTION
Authentication should be Authorization

Also, it may be preferable to suggest using the functional form:

```swift
request.setValue("Bearer \(UserManager.shared.currentAuthToken)", forHTTPHeaderField: "Authorization")
```

Saving the step of getting and setting the headers object.