### PR TITLE
Introducing delegate if there is GraphQL errors

### DIFF
--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -56,12 +56,4 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
       return GraphQLResult(data: nil, errors: errors, source: .server, dependentKeys: nil)
     }
   }
-
-  func parseErrorsOnlyFast() -> [GraphQLError]? {
-    guard let errorsEntry = self.body["errors"] as? [JSONObject] else {
-      return nil
-    }
-
-    return errorsEntry.map(GraphQLError.init)
-  }
 }

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -56,4 +56,12 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
       return GraphQLResult(data: nil, errors: errors, source: .server, dependentKeys: nil)
     }
   }
+
+  func parseErrorsOnlyFast() -> [GraphQLError]? {
+    guard let errorsEntry = self.body["errors"] as? [JSONObject] else {
+      return nil
+    }
+
+    return errorsEntry.map(GraphQLError.init)
+  }
 }

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -146,11 +146,11 @@ public class HTTPNetworkTransport {
       
       if let receivedError = error {
         self.handleErrorOrRetry(operation: operation,
-                                 files: files,
-                                 error: receivedError,
-                                 for: request,
-                                 response: response,
-                                 completionHandler: completionHandler)
+                                files: files,
+                                error: receivedError,
+                                for: request,
+                                response: response,
+                                completionHandler: completionHandler)
         return
       }
       
@@ -163,11 +163,11 @@ public class HTTPNetworkTransport {
                                                          response: httpResponse,
                                                          kind: .errorResponse)
         self.handleErrorOrRetry(operation: operation,
-                                 files: files,
-                                 error: unsuccessfulError,
-                                 for: request,
-                                 response: response,
-                                 completionHandler: completionHandler)
+                                files: files,
+                                error: unsuccessfulError,
+                                for: request,
+                                response: response,
+                                completionHandler: completionHandler)
         return
       }
       
@@ -176,11 +176,11 @@ public class HTTPNetworkTransport {
                                              response: httpResponse,
                                              kind: .invalidResponse)
         self.handleErrorOrRetry(operation: operation,
-                                 files: files,
-                                 error: error,
-                                 for: request,
-                                 response: response,
-                                 completionHandler: completionHandler)
+                                files: files,
+                                error: error,
+                                for: request,
+                                response: response,
+                                completionHandler: completionHandler)
         return
       }
       
@@ -188,9 +188,9 @@ public class HTTPNetworkTransport {
         guard let body = try self.serializationFormat.deserialize(data: data) as? JSONObject else {
           throw GraphQLHTTPResponseError(body: data, response: httpResponse, kind: .invalidResponse)
         }
-
+        
         let graphQLResponse = GraphQLResponse(operation: operation, body: body)
-
+        
         if let errors = graphQLResponse.parseErrorsOnlyFast() {
           // Handle specific errors from response
           self.handleGraphQLErrorsIfNeeded(operation: operation,
@@ -203,11 +203,11 @@ public class HTTPNetworkTransport {
         }
       } catch let parsingError {
         self.handleErrorOrRetry(operation: operation,
-                                 files: files,
-                                 error: parsingError,
-                                 for: request,
-                                 response: response,
-                                 completionHandler: completionHandler)
+                                files: files,
+                                error: parsingError,
+                                for: request,
+                                response: response,
+                                completionHandler: completionHandler)
       }
     }
     
@@ -254,11 +254,11 @@ public class HTTPNetworkTransport {
     let errorMessages = errors.compactMap { $0.message }
     if self.enableAutoPersistedQueries,
       errorMessages.contains("PersistedQueryNotFound") {
-        // We need to retry this with the full body.
-        _ = self.send(operation: operation,
-                      isPersistedQueryRetry: true,
-                      files: nil,
-                      completionHandler: completionHandler)
+      // We need to retry this with the full body.
+      _ = self.send(operation: operation,
+                    isPersistedQueryRetry: true,
+                    files: nil,
+                    completionHandler: completionHandler)
     } else {
       // Pass the response on to the rest of the chain
       let response = GraphQLResponse(operation: operation, body: body)
@@ -346,7 +346,7 @@ public class HTTPNetworkTransport {
                                   sendQueryDocument: sendQueryDocument,
                                   autoPersistQueries: autoPersistQueries)
   }
-    
+
   private func createRequest<Operation: GraphQLOperation>(for operation: Operation,
                                                           files: [GraphQLFile]?,
                                                           httpMethod: GraphQLHTTPMethod,

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -145,11 +145,12 @@ public class HTTPNetworkTransport {
                             error: error)
       
       if let receivedError = error {
-        self.handleErrorOrRetry(operation: operation,
-                                error: receivedError,
-                                for: request,
-                                response: response,
-                                completionHandler: completionHandler)
+        self?.handleErrorOrRetry(operation: operation,
+                                 files: files,
+                                 error: receivedError,
+                                 for: request,
+                                 response: response,
+                                 completionHandler: completionHandler)
         return
       }
       
@@ -161,11 +162,12 @@ public class HTTPNetworkTransport {
         let unsuccessfulError = GraphQLHTTPResponseError(body: data,
                                                          response: httpResponse,
                                                          kind: .errorResponse)
-        self.handleErrorOrRetry(operation: operation,
-                                error: unsuccessfulError,
-                                for: request,
-                                response: response,
-                                completionHandler: completionHandler)
+        self?.handleErrorOrRetry(operation: operation,
+                                 files: files,
+                                 error: unsuccessfulError,
+                                 for: request,
+                                 response: response,
+                                 completionHandler: completionHandler)
         return
       }
       
@@ -173,11 +175,12 @@ public class HTTPNetworkTransport {
         let error = GraphQLHTTPResponseError(body: nil,
                                              response: httpResponse,
                                              kind: .invalidResponse)
-        self.handleErrorOrRetry(operation: operation,
-                                error: error,
-                                for: request,
-                                response: response,
-                                completionHandler: completionHandler)
+        self?.handleErrorOrRetry(operation: operation,
+                                 files: files,
+                                 error: error,
+                                 for: request,
+                                 response: response,
+                                 completionHandler: completionHandler)
         return
       }
       
@@ -197,11 +200,12 @@ public class HTTPNetworkTransport {
           completionHandler(.success(graphQLResponse))
         }
       } catch let parsingError {
-        self.handleErrorOrRetry(operation: operation,
-                                error: parsingError,
-                                for: request,
-                                response: response,
-                                completionHandler: completionHandler)
+        self?.handleErrorOrRetry(operation: operation,
+                                 files: files,
+                                 error: parsingError,
+                                 for: request,
+                                 response: response,
+                                 completionHandler: completionHandler)
       }
     }
     
