### PR TITLE
CLI update to 2.19.1, Take 2

### DIFF
--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -25,7 +25,7 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="68633af941b314f80fbc0661b0159c678fd598b4769c59559a7f91bb17c7af25"
+  EXPECTED_SHASUM="52b3f50d9a9527565958e59e28421d75e26982c289aaf47cdd99658205f95f75"
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then
     echo "Correct version of the CLI tarball is included, checking if it's already been extracted..."


### PR DESCRIPTION
Initial version I set this up with did not contain the node binary, which only became obvious when was working on the Swift Codegen branch 🤦‍♀ 

Let's try this again. 