### PR TITLE
Add documentation for Subscriptions + ApolloWebSocket

### DIFF
--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
@@ -81,6 +81,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -26,9 +26,25 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "54DDB0BD1EA1523E0009DD99"
+            BuildableName = "ApolloSQLite.framework"
+            BlueprintName = "ApolloSQLite"
+            ReferencedContainer = "container:ApolloSQLite.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "APOLLO_TEST_CACHE_PROVIDER"
+            value = "ApolloSQLiteTestSupport.SQLiteTestCacheProvider"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -60,29 +76,12 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "54DDB0BD1EA1523E0009DD99"
-            BuildableName = "ApolloSQLite.framework"
-            BlueprintName = "ApolloSQLite"
-            ReferencedContainer = "container:ApolloSQLite.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "APOLLO_TEST_CACHE_PROVIDER"
-            value = "ApolloSQLiteTestSupport.SQLiteTestCacheProvider"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -98,8 +97,6 @@
             ReferencedContainer = "container:ApolloSQLite.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -26,9 +26,25 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "720160CA206AB3D30052B2EE"
+            BuildableName = "ApolloWebSocket.framework"
+            BlueprintName = "ApolloWebSocket"
+            ReferencedContainer = "container:ApolloWebSocket.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "APOLLO_TEST_CACHE_PROVIDER"
+            value = "ApolloTestSupport.InMemoryTestCacheProvider"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -50,29 +66,12 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "720160CA206AB3D30052B2EE"
-            BuildableName = "ApolloWebSocket.framework"
-            BlueprintName = "ApolloWebSocket"
-            ReferencedContainer = "container:ApolloWebSocket.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "APOLLO_TEST_CACHE_PROVIDER"
-            value = "ApolloTestSupport.InMemoryTestCacheProvider"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -88,8 +87,6 @@
             ReferencedContainer = "container:ApolloWebSocket.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -235,18 +235,17 @@ class StarWarsSubscriptionTests: XCTestCase {
                    count,
                    "All not fulfilled proper number of times. Expected \(count), got \(allFulfilledCount)")
     let expectedNewHope = selectedEpisodes.filter { $0 == .newhope }.count
-    XCTAssertEqual(expectedNewHope,
-                   newHopeFulfilledCount,
+    XCTAssertEqual(newHopeFulfilledCount,
+                   expectedNewHope,
                    "New Hope not fulfilled proper number of times. Expected \(expectedNewHope), got \(newHopeFulfilledCount)")
     let expectedEmpire = selectedEpisodes.filter { $0 == .empire }.count
-    XCTAssertEqual(expectedEmpire,
-                   empireFulfilledCount,
+    XCTAssertEqual(empireFulfilledCount,
+                   expectedEmpire,
                    "Empire not fulfilled proper number of times. Expected \(expectedEmpire), got \(empireFulfilledCount)")
     let expectedJedi = selectedEpisodes.filter { $0 == .jedi }.count
-    XCTAssertEqual(expectedJedi,
-                   jediFulfilledCount,
+    XCTAssertEqual(jediFulfilledCount,
+                   expectedJedi,
                    "Jedi not fulfilled proper number of times. Expected \(expectedJedi), got \(jediFulfilledCount)")
-    
     
     subAll.cancel()
     subEmpire.cancel()

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -31,6 +31,7 @@ module.exports = {
             'mutations',
             'fragments',
             'caching',
+            'subscriptions'
           ]
         }
       }

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -175,3 +175,5 @@ extension Apollo: HTTPNetworkTransportRetryDelegate {
   }
 }
 ```
+
+An example of setting up a client which can handle web sockets and subscriptions is included in the [subscription documentation](subscriptions/#sample-subscription-supporting-initializer). 

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -80,6 +80,9 @@ Here's a sample of a singleton using an advanced client which handles all three 
 - **`Logger`** to handle printing logs based on their level, and which supports `.debug`, `.error`, or `.always` log levels.
 
 ```swift
