### PR TITLE
GraphManager/Engine Headers + minor WebSocket cleanup

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */; };
 		9B1A38532332AF6F00325FB4 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1A38522332AF6F00325FB4 /* String+SHA.swift */; };
+		9B1CCDD92360F02C007C9032 /* Bundle+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDD82360F02C007C9032 /* Bundle+Helpers.swift */; };
 		9B64F6762354D219002D1BB5 /* URL+QueryDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B64F6752354D219002D1BB5 /* URL+QueryDict.swift */; };
 		9B708AAD2305884500604A11 /* ApolloClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B708AAC2305884500604A11 /* ApolloClientProtocol.swift */; };
 		9B78C71E2326E86E000C8C32 /* ErrorGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78C71B2326E859000C8C32 /* ErrorGenerationTests.swift */; };
@@ -269,6 +270,7 @@
 		90690D2422433C8000FC2E54 /* Apollo-Target-PerformanceTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-PerformanceTests.xcconfig"; sourceTree = "<group>"; };
 		90690D2522433CAF00FC2E54 /* Apollo-Target-TestSupport.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-TestSupport.xcconfig"; sourceTree = "<group>"; };
 		9B1A38522332AF6F00325FB4 /* String+SHA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA.swift"; sourceTree = "<group>"; };
+		9B1CCDD82360F02C007C9032 /* Bundle+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Helpers.swift"; sourceTree = "<group>"; };
 		9B64F6752354D219002D1BB5 /* URL+QueryDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+QueryDict.swift"; sourceTree = "<group>"; };
 		9B708AAC2305884500604A11 /* ApolloClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloClientProtocol.swift; sourceTree = "<group>"; };
 		9B74BCBE2333F4ED00508F84 /* run-bundled-codegen.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "run-bundled-codegen.sh"; path = "scripts/run-bundled-codegen.sh"; sourceTree = SOURCE_ROOT; };
@@ -732,6 +734,7 @@
 				9FEC15B31E681DAD00D461B4 /* Collections.swift */,
 				9FADC8491E6B0B2300C677E6 /* Locking.swift */,
 				9B1A38522332AF6F00325FB4 /* String+SHA.swift */,
+				9B1CCDD82360F02C007C9032 /* Bundle+Helpers.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -1243,6 +1246,7 @@
 				9FF90A651DDDEB100034C3B6 /* GraphQLExecutor.swift in Sources */,
 				9FC750611D2A59C300458D91 /* GraphQLOperation.swift in Sources */,
 				9BDE43DF22C6708600FD7C7F /* GraphQLHTTPRequestError.swift in Sources */,
+				9B1CCDD92360F02C007C9032 /* Bundle+Helpers.swift in Sources */,
 				5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */,
 				9FE941D01E62C771007CDD89 /* Promise.swift in Sources */,
 				9BA1245E22DE116B00BF1D24 /* Result+Helpers.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -725,8 +725,8 @@
 		9FCDFD211E33A09F007519DC /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				9F578D8F1D8D2CB300C0EA36 /* Utilities.swift */,
 				9FCDFD221E33A0D8007519DC /* AsynchronousOperation.swift */,
+				9B1CCDD82360F02C007C9032 /* Bundle+Helpers.swift */,
 				9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */,
 				9FE941CF1E62C771007CDD89 /* Promise.swift */,
 				9BA1245D22DE116B00BF1D24 /* Result+Helpers.swift */,
@@ -734,7 +734,7 @@
 				9FEC15B31E681DAD00D461B4 /* Collections.swift */,
 				9FADC8491E6B0B2300C677E6 /* Locking.swift */,
 				9B1A38522332AF6F00325FB4 /* String+SHA.swift */,
-				9B1CCDD82360F02C007C9032 /* Bundle+Helpers.swift */,
+				9F578D8F1D8D2CB300C0EA36 /* Utilities.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";

--- a/ApolloWebSocket.xcodeproj/project.pbxproj
+++ b/ApolloWebSocket.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		7270747C206D13F400C131F6 /* StarWarsSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72707472206D112900C131F6 /* StarWarsSubscriptionTests.swift */; };
 		7270747D206D13F400C131F6 /* MockWebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72707473206D112900C131F6 /* MockWebSocketTests.swift */; };
 		7270747E206D13F400C131F6 /* StarWarsWebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72707475206D112900C131F6 /* StarWarsWebSocketTests.swift */; };
+		9B1CCDDB23610CDC007C9032 /* ApolloWebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDDA23610CDC007C9032 /* ApolloWebSocket.swift */; };
+		9B1CCDDF236110C3007C9032 /* WebSocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDDE236110C3007C9032 /* WebSocketError.swift */; };
+		9B1CCDE123611580007C9032 /* OperationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDE023611580007C9032 /* OperationMessage.swift */; };
+		9B1CCDE323611606007C9032 /* WebSocketTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDE223611606007C9032 /* WebSocketTask.swift */; };
 		9F28B6CF206E488B00144A00 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F28B6CC206E487200144A00 /* Starscream.framework */; };
 		9F28B6D520720F2F00144A00 /* Apollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F28B6D420720F2F00144A00 /* Apollo.framework */; };
 		9F28B6D920720FD200144A00 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F28B6D820720FD100144A00 /* ApolloTestSupport.framework */; };
