### PR TITLE
Add List-related watch tests

### DIFF
--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -191,6 +191,7 @@ class WatchQueryTests: XCTestCase {
 
       var verifyResult: GraphQLResultHandler<HeroAndFriendsNamesQuery.Data>
 
+      // verify initial state
       verifyResult = { result in
         switch result {
         case .success(let graphQLResult):
@@ -217,6 +218,7 @@ class WatchQueryTests: XCTestCase {
 
       waitForExpectations(timeout: 5, handler: nil)
 
+      // verify cache update
       verifyResult = { result in
         switch result {
         case .success(let graphQLResult):
@@ -425,6 +427,7 @@ class WatchQueryTests: XCTestCase {
 
       var verifyResult: GraphQLResultHandler<HeroAndFriendsNamesWithIDsQuery.Data>
 
+      // verify initial cache state
       verifyResult = { result in
         switch result {
         case .success(let graphQLResult):
@@ -450,6 +453,7 @@ class WatchQueryTests: XCTestCase {
 
       waitForExpectations(timeout: 5, handler: nil)
 
+      // verify cache update
       verifyResult = { result in
         switch result {
         case .success(let graphQLResult):

--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -149,11 +149,101 @@ class WatchQueryTests: XCTestCase {
       expectation = self.expectation(description: "Updated after fetching other query")
 
       client.fetch(query: HeroNameQuery(), cachePolicy: .fetchIgnoringCacheData)
-      
+
       waitForExpectations(timeout: 5, handler: nil)
     }
   }
-  
+
+  func testWatchedQueryGetsUpdatedWithListReorderingFromOtherQuery() throws {
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "QUERY_ROOT.hero")],
+      "QUERY_ROOT.hero": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+        "friends": [
+          Reference(key: "QUERY_ROOT.hero.friends.0"),
+          Reference(key: "QUERY_ROOT.hero.friends.1"),
+          Reference(key: "QUERY_ROOT.hero.friends.2")
+        ]
+      ],
+      "QUERY_ROOT.hero.friends.0": ["__typename": "Human", "name": "Luke Skywalker"],
+      "QUERY_ROOT.hero.friends.1": ["__typename": "Human", "name": "Han Solo"],
+      "QUERY_ROOT.hero.friends.2": ["__typename": "Human", "name": "Leia Organa"],
+      ]
+
+    withCache(initialRecords: initialRecords) { (cache) in
+      let networkTransport = MockNetworkTransport(body: [
+        "data": [
+          "hero": [
+            "name": "Artoo",
+            "__typename": "Droid",
+            "friends": [
+              ["__typename": "Human", "name": "Luke Skywalker"],
+              ["__typename": "Human", "name": "Leia Organa"],
+            ]
+          ]
+        ]
+        ])
+      let store = ApolloStore(cache: cache)
+      let client = ApolloClient(networkTransport: networkTransport, store: store)
+
+      let query = HeroAndFriendsNamesQuery()
+
+      var verifyResult: GraphQLResultHandler<HeroAndFriendsNamesQuery.Data>
+
+      verifyResult = { result in
+        switch result {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          guard let data = graphQLResult.data else {
+            XCTFail("No data in graphQLResult!")
+            return
+          }
+
+          XCTAssertEqual(data.hero?.name, "R2-D2")
+          let friendsNames = data.hero?.friends?.compactMap { $0?.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+
+      var expectation = self.expectation(description: "Fetching query")
+
+      _ = client.watch(query: query) { result in
+        verifyResult(result)
+        expectation.fulfill()
+      }
+
+      waitForExpectations(timeout: 5, handler: nil)
+
+      verifyResult = { result in
+        switch result {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          guard let data = graphQLResult.data else {
+            XCTFail("No data in GraphQL result!")
+            return
+          }
+          XCTAssertEqual(data.hero?.name, "Artoo")
+          let friendsNames = data.hero?.friends?.compactMap { $0?.name }
+          XCTAssertEqual(friendsNames, [
+            "Luke Skywalker",
+            "Leia Organa",
+          ])
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+
+      expectation = self.expectation(description: "Updated after fetching other query")
+
+      client.fetch(query: HeroAndFriendsNamesQuery(), cachePolicy: .fetchIgnoringCacheData)
+
+      waitForExpectations(timeout: 5, handler: nil)
+    }
+  }
+
   func testWatchedQueryDoesNotRefetchAfterUnrelatedQuery() throws {
     let initialRecords: RecordSet = [
       "QUERY_ROOT": ["hero": Reference(key: "QUERY_ROOT.hero")],
@@ -295,6 +385,95 @@ class WatchQueryTests: XCTestCase {
       waitForExpectations(timeout: 5, handler: nil)
     }
   }
+
+  func testWatchedListModifyingQueryWithID() throws {
+    let query = HeroAndFriendsNamesWithIDsQuery()
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "2001")],
+      "2001": [
+        "id": "2001",
+        "name": "R2-D2",
+        "__typename": "Droid",
+        "friends": [
+          Reference(key: "LS"),
+          Reference(key: "HS"),
+          Reference(key: "LO"),
+        ],
+      ],
+      "LS": ["__typename": "Human", "id": "LS", "name": "Luke Skywalker"],
+      "HS": ["__typename": "Human", "id": "HS", "name": "Han Solo"],
+      "LO": ["__typename": "Human", "id": "LO", "name": "Leia Organa"],
+    ]
+
+    withCache(initialRecords: initialRecords) { (cache) in
+      let networkTransport = MockNetworkTransport(body: [
+        "data": [
+          "hero": [
+            "id": "2001",
+            "name": "Luke Skywalker",
+            "__typename": "Human",
+            "friends": [
+              ["__typename": "Human", "id": "LO"],
+              ["__typename": "Human", "id": "LS"],
+            ]
+          ]
+        ]
+        ])
+      let store = ApolloStore(cache: cache)
+      let client = ApolloClient(networkTransport: networkTransport, store: store)
+      client.store.cacheKeyForObject = { $0["id"] }
+
+      var verifyResult: GraphQLResultHandler<HeroAndFriendsNamesWithIDsQuery.Data>
+
+      verifyResult = { result in
+        switch result {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          let friendsNames = graphQLResult.data?.hero?.friends?.compactMap { $0?.name }
+          XCTAssertEqual(friendsNames, [
+            "Luke Skywalker",
+            "Han Solo",
+            "Leia Organa",
+          ])
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+
+      var expectation = self.expectation(description: "Fetching query")
+
+      _ = client.watch(query: query, cachePolicy: .returnCacheDataDontFetch) { result in
+        verifyResult(result)
+        expectation.fulfill()
+      }
+
+      waitForExpectations(timeout: 5, handler: nil)
+
+      verifyResult = { result in
+        switch result {
+        case .success(let graphQLResult):
+          XCTAssertNil(graphQLResult.errors)
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+
+          let friendsNames = graphQLResult.data?.hero?.friends?.compactMap { $0?.name }
+          XCTAssertEqual(friendsNames, [
+            "Leia Organa",
+            "Luke Skywalker",
+          ])
+        case .failure(let error):
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+
+      expectation = self.expectation(description: "Fetching other query")
+
+      client.fetch(query: HeroAndFriendsIDsQuery(), cachePolicy: .fetchIgnoringCacheData)
+
+      waitForExpectations(timeout: 5, handler: nil)
+    }
+  }
+
 
   func testWatchedQueryGetsUpdatedWithResultFromReadWriteTransaction() throws {
     let initialRecords: RecordSet = [

--- a/Tests/StarWarsAPI/API.swift
+++ b/Tests/StarWarsAPI/API.swift
@@ -660,6 +660,171 @@ public final class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
   }
 }
 
+public final class HeroAndFriendsIDsQuery: GraphQLQuery {
+  /// The raw GraphQL definition of this operation.
+  public let operationDefinition =
+    """
+    query HeroAndFriendsIDs($episode: Episode) {
+      hero(episode: $episode) {
+        __typename
+        id
+        name
+        friends {
+          __typename
+          id
+        }
+      }
+    }
+    """
+
+  public let operationName = "HeroAndFriendsIDs"
+
+  public let operationIdentifier: String? = "117d0f6831d8f4abe5b61ed1dbb8071b0825e19649916c0fe0906a6f578bb088"
+
+  public var episode: Episode?
+
+  public init(episode: Episode? = nil) {
+    self.episode = episode
+  }
+
+  public var variables: GraphQLMap? {
+    return ["episode": episode]
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes = ["Query"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+    ]
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(hero: Hero? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Query", "hero": hero.flatMap { (value: Hero) -> ResultMap in value.resultMap }])
+    }
+
+    public var hero: Hero? {
+      get {
+        return (resultMap["hero"] as? ResultMap).flatMap { Hero(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "hero")
+      }
+    }
+
+    public struct Hero: GraphQLSelectionSet {
+      public static let possibleTypes = ["Human", "Droid"]
+
+      public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("friends", type: .list(.object(Friend.selections))),
+      ]
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public static func makeHuman(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
+        return Hero(unsafeResultMap: ["__typename": "Human", "id": id, "name": name, "friends": friends.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }])
+      }
+
+      public static func makeDroid(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
+        return Hero(unsafeResultMap: ["__typename": "Droid", "id": id, "name": name, "friends": friends.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// The ID of the character
+      public var id: GraphQLID {
+        get {
+          return resultMap["id"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "id")
+        }
+      }
+
+      /// The name of the character
+      public var name: String {
+        get {
+          return resultMap["name"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "name")
+        }
+      }
+
+      /// The friends of the character, or an empty list if they have none
+      public var friends: [Friend?]? {
+        get {
+          return (resultMap["friends"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }
+        }
+        set {
+          resultMap.updateValue(newValue.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }, forKey: "friends")
+        }
+      }
+
+      public struct Friend: GraphQLSelectionSet {
+        public static let possibleTypes = ["Human", "Droid"]
+
+        public static let selections: [GraphQLSelection] = [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+        ]
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public static func makeHuman(id: GraphQLID) -> Friend {
+          return Friend(unsafeResultMap: ["__typename": "Human", "id": id])
+        }
+
+        public static func makeDroid(id: GraphQLID) -> Friend {
+          return Friend(unsafeResultMap: ["__typename": "Droid", "id": id])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The ID of the character
+        public var id: GraphQLID {
+          get {
+            return resultMap["id"]! as! GraphQLID
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+      }
+    }
+  }
+}
+
 public final class HeroAndFriendsNamesWithIdForParentOnlyQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
   public let operationDefinition =

--- a/Tests/StarWarsAPI/HeroAndFriendsNames.graphql
+++ b/Tests/StarWarsAPI/HeroAndFriendsNames.graphql
@@ -18,6 +18,16 @@ query HeroAndFriendsNamesWithIDs($episode: Episode) {
   }
 }
 
+query HeroAndFriendsIDs($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+    friends {
+      id
+    }
+  }
+}
+
 query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) {
   hero(episode: $episode) {
     id

--- a/Tests/StarWarsAPI/operationIdsPath.json
+++ b/Tests/StarWarsAPI/operationIdsPath.json
@@ -15,6 +15,10 @@
     "name": "HeroAndFriendsNamesWithIDs",
     "source": "query HeroAndFriendsNamesWithIDs($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      id\n      name\n    }\n  }\n}"
   },
+  "117d0f6831d8f4abe5b61ed1dbb8071b0825e19649916c0fe0906a6f578bb088": {
+    "name": "HeroAndFriendsIDs",
+    "source": "query HeroAndFriendsIDs($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      id\n    }\n  }\n}"
+  },
   "f091468a629f3b757c03a1b7710c6ede8b5c8f10df7ba3238f2bbcd71c56f90f": {
     "name": "HeroAndFriendsNamesWithIDForParentOnly",
     "source": "query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      name\n    }\n  }\n}"


### PR DESCRIPTION
Confirms that Apollo supports automatic updates to lists. Addresses reordering and deletion.