+import Foundation
+import Apollo
+
 // MARK: - Singleton Wrapper
 
 class Apollo {

--- a/docs/source/subscriptions.md
+++ b/docs/source/subscriptions.md
@@ -1,0 +1,131 @@
+---
+title: Subscriptions
+---
+
+GraphQL supports [subscriptions](https://graphql.org/blog/subscriptions-in-graphql-and-relay/) to allow clients to be immediately updated when the data changes on a server.
+
+The Apollo iOS library supports the use of subscriptions primarily through the use of [`ApolloWebSocket`](api/ApolloSQLite/README/), an optional additional library that uses popular iOS WebSocket library [`Starscream`](https://github.com/daltoniam/Starscream) under the hood to use WebSockets to connect to your GraphQL server.
+
+Subscriptions are also supported through code generation: Any time your schema declares a subscription field, an operation conforming to `GraphQLSubscription` will be generated which allows you to pass in any parameters that subscription field takes. 
+
+Once those operations are generated, you can use an instance of `ApolloClient` using a subscription-supporting network transport to subscribe, and continue to receive updates about changes until the subscription is cancelled.
+
+## Transport types which support subscriptions
+
+There are two different classes which conform to the [`NetworkTransport` protocol](api/Apollo/protocols/NetworkTransport/) within the `ApolloWebSocket` library: 
+
+- **`WebSocketTransport`** sends all operations over a web socket. 
+- **`SplitNetworkTransport`** hangs onto both a [`WebSocketTransport`](api/ApolloWebSocket/classes/WebSocketTransport/) instance and an [`UploadingNetworkTransport`](api/Apollo/protocols/UploadingNetworkTransport/) instance (usually [`HTTPNetworkTransport`](api/Apollo/classes/HTTPNetworkTransport/)) in order to create a single network transport that can use http for queries and mutations, and web sockets for subscriptions. 
+
+Typically, you'll want to use `SplitNetworkTransport`, since this allows you to retain the single `NetworkTransport` setup and avoids any potential issues of using multiple client objects. 
+
+## Sample subscription-supporting initializer 
+
+Here is an example of setting up a singleton similar to the [Example Advanced Client Setup](initialization/#advanced-client-creation), but which uses a `SplitNetworkTransport` to support both subscriptions and queries: 
+
+```swift
+import Foundation
+import Apollo
+import ApolloWebSocket
+
+// MARK: - Singleton Wrapper
+
+class Apollo {
+  static let shared = Apollo() 
+    
+  /// A web socket transport to use for subscriptions  
+  private lazy var webSocketTransport: WebSocketTransport = {
+    let url = URL(string: "ws://localhost:8080/websocket")!
+    let request = URLRequest(url: url)
+    return WebSocketTransport(request: request)
+  }()
+  
+  /// An HTTP transport to use for queries and mutations
+  private lazy var httpTransport: HTTPNetworkTransport = {
+    let url = URL(string: "http://localhost:8080/graphql")!
+    return HTTPNetworkTransport(url: url)
+  }()
+
+  /// A split network transport to allow the use of both of the above 
+  /// transports through a single `NetworkTransport` instance.
+  private lazy var splitNetworkTransport = SplitNetworkTransport(
+    httpNetworkTransport: self.httpTransport, 
+    webSocketNetworkTransport: self.webSocketTransport
+  )
+
+  /// Create a client using the `SplitNetworkTransport`.
+  private(set) lazy var client = ApolloClient(networkTransport: self.splitNetworkTransport)
+}
+```
+
+## Example usage of a subscription
+
+Let's say you're using the [Sample Star Wars API](https://github.com/apollographql/apollo-ios/blob/master/Tests/StarWarsAPI/API.swift), and you want to use a view controller with a `UITableView` to show a list of reviews that will automatically update whenever a new review is added. 
+
+You can use the [`ReviewAddedSubscription`](https://github.com/apollographql/apollo-ios/blob/25f860e04c44f1099f509120b8c256433632d131/Tests/StarWarsAPI/API.swift#L5386) to accomplish this: 
+
+```swift
+class ReviewViewController: UIViewController {
+
+  private var subscription: Cancellable?
+  private var reviewList = [Review]()
+  
+  // Assume data source and delegate are hooked up in Interface Builder
+  @IBOutlet private var reviewTableView: UITableView!
+    
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    // Set the subscription variable up - be careful not to create a retain cycle!
+    self.subscription = Apollo.shared.client
+        .subscribe(subscription: ReviewAddedSubscription()) { [weak self] result in
+          guard let self = self else {
+            return 
+          }
+      
+          switch result {
+          case .success(let graphQLResult): 
+            if let review = graphQLResult.data?.reviewAdded {
+              // A review was added - append it to the list then reload the data.
+              self.reviewList.append(review)
+              self.reviewTableView.reloadData()
+            } // else, something went wrong and you should check `graphQLResult.error` for problems
+          case .failure(let error):
+            // Not included here: Show some kind of alert
+          }
+    }
+  }
+  
+  deinit {
+    // Make sure the subscription is cancelled, if it exists, when this object is deallocated.
+    self.subscription?.cancel()
+  }
+  
+  // MARK: - Standard TableView Stuff
+  
+  func tableView(_ tableView: UITableView, 
+                 numberOfRowsInSection section: Int) -> Int {
+    return self.reviewList.count
+  }
+  
+ func tableView(_ tableView: UITableView, 
+                cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    // Assume `ReviewCell` is a cell for displaying reviews created elsewhere
+    guard let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as? ReviewCell else {
+      return UITableViewCell()
+    } 
+    
+    let review = self.reviewList[indexPath.row]
+    
+    cell.episode = review.episode
+    cell.stars = review.stars
+    cell.commentary = review.commentary
+    
+    return cell
+  }
+}
+```
+
+Each time a review is added, the subscription's closure is called and if the proper data is included, the new data will be displayed immediately. 
+
+Note that if you only wanted to be updated reviews for a specific episode, you could specify that episode in the initializer for `ReviewAddedSubscription`. 


### PR DESCRIPTION
In this PR: 
- Added real documentation for how to use subscriptions and web socket (addressing  #464)
- Fixed up some stuff in the tests for the web sockets to better identify failures
- Turned the thread sanitizer on for all tests (sort of addresses #600)

Would love feedback from anyone who's used or tried to use `ApolloWebSocket` on these docs!