### PR TITLE
Added correct way of default parameters

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -666,18 +666,18 @@
 				9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */,
 				9FF90A6A1DDDEB420034C3B6 /* InputValueEncodingTests.swift */,
 				E86D8E03214B32DA0028EFE1 /* JSONTests.swift */,
-				C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */,
 				9F91CF8E1F6C0DB2008DD0BE /* MutatingResultsTests.swift */,
 				9F295E301E27534800A24949 /* NormalizeQueryResults.swift */,
 				9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */,
 				9FE1C6E61E634C8D00C02284 /* PromiseTests.swift */,
 				F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */,
 				9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */,
+				C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */,
 				9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */,
+				C3279FC52345233000224790 /* TestCustomRequestCreator.swift */,
 				C304EBD322DDC7B200748F72 /* a.txt */,
 				C35D43BE22DDD3C100BCBABE /* b.txt */,
 				C35D43BF22DDD3C100BCBABE /* c.txt */,
-				C3279FC52345233000224790 /* TestCustomRequestCreator.swift */,
 			);
 			path = ApolloTests;
 			sourceTree = "<group>";

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -108,7 +108,7 @@
 		9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */; };
 		9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */; };
 		C304EBD722DDC8E600748F72 /* a.txt in Resources */ = {isa = PBXBuildFile; fileRef = C304EBD322DDC7B200748F72 /* a.txt */; };
-		C338DF1722DD9DE9006AF33E /* MultipartFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C338DF1622DD9DE9006AF33E /* MultipartFormDataTests.swift */; };
+		C338DF1722DD9DE9006AF33E /* RequestCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */; };
 		C35D43C222DDD4AC00BCBABE /* b.txt in Resources */ = {isa = PBXBuildFile; fileRef = C35D43BE22DDD3C100BCBABE /* b.txt */; };
 		C35D43C322DDD4AF00BCBABE /* c.txt in Resources */ = {isa = PBXBuildFile; fileRef = C35D43BF22DDD3C100BCBABE /* c.txt */; };
 		C35D43C422DDD4D100BCBABE /* b.txt in Resources */ = {isa = PBXBuildFile; fileRef = C35D43BE22DDD3C100BCBABE /* b.txt */; };
@@ -381,7 +381,7 @@
 		9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadFieldValueTests.swift; sourceTree = "<group>"; };
 		9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseQueryResponseTests.swift; sourceTree = "<group>"; };
 		C304EBD322DDC7B200748F72 /* a.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = a.txt; sourceTree = "<group>"; };
-		C338DF1622DD9DE9006AF33E /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
+		C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestCreatorTests.swift; sourceTree = "<group>"; };
 		C35D43BE22DDD3C100BCBABE /* b.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = b.txt; sourceTree = "<group>"; };
 		C35D43BF22DDD3C100BCBABE /* c.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = c.txt; sourceTree = "<group>"; };
 		C377CCA822D798BD00572E03 /* GraphQLFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLFile.swift; sourceTree = "<group>"; };
@@ -664,7 +664,7 @@
 				9BF1A94C22CA54F9005292C2 /* HTTPTransportTests.swift */,
 				9FF90A6A1DDDEB420034C3B6 /* InputValueEncodingTests.swift */,
 				E86D8E03214B32DA0028EFE1 /* JSONTests.swift */,
-				C338DF1622DD9DE9006AF33E /* MultipartFormDataTests.swift */,
+				C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */,
 				9F91CF8E1F6C0DB2008DD0BE /* MutatingResultsTests.swift */,
 				9F295E301E27534800A24949 /* NormalizeQueryResults.swift */,
 				9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */,
@@ -1257,7 +1257,7 @@
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,
 				E86D8E05214B32FD0028EFE1 /* JSONTests.swift in Sources */,
 				9F8622FA1EC2117C00C38162 /* FragmentConstructionAndConversionTests.swift in Sources */,
