### PR TITLE
Schema Download Instructions Clarification

### DIFF
--- a/docs/source/downloading-schema.md
+++ b/docs/source/downloading-schema.md
@@ -4,14 +4,24 @@ title: Downloading a schema
 
 Apollo iOS requires a GraphQL schema file as input to the code generation process. A schema file is a JSON file that contains the results of an introspection query. Conventionally this file is called `schema.json`, and you store it next to the `.graphql` files in your target.
 
-You can use `apollo` from the [apollo-cli](https://github.com/apollographql/apollo-cli) package to download a GraphQL schema by sending an introspection query to the server:
+You can use `apollo` from the [apollo-cli](https://github.com/apollographql/apollo-cli) package to download a GraphQL schema by sending an introspection query to the server.
+
+If you've installed the CLI globally, you can use the following command to download your schema: 
 
 ```sh
 apollo schema:download --endpoint=http://localhost:8080/graphql schema.json
 ```
 
+Note that if you're using the local version set up for codegen, you'll want to use the same method you're using in the [Adding A Code Generation Build Step](installation#adding-a-code-generation-build-step) instructions to access that specific CLI. For example, if you're using CocoaPods, you can set it up like this to download your schema: 
+
+```sh
+SCRIPT_PATH="${PODS_ROOT}/Apollo/scripts"
+cd "${SRCROOT}/${TARGET_NAME}"
+"${SCRIPT_PATH}"/check-and-run-apollo-cli.sh schema:download --endpoint=http://localhost:8080/graphql schema.json
+```
+
 If needed, you can use the `header` option to add additional HTTP headers to the request. For example, to include an authentication token, use `--header "Authorization: Bearer <token>"`:
 
 ```sh
-apollo schema:download --endpoint=http://localhost:8080/graphql --header="Authorization: Bearer <token>"
+[your apollo version] schema:download --endpoint=http://localhost:8080/graphql --header="Authorization: Bearer <token>"
 ```


### PR DESCRIPTION
This PR addresses an issue brought up in the discussion around #769, which is that the suggested script for downloading a schema only works if you've used `npm` to install the CLI globally. This adds instructions for using it locally. 