### PR TITLE
use awk to split shasum from file

### DIFF
--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-SHASUM="$(/usr/bin/shasum -a 256 "${ZIP_FILE}")"
+SHASUM="$(/usr/bin/shasum -a 256 "${ZIP_FILE}" | /usr/bin/awk '{ print $1 }')"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
 
@@ -20,9 +20,7 @@ remove_existing_apollo() {
 extract_cli() {
   tar xzf "${SCRIPT_DIR}"/apollo.tar.gz -C "${SCRIPT_DIR}"
   
-  # Get just the SHASUM rather than the SHASUM + path
-  ARRAY=($SHASUM)
-  echo "${ARRAY[0]}" | tee "${SHASUM_FILE}"
+  echo "${SHASUM}" | tee "${SHASUM_FILE}"
 }
 
 validate_codegen_and_extract_if_needed() {


### PR DESCRIPTION
This removes the need of converting it to a bash array.