### PR TITLE
Add workflow for publishing to Cocoapods trunk automatically when a semver tag is added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
       - checkout
       # TODO: Remove when Circle updates the version of CP installed on their
       # image to one that doesn't have https://github.com/CocoaPods/CocoaPods/issues/9176
-      - run: gem update cocoapods
+      - run: pod repo add-cdn trunk 'https://cdn.cocoapods.org/'
       - run: pod trunk push Apollo.podspec
       - run: pod trunk me clean-sessions --all
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,8 @@ workflows:
   publish:
     jobs:
       - CocoaPodsTrunk
-        requires: build-and-test
+        requires:
+          - build-and-test
         filters:
           tags:
             only: /((\d*)\.(\d*)\.(\d*)).*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,18 @@ jobs:
       CIRCLE_XCODE_SDK: iphonesimulator13.1
     steps:
       - common_test_steps
+      
+  CocoaPodsTrunk:
+  macos:
+    xcode: "11.1.0"
+  steps:
+    - checkout
+    - run: pod trunk push Apollo.podspec
+    - run: pod trunk me clean-sessions --all
 
 workflows:
   version: 2
+  # This workflow builds and tests the library across various operating systems and versions
   build-and-test:
     jobs:
       - macOS10_15:
@@ -194,3 +203,12 @@ workflows:
           name: ApolloWebSocket iOS 12.4
       - WebSocketiOS11_4:
           name: ApolloWebSocket iOS 11.4
+  # This workflow publishes new versions to trunk automatically after building and testing when a semver tag is created.
+  publish:
+    jobs:
+      - CocoaPodsTrunk
+        requires: build-and-test
+        filters:
+          tags:
+            only: /((\d*)\.(\d*)\.(\d*)).*/
+        

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,5 +223,9 @@ workflows:
             - ApolloWebSocket iOS 12.4
             - ApolloWebSocket iOS 11.4
           filters:
+            # Only build semver tags
             tags:
               only: /((\d*)\.(\d*)\.(\d*)).*/
+            # Don't run this on any branches
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,14 +163,14 @@ jobs:
       CIRCLE_XCODE_SDK: iphonesimulator13.1
     steps:
       - common_test_steps
-      
+
   CocoaPodsTrunk:
-  macos:
-    xcode: "11.1.0"
-  steps:
-    - checkout
-    - run: pod trunk push Apollo.podspec
-    - run: pod trunk me clean-sessions --all
+    macos:
+      xcode: "11.1.0"
+    steps:
+      - checkout
+      - run: pod trunk push Apollo.podspec
+      - run: pod trunk me clean-sessions --all
 
 workflows:
   version: 2
@@ -203,12 +203,22 @@ workflows:
           name: ApolloWebSocket iOS 12.4
       - WebSocketiOS11_4:
           name: ApolloWebSocket iOS 11.4
-  # This workflow publishes new versions to trunk automatically after building and testing when a semver tag is created.
-  publish:
-    jobs:
       - CocoaPodsTrunk:
-        requires:
-          - build-and-test
-        filters:
-          tags:
-            only: /((\d*)\.(\d*)\.(\d*)).*/
+          name: Push Podspec to CocoaPods Trunk
+          requires:
+            - Apollo macOS 10.15
+            - Apollo iOS 13.1
+            - Apollo iOS 12.4
+            - Apollo iOS 11.4
+            - Apollo tvOS 13.0
+            - ApolloSQLite macOS 10.15
+            - ApolloSQLite iOS 13.1
+            - ApolloSQLite iOS 12.4
+            - ApolloSQLite iOS 11.4
+            - ApolloWebSocket macOS 10.15
+            - ApolloWebSocket iOS 13.1
+            - ApolloWebSocket iOS 12.4
+            - ApolloWebSocket iOS 11.4
+          filters:
+            tags:
+              only: /((\d*)\.(\d*)\.(\d*)).*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,10 +206,9 @@ workflows:
   # This workflow publishes new versions to trunk automatically after building and testing when a semver tag is created.
   publish:
     jobs:
-      - CocoaPodsTrunk
+      - CocoaPodsTrunk:
         requires:
           - build-and-test
         filters:
           tags:
             only: /((\d*)\.(\d*)\.(\d*)).*/
-        

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,9 @@ jobs:
       xcode: "11.1.0"
     steps:
       - checkout
+      # TODO: Remove when Circle updates the version of CP installed on their
+      # image to one that doesn't have https://github.com/CocoaPods/CocoaPods/issues/9176
+      - run: gem update cocoapods
       - run: pod trunk push Apollo.podspec
       - run: pod trunk me clean-sessions --all
 


### PR DESCRIPTION
Won't really be able to fully test this until the next version lands, but this *should* address #874. Will leave that issue open until I actually publish a new version. 