### PR TITLE
Make buildable when using SPM in XCode 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
 

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol NormalizedCache {
   
   /// Loads records corresponding to the given keys.


### PR DESCRIPTION
I tried adding apollo to our project using SPM in XCode 11 and got some build issues.

The first issue was due to the swift version being specified to 4.0 in `Package.swift`, making XCode trying to build this with the old toolchain, leading to a build error at:
https://github.com/apollographql/apollo-ios/blob/beb6127feada2064dd25dc225d97549e4354462a/Sources/Apollo/GraphQLHTTPResponseError.swift#L39
Due to this depending on the nil-coalescing feature in swift 5.0, changing the `swift-tools-version` in `Package.swift` fixes this.

When this was fixed I got some build-errors due to `Foundation` not being imported in two files, so I added this as well.