-				C338DF1722DD9DE9006AF33E /* MultipartFormDataTests.swift in Sources */,
+				C338DF1722DD9DE9006AF33E /* RequestCreatorTests.swift in Sources */,
 				F16D083C21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift in Sources */,
 				9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */,
 				9F295E311E27534800A24949 /* NormalizeQueryResults.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */; };
 		9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */; };
 		C304EBD722DDC8E600748F72 /* a.txt in Resources */ = {isa = PBXBuildFile; fileRef = C304EBD322DDC7B200748F72 /* a.txt */; };
+		C3279FC72345234D00224790 /* TestCustomRequestCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3279FC52345233000224790 /* TestCustomRequestCreator.swift */; };
 		C338DF1722DD9DE9006AF33E /* RequestCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */; };
 		C35D43C222DDD4AC00BCBABE /* b.txt in Resources */ = {isa = PBXBuildFile; fileRef = C35D43BE22DDD3C100BCBABE /* b.txt */; };
 		C35D43C322DDD4AF00BCBABE /* c.txt in Resources */ = {isa = PBXBuildFile; fileRef = C35D43BF22DDD3C100BCBABE /* c.txt */; };
@@ -381,6 +382,7 @@
 		9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadFieldValueTests.swift; sourceTree = "<group>"; };
 		9FF90A6C1DDDEB420034C3B6 /* ParseQueryResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseQueryResponseTests.swift; sourceTree = "<group>"; };
 		C304EBD322DDC7B200748F72 /* a.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = a.txt; sourceTree = "<group>"; };
+		C3279FC52345233000224790 /* TestCustomRequestCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCustomRequestCreator.swift; sourceTree = "<group>"; };
 		C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestCreatorTests.swift; sourceTree = "<group>"; };
 		C35D43BE22DDD3C100BCBABE /* b.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = b.txt; sourceTree = "<group>"; };
 		C35D43BF22DDD3C100BCBABE /* c.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = c.txt; sourceTree = "<group>"; };
@@ -675,6 +677,7 @@
 				C304EBD322DDC7B200748F72 /* a.txt */,
 				C35D43BE22DDD3C100BCBABE /* b.txt */,
 				C35D43BF22DDD3C100BCBABE /* c.txt */,
+				C3279FC52345233000224790 /* TestCustomRequestCreator.swift */,
 			);
 			path = ApolloTests;
 			sourceTree = "<group>";
@@ -1251,6 +1254,7 @@
 				9F91CF8F1F6C0DB2008DD0BE /* MutatingResultsTests.swift in Sources */,
 				9F19D8461EED8D3B00C57247 /* ResultOrPromiseTests.swift in Sources */,
 				9F533AB31E6C4A4200CBE097 /* BatchedLoadTests.swift in Sources */,
+				C3279FC72345234D00224790 /* TestCustomRequestCreator.swift in Sources */,
 				9B95EDC022CAA0B000702BB2 /* GETTransformerTests.swift in Sources */,
 				9FF90A6F1DDDEB420034C3B6 /* InputValueEncodingTests.swift in Sources */,
 				9FE1C6E71E634C8D00C02284 /* PromiseTests.swift in Sources */,

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -237,7 +237,8 @@ public class HTTPNetworkTransport {
             for: operation,
             files: files,
             sendOperationIdentifiers: self.sendOperationIdentifiers,
-            serializationFormat: self.serializationFormat)
+            serializationFormat: self.serializationFormat,
+            manualBoundary: nil)
           
           request.setValue("multipart/form-data; boundary=\(formData.boundary)", forHTTPHeaderField: "Content-Type")
           request.httpBody = try formData.encode()

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -34,7 +34,12 @@ public class MultipartFormData {
     self.init(boundary: "apollo-ios.boundary.\(UUID().uuidString)")
   }
 
