### PR TITLE
Introducing RequestCreator protocol

### DIFF
--- a/Sources/Apollo/GraphQLFile.swift
+++ b/Sources/Apollo/GraphQLFile.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// A file which can be uploaded to a GraphQL server
 public struct GraphQLFile {
-  let fieldName: String
-  let originalName: String
-  let mimeType: String
-  let inputStream: InputStream
-  let contentLength: UInt64
+  public let fieldName: String
+  public let originalName: String
+  public let mimeType: String
+  public let inputStream: InputStream
+  public let contentLength: UInt64
   
   /// A convenience constant for declaring your mimetype is octet-stream.
   public static let octetStreamMimeType = "application/octet-stream"

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -90,13 +90,13 @@ public class HTTPNetworkTransport {
               sendOperationIdentifiers: Bool = false,
               useGETForQueries: Bool = false,
               delegate: HTTPNetworkTransportDelegate? = nil,
-              requestCreator: RequestCreator? = nil) {
+              requestCreator: RequestCreator = ApolloRequestCreator()) {
     self.url = url
     self.session = session
     self.sendOperationIdentifiers = sendOperationIdentifiers
     self.useGETForQueries = useGETForQueries
     self.delegate = delegate
-    self.requestCreator = requestCreator ?? ApolloRequestCreator()
+    self.requestCreator = requestCreator
   }
 
   private func send<Operation>(operation: Operation, files: [GraphQLFile]?, completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A helper for building out multi-part form data for upload
-class MultipartFormData {
+public class MultipartFormData {
   
   enum FormDataError: Error, LocalizedError {
     case encodingStringToDataFailed(_ string: String)

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -48,9 +48,9 @@ public class MultipartFormData {
   ///   - contentType: [optional] The content type of this part. Defaults to nil.
   ///   - filename: [optional] The name of the file for this part. Defaults to nil.
   public func appendPart(data: Data,
-                  name: String,
-                  contentType: String? = nil,
-                  filename: String? = nil) {
+                         name: String,
+                         contentType: String? = nil,
+                         filename: String? = nil) {
     let inputStream = InputStream(data: data)
     let contentLength = UInt64(data.count)
 

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -24,13 +24,13 @@ public class MultipartFormData {
   /// Designated initializer
   ///
   /// - Parameter boundary: The boundary to use between parts of the form.
-  init(boundary: String) {
+  public init(boundary: String) {
     self.boundary = boundary
     self.bodyParts = []
   }
   
   /// Convenience initializer which uses a pre-defined boundary
-  convenience init() {
+  public convenience init() {
     self.init(boundary: "apollo-ios.boundary.\(UUID().uuidString)")
   }
 
@@ -47,7 +47,7 @@ public class MultipartFormData {
   ///   - name: The name of the part to pass along to the server
   ///   - contentType: [optional] The content type of this part. Defaults to nil.
   ///   - filename: [optional] The name of the file for this part. Defaults to nil.
-  func appendPart(data: Data,
+  public func appendPart(data: Data,
                   name: String,
                   contentType: String? = nil,
                   filename: String? = nil) {
@@ -61,7 +61,7 @@ public class MultipartFormData {
                     filename: filename)
   }
 
-  func appendPart(inputStream: InputStream,
+  public func appendPart(inputStream: InputStream,
                   contentLength: UInt64,
                   name: String,
                   contentType: String? = nil,

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -61,6 +61,14 @@ public class MultipartFormData {
                     filename: filename)
   }
 
+  /// Appends the passed-in input stream as a part of the body.
+  ///
+  /// - Parameters:
+  ///   - inputStream: The input stream to append.
+  ///   - contentLength: Length of the input stream data.
+  ///   - name: The name of the part to pass along to the server
+  ///   - contentType: [optional] The content type of this part. Defaults to nil.
+  ///   - filename: [optional] The name of the file for this part. Defaults to nil.
   public func appendPart(inputStream: InputStream,
                   contentLength: UInt64,
                   name: String,

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -70,10 +70,10 @@ public class MultipartFormData {
   ///   - contentType: [optional] The content type of this part. Defaults to nil.
   ///   - filename: [optional] The name of the file for this part. Defaults to nil.
   public func appendPart(inputStream: InputStream,
-                  contentLength: UInt64,
-                  name: String,
-                  contentType: String? = nil,
-                  filename: String? = nil) {
+                         contentLength: UInt64,
+                         name: String,
+                         contentType: String? = nil,
+                         filename: String? = nil) {
     self.bodyParts.append(BodyPart(name: name,
                                    inputStream: inputStream,
                                    contentLength: contentLength,

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -1,33 +1,14 @@
 import Foundation
 
-// Helper struct to create requests independently of HTTP operations.
-public struct RequestCreator {
-  
+public protocol RequestCreator {
   /// Creates a `GraphQLMap` out of the passed-in operation
   ///
   /// - Parameters:
   ///   - operation: The operation to use
   ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
   /// - Returns: The created `GraphQLMap`
-  public static func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
-    var body: GraphQLMap = [
-      "variables": operation.variables,
-      "operationName": operation.operationName,
-    ]
-    
-    if sendOperationIdentifiers {
-      guard let operationIdentifier = operation.operationIdentifier else {
-        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
-      }
-      
-      body["id"] = operationIdentifier
-    } else {
-      body["query"] = operation.queryDocument
-    }
-    
-    return body
-  }
-  
+  func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap
+
   /// Creates multi-part form data to send with a request
   ///
   /// - Parameters:
@@ -38,7 +19,50 @@ public struct RequestCreator {
   ///   - manualBoundary: [optional] A manual boundary to pass in. A default boundary will be used otherwise.
   /// - Returns: The created form data
   /// - Throws: Errors creating or loading the form  data
-  static func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
+  func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
+                                                             files: [GraphQLFile],
+                                                             sendOperationIdentifiers: Bool,
+                                                             serializationFormat: JSONSerializationFormat.Type,
+                                                             manualBoundary: String?) throws -> MultipartFormData
+}
+
+extension RequestCreator {
+  /// Creates a `GraphQLMap` out of the passed-in operation
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to use
+  ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
+  /// - Returns: The created `GraphQLMap`
+  public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
+    var body: GraphQLMap = [
+      "variables": operation.variables,
+      "operationName": operation.operationName,
+    ]
+
+    if sendOperationIdentifiers {
+      guard let operationIdentifier = operation.operationIdentifier else {
+        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
+      }
+
+      body["id"] = operationIdentifier
+    } else {
+      body["query"] = operation.queryDocument
+    }
+
+    return body
+  }
+
+  /// Creates multi-part form data to send with a request
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to create the data for.
+  ///   - files: An array of files to use.
+  ///   - sendOperationIdentifiers: True if operation identifiers should be sent, false if not.
+  ///   - serializationFormat: The format to use to serialize data.
+  ///   - manualBoundary: [optional] A manual boundary to pass in. A default boundary will be used otherwise.
+  /// - Returns: The created form data
+  /// - Throws: Errors creating or loading the form  data
+  public func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
                                                                     files: [GraphQLFile],
                                                                     sendOperationIdentifiers: Bool,
                                                                     serializationFormat: JSONSerializationFormat.Type,
@@ -50,48 +74,34 @@ public struct RequestCreator {
     } else {
       formData = MultipartFormData()
     }
-    
-    // Make sure all fields for files are set to null, or the server won't look
-    // for the files in the rest of the form data
-    let fieldsForFiles = Set(files.map { $0.fieldName })
-    var fields = requestBody(for: operation, sendOperationIdentifiers: sendOperationIdentifiers)
-    var variables = fields["variables"] as? GraphQLMap ?? GraphQLMap()
-    for fieldName in fieldsForFiles {
-      if
-        let value = variables[fieldName],
-        let arrayValue = value as? [JSONEncodable] {
-        let updatedArray: [JSONEncodable?] = arrayValue.map { _ in nil }
-          variables.updateValue(updatedArray, forKey: fieldName)
+
+    let fields = requestBody(for: operation)
+    for (name, data) in fields {
+      if let data = data as? GraphQLMap {
+        let data = try serializationFormat.serialize(value: data)
+        formData.appendPart(data: data, name: name)
+      } else if let data = data as? String {
+        try formData.appendPart(string: data, name: name)
       } else {
-        variables.updateValue(nil, forKey: fieldName)
+        try formData.appendPart(string: data.debugDescription, name: name)
       }
     }
-    fields["variables"] = variables
-    
-    let operationData = try serializationFormat.serialize(value: fields)
-    formData.appendPart(data: operationData, name: "operations")
-    
-    var map = [String: [String]]()
-    if files.count == 1 {
-      let firstFile = files.first!
-      map["0"] = ["variables.\(firstFile.fieldName)"]
-    } else {
-      for (index, file) in files.enumerated() {
-        map["\(index)"] = ["variables.\(file.fieldName).\(index)"]
-      }
+
+    files.forEach {
+      formData.appendPart(inputStream: $0.inputStream, contentLength: $0.contentLength, name: $0.fieldName, contentType: $0.mimeType, filename: $0.originalName)
     }
-    
-    let mapData = try serializationFormat.serialize(value: map)
-    formData.appendPart(data: mapData, name: "map")
-    
-    for (index, file) in files.enumerated() {
-      formData.appendPart(inputStream: file.inputStream,
-                          contentLength: file.contentLength,
-                          name: "\(index)",
-                          contentType: file.mimeType,
-                          filename: file.originalName)
-    }
-    
+
     return formData
+  }
+}
+
+// Helper struct to create requests independently of HTTP operations.
+struct ApolloRequestCreator: RequestCreator {
+
+  /// Default Apollo request creator
+  ///
+  /// - Returns: Default apollo request creator
+  static func `default`() -> RequestCreator {
+    return ApolloRequestCreator()
   }
 }

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -96,12 +96,7 @@ extension RequestCreator {
 }
 
 // Helper struct to create requests independently of HTTP operations.
-struct ApolloRequestCreator: RequestCreator {
-
-  /// Default Apollo request creator
-  ///
-  /// - Returns: Default apollo request creator
-  static func `default`() -> RequestCreator {
-    return ApolloRequestCreator()
-  }
+public struct ApolloRequestCreator: RequestCreator {
+  // Internal init methods cannot be used in public methods
+  public init() { }
 }

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -11,12 +11,12 @@ import XCTest
 import StarWarsAPI
 
 class GETTransformerTests: XCTestCase {
-  
+  private let requestCreator = ApolloRequestCreator()
   private lazy var url = URL(string: "http://localhost:8080/graphql")!
   
   func testEncodingQueryWithSingleParameter() {
     let operation = HeroNameQuery(episode: .empire)
-    let body = RequestCreator.requestBody(for: operation)
+    let body = requestCreator.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -27,7 +27,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() {
     let operation = HeroNameTypeSpecificConditionalInclusionQuery(episode: .jedi, includeName: true)
-    let body = RequestCreator.requestBody(for: operation)
+    let body = requestCreator.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -90,7 +90,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithNullDefaultParameter() {
     let operation = HeroNameQuery()
-    let body = RequestCreator.requestBody(for: operation)
+    let body = requestCreator.requestBody(for: operation)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     

--- a/Tests/ApolloTests/MultipartFormDataTests.swift
+++ b/Tests/ApolloTests/MultipartFormDataTests.swift
@@ -11,7 +11,8 @@ import XCTest
 import StarWarsAPI
 
 class MultipartFormDataTests: XCTestCase {
-  
+  private let requestCreator = ApolloRequestCreator()
+
   private func checkString(_ string: String,
                            includes expectedString: String,
                            file: StaticString = #file,
@@ -165,7 +166,7 @@ Charlie file content.
                                 mimeType: "text/plain",
                                 fileURL: alphaFileUrl)
     
-    let data = try RequestCreator.requestMultipartFormData(
+    let data = try requestCreator.requestMultipartFormData(
       for: HeroNameQuery(),
       files: [alphaFile!],
       sendOperationIdentifiers: false,
@@ -227,7 +228,7 @@ Alpha file content.
                                fileURL: betaFileURL)!
     
     
-    let data = try RequestCreator.requestMultipartFormData(
+    let data = try requestCreator.requestMultipartFormData(
       for: HeroNameQuery(),
       files: [alphaFile, betaFile],
       sendOperationIdentifiers: false,


### PR DESCRIPTION
This will make it possible to modify how requests are created. 

Useful in file uploads as the specs can be different from framework to framework