### PR TITLE
Cleanup on Aisle 5

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -548,15 +548,15 @@
 		9F27D4601D40363A00715680 /* Execution */ = {
 			isa = PBXGroup;
 			children = (
-				9FF90A5C1DDDEB100034C3B6 /* GraphQLExecutor.swift */,
 				9F8F334B229044A200C0E83B /* Decoding.swift */,
-				9FA6F3671E65DF4700BF8D73 /* GraphQLResultAccumulator.swift */,
-				9F86B68A1E6438D700B885FF /* GraphQLSelectionSetMapper.swift */,
-				9F295E371E277B2A00A24949 /* GraphQLResultNormalizer.swift */,
 				9FC2333C1E66BBF7001E4541 /* GraphQLDependencyTracker.swift */,
-				9F86B68F1E65533D00B885FF /* GraphQLResponseGenerator.swift */,
-				9FC9A9C41E2D6CE70023C4D5 /* GraphQLSelectionSet.swift */,
+				9FF90A5C1DDDEB100034C3B6 /* GraphQLExecutor.swift */,
 				9FC9A9C11E2D3CAF0023C4D5 /* GraphQLInputValue.swift */,
+				9F86B68F1E65533D00B885FF /* GraphQLResponseGenerator.swift */,
+				9FA6F3671E65DF4700BF8D73 /* GraphQLResultAccumulator.swift */,
+				9F295E371E277B2A00A24949 /* GraphQLResultNormalizer.swift */,
+				9FC9A9C41E2D6CE70023C4D5 /* GraphQLSelectionSet.swift */,
+				9F86B68A1E6438D700B885FF /* GraphQLSelectionSetMapper.swift */,
 				9F7BA89822927A3700999B3B /* ResponsePath.swift */,
 			);
 			name = Execution;
@@ -608,8 +608,8 @@
 			children = (
 				9FC4B91F1D2A6F8D0046A641 /* JSON.swift */,
 				9FEB050C1DB5732300DA3B44 /* JSONSerializationFormat.swift */,
-				9F27D4631D40379500715680 /* JSONStandardTypeConversions.swift */,
 				9BA1244922D8A8EA00BF1D24 /* JSONSerialziation+Sorting.swift */,
+				9F27D4631D40379500715680 /* JSONStandardTypeConversions.swift */,
 			);
 			name = JSON;
 			sourceTree = "<group>";
@@ -708,11 +708,11 @@
 			isa = PBXGroup;
 			children = (
 				9F55347A1DE1DB2100E54264 /* ApolloStore.swift */,
-				9FCE2CED1E6BE2D800E34457 /* NormalizedCache.swift */,
-				54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */,
-				9FC9A9BC1E2C271C0023C4D5 /* RecordSet.swift */,
-				9FC9A9CB1E2FD0760023C4D5 /* Record.swift */,
 				9FADC84E1E6B865E00C677E6 /* DataLoader.swift */,
+				54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */,
+				9FCE2CED1E6BE2D800E34457 /* NormalizedCache.swift */,
+				9FC9A9CB1E2FD0760023C4D5 /* Record.swift */,
+				9FC9A9BC1E2C271C0023C4D5 /* RecordSet.swift */,
 			);
 			name = Store;
 			sourceTree = "<group>";
@@ -720,15 +720,15 @@
 		9FC9A9CE1E2FD0CC0023C4D5 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
-				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
 				C377CCA822D798BD00572E03 /* GraphQLFile.swift */,
 				9BF1A95022CA6E71005292C2 /* GraphQLGETTransformer.swift */,
 				5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */,
-				9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */,
 				9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */,
+				9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */,
 				9FF90A5B1DDDEB100034C3B6 /* GraphQLResponse.swift */,
+				9F4DAF2D1E48B84B00EBFF0B /* HTTPNetworkTransport.swift */,
 				C377CCAA22D7992E00572E03 /* MultipartFormData.swift */,
+				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
 				9BEDC79D22E5D2CF00549BF6 /* RequestCreator.swift */,
 			);
 			name = Network;

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -63,7 +63,10 @@ public class ApolloClient {
     self.init(networkTransport: HTTPNetworkTransport(url: url))
   }
   
