### PR TITLE
Add default apollo engine headers

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -78,7 +78,25 @@ public class HTTPNetworkTransport {
   let delegate: HTTPNetworkTransportDelegate?
   private let requestCreator: RequestCreator
   private let sendOperationIdentifiers: Bool
-  
+
+  /// The default client headers that Apollo Engine uses to identify its clients
+  /// Please see https://www.apollographql.com/docs/graph-manager/client-awareness/
+  ///
+  /// This should be set as headers on your URLRequests, if you're using Apollo Engine, eg:
+  /// sessionConfiguration.httpAdditionalHeaders = HTTPNetworkTransport.apolloEngineClientHeaders
+  static let apolloEngineClientHeaders: [String: String] = {
+    func bundleValue(forKey key: String) -> String? {
+      return Bundle.main.object(forInfoDictionaryKey: key) as? String
+    }
+    let identifier = bundleValue(forKey: String(kCFBundleIdentifierKey)) ?? ""
+    let version = bundleValue(forKey: "CFBundleShortVersionString") ??
+      bundleValue(forKey: String(kCFBundleVersionKey)) ?? ""
+    return [
+      "apollographql-client-name": identifier,
+      "apollographql-client-version": version,
+    ]
+  }()
+
   /// Creates a network transport with the specified server URL and session configuration.
   ///
   /// - Parameters:

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -193,6 +193,12 @@ class HTTPTransportTests: XCTestCase {
                                                      delegate: self)
     XCTAssertNotEqual(self.networkTransport, nonIdenticalTransport)
   }
+
+  func testEngineDefaultHeaders() {
+    let headers = HTTPNetworkTransport.apolloEngineClientHeaders
+    XCTAssertNotNil(headers["apollographql-client-name"])
+    XCTAssertNotNil(headers["apollographql-client-version"])
+  }
 }
 
 // MARK: - HTTPNetworkTransportPreflightDelegate


### PR DESCRIPTION
If you're using Apollo Engine, there's an option to [identify clients and their versions](https://www.apollographql.com/docs/graph-manager/client-awareness/). 

To be perfectly frank I'm not quite sure how such an API should actually look in the iOS SDK, since the URLSession is passed in and there's really no existing API (?) for mutating the request outside of that. So not quite sure where this belongs, if at all, or how the API should look. So here's a getter with the headers and some default values that users can merge into their url session or whatever.

is this even worth doing? 🤷‍♂ 😄 