@@ -59,6 +63,10 @@
 		90690D0D224334C900FC2E54 /* ApolloWebSocket-Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ApolloWebSocket-Project-Release.xcconfig"; sourceTree = "<group>"; };
 		90690D12224334FD00FC2E54 /* ApolloWebSocket-Target-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ApolloWebSocket-Target-Framework.xcconfig"; sourceTree = "<group>"; };
 		90690D132243350400FC2E54 /* ApolloWebSocket-Target-Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ApolloWebSocket-Target-Tests.xcconfig"; sourceTree = "<group>"; };
+		9B1CCDDA23610CDC007C9032 /* ApolloWebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloWebSocket.swift; sourceTree = "<group>"; };
+		9B1CCDDE236110C3007C9032 /* WebSocketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketError.swift; sourceTree = "<group>"; };
+		9B1CCDE023611580007C9032 /* OperationMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMessage.swift; sourceTree = "<group>"; };
+		9B1CCDE223611606007C9032 /* WebSocketTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketTask.swift; sourceTree = "<group>"; };
 		9F28B6C6206E487200144A00 /* Starscream.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Starscream.xcodeproj; path = Carthage/Checkouts/Starscream/Starscream.xcodeproj; sourceTree = "<group>"; };
 		9F28B6D420720F2F00144A00 /* Apollo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Apollo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F28B6D820720FD100144A00 /* ApolloTestSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApolloTestSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -124,7 +132,11 @@
 		72707469206D111A00C131F6 /* ApolloWebSocket */ = {
 			isa = PBXGroup;
 			children = (
+				9B1CCDDA23610CDC007C9032 /* ApolloWebSocket.swift */,
+				9B1CCDE023611580007C9032 /* OperationMessage.swift */,
 				7270746A206D111A00C131F6 /* SplitNetworkTransport.swift */,
+				9B1CCDDE236110C3007C9032 /* WebSocketError.swift */,
+				9B1CCDE223611606007C9032 /* WebSocketTask.swift */,
 				7270746B206D111A00C131F6 /* WebSocketTransport.swift */,
 				7270746C206D111A00C131F6 /* Info.plist */,
 			);
@@ -292,8 +304,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B1CCDDF236110C3007C9032 /* WebSocketError.swift in Sources */,
 				7270746D206D111A00C131F6 /* SplitNetworkTransport.swift in Sources */,
+				9B1CCDE323611606007C9032 /* WebSocketTask.swift in Sources */,
 				7270746E206D111A00C131F6 /* WebSocketTransport.swift in Sources */,
+				9B1CCDE123611580007C9032 /* OperationMessage.swift in Sources */,
+				9B1CCDDB23610CDC007C9032 /* ApolloWebSocket.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ApolloWebSocket.xcodeproj/project.pbxproj
+++ b/ApolloWebSocket.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9B1CCDDF236110C3007C9032 /* WebSocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDDE236110C3007C9032 /* WebSocketError.swift */; };
 		9B1CCDE123611580007C9032 /* OperationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDE023611580007C9032 /* OperationMessage.swift */; };
 		9B1CCDE323611606007C9032 /* WebSocketTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDE223611606007C9032 /* WebSocketTask.swift */; };
+		9B1CCDEA23611B07007C9032 /* SplitNetworkTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1CCDE923611B07007C9032 /* SplitNetworkTransportTests.swift */; };
 		9F28B6CF206E488B00144A00 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F28B6CC206E487200144A00 /* Starscream.framework */; };
 		9F28B6D520720F2F00144A00 /* Apollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F28B6D420720F2F00144A00 /* Apollo.framework */; };
 		9F28B6D920720FD200144A00 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F28B6D820720FD100144A00 /* ApolloTestSupport.framework */; };
@@ -67,6 +68,7 @@
 		9B1CCDDE236110C3007C9032 /* WebSocketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketError.swift; sourceTree = "<group>"; };
 		9B1CCDE023611580007C9032 /* OperationMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMessage.swift; sourceTree = "<group>"; };
 		9B1CCDE223611606007C9032 /* WebSocketTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketTask.swift; sourceTree = "<group>"; };
+		9B1CCDE923611B07007C9032 /* SplitNetworkTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SplitNetworkTransportTests.swift; path = Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift; sourceTree = SOURCE_ROOT; };
 		9F28B6C6206E487200144A00 /* Starscream.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Starscream.xcodeproj; path = Carthage/Checkouts/Starscream/Starscream.xcodeproj; sourceTree = "<group>"; };
 		9F28B6D420720F2F00144A00 /* Apollo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Apollo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F28B6D820720FD100144A00 /* ApolloTestSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ApolloTestSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -148,10 +150,11 @@
 			isa = PBXGroup;
 			children = (
 				72707471206D112900C131F6 /* MockWebSocket.swift */,
-				72707472206D112900C131F6 /* StarWarsSubscriptionTests.swift */,
 				72707473206D112900C131F6 /* MockWebSocketTests.swift */,