-  fileprivate func send<Operation: GraphQLOperation>(operation: Operation, shouldPublishResultToStore: Bool, context: UnsafeMutableRawPointer?, resultHandler: @escaping GraphQLResultHandler<Operation.Data>) -> Cancellable {
+  fileprivate func send<Operation: GraphQLOperation>(operation: Operation,
+                                                     shouldPublishResultToStore: Bool,
+                                                     context: UnsafeMutableRawPointer?,
+                                                     resultHandler: @escaping GraphQLResultHandler<Operation.Data>) -> Cancellable {
     return networkTransport.send(operation: operation) { [weak self] result in
       guard let self = self else {
         return
@@ -75,7 +78,10 @@ public class ApolloClient {
     }
   }
   
-  private func handleOperationResult<Operation>(shouldPublishResultToStore: Bool, context: UnsafeMutableRawPointer?, _ result: Result<GraphQLResponse<Operation>, Error>, resultHandler: @escaping GraphQLResultHandler<Operation.Data>) {
+  private func handleOperationResult<Operation>(shouldPublishResultToStore: Bool,
+                                                context: UnsafeMutableRawPointer?,
+                                                _ result: Result<GraphQLResponse<Operation>, Error>,
+                                                resultHandler: @escaping GraphQLResultHandler<Operation.Data>) {
     switch result {
     case .failure(let error):
       resultHandler(.failure(error))
@@ -223,7 +229,11 @@ private final class FetchQueryOperation<Query: GraphQLQuery>: AsynchronousOperat
   
   private var networkTask: Cancellable?
   
-  init(client: ApolloClient, query: Query, cachePolicy: CachePolicy, context: UnsafeMutableRawPointer?, resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
+  init(client: ApolloClient,
+       query: Query,
+       cachePolicy: CachePolicy,
+       context: UnsafeMutableRawPointer?,
+       resultHandler: @escaping GraphQLResultHandler<Query.Data>) {
     self.client = client
     self.query = query
     self.cachePolicy = cachePolicy
@@ -271,7 +281,9 @@ private final class FetchQueryOperation<Query: GraphQLQuery>: AsynchronousOperat
   }
   
   func fetchFromNetwork() {
-    networkTask = client?.send(operation: query, shouldPublishResultToStore: true, context: context) { result in
+    networkTask = client?.send(operation: query,
+                               shouldPublishResultToStore: true,
+                               context: context) { result in
       self.resultHandler(result)
       self.state = .finished
       return

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -16,7 +16,9 @@ func rootCacheKey<Operation: GraphQLOperation>(for operation: Operation) -> Stri
 }
 
 protocol ApolloStoreSubscriber: class {
-  func store(_ store: ApolloStore, didChangeKeys changedKeys: Set<CacheKey>, context: UnsafeMutableRawPointer?)
+  func store(_ store: ApolloStore,
+             didChangeKeys changedKeys: Set<CacheKey>,
+             context: UnsafeMutableRawPointer?)
 }
 
 /// The `ApolloStore` class acts as a local cache for normalized GraphQL results.
@@ -128,7 +130,9 @@ public final class ApolloStore {
     return Promise<ReadWriteTransaction> { fulfill, reject in
       self.queue.async(flags: .barrier) {
         self.cacheLock.lockForWriting()
-        fulfill(ReadWriteTransaction(cache: self.cache, cacheKeyForObject: self.cacheKeyForObject, updateChangedKeysFunc: self.didChangeKeys))
+        fulfill(ReadWriteTransaction(cache: self.cache,
+                                     cacheKeyForObject: self.cacheKeyForObject,
+                                     updateChangedKeysFunc: self.didChangeKeys))
       }
     }.flatMap(body)
      .finally {
@@ -165,9 +169,15 @@ public final class ApolloStore {
       let mapper = GraphQLSelectionSetMapper<Query.Data>()
       let dependencyTracker = GraphQLDependencyTracker()
 
-      return try transaction.execute(selections: Query.Data.selections, onObjectWithKey: rootCacheKey(for: query), variables: query.variables, accumulator: zip(mapper, dependencyTracker))
+      return try transaction.execute(selections: Query.Data.selections,
+                                     onObjectWithKey: rootCacheKey(for: query),
+                                     variables: query.variables,
+                                     accumulator: zip(mapper, dependencyTracker))
     }.map { (data: Query.Data, dependentKeys: Set<CacheKey>) in
-      GraphQLResult(data: data, errors: nil, source:.cache, dependentKeys: dependentKeys)
+      GraphQLResult(data: data,
+                    errors: nil,
+                    source:.cache,
+                    dependentKeys: dependentKeys)
     }
   }
   
@@ -196,12 +206,19 @@ public final class ApolloStore {
     }
 
     public func read<Query: GraphQLQuery>(query: Query) throws -> Query.Data {
-      return try readObject(ofType: Query.Data.self, withKey: rootCacheKey(for: query), variables: query.variables)
+      return try readObject(ofType: Query.Data.self,
+                            withKey: rootCacheKey(for: query),
+                            variables: query.variables)
     }
 
-    public func readObject<SelectionSet: GraphQLSelectionSet>(ofType type: SelectionSet.Type, withKey key: CacheKey, variables: GraphQLMap? = nil) throws -> SelectionSet {
+    public func readObject<SelectionSet: GraphQLSelectionSet>(ofType type: SelectionSet.Type,
+                                                              withKey key: CacheKey,
+                                                              variables: GraphQLMap? = nil) throws -> SelectionSet {
       let mapper = GraphQLSelectionSetMapper<SelectionSet>()
-      return try execute(selections: type.selections, onObjectWithKey: key, variables: variables, accumulator: mapper).await()
+      return try execute(selections: type.selections,
+                         onObjectWithKey: key,
+                         variables: variables,
+                         accumulator: mapper).await()
     }
 
     public func loadRecords(forKeys keys: [CacheKey],
@@ -232,11 +249,14 @@ public final class ApolloStore {
           return self.complete(value: value)
         }
         
-        
         executor.dispatchDataLoads = self.loader.dispatch
         executor.cacheKeyForObject = self.cacheKeyForObject
         
-        return try executor.execute(selections: selections, on: object, withKey: key, variables: variables, accumulator: accumulator)
+        return try executor.execute(selections: selections,
+                                    on: object,
+                                    withKey: key,
+                                    variables: variables,
+                                    accumulator: accumulator)
       }
     }
 
@@ -265,21 +285,35 @@ public final class ApolloStore {
       try write(data: data, forQuery: query)
     }
 
-    public func updateObject<SelectionSet: GraphQLSelectionSet>(ofType type: SelectionSet.Type, withKey key: CacheKey, variables: GraphQLMap? = nil, _ body: (inout SelectionSet) throws -> Void) throws {
-      var object = try readObject(ofType: type, withKey: key, variables: variables)
+    public func updateObject<SelectionSet: GraphQLSelectionSet>(ofType type: SelectionSet.Type,
+                                                                withKey key: CacheKey,
+                                                                variables: GraphQLMap? = nil,
+                                                                _ body: (inout SelectionSet) throws -> Void) throws {
+      var object = try readObject(ofType: type,
+                                  withKey: key,
+                                  variables: variables)
       try body(&object)
       try write(object: object, withKey: key, variables: variables)
     }
 
     public func write<Query: GraphQLQuery>(data: Query.Data, forQuery query: Query) throws {
-      try write(object: data, withKey: rootCacheKey(for: query), variables: query.variables)
+      try write(object: data,
+                withKey: rootCacheKey(for: query),
+                variables: query.variables)
     }
 
-    public func write(object: GraphQLSelectionSet, withKey key: CacheKey, variables: GraphQLMap? = nil) throws {
-      try write(object: object.jsonObject, forSelections: type(of: object).selections, withKey: key, variables: variables)
+    public func write(object: GraphQLSelectionSet,
+                      withKey key: CacheKey,
+                      variables: GraphQLMap? = nil) throws {
+      try write(object: object.jsonObject,
+                forSelections: type(of: object).selections,
+                withKey: key, variables: variables)
     }
 
-    private func write(object: JSONObject, forSelections selections: [GraphQLSelection], withKey key: CacheKey, variables: GraphQLMap?) throws {
+    private func write(object: JSONObject,
+                       forSelections selections: [GraphQLSelection],
+                       withKey key: CacheKey,
+                       variables: GraphQLMap?) throws {
       let normalizer = GraphQLResultNormalizer()
       let executor = GraphQLExecutor { object, info in
         return .result(.success(object[info.responseKeyForField]))
@@ -287,7 +321,11 @@ public final class ApolloStore {
       
       executor.cacheKeyForObject = self.cacheKeyForObject
       
-      _ = try executor.execute(selections: selections, on: object, withKey: key, variables: variables, accumulator: normalizer)
+      _ = try executor.execute(selections: selections,
+                               on: object,
+                               withKey: key,
+                               variables: variables,
+                               accumulator: normalizer)
       .flatMap {
         self.cache.mergePromise(records: $0)
       }.andThen { changedKeys in

--- a/Sources/Apollo/Decoding.swift
+++ b/Sources/Apollo/Decoding.swift
@@ -2,20 +2,33 @@ import Foundation
 
 private typealias GroupedFields = GroupedSequence<String, GraphQLField>
 
-func decode<SelectionSet: GraphQLSelectionSet>(selectionSet: SelectionSet.Type, from object: JSONObject, variables: GraphQLMap? = nil) throws -> SelectionSet {
+func decode<SelectionSet: GraphQLSelectionSet>(selectionSet: SelectionSet.Type,
+                                               from object: JSONObject,
+                                               variables: GraphQLMap? = nil) throws -> SelectionSet {
   var groupedFields = GroupedFields()
-  try collectFields(from: selectionSet.selections, into: &groupedFields, variables: variables)
-  let resultMap = try decode(groupedFields: groupedFields, from: object, path: [], variables: variables)
+  try collectFields(from: selectionSet.selections,
+                    into: &groupedFields,
+                    variables: variables)
+  let resultMap = try decode(groupedFields: groupedFields,
+                             from: object,
+                             path: [],
+                             variables: variables)
   
   return SelectionSet.init(unsafeResultMap: resultMap)
 }
 
-private func decode(groupedFields: GroupedFields, from object: JSONObject, path: ResponsePath, variables: GraphQLMap?) throws -> ResultMap {
+private func decode(groupedFields: GroupedFields,
+                    from object: JSONObject,
+                    path: ResponsePath,
+                    variables: GraphQLMap?) throws -> ResultMap {
   var fieldEntries: [(String, Any?)] = []
   fieldEntries.reserveCapacity(groupedFields.keys.count)
   
   for (responseName, fields) in groupedFields {
-    let fieldEntry = try decode(fields: fields, from: object, path: path + responseName, variables: variables)
+    let fieldEntry = try decode(fields: fields,
+                                from: object,
+                                path: path + responseName,
+                                variables: variables)
     fieldEntries.append((responseName, fieldEntry))
   }
   
@@ -23,7 +36,10 @@ private func decode(groupedFields: GroupedFields, from object: JSONObject, path:
 }
 
 /// Before execution, the selection set is converted to a grouped field set. Each entry in the grouped field set is a list of fields that share a response key. This ensures all fields with the same response key (alias or field name) included via referenced fragments are executed at the same time.
-private func collectFields(from selections: [GraphQLSelection], forRuntimeType runtimeType: String? = nil, into groupedFields: inout GroupedFields, variables: GraphQLMap?) throws {
+private func collectFields(from selections: [GraphQLSelection],
+                           forRuntimeType runtimeType: String? = nil,
+                           into groupedFields: inout GroupedFields,
+                           variables: GraphQLMap?) throws {
   for selection in selections {
     switch selection {
     case let field as GraphQLField:
@@ -33,13 +49,19 @@ private func collectFields(from selections: [GraphQLSelection], forRuntimeType r
         throw GraphQLError("Variable \(booleanCondition.variableName) was not provided.")
       }
       if value as? Bool == !booleanCondition.inverted {
-        try collectFields(from: booleanCondition.selections, forRuntimeType: runtimeType, into: &groupedFields, variables: variables)
+        try collectFields(from: booleanCondition.selections,
+                          forRuntimeType: runtimeType,
+                          into: &groupedFields,
+                          variables: variables)
       }
     case let fragmentSpread as GraphQLFragmentSpread:
       let fragment = fragmentSpread.fragment
       
       if let runtimeType = runtimeType, fragment.possibleTypes.contains(runtimeType) {
-        try collectFields(from: fragment.selections, forRuntimeType: runtimeType, into: &groupedFields, variables: variables)
+        try collectFields(from: fragment.selections,
+                          forRuntimeType: runtimeType,
+                          into: &groupedFields,
+                          variables: variables)
       }
     case let typeCase as GraphQLTypeCase:
       let selections: [GraphQLSelection]
@@ -48,7 +70,10 @@ private func collectFields(from selections: [GraphQLSelection], forRuntimeType r
       } else {
         selections = typeCase.default
       }
-      try collectFields(from: selections, forRuntimeType: runtimeType, into: &groupedFields, variables: variables)
+      try collectFields(from: selections,
+                        forRuntimeType: runtimeType,
+                        into: &groupedFields,
+                        variables: variables)
     default:
       preconditionFailure()
     }
@@ -56,7 +81,10 @@ private func collectFields(from selections: [GraphQLSelection], forRuntimeType r
 }
 
 /// Each field requested in the grouped field set that is defined on the selected objectType will result in an entry in the response map. Field execution first coerces any provided argument values, then resolves a value for the field, and finally completes that value either by recursively executing another selection set or coercing a scalar value.
-private func decode(fields: [GraphQLField], from object: JSONObject, path: ResponsePath, variables: GraphQLMap?) throws -> Any? {
+private func decode(fields: [GraphQLField],
+                    from object: JSONObject,
+                    path: ResponsePath,
+                    variables: GraphQLMap?) throws -> Any? {
   // GraphQL validation makes sure all fields sharing the same response key have the same arguments and are of the same type, so we only need to resolve one field.
   let firstField = fields[0]
   
@@ -65,7 +93,11 @@ private func decode(fields: [GraphQLField], from object: JSONObject, path: Respo
       throw JSONDecodingError.missingValue
     }
     
-    return try complete(value: value, ofType: firstField.type, fields: fields, path: path, variables: variables)
+    return try complete(value: value,
+                        ofType: firstField.type,
+                        fields: fields,
+                        path: path,
+                        variables: variables)
   } catch {
     if !(error is GraphQLResultError) {
       throw GraphQLResultError(path: path, underlying: error)
@@ -76,13 +108,21 @@ private func decode(fields: [GraphQLField], from object: JSONObject, path: Respo
 }
 
 /// After resolving the value for a field, it is completed by ensuring it adheres to the expected return type. If the return type is another Object type, then the field execution process continues recursively.
-private func complete(value: JSONValue, ofType returnType: GraphQLOutputType, fields: [GraphQLField], path: ResponsePath, variables: GraphQLMap?) throws -> Any? {
+private func complete(value: JSONValue,
+                      ofType returnType: GraphQLOutputType,
+                      fields: [GraphQLField],
+                      path: ResponsePath,
+                      variables: GraphQLMap?) throws -> Any? {
   if case .nonNull(let innerType) = returnType {
     if value is NSNull {
       throw JSONDecodingError.nullValue
     }
     
-    return try complete(value: value, ofType: innerType, fields: fields, path: path, variables: variables)
+    return try complete(value: value,
+                        ofType: innerType,
+                        fields: fields,
+                        path: path,
+                        variables: variables)
   }
   
   if value is NSNull {
@@ -98,7 +138,11 @@ private func complete(value: JSONValue, ofType returnType: GraphQLOutputType, fi
     return try array.enumerated().map { index, element -> Any? in
       var path = path
       path.append(String(index))
-      return try complete(value: element, ofType: innerType, fields: fields, path: path, variables: variables)
+      return try complete(value: element,
+                          ofType: innerType,
+                          fields: fields,
+                          path: path,
+                          variables: variables)
     }
   case .object:
     guard let object = value as? JSONObject else { throw JSONDecodingError.wrongType }
@@ -106,19 +150,29 @@ private func complete(value: JSONValue, ofType returnType: GraphQLOutputType, fi
       throw GraphQLResultError(path: path + "__typename", underlying: JSONDecodingError.missingValue)
     }
     // The merged selection set is a list of fields from all sub‐selection sets of the original fields.
-    let subFields = try collectSubfields(from: fields, forRuntimeType: runtimeType, variables: variables)
+    let subFields = try collectSubfields(from: fields,
+                                         forRuntimeType: runtimeType,
+                                         variables: variables)
     // We execute the merged selection set on the object to complete the value. This is the recursive step in the GraphQL execution model.
-    return try decode(groupedFields: subFields, from: object, path: path, variables: variables)
+    return try decode(groupedFields: subFields,
+                      from: object,
+                      path: path,
+                      variables: variables)
   default:
     preconditionFailure()
   }
 }
 
-private func collectSubfields(from fields: [GraphQLField], forRuntimeType runtimeType: String, variables: GraphQLMap?) throws -> GroupedFields {
+private func collectSubfields(from fields: [GraphQLField],
+                              forRuntimeType runtimeType: String,
+                              variables: GraphQLMap?) throws -> GroupedFields {
   var groupedFields = GroupedFields()
   for field in fields {
     if case let .object(subSelections) = field.type.namedType {
-      try collectFields(from: subSelections, forRuntimeType: runtimeType, into: &groupedFields, variables: variables)
+      try collectFields(from: subSelections,
+                        forRuntimeType: runtimeType,
+                        into: &groupedFields,
+                        variables: variables)
     }
   }
   return groupedFields

--- a/Sources/Apollo/DispatchQueue+Optional.swift
+++ b/Sources/Apollo/DispatchQueue+Optional.swift
@@ -14,7 +14,9 @@ public extension DispatchQueue {
     }
   }
   
-  static func apollo_returnResultAsyncIfNeeded<T>(on callbackQueue: DispatchQueue?, action: ((Result<T, Error>) -> Void)?, result: Result<T, Error>) {
+  static func apollo_returnResultAsyncIfNeeded<T>(on callbackQueue: DispatchQueue?,
+                                                  action: ((Result<T, Error>) -> Void)?,
+                                                  result: Result<T, Error>) {
     guard let action = action else {
       return
     }

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -120,23 +120,39 @@ final class GraphQLExecutor {
   
   // MARK: - Execution
   
-  func execute<Accumulator: GraphQLResultAccumulator>(selections: [GraphQLSelection], on object: JSONObject, withKey key: CacheKey? = nil, variables: GraphQLMap? = nil, accumulator: Accumulator) throws -> Promise<Accumulator.FinalResult> {
+  func execute<Accumulator: GraphQLResultAccumulator>(selections: [GraphQLSelection],
+                                                      on object: JSONObject,
+                                                      withKey key: CacheKey? = nil,
+                                                      variables: GraphQLMap? = nil,
+                                                      accumulator: Accumulator) throws -> Promise<Accumulator.FinalResult> {
     let info = GraphQLResolveInfo(rootKey: key, variables: variables)
     
-    return try execute(selections: selections, on: object, info: info, accumulator: accumulator).map {
+    return try execute(selections: selections,
+                       on: object,
+                       info: info,
+                       accumulator: accumulator).map {
       try accumulator.finish(rootValue: $0, info: info)
     }.asPromise()
   }
   
-  private func execute<Accumulator: GraphQLResultAccumulator>(selections: [GraphQLSelection], on object: JSONObject, info: GraphQLResolveInfo, accumulator: Accumulator) throws -> ResultOrPromise<Accumulator.ObjectResult> {
+  private func execute<Accumulator: GraphQLResultAccumulator>(selections: [GraphQLSelection],
+                                                              on object: JSONObject,
+                                                              info: GraphQLResolveInfo,
+                                                              accumulator: Accumulator) throws -> ResultOrPromise<Accumulator.ObjectResult> {
     var groupedFields = GroupedSequence<String, GraphQLField>()
-    try collectFields(selections: selections, forRuntimeType: runtimeType(of: object), into: &groupedFields, info: info)
+    try collectFields(selections: selections,
+                      forRuntimeType: runtimeType(of: object),
+                      into: &groupedFields,
+                      info: info)
     
     var fieldEntries: [ResultOrPromise<Accumulator.FieldEntry>] = []
     fieldEntries.reserveCapacity(groupedFields.keys.count)
     
     for (_, fields) in groupedFields {
-      let fieldEntry = try execute(fields: fields, on: object, info: info, accumulator: accumulator)
+      let fieldEntry = try execute(fields: fields,
+                                   on: object,
+                                   info: info,
+                                   accumulator: accumulator)
       fieldEntries.append(fieldEntry)
     }
     
@@ -155,7 +171,10 @@ final class GraphQLExecutor {
   }
   
   /// Before execution, the selection set is converted to a grouped field set. Each entry in the grouped field set is a list of fields that share a response key. This ensures all fields with the same response key (alias or field name) included via referenced fragments are executed at the same time.
-  private func collectFields(selections: [GraphQLSelection], forRuntimeType runtimeType: String?, into groupedFields: inout GroupedSequence<String, GraphQLField>, info: GraphQLResolveInfo) throws {
+  private func collectFields(selections: [GraphQLSelection],
+                             forRuntimeType runtimeType: String?,
+                             into groupedFields: inout GroupedSequence<String, GraphQLField>,
+                             info: GraphQLResolveInfo) throws {
     for selection in selections {
       switch selection {
       case let field as GraphQLField:
@@ -165,13 +184,19 @@ final class GraphQLExecutor {
           throw GraphQLError("Variable \(booleanCondition.variableName) was not provided.")
         }
         if value as? Bool == !booleanCondition.inverted {
-          try collectFields(selections: booleanCondition.selections, forRuntimeType: runtimeType, into: &groupedFields, info: info)
+          try collectFields(selections: booleanCondition.selections,
+                            forRuntimeType: runtimeType,
+                            into: &groupedFields,
+                            info: info)
         }
       case let fragmentSpread as GraphQLFragmentSpread:
         let fragment = fragmentSpread.fragment
         
         if let runtimeType = runtimeType, fragment.possibleTypes.contains(runtimeType) {
-          try collectFields(selections: fragment.selections, forRuntimeType: runtimeType, into: &groupedFields, info: info)
+          try collectFields(selections: fragment.selections,
+                            forRuntimeType: runtimeType,
+                            into: &groupedFields,
+                            info: info)
         }
       case let typeCase as GraphQLTypeCase:
         let selections: [GraphQLSelection]
@@ -180,7 +205,10 @@ final class GraphQLExecutor {
         } else {
           selections = typeCase.default
         }
-        try collectFields(selections: selections, forRuntimeType: runtimeType, into: &groupedFields, info: info)
+        try collectFields(selections: selections,
+                          forRuntimeType: runtimeType,
+                          into: &groupedFields,
+                          info: info)
       default:
         preconditionFailure()
       }
@@ -188,7 +216,10 @@ final class GraphQLExecutor {
   }
   
   /// Each field requested in the grouped field set that is defined on the selected objectType will result in an entry in the response map. Field execution first coerces any provided argument values, then resolves a value for the field, and finally completes that value either by recursively executing another selection set or coercing a scalar value.
-  private func execute<Accumulator: GraphQLResultAccumulator>(fields: [GraphQLField], on object: JSONObject, info: GraphQLResolveInfo, accumulator: Accumulator) throws -> ResultOrPromise<Accumulator.FieldEntry> {
+  private func execute<Accumulator: GraphQLResultAccumulator>(fields: [GraphQLField],
+                                                              on object: JSONObject,
+                                                              info: GraphQLResolveInfo,
+                                                              accumulator: Accumulator) throws -> ResultOrPromise<Accumulator.FieldEntry> {
     // GraphQL validation makes sure all fields sharing the same response key have the same arguments and are of the same type, so we only need to resolve one field.
     let firstField = fields[0]
     
@@ -214,7 +245,10 @@ final class GraphQLExecutor {
         throw JSONDecodingError.missingValue
       }
       
-      return try self.complete(value: value, ofType: firstField.type, info: info, accumulator: accumulator)
+      return try self.complete(value: value,
+                               ofType: firstField.type,
+                               info: info,
+                               accumulator: accumulator)
     }.map {
       try accumulator.accept(fieldEntry: $0, info: info)
     }.catch { error in
@@ -225,13 +259,19 @@ final class GraphQLExecutor {
   }
   
   /// After resolving the value for a field, it is completed by ensuring it adheres to the expected return type. If the return type is another Object type, then the field execution process continues recursively.
-  private func complete<Accumulator: GraphQLResultAccumulator>(value: JSONValue, ofType returnType: GraphQLOutputType, info: GraphQLResolveInfo, accumulator: Accumulator) throws -> ResultOrPromise<Accumulator.PartialResult> {
+  private func complete<Accumulator: GraphQLResultAccumulator>(value: JSONValue,
+                                                               ofType returnType: GraphQLOutputType,
+                                                               info: GraphQLResolveInfo,
+                                                               accumulator: Accumulator) throws -> ResultOrPromise<Accumulator.PartialResult> {
     if case .nonNull(let innerType) = returnType {
       if value is NSNull {
         return .result(.failure(JSONDecodingError.nullValue))
       }
       
-      return try complete(value: value, ofType: innerType, info: info, accumulator: accumulator)
+      return try complete(value: value,
+                          ofType: innerType,
+                          info: info,
+                          accumulator: accumulator)
     }
     
     if value is NSNull {
@@ -251,7 +291,10 @@ final class GraphQLExecutor {
         info.responsePath.append(indexSegment)
         info.cachePath.append(indexSegment)
         
-        return try self.complete(value: element, ofType: innerType, info: info, accumulator: accumulator)
+        return try self.complete(value: element,
+                                 ofType: innerType,
+                                 info: info,
+                                 accumulator: accumulator)
       }, notifyOn: queue).map { completedArray in
         return try accumulator.accept(list: completedArray, info: info)
       }
@@ -267,7 +310,10 @@ final class GraphQLExecutor {
       }
       
       // We execute the merged selection set on the object to complete the value. This is the recursive step in the GraphQL execution model.
-      return try execute(selections: selections, on: object, info: info, accumulator: accumulator).map { return $0 as! Accumulator.PartialResult }
+      return try execute(selections: selections,
+                         on: object,
+                         info: info,
+                         accumulator: accumulator).map { return $0 as! Accumulator.PartialResult }
     default:
       preconditionFailure()
     }

--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -18,8 +18,7 @@ struct GraphQLGETTransformer {
   /// - Parameters:
   ///   - body: The GraphQLMap to transform from the body of a `POST` request
   ///   - url: The base url to append the query to.
-  init(body: GraphQLMap,
-       url: URL) {
+  init(body: GraphQLMap, url: URL) {
     self.body = body
     self.url = url
   }

--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -1,11 +1,3 @@
-//
-//  GraphQLGETTransformer.swift
-//  Apollo
-//
-//  Created by Ellen Shapiro on 7/1/19.
-//  Copyright © 2019 Apollo GraphQL. All rights reserved.
-//
-
 import Foundation
 
 struct GraphQLGETTransformer {

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -54,7 +54,9 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
     client?.store.unsubscribe(self)
   }
   
-  func store(_ store: ApolloStore, didChangeKeys changedKeys: Set<CacheKey>, context: UnsafeMutableRawPointer?) {
+  func store(_ store: ApolloStore,
+             didChangeKeys changedKeys: Set<CacheKey>,
+             context: UnsafeMutableRawPointer?) {
     if context == &self.context { return }
     
     guard let dependentKeys = dependentKeys else { return }

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -29,12 +29,28 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
       let dependencyTracker = GraphQLDependencyTracker()
       
       return firstly {
-        try executor.execute(selections: Operation.Data.selections, on: dataEntry, withKey: rootCacheKey(for: operation), variables: operation.variables, accumulator: zip(mapper, normalizer, dependencyTracker))
+        try executor.execute(selections: Operation.Data.selections,
+                             on: dataEntry,
+                             withKey: rootCacheKey(for: operation),
+                             variables: operation.variables,
+                             accumulator: zip(mapper, normalizer, dependencyTracker))
         }.map { (data, records, dependentKeys) in
-          (GraphQLResult(data: data, errors: errors, source: .server, dependentKeys: dependentKeys), records)
+          (
+            GraphQLResult(data: data,
+                         errors: errors,
+                         source: .server,
+                         dependentKeys: dependentKeys),
+            records
+          )
       }
     } else {
-      return Promise(fulfilled: (GraphQLResult(data: nil, errors: errors, source: .server, dependentKeys: nil), nil))
+      return Promise(fulfilled: (
+        GraphQLResult(data: nil,
+                      errors: errors,
+                      source: .server,
+                      dependentKeys: nil),
+        nil
+      ))
     }
   }
   
@@ -50,10 +66,19 @@ public final class GraphQLResponse<Operation: GraphQLOperation> {
     let errors = self.parseErrorsOnlyFast()
     
     if let dataEntry = body["data"] as? JSONObject {      
-      let data = try decode(selectionSet: Operation.Data.self, from: dataEntry, variables: operation.variables)
-      return GraphQLResult(data: data, errors: errors, source: .server, dependentKeys: nil)
+      let data = try decode(selectionSet: Operation.Data.self,
+                            from: dataEntry,
+                            variables: operation.variables)
+      
+      return GraphQLResult(data: data,
+                           errors: errors,
+                           source: .server,
+                           dependentKeys: nil)
     } else {
-      return GraphQLResult(data: nil, errors: errors, source: .server, dependentKeys: nil)
+      return GraphQLResult(data: nil,
+                           errors: errors,
+                           source: .server,
+                           dependentKeys: nil)
     }
   }
 }

--- a/Sources/Apollo/GraphQLResult.swift
+++ b/Sources/Apollo/GraphQLResult.swift
@@ -15,7 +15,10 @@ public struct GraphQLResult<Data> {
     
   let dependentKeys: Set<CacheKey>?
   
-  public init(data: Data?, errors: [GraphQLError]?, source: Source, dependentKeys: Set<CacheKey>?) {
+  public init(data: Data?,
+              errors: [GraphQLError]?,
+              source: Source,
+              dependentKeys: Set<CacheKey>?) {
     self.data = data
     self.errors = errors
     self.source = source

--- a/Sources/Apollo/GraphQLResultAccumulator.swift
+++ b/Sources/Apollo/GraphQLResultAccumulator.swift
@@ -74,7 +74,9 @@ final class Zip3Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2
   private let accumulator3: Accumulator3
   
   
-  fileprivate init(_ accumulator1: Accumulator1, _ accumulator2: Accumulator2, _ accumulator3: Accumulator3) {
+  fileprivate init(_ accumulator1: Accumulator1,
+                   _ accumulator2: Accumulator2,
+                   _ accumulator3: Accumulator3) {
     self.accumulator1 = accumulator1
     self.accumulator2 = accumulator2
     self.accumulator3 = accumulator3

--- a/Sources/Apollo/GraphQLSelectionSet.swift
+++ b/Sources/Apollo/GraphQLSelectionSet.swift
@@ -41,7 +41,10 @@ public struct GraphQLField: GraphQLSelection {
   
   let type: GraphQLOutputType
   
-  public init(_ name: String, alias: String? = nil, arguments: [String: GraphQLInputValue]? = nil, type: GraphQLOutputType) {
+  public init(_ name: String,
+              alias: String? = nil,
+              arguments: [String: GraphQLInputValue]? = nil,
+              type: GraphQLOutputType) {
     self.name = name
     self.alias = alias
     
@@ -93,7 +96,9 @@ public struct GraphQLBooleanCondition: GraphQLSelection {
   let inverted: Bool
   let selections: [GraphQLSelection]
   
-  public init(variableName: String, inverted: Bool, selections: [GraphQLSelection]) {
+  public init(variableName: String,
+              inverted: Bool,
+              selections: [GraphQLSelection]) {
     self.variableName = variableName
     self.inverted = inverted;
     self.selections = selections;

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -84,7 +84,9 @@ public protocol HTTPNetworkTransportGraphQLErrorDelegate: HTTPNetworkTransportDe
   ///   - networkTransport: The network transport which received the error
   ///   - errors: The received GraphQL errors
   ///   - retryHandler: A closure indicating whether the operation should be retried. Asyncrhonous to allow for re-authentication or other async operations to complete.
-  func networkTransport(_ networkTransport: HTTPNetworkTransport, receivedGraphQLErrors errors: [GraphQLError], retryHandler: @escaping (_ shouldRetry: Bool) -> Void)
+  func networkTransport(_ networkTransport: HTTPNetworkTransport,
+                        receivedGraphQLErrors errors: [GraphQLError],
+                        retryHandler: @escaping (_ shouldRetry: Bool) -> Void)
 }
 
 // MARK: -
@@ -132,7 +134,10 @@ public class HTTPNetworkTransport {
     self.requestCreator = requestCreator
   }
   
-  private func send<Operation>(operation: Operation, isPersistedQueryRetry: Bool, files: [GraphQLFile]?, completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+  private func send<Operation>(operation: Operation,
+                               isPersistedQueryRetry: Bool,
+                               files: [GraphQLFile]?,
+                               completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     let request: URLRequest
     do {
       request = try self.createRequest(for: operation,
@@ -332,7 +337,9 @@ public class HTTPNetworkTransport {
                                   error: error)
   }
   
-  private func createRequest<Operation: GraphQLOperation>(for operation: Operation, isPersistedQueryRetry: Bool, files: [GraphQLFile]?) throws -> URLRequest {
+  private func createRequest<Operation: GraphQLOperation>(for operation: Operation,
+                                                          isPersistedQueryRetry: Bool,
+                                                          files: [GraphQLFile]?) throws -> URLRequest {
     let useGetMethod: Bool
     let sendQueryDocument: Bool
     let autoPersistQueries: Bool
@@ -446,7 +453,9 @@ extension HTTPNetworkTransport: NetworkTransport {
 
 extension HTTPNetworkTransport: UploadingNetworkTransport {
   
-  public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+  public func upload<Operation>(operation: Operation,
+                                files: [GraphQLFile],
+                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
     return send(operation: operation,
                 isPersistedQueryRetry: false,
                 files: files,

--- a/Sources/Apollo/JSONSerialziation+Sorting.swift
+++ b/Sources/Apollo/JSONSerialziation+Sorting.swift
@@ -1,11 +1,3 @@
-//
-//  JSONSerialziation+Sorting.swift
-//  Apollo
-//
-//  Created by Ellen Shapiro on 7/12/19.
-//  Copyright © 2019 Apollo GraphQL. All rights reserved.
-//
-
 import Foundation
 
 extension JSONSerialization {

--- a/Sources/Apollo/Matchable.swift
+++ b/Sources/Apollo/Matchable.swift
@@ -1,11 +1,3 @@
-//
-//  Matchable.swift
-//  Apollo
-//
-//  Created by Ellen Shapiro on 10/29/19.
-//  Copyright © 2019 Apollo GraphQL. All rights reserved.
-//
-
 import Foundation
 
 public protocol Matchable {

--- a/Sources/ApolloWebSocket/ApolloWebSocket.swift
+++ b/Sources/ApolloWebSocket/ApolloWebSocket.swift
@@ -24,6 +24,8 @@ public protocol ApolloWebSocketClient: WebSocketClient {
 /// Included implementation of an `ApolloWebSocketClient`, based on `Starscream`'s `WebSocket`.
 public class ApolloWebSocket: WebSocket, ApolloWebSocketClient {
   required public convenience init(request: URLRequest, protocols: [String]? = nil) {
-    self.init(request: request, protocols: protocols, stream: FoundationStream())
+    self.init(request: request,
+              protocols: protocols,
+              stream: FoundationStream())
   }
 }

--- a/Sources/ApolloWebSocket/OperationMessage.swift
+++ b/Sources/ApolloWebSocket/OperationMessage.swift
@@ -31,7 +31,9 @@ final class OperationMessage {
     }
   }
   
-  init(payload: GraphQLMap? = nil, id: String? = nil, type: Types = .start) {
+  init(payload: GraphQLMap? = nil,
+       id: String? = nil,
+       type: Types = .start) {
     if let payload = payload {
       message += ["payload": payload]
     }

--- a/Sources/ApolloWebSocket/OperationMessage.swift
+++ b/Sources/ApolloWebSocket/OperationMessage.swift
@@ -47,14 +47,24 @@ final class OperationMessage {
     self.serialized = serialized
   }
   
-  func parse(handler: (_ type: String?, _ id: String?, _ payload: JSONObject?, _ error: Error?) -> Void) {
+  func parse(handler: (ParseHandler) -> Void) {
     guard let serialized = self.serialized else {
-      handler(nil, nil, nil, WebSocketError(payload: nil, error: nil, kind: .serializedMessageError))
+      handler(ParseHandler(nil,
+                           nil,
+                           nil,
+                           WebSocketError(payload: nil,
+                                          error: nil,
+                                          kind: .serializedMessageError)))
       return
     }
 
     guard let data = self.serialized?.data(using: (.utf8) ) else {
-      handler(nil, nil, nil, WebSocketError(payload: nil, error: nil, kind: .unprocessedMessage(serialized)))
+      handler(ParseHandler(nil,
+                           nil,
+                           nil,
+                           WebSocketError(payload: nil,
+                                          error: nil,
+                                          kind: .unprocessedMessage(serialized))))
       return
     }
 
@@ -69,10 +79,36 @@ final class OperationMessage {
       type = json?["type"] as? String
       payload = json?["payload"] as? JSONObject
 
-      handler(type,id,payload,nil)
+      handler(ParseHandler(type,
+                           id,
+                           payload,
+                           nil))
     }
     catch {
-      handler(type, id, payload, WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(serialized)))
+      handler(ParseHandler(type,
+                           id,
+                           payload,
+                           WebSocketError(payload: payload,
+                                          error: error,
+                                          kind: .unprocessedMessage(serialized))))
     }
+  }
+}
+
+struct ParseHandler {
+  
+  let type: String?
+  let id: String?
+  let payload: JSONObject?
+  let error: Error?
+  
+  init(_ type: String?,
+       _ id: String?,
+       _ payload: JSONObject?,
+       _ error: Error?) {
+    self.type = type
+    self.id = id
+    self.payload = payload
+    self.error = error
   }
 }

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -67,7 +67,11 @@ extension SplitNetworkTransport: NetworkTransport {
 
 extension SplitNetworkTransport: UploadingNetworkTransport {
   
-  public func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
-    return httpNetworkTransport.upload(operation: operation, files: files, completionHandler: completionHandler)
+  public func upload<Operation>(operation: Operation,
+                                files: [GraphQLFile],
+                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+    return httpNetworkTransport.upload(operation: operation,
+                                       files: files,
+                                       completionHandler: completionHandler)
   }
 }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -137,7 +137,9 @@ public class WebSocketTransport {
             subscribers.removeValue(forKey: id)
           }
         } else {
-          notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
+          notifyErrorAllHandlers(WebSocketError(payload: payload,
+                                                error: error,
+                                                kind: .unprocessedMessage(text)))
         }
 
       case .connectionAck:
@@ -147,8 +149,14 @@ public class WebSocketTransport {
       case .connectionKeepAlive:
         writeQueue()
 
-      case .connectionInit, .connectionTerminate, .start, .stop, .connectionError:
-        notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
+      case .connectionInit,
+           .connectionTerminate,
+           .start,
+           .stop,
+           .connectionError:
+        notifyErrorAllHandlers(WebSocketError(payload: payload,
+                                              error: error,
+                                              kind: .unprocessedMessage(text)))
       }
     }
   }
@@ -199,7 +207,9 @@ public class WebSocketTransport {
     }
   }
   
-  private func write(_ str: String, force forced: Bool = false, id: Int? = nil) {
+  private func write(_ str: String,
+                     force forced: Bool = false,
+                     id: Int? = nil) {
     if websocket.isConnected && (acked || forced) {
       websocket.write(string: str)
     } else {

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -100,11 +100,13 @@ public class WebSocketTransport {
   }
 
   private func processMessage(socket: WebSocketClient, text: String) {
-    OperationMessage(serialized: text).parse { (type, id, payload, error) in
+    OperationMessage(serialized: text).parse { parseHandler in
       guard
-        let type = type,
+        let type = parseHandler.type,
         let messageType = OperationMessage.Types(rawValue: type) else {
-          self.notifyErrorAllHandlers(WebSocketError(payload: payload, error: error, kind: .unprocessedMessage(text)))
+          self.notifyErrorAllHandlers(WebSocketError(payload: parseHandler.payload,
+                                                     error: parseHandler.error,
+                                                     kind: .unprocessedMessage(text)))
           return
       }
 
@@ -112,33 +114,33 @@ public class WebSocketTransport {
       case .data,
            .error:
         if
-          let id = id,
+          let id = parseHandler.id,
           let responseHandler = subscribers[id] {
-          if let payload = payload {
+          if let payload = parseHandler.payload {
             responseHandler(.success(payload))
-          } else if let error = error {
+          } else if let error = parseHandler.error {
             responseHandler(.failure(error))
           } else {
-            let websocketError = WebSocketError(payload: payload,
-                                                error: error,
+            let websocketError = WebSocketError(payload: parseHandler.payload,
+                                                error: parseHandler.error,
                                                 kind: .neitherErrorNorPayloadReceived)
             responseHandler(.failure(websocketError))
           }
         } else {
-          let websocketError = WebSocketError(payload: payload,
-                                              error: error,
+          let websocketError = WebSocketError(payload: parseHandler.payload,
+                                              error: parseHandler.error,
                                               kind: .unprocessedMessage(text))
           self.notifyErrorAllHandlers(websocketError)
         }
       case .complete:
-        if let id = id {
+        if let id = parseHandler.id {
           // remove the callback if NOT a subscription
           if subscriptions[id] == nil {
             subscribers.removeValue(forKey: id)
           }
         } else {
-          notifyErrorAllHandlers(WebSocketError(payload: payload,
-                                                error: error,
+          notifyErrorAllHandlers(WebSocketError(payload: parseHandler.payload,
+                                                error: parseHandler.error,
                                                 kind: .unprocessedMessage(text)))
         }
 
@@ -154,8 +156,8 @@ public class WebSocketTransport {
            .start,
            .stop,
            .connectionError:
-        notifyErrorAllHandlers(WebSocketError(payload: payload,
-                                              error: error,
+        notifyErrorAllHandlers(WebSocketError(payload: parseHandler.payload,
+                                              error: parseHandler.error,
                                               kind: .unprocessedMessage(text)))
       }
     }


### PR DESCRIPTION
Doing some Code Janitor tasks while my I'm too jetlagged to deal with anything that requires my brain to not be made of pudding: 

- Updated 3+ parameter methods to always use newlines for parameters. This is more of a personal readability preference thing than anything else, but it's made quite a bit of stuff more annoying to read so I figured this was as good a time as any to change it up
- Anal-retentively organized folder contents alphabetically within Xcode
- Got rid of a 4-param tuple in favor of a struct because if it's that many properties it should be a struct
- Got rid of a few headers I forgot to delete in the past