### PR TITLE
Expose internal members of MultipartFormData

### DIFF
--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A helper for building out multi-part form data for upload
 public class MultipartFormData {
   
-  enum FormDataError: Error, LocalizedError {
+  public enum FormDataError: Error, LocalizedError {
     case encodingStringToDataFailed(_ string: String)
     
     var errorDescription: String? {
@@ -15,9 +15,9 @@ public class MultipartFormData {
   }
 
   /// A Carriage Return Line Feed character, which will be seen as a newline on both unix and Windows servers.
-  static let CRLF = "\r\n"
+  public static let CRLF = "\r\n"
 
-  let boundary: String
+  public let boundary: String
 
   private var bodyParts: [BodyPart]
 
@@ -89,7 +89,7 @@ public class MultipartFormData {
   /// Encodes everything into the final form data to send to a server.
   ///
   /// - Returns: The final form data to send to a server.
-  func encode() throws -> Data {
+  public func encode() throws -> Data {
     var data = Data()
 
     for p in self.bodyParts {

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -6,7 +6,7 @@ public class MultipartFormData {
   public enum FormDataError: Error, LocalizedError {
     case encodingStringToDataFailed(_ string: String)
     
-    var errorDescription: String? {
+    public var errorDescription: String? {
       switch self {
       case .encodingStringToDataFailed(let string):
         return "Could not encode \"\(string)\" as .utf8 data."


### PR DESCRIPTION
Implementing a custom `NetworkTransport` that mimics similar behavior to the default `HTTPNetworkTransport` depends on these members being public. Targets linking to the library can now access the full functionality `MultipartFormData` objects.