### PR TITLE
Fix caching docs parens

### DIFF
--- a/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
@@ -15,7 +15,7 @@ class ReadWriteFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery()
       
-      store.withinReadTransaction({transaction in
+      store.withinReadTransaction({ transaction in
         let data = try transaction.read(query: query)
         
         XCTAssertEqual(data.hero?.__typename, "Droid")

--- a/docs/source/caching.md
+++ b/docs/source/caching.md
@@ -68,17 +68,17 @@ The `read` function is similar to React Apollo's [`readQuery`](https://www.apoll
 ```swift
 // Assuming we have defined an ApolloClient instance `client`:
 // Read from a GraphQL query
-client.store.withinReadTransaction { transaction in
+client.store.withinReadTransaction({ transaction in
   let data = try transaction.read(
     query: HeroNameQuery(episode: .jedi)
   )
 
   // Prints "R2-D2"
   print(data.hero?.name)
-}
+})
 
 // Read from a GraphQL fragment
-client.store.withinReadTransaction { transaction -> HeroDetails in
+client.store.withinReadTransaction({ transaction -> HeroDetails in
   let data = try transaction.readObject(
     ofType: HeroDetails.self,
     withKey: id
@@ -86,8 +86,7 @@ client.store.withinReadTransaction { transaction -> HeroDetails in
   
   // Prints "R2-D2"
   print(data.hero?.name)
-}
-
+})
 ```
 
 ### update
@@ -96,7 +95,7 @@ The `update` function is similar to React Apollo's [`writeQuery`](https://www.ap
 
 ```swift
 // Assuming we have defined an ApolloClient instance `client`:
-store.withinReadWriteTransaction { transaction in
+store.withinReadWriteTransaction({ transaction in
   let query = HeroNameQuery(episode: .jedi)
 
   try transaction.update(query: query) { (data: inout HeroNameQuery.Data) in
@@ -107,5 +106,5 @@ store.withinReadWriteTransaction { transaction in
     // Prints "Artoo"
     print(graphQLResult?.data?.hero?.name)
   }
-}
+})
 ```


### PR DESCRIPTION
[Spectrum thread pointed out that the sample code for direct cache interaction was out of date](https://spectrum.chat/apollo/apollo-ios/compilation-error-when-using-withinreadwritetransaction~4b34ae9d-a4e8-4730-94d1-63033052443f).

Basically when we dropped using promises and went to a couple things that had default parameters, it caused parens around the closure to become necessary in order to make sure the default params were recognized. 

Also fixed a spacing issue in the tests that made my eye twitch when I was searching it. 🙃