@@ -251,6 +255,7 @@ public class HTTPNetworkTransport {
   }
   
   private func handleErrorOrRetry<Operation>(operation: Operation,
+                                             files: [GraphQLFile]?,
                                              error: Error,
                                              for request: URLRequest,
                                              response: URLResponse?,
@@ -273,7 +278,7 @@ public class HTTPNetworkTransport {
           return
         }
         
-        _ = self?.send(operation: operation, completionHandler: completionHandler)
+        _ = self?.send(operation: operation, files: files, completionHandler: completionHandler)
     })
   }
   

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -66,7 +66,7 @@ public protocol HTTPNetworkTransportRetryDelegate: HTTPNetworkTransportDelegate 
 }
 
 /// Methods which will be called after some kind of response has been received and it contains GraphQLErrors
-public protocol NetworkGraphQLErrorDelegate: HTTPNetworkTransportDelegate {
+public protocol HTTPNetworkTransportGraphQLErrorDelegate: HTTPNetworkTransportDelegate {
 
 
   /// Called when response contains one or more GraphQL errors.
@@ -218,7 +218,7 @@ public class HTTPNetworkTransport {
                                                         files: [GraphQLFile]?,
                                                         response: GraphQLResponse<Operation>,
                                                         completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) throws {
-    guard let delegate = self.delegate as? NetworkGraphQLErrorDelegate,
+    guard let delegate = self.delegate as? HTTPNetworkTransportGraphQLErrorDelegate,
       let graphQLErrors = response.parseErrorsOnlyFast(),
       !graphQLErrors.isEmpty else {
         completionHandler(.success(response))

--- a/Tests/ApolloTestSupport/MockURLSession.swift
+++ b/Tests/ApolloTestSupport/MockURLSession.swift
@@ -11,7 +11,7 @@ public final class MockURLSession: URLSession {
   public private (set) var lastRequest: URLRequest?
 
   public var data: Data?
-  public var response: URLResponse?
+  public var response: HTTPURLResponse?
   public var error: Error?
 
   override public func dataTask(with request: URLRequest) -> URLSessionDataTask {
@@ -21,7 +21,9 @@ public final class MockURLSession: URLSession {
   
   override public func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     lastRequest = request
-    completionHandler(data, response, error)
+    if let response = response {
+      completionHandler(data, response, error)
+    }
     return URLSessionDataTaskMock()
   }
 }

--- a/Tests/ApolloTestSupport/MockURLSession.swift
+++ b/Tests/ApolloTestSupport/MockURLSession.swift
@@ -9,7 +9,11 @@ import Foundation
 
 public final class MockURLSession: URLSession {
   public private (set) var lastRequest: URLRequest?
-  
+
+  public var data: Data?
+  public var response: URLResponse?
+  public var error: Error?
+
   override public func dataTask(with request: URLRequest) -> URLSessionDataTask {
     lastRequest = request
     return URLSessionDataTaskMock()
@@ -17,11 +21,13 @@ public final class MockURLSession: URLSession {
   
   override public func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     lastRequest = request
+    completionHandler(data, response, error)
     return URLSessionDataTaskMock()
   }
 }
 
 private final class URLSessionDataTaskMock: URLSessionDataTask {
   override func resume() {
+
   }
 }

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -201,6 +201,7 @@ class HTTPTransportTests: XCTestCase {
     self.retryCount = 0
     self.graphQlErrors = []
     let query = HeroNameQuery()
+    // TODO: Replace this with once it is codable https://github.com/apollographql/apollo-ios/issues/467
     let body = ["errors": [["message": "Test graphql error"]]]
 
     let mockSession = MockURLSession()
@@ -234,6 +235,7 @@ class HTTPTransportTests: XCTestCase {
     self.retryCount = 0
     self.graphQlErrors = []
     let query = HeroNameQuery()
+    // TODO: Replace this with once it is codable https://github.com/apollographql/apollo-ios/issues/467
     let body = ["errors": []]
 
     let mockSession = MockURLSession()


### PR DESCRIPTION
The idea of this delegate is based on 
- https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-error
- https://blog.apollographql.com/full-stack-error-handling-with-graphql-apollo-5c12da407210

It adds ability for better error handling on the clients when there is Graphql errors  
Etc when a token is expired. 

The diffrent from this delegate and `HTTPNetworkTransportRetryDelegate` is that some errors might come from the GraphQL API and not from middleware etc. 

 - [x] Add tests