### PR TITLE
Update singleton naming suggestions in docs

### DIFF
--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -7,14 +7,14 @@ title: Creating a client
 In most cases, you'll want to create a single shared instance of `ApolloClient` and point it at your GraphQL server. The easiest way to do this is to create a singleton:
 
 ```swift
-class Apollo {
-  static let shared = Apollo() 
+class Network {
+  static let shared = Network() 
     
-  private(set) lazy var client = ApolloClient(url: URL(string: "http://localhost:8080/graphql")!)
+  private(set) lazy var apollo = ApolloClient(url: URL(string: "http://localhost:8080/graphql")!)
 }
 ```
 
-Under the hood, this will create a client using `HTTPNetworkTransport` with a default configuration. You can then use this client from anywhere in your code with `Apollo.shared.client`. 
+Under the hood, this will create a client using `HTTPNetworkTransport` with a default configuration. You can then use this client from anywhere in your code with `Network.shared.apollo`. 
 
 ## Advanced Client Creation
 
@@ -85,8 +85,8 @@ import Apollo
 
 // MARK: - Singleton Wrapper
 
-class Apollo {
-  static let shared = Apollo() 
+class Network {
+  static let shared = Network() 
   
   // Configure the network transport to use the singleton as the delegate. 
   private lazy var networkTransport = HTTPNetworkTransport(
@@ -94,13 +94,13 @@ class Apollo {
     delegate: self
   )
     
-  // Use the configured network transport in your client.
-  private(set) lazy var client = ApolloClient(networkTransport: self.networkTransport)
+  // Use the configured network transport in your Apollo client.
+  private(set) lazy var apollo = ApolloClient(networkTransport: self.networkTransport)
 }
 
 // MARK: - Pre-flight delegate 
 
-extension Apollo: HTTPNetworkTransportPreflightDelegate {
+extension Network: HTTPNetworkTransportPreflightDelegate {
 
   func networkTransport(_ networkTransport: HTTPNetworkTransport, 
                           shouldSend request: URLRequest) -> Bool {
@@ -126,7 +126,7 @@ extension Apollo: HTTPNetworkTransportPreflightDelegate {
 
 // MARK: - Task Completed Delegate
 
-extension Apollo: HTTPNetworkTransportTaskCompletedDelegate {
+extension Network: HTTPNetworkTransportTaskCompletedDelegate {
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
                         didCompleteRawTaskForRequest request: URLRequest,
                         withData data: Data?,
@@ -154,7 +154,7 @@ extension Apollo: HTTPNetworkTransportTaskCompletedDelegate {
 
 // MARK: - Retry Delegate
 
-extension Apollo: HTTPNetworkTransportRetryDelegate {
+extension Network: HTTPNetworkTransportRetryDelegate {
 
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
                         receivedError error: Error,


### PR DESCRIPTION
Some recent replies to #348 uncovered that our default naming suggestion for a singleton, which had been `Apollo`, could cause some conflicts with enums, which need to conform to `Apollo.JSONEncodable` and `Apollo.JSONDecodable`. 

I've updated the suggested singleton naming to `Network.shared.apollo`, since that at least will not cause conflicts with our own damned library 🤦‍♀. 