### PR TITLE
Expose GraphQLQueryWatcher init method

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -18,9 +18,9 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   ///   - client: The client protocol to pass in
   ///   - query: The query to watch
   ///   - resultHandler: The result handler to call with changes.
-  init(client: ApolloClientProtocol,
-       query: Query,
-       resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
+  public init(client: ApolloClientProtocol,
+              query: Query,
+              resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
     self.client = client
     self.query = query
     self.resultHandler = resultHandler


### PR DESCRIPTION
This is a small fix exposing GraphQLQueryWatcher init method.

We would like to have this to be able to mock and test using ApolloClientProtocol.