-				72707474206D112900C131F6 /* Info.plist */,
+				9B1CCDE923611B07007C9032 /* SplitNetworkTransportTests.swift */,
+				72707472206D112900C131F6 /* StarWarsSubscriptionTests.swift */,
 				72707475206D112900C131F6 /* StarWarsWebSocketTests.swift */,
+				72707474206D112900C131F6 /* Info.plist */,
 			);
 			name = ApolloWebSocketTests;
 			path = Tests/ApolloWebSocketTests;
@@ -318,6 +321,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7270747B206D13F400C131F6 /* MockWebSocket.swift in Sources */,
+				9B1CCDEA23611B07007C9032 /* SplitNetworkTransportTests.swift in Sources */,
 				7270747C206D13F400C131F6 /* StarWarsSubscriptionTests.swift in Sources */,
 				7270747D206D13F400C131F6 /* MockWebSocketTests.swift in Sources */,
 				7270747E206D13F400C131F6 /* StarWarsWebSocketTests.swift in Sources */,

--- a/Sources/Apollo/Bundle+Helpers.swift
+++ b/Sources/Apollo/Bundle+Helpers.swift
@@ -1,0 +1,33 @@
+//
+//  Bundle+Helpers.swift
+//  Apollo
+//
+//  Created by Ellen Shapiro on 10/23/19.
+//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+
+extension Bundle {
+  
+  /// Type-safe getter for info dictionary key objects
+  ///
+  /// - Parameter key: The key to try to grab an object for
+  /// - Returns: The object of the desired type, or nil if it is not present or of the incorrect type.
+  func bundleValue<T>(forKey key: String) -> T? {
+    return object(forInfoDictionaryKey: key) as? T
+  }
+  
+  /// The bundle identifier of this bundle, or nil if not present.
+  var bundleIdentifier: String? {
+    return self.bundleValue(forKey: String(kCFBundleIdentifierKey))
+  }
+  
+  var buildNumber: String? {
+    return self.bundleValue(forKey: String(kCFBundleVersionKey))
+  }
+  
+  var shortVersion: String? {
+    return self.bundleValue(forKey: "CFBundleShortVersionString")
+  }
+}

--- a/Sources/Apollo/Bundle+Helpers.swift
+++ b/Sources/Apollo/Bundle+Helpers.swift
@@ -23,10 +23,12 @@ extension Bundle {
     return self.bundleValue(forKey: String(kCFBundleIdentifierKey))
   }
   
+  /// The build number of this bundle (kCFBundleVersion) as a string, or nil if not present.
   var buildNumber: String? {
     return self.bundleValue(forKey: String(kCFBundleVersionKey))
   }
   
+  /// The short version string for this bundle, or nil if not present.
   var shortVersion: String? {
     return self.bundleValue(forKey: "CFBundleShortVersionString")
   }

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -362,6 +362,8 @@ public class HTTPNetworkTransport {
                                                sendQueryDocument: sendQueryDocument,
                                                autoPersistQuery: autoPersistQueries)
     var request = URLRequest(url: self.url)