-  func appendPart(string: String, name: String) throws {
+  /// Appends the passed-in string as a part of the body.
+  ///
+  /// - Parameters:
+  ///   - string: The string to append
+  ///   - name: The name of the part to pass along to the server
+  public func appendPart(string: String, name: String) throws {
     self.appendPart(data: try self.encode(string: string),
                     name: name,
                     contentType: nil)

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -31,6 +31,15 @@ extension RequestCreator {
   ///
   /// - Parameters:
   ///   - operation: The operation to use
+  /// - Returns: The created `GraphQLMap`
+  public func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
+    return requestBody(for: operation, sendOperationIdentifiers: false)
+  }
+
+  /// Creates a `GraphQLMap` out of the passed-in operation
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to use
   ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
   /// - Returns: The created `GraphQLMap`
   public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
@@ -59,6 +68,26 @@ extension RequestCreator {
   ///   - files: An array of files to use.
   ///   - sendOperationIdentifiers: True if operation identifiers should be sent, false if not.
   ///   - serializationFormat: The format to use to serialize data.
+  /// - Returns: The created form data
+  /// - Throws: Errors creating or loading the form  data
+  public func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
+                                                                    files: [GraphQLFile],
+                                                                    sendOperationIdentifiers: Bool,
+                                                                    serializationFormat: JSONSerializationFormat.Type) throws -> MultipartFormData {
+    return try requestMultipartFormData(for: operation,
+                                        files: files,
+                                        sendOperationIdentifiers: sendOperationIdentifiers,
+                                        serializationFormat: serializationFormat,
+                                        manualBoundary: nil)
+  }
+
+  /// Creates multi-part form data to send with a request
+  ///
+  /// - Parameters:
+  ///   - operation: The operation to create the data for.
+  ///   - files: An array of files to use.
+  ///   - sendOperationIdentifiers: True if operation identifiers should be sent, false if not.
+  ///   - serializationFormat: The format to use to serialize data.
   ///   - manualBoundary: [optional] A manual boundary to pass in. A default boundary will be used otherwise.
   /// - Returns: The created form data
   /// - Throws: Errors creating or loading the form  data
@@ -66,7 +95,7 @@ extension RequestCreator {
                                                                     files: [GraphQLFile],
                                                                     sendOperationIdentifiers: Bool,
                                                                     serializationFormat: JSONSerializationFormat.Type,
-                                                                    manualBoundary: String? = nil) throws -> MultipartFormData {
+                                                                    manualBoundary: String?) throws -> MultipartFormData {
     let formData: MultipartFormData
 
     if let boundary = manualBoundary {

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -42,7 +42,7 @@ extension RequestCreator {
   ///   - operation: The operation to use
   ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
   /// - Returns: The created `GraphQLMap`
-  public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool = false) -> GraphQLMap {
+  public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap {
     var body: GraphQLMap = [
       "variables": operation.variables,
       "operationName": operation.operationName,

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -31,15 +31,6 @@ extension RequestCreator {
   ///
   /// - Parameters:
   ///   - operation: The operation to use
-  /// - Returns: The created `GraphQLMap`
-  public func requestBody<Operation: GraphQLOperation>(for operation: Operation) -> GraphQLMap {
-    return requestBody(for: operation, sendOperationIdentifiers: false)
-  }
-
-  /// Creates a `GraphQLMap` out of the passed-in operation
-  ///
-  /// - Parameters:
-  ///   - operation: The operation to use
   ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
   /// - Returns: The created `GraphQLMap`
   public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap {
@@ -59,26 +50,6 @@ extension RequestCreator {
     }
 
     return body
-  }
-
-  /// Creates multi-part form data to send with a request
-  ///
-  /// - Parameters:
-  ///   - operation: The operation to create the data for.
-  ///   - files: An array of files to use.
-  ///   - sendOperationIdentifiers: True if operation identifiers should be sent, false if not.
-  ///   - serializationFormat: The format to use to serialize data.
-  /// - Returns: The created form data
-  /// - Throws: Errors creating or loading the form  data
-  public func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
-                                                                    files: [GraphQLFile],
-                                                                    sendOperationIdentifiers: Bool,
-                                                                    serializationFormat: JSONSerializationFormat.Type) throws -> MultipartFormData {
-    return try requestMultipartFormData(for: operation,
-                                        files: files,
-                                        sendOperationIdentifiers: sendOperationIdentifiers,
-                                        serializationFormat: serializationFormat,
-                                        manualBoundary: nil)
   }
 
   /// Creates multi-part form data to send with a request

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -16,7 +16,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithSingleParameter() {
     let operation = HeroNameQuery(episode: .empire)
-    let body = requestCreator.requestBody(for: operation)
+    let body = requestCreator.requestBody(for: operation, sendOperationIdentifiers: false)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -27,7 +27,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() {
     let operation = HeroNameTypeSpecificConditionalInclusionQuery(episode: .jedi, includeName: true)
-    let body = requestCreator.requestBody(for: operation)
+    let body = requestCreator.requestBody(for: operation, sendOperationIdentifiers: false)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -90,7 +90,7 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithNullDefaultParameter() {
     let operation = HeroNameQuery()
-    let body = requestCreator.requestBody(for: operation)
+    let body = requestCreator.requestBody(for: operation, sendOperationIdentifiers: false)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     

--- a/Tests/ApolloTests/RequestCreatorTests.swift
+++ b/Tests/ApolloTests/RequestCreatorTests.swift
@@ -312,8 +312,6 @@ Bravo file content.
 
     let stringToCompare = try self.string(from: data)
 
-    print(stringToCompare)
-
     if #available(iOS 11, macOS 13, tvOS 11, watchOS 4, *) {
       let expectedString = """
 --TEST.BOUNDARY
@@ -341,11 +339,19 @@ Alpha file content.
       // Operation parameters may be in weird order, so let's at least check that the files and single parameter got encoded properly.
       let expectedEndString = """
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="map"
+Content-Disposition: form-data; name="test_operationName"
 
-{"0":["variables.upload"]}
+HeroName
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="0"; filename="a.txt"
+Content-Disposition: form-data; name="test_query"
+
+query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="test_variables"
+
+{"episode":null}
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="upload"; filename="a.txt"
 Content-Type: text/plain
 
 Alpha file content.

--- a/Tests/ApolloTests/RequestCreatorTests.swift
+++ b/Tests/ApolloTests/RequestCreatorTests.swift
@@ -312,45 +312,9 @@ Bravo file content.
 
     let stringToCompare = try self.string(from: data)
 
-    if #available(iOS 11, macOS 13, tvOS 11, watchOS 4, *) {
-      let expectedString = """
---TEST.BOUNDARY
-Content-Disposition: form-data; name="test_variables"
-
-{"episode":null}
---TEST.BOUNDARY
-Content-Disposition: form-data; name="test_query"
-
-query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }
---TEST.BOUNDARY
-Content-Disposition: form-data; name="test_operationName"
-
-HeroName
---TEST.BOUNDARY
-Content-Disposition: form-data; name="upload"; filename="a.txt"
-Content-Type: text/plain
-
-Alpha file content.
-
---TEST.BOUNDARY--
-"""
-      XCTAssertEqual(stringToCompare, expectedString)
-    } else {
-      // Operation parameters may be in weird order, so let's at least check that the files and single parameter got encoded properly.
+    // Operation parameters may be in weird order, so let's at least check that the files and single parameter got encoded properly.
       let expectedEndString = """
 --TEST.BOUNDARY
-Content-Disposition: form-data; name="test_operationName"
-
-HeroName
---TEST.BOUNDARY
-Content-Disposition: form-data; name="test_query"
-
-query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }
---TEST.BOUNDARY
-Content-Disposition: form-data; name="test_variables"
-
-{"episode":null}
---TEST.BOUNDARY
 Content-Disposition: form-data; name="upload"; filename="a.txt"
 Content-Type: text/plain
 
@@ -358,8 +322,15 @@ Alpha file content.
 
 --TEST.BOUNDARY--
 """
-      self.checkString(stringToCompare, includes: expectedEndString)
-    }
+
+    let expectedQueryString = """
+--TEST.BOUNDARY
+Content-Disposition: form-data; name="test_query"
+
+query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }
+"""
+    self.checkString(stringToCompare, includes: expectedEndString)
+    self.checkString(stringToCompare, includes: expectedQueryString)
   }
 
   func testRequestBodyWithCustomRequestCreator() {

--- a/Tests/ApolloTests/TestCustomRequestCreator.swift
+++ b/Tests/ApolloTests/TestCustomRequestCreator.swift
@@ -1,0 +1,62 @@
+//
+//  TestCustomRequestCreator.swift
+//  Apollo
+//
+//  Created by Kim de Vos on 02/10/2019.
+//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//
+
+import Apollo
+
+fileprivate struct TestCustomRequestCreator: RequestCreator {
+  public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap {
+    var body: GraphQLMap = [
+      "test_variables": operation.variables,
+      "test_operationName": operation.operationName,
+    ]
+
+    if sendOperationIdentifiers {
+      guard let operationIdentifier = operation.operationIdentifier else {
+        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
+      }
+
+      body["test_id"] = operationIdentifier
+    } else {
+      body["test_query"] = operation.queryDocument
+    }
+
+    return body
+  }
+
+  public func requestMultipartFormData<Operation: GraphQLOperation>(for operation: Operation,
+                                                                    files: [GraphQLFile],
+                                                                    sendOperationIdentifiers: Bool,
+                                                                    serializationFormat: JSONSerializationFormat.Type,
+                                                                    manualBoundary: String?) throws -> MultipartFormData {
+    let formData: MultipartFormData
+
+    if let boundary = manualBoundary {
+      formData = MultipartFormData(boundary: boundary)
+    } else {
+      formData = MultipartFormData()
+    }
+
+    let fields = requestBody(for: operation, sendOperationIdentifiers: false)
+    for (name, data) in fields {
+      if let data = data as? GraphQLMap {
+        let data = try serializationFormat.serialize(value: data)
+        formData.appendPart(data: data, name: name)
+      } else if let data = data as? String {
+        try formData.appendPart(string: data, name: name)
+      } else {
+        try formData.appendPart(string: data.debugDescription, name: name)
+      }
+    }
+
+    files.forEach {
+      formData.appendPart(inputStream: $0.inputStream, contentLength: $0.contentLength, name: $0.fieldName, contentType: $0.mimeType, filename: $0.originalName)
+    }
+
+    return formData
+  }
+}

--- a/Tests/ApolloTests/TestCustomRequestCreator.swift
+++ b/Tests/ApolloTests/TestCustomRequestCreator.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2019 Apollo GraphQL. All rights reserved.
 //
 
-import Apollo
+@testable import Apollo
 
-fileprivate struct TestCustomRequestCreator: RequestCreator {
+struct TestCustomRequestCreator: RequestCreator {
   public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap {
     var body: GraphQLMap = [
       "test_variables": operation.variables,

--- a/Tests/ApolloTests/TestCustomRequestCreator.swift
+++ b/Tests/ApolloTests/TestCustomRequestCreator.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Apollo GraphQL. All rights reserved.
 //
 
-@testable import Apollo
+import Apollo
 
 struct TestCustomRequestCreator: RequestCreator {
   public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap {


### PR DESCRIPTION
How I missed that I don't know.. 

Because the `HTTPNetworkTransport` didn't use `manualBoundary` it will use de protocol extension and not the requestCreator that is provided and implements the method.

I think this is the best way to implement "default" parameters 