### PR TITLE
ApolloWebSocket should depend on Apollo since it imports Apollo.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
 			dependencies: ["Apollo", "SQLite"]),
 		.target(
 			name: "ApolloWebSocket",
-			dependencies: ["Starscream"]),
+			dependencies: ["Apollo", "Starscream"]),
         .testTarget(
             name: "ApolloTestSupport",
             dependencies: ["Apollo"]),


### PR DESCRIPTION
Trying to profile my iOS app project failed because SplitNetworkTransport.swift does `import Apollo` but ApolloWebSocket doesn't depend on Apollo in Package.swift like it needs to.

With this change I am able to profile my app. I'm using Xcode 11.1.