### PR TITLE
Remove TSAN on run in schemes

### DIFF
--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
@@ -81,7 +81,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/ApolloSQLite.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -81,7 +81,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/ApolloWebSocket.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -71,7 +71,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Addresses #859 - apparently having the scheme enable TSAN on run causes TSAN builds to get linked even when building for release with Carthage. 