+    request.setValue(self.clientName, forHTTPHeaderField: "apollographql-client-name")
+    request.setValue(self.clientVersion, forHTTPHeaderField: "apollographql-client-version")
     
     // We default to json, but this can be changed below if needed.
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -94,6 +94,9 @@ public class HTTPNetworkTransport {
   private let requestCreator: RequestCreator
   private let sendOperationIdentifiers: Bool
   
+  public lazy var clientName = HTTPNetworkTransport.defaultClientName
+  public lazy var clientVersion = HTTPNetworkTransport.defaultClientVersion
+  
   /// Creates a network transport with the specified server URL and session configuration.
   ///
   /// - Parameters:

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -362,8 +362,8 @@ public class HTTPNetworkTransport {
                                                sendQueryDocument: sendQueryDocument,
                                                autoPersistQuery: autoPersistQueries)
     var request = URLRequest(url: self.url)
-    request.setValue(self.clientName, forHTTPHeaderField: "apollographql-client-name")
-    request.setValue(self.clientVersion, forHTTPHeaderField: "apollographql-client-version")
+    request.setValue(self.clientName, forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName)
+    request.setValue(self.clientVersion, forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion)
     
     // We default to json, but this can be changed below if needed.
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -8,7 +8,49 @@ public protocol NetworkTransport: class {
   ///   - completionHandler: A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred.
   /// - Returns: An object that can be used to cancel an in progress request.
   func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+  
+  /// The name of the client to send as the `"apollographql-client-name"` header.
+  var clientName: String { get set }
+  
+  /// The version of the client to send as the `"apollographql-client-version"` header
+  var clientVersion: String { get set }
 }
+
+public extension NetworkTransport {
+  
+  /// The default client name to use when setting up the `clientName` property
+  static var defaultClientName: String {
+    guard let identifier = Bundle.main.bundleIdentifier else {
+      return "apollo-ios-client"
+    }
+    
+    return "\(identifier)-apollo-ios"
+  }
+  
+  /// The default client version to use when setting up the `clientVersion` property.
+  static var defaultClientVersion: String {
+    var version = String()
+    if let shortVersion = Bundle.main.shortVersion {
+      version.append(shortVersion)
+    }
+    
+    if let buildNumber = Bundle.main.buildNumber {
+      if version.isEmpty {
+        version.append(buildNumber)
+      } else {
+        version.append("-\(buildNumber)")
+      }
+    }
+    
+    if version.isEmpty {
+      version = "(unknown)"
+    }
+    
+    return version
+  }
+}
+
+// MARK: -
 
 /// A network transport which can also handle uploads of files.
 public protocol UploadingNetworkTransport: NetworkTransport {

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -18,6 +18,16 @@ public protocol NetworkTransport: class {
 
 public extension NetworkTransport {
   
+  /// The header field name for the Client Name
+  static var headerFieldNameClientName: String {
+    return "apollographql-client-name"
+  }
+  
+  /// The header field name for the client version
+  static var headerFieldNameClientVersion: String {
+    return "apollographql-client-version"
+  }
+  
   /// The default client name to use when setting up the `clientName` property
   static var defaultClientName: String {
     guard let identifier = Bundle.main.bundleIdentifier else {

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -1,5 +1,5 @@
 /// A network transport is responsible for sending GraphQL operations to a server.
-public protocol NetworkTransport {
+public protocol NetworkTransport: class {
   
   /// Send a GraphQL operation to a server and return a response.
   ///

--- a/Sources/ApolloWebSocket/ApolloWebSocket.swift
+++ b/Sources/ApolloWebSocket/ApolloWebSocket.swift
@@ -1,0 +1,26 @@
+import Starscream
+import Foundation
+
+// MARK: - Client protocol
+
+/// Protocol allowing alternative implementations of web sockets beyond `ApolloWebSocket`. Extends `Starscream`'s `WebSocketClient` protocol.
+public protocol ApolloWebSocketClient: WebSocketClient {
+  
+  /// Required initializer
+  ///
+  /// - Parameter request: The URLRequest to use on connection.
+  /// - Parameter protocols: The supported protocols
+  init(request: URLRequest, protocols: [String]?)
+  
+  /// The URLRequest used on connection. 
+  var request: URLRequest { get set }
+}
+
+// MARK: - WebSocket
+
+/// Included implementation of an `ApolloWebSocketClient`, based on `Starscream`'s `WebSocket`.
+public class ApolloWebSocket: WebSocket, ApolloWebSocketClient {
+  required public convenience init(request: URLRequest, protocols: [String]? = nil) {
+    self.init(request: request, protocols: protocols, stream: FoundationStream())
+  }
+}

--- a/Sources/ApolloWebSocket/OperationMessage.swift
+++ b/Sources/ApolloWebSocket/OperationMessage.swift
@@ -1,0 +1,76 @@
+#if !COCOAPODS
+import Apollo
+#endif
+import Foundation
+
+final class OperationMessage {
+  enum Types : String {
+    case connectionInit = "connection_init"            // Client -> Server
+    case connectionTerminate = "connection_terminate"  // Client -> Server
+    case start = "start"                               // Client -> Server
+    case stop = "stop"                                 // Client -> Server
+    
+    case connectionAck = "connection_ack"              // Server -> Client
+    case connectionError = "connection_error"          // Server -> Client
+    case connectionKeepAlive = "ka"                    // Server -> Client
+    case data = "data"                                 // Server -> Client
+    case error = "error"                               // Server -> Client
+    case complete = "complete"                         // Server -> Client
+  }
+  
+  let serializationFormat = JSONSerializationFormat.self
+  var message: GraphQLMap = [:]
+  var serialized: String?
+  
+  var rawMessage : String? {
+    let serialized = try! serializationFormat.serialize(value: message)
+    if let str = String(data: serialized, encoding: .utf8) {
+      return str
+    } else {
+      return nil
+    }
+  }
+  
+  init(payload: GraphQLMap? = nil, id: String? = nil, type: Types = .start) {
+    if let payload = payload {
+      message += ["payload": payload]
+    }
+    if let id = id {
+      message += ["id": id]
+    }
+    message += ["type": type.rawValue]
+  }
+  
+  init(serialized: String) {
+    self.serialized = serialized
+  }
+  
+  func parse(handler: (_ type: String?, _ id: String?, _ payload: JSONObject?, _ error: Error?) -> Void) {
+    guard let serialized = self.serialized else {
+      handler(nil, nil, nil, WebSocketError(payload: nil, error: nil, kind: .serializedMessageError))
+      return
+    }
+
+    guard let data = self.serialized?.data(using: (.utf8) ) else {
+      handler(nil, nil, nil, WebSocketError(payload: nil, error: nil, kind: .unprocessedMessage(serialized)))
+      return
+    }
+
+    var type : String?
+    var id : String?
+    var payload : JSONObject?
+
+    do {
+      let json = try JSONSerializationFormat.deserialize(data: data ) as? JSONObject
+
+      id = json?["id"] as? String
+      type = json?["type"] as? String
+      payload = json?["payload"] as? JSONObject
+
+      handler(type,id,payload,nil)
+    }
+    catch {
+      handler(type, id, payload, WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(serialized)))
+    }
+  }
+}

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -8,16 +8,34 @@ public class SplitNetworkTransport {
   private let webSocketNetworkTransport: NetworkTransport
   
   public var clientName: String {
-    didSet {
-      self.httpNetworkTransport.clientName = self.clientName
-      self.webSocketNetworkTransport.clientName = self.clientName
+    get {
+      let httpName = self.httpNetworkTransport.clientName
+      let websocketName = self.webSocketNetworkTransport.clientName
+      if httpName == websocketName {
+        return httpName
+      } else {
+        return "SPLIT_HTTPNAME_\(httpName)_WEBSOCKETNAME_\(websocketName)"
+      }
+    }
+    set {
+      self.httpNetworkTransport.clientName = newValue
+      self.webSocketNetworkTransport.clientName = newValue
     }
   }
-  
+
   public var clientVersion: String {
-    didSet {
-      self.httpNetworkTransport.clientName = self.clientName
-      self.webSocketNetworkTransport.clientName = self.clientVersion
+    get {
+      let httpVersion = self.httpNetworkTransport.clientVersion
+      let websocketVersion = self.webSocketNetworkTransport.clientVersion
+      if httpVersion == websocketVersion {
+        return httpVersion
+      } else {
+        return "SPLIT_HTTPVERSION_\(httpVersion)_WEBSOCKETNAME_\(websocketVersion)"
+      }
+    }
+    set {
+      self.httpNetworkTransport.clientVersion = newValue
+      self.webSocketNetworkTransport.clientVersion = newValue
     }
   }
   
@@ -27,8 +45,6 @@ public class SplitNetworkTransport {
   ///   - httpNetworkTransport: An `UploadingNetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
   ///   - webSocketNetworkTransport: A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar.
   public init(httpNetworkTransport: UploadingNetworkTransport, webSocketNetworkTransport: NetworkTransport) {
-    self.clientName = SplitNetworkTransport.defaultClientName
-    self.clientVersion = SplitNetworkTransport.defaultClientVersion
     self.httpNetworkTransport = httpNetworkTransport
     self.webSocketNetworkTransport = webSocketNetworkTransport
   }

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -7,12 +7,28 @@ public class SplitNetworkTransport {
   private let httpNetworkTransport: UploadingNetworkTransport
   private let webSocketNetworkTransport: NetworkTransport
   
+  public var clientName: String {
+    didSet {
+      self.httpNetworkTransport.clientName = self.clientName
+      self.webSocketNetworkTransport.clientName = self.clientName
+    }
+  }
+  
+  public var clientVersion: String {
+    didSet {
+      self.httpNetworkTransport.clientName = self.clientName
+      self.webSocketNetworkTransport.clientName = self.clientVersion
+    }
+  }
+  
   /// Designated initializer
   ///
   /// - Parameters:
   ///   - httpNetworkTransport: An `UploadingNetworkTransport` to use for non-subscription requests. Should generally be a `HTTPNetworkTransport` or something similar.
   ///   - webSocketNetworkTransport: A `NetworkTransport` to use for subscription requests. Should generally be a `WebSocketTransport` or something similar.
   public init(httpNetworkTransport: UploadingNetworkTransport, webSocketNetworkTransport: NetworkTransport) {
+    self.clientName = SplitNetworkTransport.defaultClientName
+    self.clientVersion = SplitNetworkTransport.defaultClientVersion
     self.httpNetworkTransport = httpNetworkTransport
     self.webSocketNetworkTransport = webSocketNetworkTransport
   }

--- a/Sources/ApolloWebSocket/WebSocketError.swift
+++ b/Sources/ApolloWebSocket/WebSocketError.swift
@@ -1,0 +1,43 @@
+#if !COCOAPODS
+import Apollo
+#endif
+import Foundation
+
+/// A structure for capturing problems and any associated errors from a `WebSocketTransport`. 
+public struct WebSocketError: Error, LocalizedError {
+  public enum ErrorKind {
+    case errorResponse
+    case networkError
+    case unprocessedMessage(String)
+    case serializedMessageError
+    case neitherErrorNorPayloadReceived
+    
+    var description: String {
+      switch self {
+      case .errorResponse:
+        return "Received error response"
+      case .networkError:
+        return "Websocket network error"
+      case .unprocessedMessage(let message):
+        return "Websocket error: Unprocessed message \(message)"
+      case .serializedMessageError:
+        return "Websocket error: Serialized message not found"
+      case .neitherErrorNorPayloadReceived:
+        return "Websocket error: Did not receive an error or a payload."
+      }
+    }
+  }
+  
+  /// The payload of the response.
+  public let payload: JSONObject?
+  
+  /// The underlying error, or nil if one was not returned
+  public let error: Error?
+  
+  /// The kind of problem which occurred.
+  public let kind: ErrorKind
+  
+  public var errorDescription: String? {
+    return "\(self.kind.description). Error: \(String(describing: self.error))"
+  }
+}

--- a/Sources/ApolloWebSocket/WebSocketTask.swift
+++ b/Sources/ApolloWebSocket/WebSocketTask.swift
@@ -1,0 +1,26 @@
+#if !COCOAPODS
+import Apollo
+#endif
+import Foundation
+import Starscream
+
+final class WebSocketTask<Operation: GraphQLOperation>: Cancellable {
+  let sequenceNumber : String?
+  let transport: WebSocketTransport
+  
+  init(_ ws: WebSocketTransport, _ operation: Operation, _ completionHandler: @escaping (_ result: Result<JSONObject, Error>) -> Void) {
+    sequenceNumber = ws.sendHelper(operation: operation, resultHandler: completionHandler)
+    transport = ws
+  }
+  
+  public func cancel() {
+    if let sequenceNumber = sequenceNumber {
+      transport.unsubscribe(sequenceNumber)
+    }
+  }
+  
+  // unsubscribe same as cancel
+  public func unsubscribe() {
+    cancel()
+  }
+}

--- a/Sources/ApolloWebSocket/WebSocketTask.swift
+++ b/Sources/ApolloWebSocket/WebSocketTask.swift
@@ -4,11 +4,19 @@ import Apollo
 import Foundation
 import Starscream
 
+/// A task to wrap sending/canceling operations over a websocket.
 final class WebSocketTask<Operation: GraphQLOperation>: Cancellable {
   let sequenceNumber : String?
   let transport: WebSocketTransport
   
-  init(_ ws: WebSocketTransport, _ operation: Operation, _ completionHandler: @escaping (_ result: Result<JSONObject, Error>) -> Void) {
+  /// Designated initializer
+  ///
+  /// - Parameter ws: The `WebSocketTransport` to use for this task
+  /// - Parameter operation: The `GraphQLOperation` to use
+  /// - Parameter completionHandler: A completion handler to fire when the operation has a result.
+  init(_ ws: WebSocketTransport,
+       _ operation: Operation,
+       _ completionHandler: @escaping (_ result: Result<JSONObject, Error>) -> Void) {
     sequenceNumber = ws.sendHelper(operation: operation, resultHandler: completionHandler)
     transport = ws
   }
@@ -19,7 +27,7 @@ final class WebSocketTask<Operation: GraphQLOperation>: Cancellable {
     }
   }
   
-  // unsubscribe same as cancel
+  // Unsubscribes from further results from this task.
   public func unsubscribe() {
     cancel()
   }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -53,6 +53,9 @@ public class WebSocketTransport {
   fileprivate var sequenceNumber = 0
   fileprivate var reconnected = false
 
+  public lazy var clientName = WebSocketTransport.defaultClientName
+  public lazy var clientVersion = WebSocketTransport.defaultClientVersion
+  
   public init(request: URLRequest, sendOperationIdentifiers: Bool = false, reconnectionInterval: TimeInterval = 0.5, connectingPayload: GraphQLMap? = [:], requestCreator: RequestCreator = ApolloRequestCreator()) {
     self.connectingPayload = connectingPayload
     self.sendOperationIdentifiers = sendOperationIdentifiers

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -213,7 +213,7 @@ public class WebSocketTransport {
     websocket.delegate = nil
   }
   
-  fileprivate func nextSequenceNumber() -> Int {
+  private func nextSequenceNumber() -> Int {
     sequenceNumber += 1
     return sequenceNumber
   }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -62,13 +62,13 @@ public class WebSocketTransport {
   
   /// Designated initializer
   ///
-  /// - Parameter request: <#request description#>
-  /// - Parameter clientName: <#clientName description#>
-  /// - Parameter clientVersion: <#clientVersion description#>
-  /// - Parameter sendOperationIdentifiers: <#sendOperationIdentifiers description#>
-  /// - Parameter reconnectionInterval: <#reconnectionInterval description#>
-  /// - Parameter connectingPayload: <#connectingPayload description#>
-  /// - Parameter requestCreator: <#requestCreator description#>
+  /// - Parameter request: The connection URLRequest
+  /// - Parameter clientName: The client name to use for this client. Defauls to `Self.defaultClientName`
+  /// - Parameter clientVersion: The client version to use for this client. Defaults to `Self.defaultClientVersion`.
+  /// - Parameter sendOperationIdentifiers: Whether or not to send operation identifiers with operations. Defaults to false.
+  /// - Parameter reconnectionInterval: How long to wait before attempting to reconnect. Defaults to half a second.
+  /// - Parameter connectingPayload: [optional] The payload to send on connection. Dfaults to an empty `GraphQLMap`.
+  /// - Parameter requestCreator: The request creator to use when serializing requests. Defaults to an `ApolloRequestCreator`.
   public init(request: URLRequest,
               clientName: String = WebSocketTransport.defaultClientName,
               clientVersion: String = WebSocketTransport.defaultClientVersion,

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -46,16 +46,45 @@ public class WebSocketTransport {
   fileprivate var sequenceNumber = 0
   fileprivate var reconnected = false
 
-  public lazy var clientName = WebSocketTransport.defaultClientName
-  public lazy var clientVersion = WebSocketTransport.defaultClientVersion
+  /// NOTE: Setting this won't override immediately if the socket is still connected, only on reconnection.
+  public var clientName: String {
+    didSet {
+      self.websocket.request.setValue(self.clientName, forHTTPHeaderField: "apollographql-client-name")
+    }
+  }
   
-  public init(request: URLRequest, sendOperationIdentifiers: Bool = false, reconnectionInterval: TimeInterval = 0.5, connectingPayload: GraphQLMap? = [:], requestCreator: RequestCreator = ApolloRequestCreator()) {
+  /// NOTE: Setting this won't override immediately if the socket is still connected, only on reconnection.
+  public var clientVersion: String {
+    didSet {
+      self.websocket.request.setValue(self.clientVersion, forHTTPHeaderField: "apollographql-client-version")
+    }
+  }
+  
+  /// Designated initializer
+  ///
+  /// - Parameter request: <#request description#>
+  /// - Parameter clientName: <#clientName description#>
+  /// - Parameter clientVersion: <#clientVersion description#>
+  /// - Parameter sendOperationIdentifiers: <#sendOperationIdentifiers description#>
+  /// - Parameter reconnectionInterval: <#reconnectionInterval description#>
+  /// - Parameter connectingPayload: <#connectingPayload description#>
+  /// - Parameter requestCreator: <#requestCreator description#>
+  public init(request: URLRequest,
+              clientName: String = WebSocketTransport.defaultClientName,
+              clientVersion: String = WebSocketTransport.defaultClientVersion,
+              sendOperationIdentifiers: Bool = false,
+              reconnectionInterval: TimeInterval = 0.5,
+              connectingPayload: GraphQLMap? = [:],
+              requestCreator: RequestCreator = ApolloRequestCreator()) {
     self.connectingPayload = connectingPayload
     self.sendOperationIdentifiers = sendOperationIdentifiers
     self.reconnectionInterval = reconnectionInterval
     self.requestCreator = requestCreator
-
     self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
+    self.clientName = clientName
+    self.clientVersion = clientVersion
+    self.websocket.request.setValue(self.clientName, forHTTPHeaderField: "apollographql-client-name")
+    self.websocket.request.setValue(self.clientVersion, forHTTPHeaderField: "apollographql-client-version")
     self.websocket.delegate = self
     self.websocket.connect()
   }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -83,8 +83,8 @@ public class WebSocketTransport {
     self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
     self.clientName = clientName
     self.clientVersion = clientVersion
-    self.websocket.request.setValue(self.clientName, forHTTPHeaderField: "apollographql-client-name")
-    self.websocket.request.setValue(self.clientVersion, forHTTPHeaderField: "apollographql-client-version")
+    self.websocket.request.setValue(self.clientName, forHTTPHeaderField: WebSocketTransport.headerFieldNameClientName)
+    self.websocket.request.setValue(self.clientVersion, forHTTPHeaderField: WebSocketTransport.headerFieldNameClientVersion)
     self.websocket.delegate = self
     self.websocket.connect()
   }

--- a/Tests/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Tests/ApolloTestSupport/MockNetworkTransport.swift
@@ -4,6 +4,9 @@ import Dispatch
 public final class MockNetworkTransport: NetworkTransport {
   let body: JSONObject
 
+  public var clientName = "MockNetworkTransport"
+  public var clientVersion = "mock_version"
+  
   public init(body: JSONObject) {
     self.body = body
   }

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import Apollo
+import ApolloTestSupport
 import StarWarsAPI
 import ApolloTestSupport
 
@@ -262,8 +263,36 @@ class HTTPTransportTests: XCTestCase {
     XCTAssertEqual(self.retryCount, 0)
     XCTAssertEqual(self.graphQlErrors.count, 0)
     wait(for: [expectation], timeout: 1)
-
   }
+}
+
+func testClientNameAndVersionHeadersAreSent() {
+  let mockSession = MockURLSession()
+  let network = HTTPNetworkTransport(url: self.url,
+                                     session: mockSession)
+  let query = HeroNameQuery(episode: .empire)
+  let _ = network.send(operation: query) { _ in }
+  
+  guard let request = mockSession.lastRequest else {
+    XCTFail("last request should not be nil")
+    return
+  }
+  
+  guard let clientName = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName) else {
+    XCTFail("Client name on last request was nil!")
+    return
+  }
+  
+  XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
+  XCTAssertEqual(clientName, network.clientName)
+  
+  guard let clientVersion = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion) else {
+    XCTFail("Client version on last request was nil!")
+    return
+  }
+  
+  XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")
+  XCTAssertEqual(clientVersion, network.clientVersion)
 }
 
 // MARK: - HTTPNetworkTransportPreflightDelegate

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -264,35 +264,35 @@ class HTTPTransportTests: XCTestCase {
     XCTAssertEqual(self.graphQlErrors.count, 0)
     wait(for: [expectation], timeout: 1)
   }
-}
-
-func testClientNameAndVersionHeadersAreSent() {
-  let mockSession = MockURLSession()
-  let network = HTTPNetworkTransport(url: self.url,
-                                     session: mockSession)
-  let query = HeroNameQuery(episode: .empire)
-  let _ = network.send(operation: query) { _ in }
   
-  guard let request = mockSession.lastRequest else {
-    XCTFail("last request should not be nil")
-    return
+  func testClientNameAndVersionHeadersAreSent() {
+    let mockSession = MockURLSession()
+    let network = HTTPNetworkTransport(url: self.url,
+                                       session: mockSession)
+    let query = HeroNameQuery(episode: .empire)
+    let _ = network.send(operation: query) { _ in }
+    
+    guard let request = mockSession.lastRequest else {
+      XCTFail("last request should not be nil")
+      return
+    }
+    
+    guard let clientName = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName) else {
+      XCTFail("Client name on last request was nil!")
+      return
+    }
+    
+    XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
+    XCTAssertEqual(clientName, network.clientName)
+    
+    guard let clientVersion = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion) else {
+      XCTFail("Client version on last request was nil!")
+      return
+    }
+    
+    XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")
+    XCTAssertEqual(clientVersion, network.clientVersion)
   }
-  
-  guard let clientName = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName) else {
-    XCTFail("Client name on last request was nil!")
-    return
-  }
-  
-  XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
-  XCTAssertEqual(clientName, network.clientName)
-  
-  guard let clientVersion = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion) else {
-    XCTFail("Client version on last request was nil!")
-    return
-  }
-  
-  XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")
-  XCTAssertEqual(clientVersion, network.clientVersion)
 }
 
 // MARK: - HTTPNetworkTransportPreflightDelegate

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -314,9 +314,7 @@ extension HTTPTransportTests: HTTPNetworkTransportPreflightDelegate {
     
     headers.forEach { tuple in
       let (key, value) = tuple
-      var headers = request.allHTTPHeaderFields ?? [String: String]()
-      headers[key] = value
-      request.allHTTPHeaderFields = headers
+      request.addValue(value, forHTTPHeaderField: key)
     }
   }
 }

--- a/Tests/ApolloWebsocketTests/MockWebSocket.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocket.swift
@@ -3,13 +3,16 @@ import Starscream
 
 class MockWebSocket: ApolloWebSocketClient {
   var pongDelegate: WebSocketPongDelegate?
+  var request: URLRequest
   
   var sslClientCertificate: SSLClientCertificate?
   
   required init(request: URLRequest, protocols: [String]?) {
+    self.request = request
   }
   
   public init() {
+    self.request = URLRequest(url: URL(string: "http://localhost:8080")!)
   }
   
   open func write(string: String, completion: (() -> ())?) {

--- a/Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift
+++ b/Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift
@@ -1,0 +1,77 @@
+//
+//  SplitNetworkTransportTests.swift
+//  ApolloWebSocketTests
+//
+//  Created by Ellen Shapiro on 10/23/19.
+//
+
+import Foundation
+import XCTest
+import Apollo
+@testable import ApolloWebSocket
+
+class SplitNetworkTransportTests: XCTestCase {
+  
+  private let httpName = "TestHTTPNetworkTransport"
+  private let httpVersion = "TestHTTPNetworkTransportVersion"
+  
+  private let webSocketName = "TestWebSocketTransport"
+  private let webSocketVersion = "TestWebSocketTransportVersion"
+  
+  private lazy var httpTransport: HTTPNetworkTransport = {
+    let url = URL(string: "http://localhost:8080/graphql")!
+    let transport = HTTPNetworkTransport(url: url)
+    
+    transport.clientName = self.httpName
+    transport.clientVersion = self.httpVersion
+    return transport
+  }()
+
+  private lazy var webSocketTransport: WebSocketTransport = {
+    let url = URL(string: "ws://localhost:8080/websocket")!
+    let request = URLRequest(url: url)
+    return WebSocketTransport(request: request,
+                              clientName: self.webSocketName,
+                              clientVersion: self.webSocketVersion)
+  }()
+  
+  private lazy var splitTransport = SplitNetworkTransport(
+    httpNetworkTransport: self.httpTransport,
+    webSocketNetworkTransport: self.webSocketTransport
+  )
+  
+  
+  func testGettingSplitClientName() {
+    let splitName = self.splitTransport.clientName
+    XCTAssertTrue(splitName.hasPrefix("SPLIT_"))
+    XCTAssertTrue(splitName.contains(self.httpName))
+    XCTAssertTrue(splitName.contains(self.webSocketName))
+  }
+  
+  func testGettingSplitClientVersion() {
+    let splitVersion = self.splitTransport.clientVersion
+    XCTAssertTrue(splitVersion.hasPrefix("SPLIT_"))
+    XCTAssertTrue(splitVersion.contains(self.httpVersion))
+    XCTAssertTrue(splitVersion.contains(self.webSocketVersion))
+  }
+
+  func testSettingSplitClientName() {
+    let splitName = "TestSplitClientName"
+    
+    self.splitTransport.clientName = splitName
+    
+    XCTAssertEqual(self.splitTransport.clientName, splitName)
+    XCTAssertEqual(self.webSocketTransport.clientName, splitName)
+    XCTAssertEqual(self.httpTransport.clientName, splitName)
+  }
+  
+  func testSettingSplitClientVersion() {
+    let splitVersion = "TestSplitClientVersion"
+    
+    self.splitTransport.clientVersion = splitVersion
+    
+    XCTAssertEqual(self.splitTransport.clientVersion, splitVersion)
+    XCTAssertEqual(self.webSocketTransport.clientVersion, splitVersion)
+    XCTAssertEqual(self.httpTransport.clientVersion, splitVersion)
+  }
+}


### PR DESCRIPTION
In this PR: 

- Added default and ability to set non-default name and version headers for Apollo GraphManager and Apollo Engine
- Pulled some web socket components out of the giant class file into their own classes, start adding inline documentation (to the extent that I understand what's happening 🙃). 
- Added a convenience extension for getting stuff out of a bundle's info dictionary. 