### PR TITLE
fail download if server returns an invalid status code

### DIFF
--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -26,7 +26,7 @@ download_apollo_cli_if_needed() {
 
 download_cli() {
   echo "Downloading zip file with the CLI..."
-  curl --silent "${ZIP_FILE_DOWNLOAD_URL}" -o "${ZIP_FILE}"
+  curl --silent --retry 3 --fail --show-error "${ZIP_FILE_DOWNLOAD_URL}" -o "${ZIP_FILE}"
 }
 
 force_cli_download() {


### PR DESCRIPTION
It sometimes happens that the CircleCI artifact endpoint is returning a 5xx error, but the script didn't account for that.

By adding these additional flags we allow curl to retry it 3 times, and otherwise fail the script, showing the actual error.

A failure would look something like this:

```
$ Pods/Apollo/scripts/run-bundled-codegen.sh
Checking if CLI needs to be downloaded...
Downloading zip file with the CLI...
curl: (22) The requested URL returned error: 502 Bad Gateway
```