### PR TITLE
Download the CLI from artifacts rather than including in repo + update to 2.21.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Carthage/Build
 node_modules/
 package-lock.json
 scripts/apollo
+scripts/apollo.tar.gz

--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
     ss.source_files = 'Sources/Apollo/*.swift'
     ss.preserve_paths = [
       'scripts/run-bundled-codegen.sh',
-      'scripts/apollo.tar.gz',
     ]
   end
 

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -8,13 +8,43 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-SHASUM="$(/usr/bin/shasum -a 256 "${ZIP_FILE}" | /usr/bin/awk '{ print $1 }')"
+ZIP_FILE_DOWNLOAD_URL="https://34622-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.21.0/apollo-v2.21.0-darwin-x64.tar.gz"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
+IS_RETRY="false"
+SHASUM=""
 
 # Helper functions
+download_apollo_cli_if_needed() {
+  echo "Checking if CLI needs to be downloaded..."
+  if [ -f "${ZIP_FILE}" ]; then
+    echo "Zip file already downloaded!"
+  else
+    download_cli
+  fi
+}
+
+download_cli() {
+  echo "Downloading zip file with the CLI..."
+  curl --silent "${ZIP_FILE_DOWNLOAD_URL}" -o "${ZIP_FILE}"
+}
+
+force_cli_download() {
+  rm -r "${ZIP_FILE}"
+  remove_existing_apollo
+  download_cli
+  IS_RETRY="true"
+  validate_codegen_and_extract_if_needed
+}
+
+update_shasum() {
+  SHASUM="$(/usr/bin/shasum -a 256 "${ZIP_FILE}" | /usr/bin/awk '{ print $1 }')"
+}
+
 remove_existing_apollo() {
-  rm -r "${APOLLO_DIR}"
+  if [[ -f "${APOLLO_DIR}" ]]; then
+    rm -r "${APOLLO_DIR}"
+  fi
 }
 
 extract_cli() {
@@ -25,13 +55,21 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="0845089ac6fca8a910a317fdb90f2fe486d6e50f0a5caeb6e9c779c839188798"
+  EXPECTED_SHASUM="14e24195e73846111f21b0239dd44afdadc3249ff3fdbc8d0fc74e76459eb3b7"
+  update_shasum
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then
-    echo "Correct version of the CLI tarball is included, checking if it's already been extracted..."
+    echo "Correct version of the CLI tarball is downloaded locally, checking if it's already been extracted..."
   else
-    echo "Error: The SHASUM of this zip file does not match the official released version from Apollo! This may present security issues. Terminating code generation." >&2
-    exit 1
+    if [[ "${IS_RETRY}" == "true" ]]; then
+      #This was a retry, and the SHASUM still doesn't match.
+      echo "Error: The SHASUM of this zip file does not match the official released version from Apollo! This may present security issues. Terminating code generation." >&2
+      exit 1
+    else
+      # This was the first attempt, the version may have changed.
+      echo "Incorrect version of the CLI tarball is downloaded locally, redownloading the zip from the server."
+      force_cli_download
+    fi
   fi
 
   # Check if the SHASUM file has already been written for this version
@@ -51,6 +89,9 @@ validate_codegen_and_extract_if_needed() {
     extract_cli
   fi
 }
+
+# Download the current version of the CLI if it doesn't exist
+download_apollo_cli_if_needed
 
 # Make sure we're using an up-to-date and valid version of the Apollo CLI
 validate_codegen_and_extract_if_needed


### PR DESCRIPTION
This PR addresses #791 by removing the node binaries from the iOS repo and downloading them from artifacts created by the `apollo-tooling` CI jobs. Eventually we're going to move this to something more stable, but for now this should at least get the zip out of the repo. 

This PR also updates to v2.21.0 of the CLI. 