### PR TITLE
Fix error with errors

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -34,7 +34,7 @@ public class ApolloClient {
   public enum ApolloClientError: Error, LocalizedError {
     case noUploadTransport
     
-    public var localizedDescription: String {
+    public var errorDescription: String? {
       switch self {
       case .noUploadTransport:
         return "Attempting to upload using a transport which does not support uploads. This is a developer error."

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -6,7 +6,7 @@ public class MultipartFormData {
   enum FormDataError: Error, LocalizedError {
     case encodingStringToDataFailed(_ string: String)
     
-    var localizedDescription: String {
+    var errorDescription: String? {
       switch self {
       case .encodingStringToDataFailed(let string):
         return "Could not encode \"\(string)\" as .utf8 data."


### PR DESCRIPTION
I discovered working on codegen tests that I've basically been using `LocalizedError` all wrong for some time: It only gives you something useful on a test failure or a log if you override `errorDescription` and not `localizedDescription`. Whoops! 

Audited the codebase and found a couple instances where this needed to be changed.