### PR TITLE
Update SPM Build Script

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -164,14 +164,23 @@ The location of this wrapper script is slightly different based on how you've in
 If you're using Xcode 11 or higher, SPM will check out the appropriate build script along with the rest of the files when it checks out the repo. Add the following to your Run Script build phase: 
 
 ```sh
-# Go to the build root and go back up to where SPM keeps the Apollo iOS repo checked out.
-cd "${BUILD_ROOT}"
-cd "../../SourcePackages/checkouts/apollo-ios/scripts"
+# Go to the build root and search up the chain to find the Derived Data Path where the source packages are checked out.
+DERIVED_DATA_CANDIDATE="${BUILD_ROOT}"
 
-APOLLO_SCRIPT_PATH="$(pwd)"
+while ! [ -d "${DERIVED_DATA_CANDIDATE}/SourcePackages" ]; do
+  if [ "${DERIVED_DATA_CANDIDATE}" = / ]; then
+    echo >&2 "error: Unable to locate SourcePackages directory from BUILD_ROOT: '${BUILD_ROOT}'"
+    exit 1
+  fi
+
+  DERIVED_DATA_CANDIDATE="$(dirname "${DERIVED_DATA_CANDIDATE}")"
+done
+
+# Grab a reference to the directory where scripts are checked out
+APOLLO_SCRIPT_PATH="${DERIVED_DATA_CANDIDATE}/SourcePackages/checkouts/apollo-ios/scripts"
 
 if [ -z "${APOLLO_SCRIPT_PATH}" ]; then
-    echo "error: Couldn't find the CLI script in your checked out SPM packages; make sure to add the framework to your project."
+    echo >&2 "error: Couldn't find the CLI script in your checked out SPM packages; make sure to add the framework to your project."
     exit 1
 fi
 


### PR DESCRIPTION
#801 and some other issues revealed something rather annoying in terms of trying to back out a consistent route to where SPM checks out code : The `BUILD_ROOT` isn't actually in a consistent place, so hard-coding the `../../` style of path would work for builds but not for archives. 

Big ups to @sharplet for suggesting what I've ultimately gone with: Searching up the directory path to find the parent of `SourcePackages`, which in most cases is the Derived Data folder for the target being run (hence the naming). 