### PR TITLE
Update tests to use `XCTUnwrap` instead of guard let else fail

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -496,6 +496,15 @@
 			path = Configuration/Apollo;
 			sourceTree = "<group>";
 		};
+		9B0417812390320A00C9EC4E /* TestHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				C3279FC52345233000224790 /* TestCustomRequestCreator.swift */,
+				9B64F6752354D219002D1BB5 /* URL+QueryDict.swift */,
+			);
+			name = TestHelpers;
+			sourceTree = "<group>";
+		};
 		9B8D864A22E7A60C001F6D50 /* TestFolder */ = {
 			isa = PBXGroup;
 			children = (
@@ -675,6 +684,7 @@
 		9FC750521D2A532D00458D91 /* ApolloTests */ = {
 			isa = PBXGroup;
 			children = (
+				9B0417812390320A00C9EC4E /* TestHelpers */,
 				9FC750551D2A532D00458D91 /* Info.plist */,
 				F82E62E022BCD223000C311B /* AutomaticPersistedQueriesTests.swift */,
 				9F438D0B1E6C494C007BDC1A /* BatchedLoadTests.swift */,
@@ -694,8 +704,6 @@
 				9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */,
 				C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */,
 				9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */,
-				C3279FC52345233000224790 /* TestCustomRequestCreator.swift */,
-				9B64F6752354D219002D1BB5 /* URL+QueryDict.swift */,
 				5BB2C0222380836100774170 /* VersionNumberTests.swift */,
 				C304EBD322DDC7B200748F72 /* a.txt */,
 				C35D43BE22DDD3C100BCBABE /* b.txt */,

--- a/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
@@ -102,7 +102,7 @@ class ReadWriteFromStoreTests: XCTestCase {
 
       let result = try await(store.load(query: query))
 
-      guard let data = result.data else { XCTFail(); return }
+      let data = try XCTUnwrap(result.data)
       XCTAssertEqual(data.hero?.name, "Artoo")
     }
   }
@@ -124,7 +124,8 @@ class ReadWriteFromStoreTests: XCTestCase {
           case .success:
             XCTFail("write should fail")
           case .failure(let error):
-            guard let error = error as? GraphQLResultError,
+            guard
+              let error = error as? GraphQLResultError,
               let jsonError = error.underlying as? JSONDecodingError else {
                 XCTFail("unexpected error")
                 return
@@ -210,7 +211,7 @@ class ReadWriteFromStoreTests: XCTestCase {
       self.waitForExpectations(timeout: 1, handler: nil)
       
       let result = try await(store.load(query: query))
-      guard let data = result.data else { XCTFail(); return }
+      let data = try XCTUnwrap(result.data)
       
       XCTAssertEqual(data.hero?.name, "R2-D2")
       let friendsNames = data.hero?.friends?.compactMap { $0?.name }
@@ -250,7 +251,7 @@ class ReadWriteFromStoreTests: XCTestCase {
       self.waitForExpectations(timeout: 1, handler: nil)
 
       let result = try await(store.load(query: query))
-      guard let data = result.data else { XCTFail(); return }
+      let data = try XCTUnwrap(result.data)
 
       XCTAssertEqual(data.hero?.name, "R2-D2")
       let friendsNames = data.hero?.friends?.compactMap { $0?.name }
@@ -367,7 +368,7 @@ class ReadWriteFromStoreTests: XCTestCase {
       self.waitForExpectations(timeout: 1, handler: nil)
 
       let result = try await(store.load(query: HeroAndFriendsNamesQuery()))
-      guard let data = result.data else { XCTFail(); return }
+      let data = try XCTUnwrap(result.data)
 
       XCTAssertEqual(data.hero?.name, "R2-D2")
       let friendsNames = data.hero?.friends?.compactMap { $0?.name }

--- a/Tests/ApolloTests/ErrorGenerationTests.swift
+++ b/Tests/ApolloTests/ErrorGenerationTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class ErrorGenerationTests: XCTestCase {
   
-  func testLocalizedStringFromErrorResponse() {
+  func testLocalizedStringFromErrorResponse() throws {
     let json = """
 {
   "errors": [
@@ -30,10 +30,8 @@ class ErrorGenerationTests: XCTestCase {
                                    httpVersion: nil,
                                    headerFields: nil)!
     
-    guard let data = json.data(using: .utf8) else {
-      XCTFail("Couldn't create json data")
-      return
-    }
+    let data = try XCTUnwrap(json.data(using: .utf8),
+                             "Couldn't create json data")
     
     let httpResponseError = GraphQLHTTPResponseError(body: data,
                                                      response: response,
@@ -42,7 +40,7 @@ class ErrorGenerationTests: XCTestCase {
     XCTAssertEqual(httpResponseError.localizedDescription, "Received error response: Invalid client auth token.")
   }
   
-  func testLocalizedStringFromErrorResponseWithMultipleErrors() {
+  func testLocalizedStringFromErrorResponseWithMultipleErrors() throws {
     let json = """
 {
   "errors": [
@@ -67,10 +65,8 @@ class ErrorGenerationTests: XCTestCase {
                                    httpVersion: nil,
                                    headerFields: nil)!
     
-    guard let data = json.data(using: .utf8) else {
-      XCTFail("Couldn't create json data")
-      return
-    }
+    let data = try XCTUnwrap(json.data(using: .utf8),
+                             "Couldn't create json data")
     
     let httpResponseError = GraphQLHTTPResponseError(body: data,
                                                      response: response,
@@ -79,7 +75,7 @@ class ErrorGenerationTests: XCTestCase {
     XCTAssertEqual(httpResponseError.localizedDescription, "Received error response: Invalid client auth token.\nServer is having a sad.")
   }
   
-  func testLocalizedStringFromPlaintextResponse() {
+  func testLocalizedStringFromPlaintextResponse() throws {
     let text = "The server is having a sad."
     
     let response = HTTPURLResponse(url: URL(string: "https://www.fake.com")!,
@@ -87,10 +83,9 @@ class ErrorGenerationTests: XCTestCase {
                                    httpVersion: nil,
                                    headerFields: nil)!
     
-    guard let data = text.data(using: .utf8) else {
-      XCTFail("Couldn't create text data")
-      return
-    }
+    let data = try XCTUnwrap(text.data(using: .utf8),
+                             "Couldn't create text data")
+
     
     let httpResponseError = GraphQLHTTPResponseError(body: data,
                                                      response: response,

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -25,7 +25,7 @@ class GETTransformerTests: XCTestCase {
     XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroName&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22EMPIRE%22%7D")
   }
   
-  func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() {
+  func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() throws {
     let operation = HeroNameTypeSpecificConditionalInclusionQuery(episode: .jedi, includeName: true)
     let body = requestCreator.requestBody(for: operation, sendOperationIdentifiers: false)
     
@@ -40,20 +40,14 @@ class GETTransformerTests: XCTestCase {
     } else {
       // We can't guarantee order of encoding, so we need to pull the JSON back
       // out and check that it has the correct and correctly typed properties.
-      guard let transformedURL = url else {
-        XCTFail("URL not created!")
-        return
-      }
+      let transformedURL = try XCTUnwrap(url,
+                                         "URL not created!")
       
-      guard let urlComponents = URLComponents(url: transformedURL, resolvingAgainstBaseURL: false) else {
-        XCTFail("Couldn't access URL components")
-        return
-      }
+      let urlComponents = try XCTUnwrap(URLComponents(url: transformedURL, resolvingAgainstBaseURL: false),
+                                        "Couldn't access URL components")
       
-      guard let queryItems = urlComponents.queryItems else {
-        XCTFail("No query items!")
-        return
-      }
+      let queryItems = try XCTUnwrap(urlComponents.queryItems,
+                                     "No query items!")
       
       guard
         let operationNameItem = queryItems.first(where: { $0.name == "operationName" }),
@@ -71,10 +65,8 @@ class GETTransformerTests: XCTestCase {
           return
       }
       
-      guard let data = variables.data(using: .utf8) else {
-        XCTFail("Couldn't convert data to UTF8 string!")
-        return
-      }
+      let data = try XCTUnwrap(variables.data(using: .utf8),
+                               "Couldn't convert data to UTF8 string!")
       
       guard
         let object = try? JSONSerialization.jsonObject(with: data),
@@ -88,7 +80,7 @@ class GETTransformerTests: XCTestCase {
     }
   }
   
-  func testEncodingQueryWith2DParameter() {
+  func testEncodingQueryWith2DParameter() throws {
     let operation = HeroNameQuery(episode: .empire)
     
     let persistedQuery: GraphQLMap = [
@@ -115,19 +107,16 @@ class GETTransformerTests: XCTestCase {
 
       XCTAssertTrue(queryString)
     } else {
-      guard let query = url?.queryItemDictionary?["query"] else {
-        XCTFail("query should not nil")
-        return
-      }
+      let query = try XCTUnwrap(url?.queryItemDictionary?["query"],
+                                "query should not be nil")
       XCTAssertTrue(query == operation.queryDocument)
       
-      guard let variables = url?.queryItemDictionary?["variables"] else {
-        XCTFail("variables should not nil")
-        return
-      }
+      let variables = try XCTUnwrap(url?.queryItemDictionary?["variables"],
+                                    "variables should not nil")
       XCTAssertEqual(variables, "{\"episode\":\"EMPIRE\"}")
       
-      guard let ext = url?.queryItemDictionary?["extensions"],
+      guard
+        let ext = url?.queryItemDictionary?["extensions"],
         let data = ext.data(using: .utf8),
         let jsonBody = try? JSONSerializationFormat.deserialize(data: data) as? JSONObject
         else {
@@ -135,27 +124,21 @@ class GETTransformerTests: XCTestCase {
           return
       }
       
-      guard let comparePersistedQuery = jsonBody["persistedQuery"] as? JSONObject else {
-        XCTFail("persistedQuery is missing")
-        return
-      }
+      let comparePersistedQuery = try XCTUnwrap(jsonBody["persistedQuery"] as? JSONObject,
+                                                "persistedQuery is missing")
       
-      guard let sha256Hash = comparePersistedQuery["sha256Hash"] as? String else {
-        XCTFail("sha256Hash is missing")
-        return
-      }
+      let sha256Hash = try XCTUnwrap(comparePersistedQuery["sha256Hash"] as? String,
+                                     "sha256Hash is missing")
       
-      guard let version = comparePersistedQuery["version"] as? Int else {
-        XCTFail("version is missing")
-        return
-      }
+      let version = try XCTUnwrap(comparePersistedQuery["version"] as? Int,
+                                  "version is missing")
       
       XCTAssertEqual(version, 1)
       XCTAssertEqual(sha256Hash, "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671")
     }
   }
   
-  func testEncodingQueryWith2DWOQueryParameter() {
+  func testEncodingQueryWith2DWOQueryParameter() throws {
     let operation = HeroNameQuery(episode: .empire)
     
     let persistedQuery: GraphQLMap = [
@@ -181,13 +164,13 @@ class GETTransformerTests: XCTestCase {
       XCTAssertTrue(queryString)
     } else {
 
-      guard let variables = url?.queryItemDictionary?["variables"] else {
-        XCTFail("variables should not nil")
-        return
-      }
+      let variables = try XCTUnwrap(url?.queryItemDictionary?["variables"],
+                                    "variables should not nil")
+
       XCTAssertEqual(variables, "{\"episode\":\"EMPIRE\"}")
       
-      guard let ext = url?.queryItemDictionary?["extensions"],
+      guard
+        let ext = url?.queryItemDictionary?["extensions"],
         let data = ext.data(using: .utf8),
         let jsonBody = try? JSONSerializationFormat.deserialize(data: data) as? JSONObject
         else {
@@ -195,20 +178,14 @@ class GETTransformerTests: XCTestCase {
           return
       }
       
-      guard let comparePersistedQuery = jsonBody["persistedQuery"] as? JSONObject else {
-        XCTFail("persistedQuery is missing")
-        return
-      }
+      let comparePersistedQuery = try XCTUnwrap(jsonBody["persistedQuery"] as? JSONObject,
+                                                "persistedQuery is missing")
       
-      guard let sha256Hash = comparePersistedQuery["sha256Hash"] as? String else {
-        XCTFail("sha256Hash is missing")
-        return
-      }
+      let sha256Hash = try XCTUnwrap(comparePersistedQuery["sha256Hash"] as? String,
+                                     "sha256Hash is missing")
       
-      guard let version = comparePersistedQuery["version"] as? Int else {
-        XCTFail("version is missing")
-        return
-      }
+      let version = try XCTUnwrap(comparePersistedQuery["version"] as? Int,
+                                  "version is missing")
       
       XCTAssertEqual(version, 1)
       XCTAssertEqual(sha256Hash, "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671")
@@ -226,7 +203,7 @@ class GETTransformerTests: XCTestCase {
     XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroName&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D")
   }
   
-  func testEncodingQueryWith2DNullDefaultParameter() {
+  func testEncodingQueryWith2DNullDefaultParameter() throws {
     let operation = HeroNameQuery()
     
     let persistedQuery: GraphQLMap = [
@@ -252,13 +229,12 @@ class GETTransformerTests: XCTestCase {
     let queryString = url?.absoluteString == "http://localhost:8080/graphql?extensions=%7B%22persistedQuery%22:%7B%22sha256Hash%22:%22f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671%22,%22version%22:1%7D%7D&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D"
       XCTAssertTrue(queryString)
     } else {
-      guard let variables = url?.queryItemDictionary?["variables"] else {
-        XCTFail("variables should not nil")
-        return
-      }
+      let variables = try XCTUnwrap(url?.queryItemDictionary?["variables"],
+                                    "variables should not nil")
       XCTAssertEqual(variables, "{\"episode\":null}")
       
-      guard let ext = url?.queryItemDictionary?["extensions"],
+      guard
+        let ext = url?.queryItemDictionary?["extensions"],
         let data = ext.data(using: .utf8),
         let jsonBody = try? JSONSerializationFormat.deserialize(data: data) as? JSONObject
         else {
@@ -266,20 +242,14 @@ class GETTransformerTests: XCTestCase {
           return
       }
       
-      guard let comparePersistedQuery = jsonBody["persistedQuery"] as? JSONObject else {
-        XCTFail("persistedQuery is missing")
-        return
-      }
+      let comparePersistedQuery = try XCTUnwrap(jsonBody["persistedQuery"] as? JSONObject,
+                                                "persistedQuery is missing")
       
-      guard let sha256Hash = comparePersistedQuery["sha256Hash"] as? String else {
-        XCTFail("sha256Hash is missing")
-        return
-      }
+      let sha256Hash = try XCTUnwrap(comparePersistedQuery["sha256Hash"] as? String,
+                                     "sha256Hash is missing")
       
-      guard let version = comparePersistedQuery["version"] as? Int else {
-        XCTFail("version is missing")
-        return
-      }
+      let version = try XCTUnwrap(comparePersistedQuery["version"] as? Int,
+                                  "version is missing")
       
       XCTAssertEqual(version, 1)
       XCTAssertEqual(sha256Hash, "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671")

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -220,10 +220,9 @@ class HTTPTransportTests: XCTestCase {
       }
     }
 
-    guard let request = mockSession.lastRequest else {
-      XCTFail("last request should not be nil")
-      return
-    }
+    let request = try XCTUnwrap(mockSession.lastRequest,
+                                "last request should not be nil")
+    
     XCTAssertEqual(request.url?.host, network.url.host)
     XCTAssertEqual(request.httpMethod, "POST")
 
@@ -254,10 +253,9 @@ class HTTPTransportTests: XCTestCase {
       }
     }
 
-    guard let request = mockSession.lastRequest else {
-      XCTFail("last request should not be nil")
-      return
-    }
+    let request = try XCTUnwrap(mockSession.lastRequest,
+                                "last request should not be nil")
+
     XCTAssertEqual(request.url?.host, network.url.host)
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(self.retryCount, 0)
@@ -265,30 +263,24 @@ class HTTPTransportTests: XCTestCase {
     wait(for: [expectation], timeout: 1)
   }
   
-  func testClientNameAndVersionHeadersAreSent() {
+  func testClientNameAndVersionHeadersAreSent() throws {
     let mockSession = MockURLSession()
     let network = HTTPNetworkTransport(url: self.url,
                                        session: mockSession)
     let query = HeroNameQuery(episode: .empire)
     let _ = network.send(operation: query) { _ in }
     
-    guard let request = mockSession.lastRequest else {
-      XCTFail("last request should not be nil")
-      return
-    }
+    let request = try XCTUnwrap(mockSession.lastRequest,
+                                "last request should not be nil")
     
-    guard let clientName = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName) else {
-      XCTFail("Client name on last request was nil!")
-      return
-    }
+    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName),
+                                   "Client name on last request was nil!")
     
     XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
     XCTAssertEqual(clientName, network.clientName)
     
-    guard let clientVersion = request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion) else {
-      XCTFail("Client version on last request was nil!")
-      return
-    }
+    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion),
+                                      "Client version on last request was nil!")
     
     XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")
     XCTAssertEqual(clientVersion, network.clientVersion)

--- a/Tests/ApolloTests/NormalizeQueryResults.swift
+++ b/Tests/ApolloTests/NormalizeQueryResults.swift
@@ -17,7 +17,7 @@ class NormalizeQueryResults: XCTestCase {
     
     XCTAssertEqual(records?["QUERY_ROOT"]?["hero"] as? Reference, Reference(key: "QUERY_ROOT.hero"))
     
-    guard let hero = records?["QUERY_ROOT.hero"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero"])
     XCTAssertEqual(hero["name"] as? String, "R2-D2")
   }
   
@@ -34,7 +34,7 @@ class NormalizeQueryResults: XCTestCase {
     
     XCTAssertEqual(records?["QUERY_ROOT"]?["hero(episode:JEDI)"] as? Reference, Reference(key: "QUERY_ROOT.hero(episode:JEDI)"))
     
-    guard let hero = records?["QUERY_ROOT.hero(episode:JEDI)"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero(episode:JEDI)"])
     XCTAssertEqual(hero["name"] as? String, "R2-D2")
   }
   
@@ -51,7 +51,7 @@ class NormalizeQueryResults: XCTestCase {
     
     XCTAssertEqual(records?["QUERY_ROOT"]?["hero"] as? Reference, Reference(key: "QUERY_ROOT.hero"))
     
-    guard let hero = records?["QUERY_ROOT.hero"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero"])
     XCTAssertEqual(hero["appearsIn"] as? [String], ["NEWHOPE", "EMPIRE", "JEDI"])
   }
   
@@ -76,11 +76,11 @@ class NormalizeQueryResults: XCTestCase {
     
     XCTAssertEqual(records?["QUERY_ROOT"]?["hero(episode:JEDI)"] as? Reference, Reference(key: "QUERY_ROOT.hero(episode:JEDI)"))
     
-    guard let hero = records?["QUERY_ROOT.hero(episode:JEDI)"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero(episode:JEDI)"])
     XCTAssertEqual(hero["name"] as? String, "R2-D2")
     XCTAssertEqual(hero["friends"] as? [Reference], [Reference(key: "QUERY_ROOT.hero(episode:JEDI).friends.0"), Reference(key: "QUERY_ROOT.hero(episode:JEDI).friends.1"), Reference(key: "QUERY_ROOT.hero(episode:JEDI).friends.2")])
     
-    guard let luke = records?["QUERY_ROOT.hero(episode:JEDI).friends.0"] else { XCTFail(); return }
+    let luke = try XCTUnwrap(records?["QUERY_ROOT.hero(episode:JEDI).friends.0"])
     XCTAssertEqual(luke["name"] as? String, "Luke Skywalker")
   }
   
@@ -106,11 +106,11 @@ class NormalizeQueryResults: XCTestCase {
     
     XCTAssertEqual(records?["QUERY_ROOT"]?["hero(episode:JEDI)"] as? Reference, Reference(key: "2001"))
     
-    guard let hero = records?["2001"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["2001"])
     XCTAssertEqual(hero["name"] as? String, "R2-D2")
     XCTAssertEqual(hero["friends"] as? [Reference], [Reference(key: "1000"), Reference(key: "1002"), Reference(key: "1003")])
     
-    guard let luke = records?["1000"] else { XCTFail(); return }
+    let luke = try XCTUnwrap(records?["1000"])
     XCTAssertEqual(luke["name"] as? String, "Luke Skywalker")
   }
   
@@ -136,11 +136,11 @@ class NormalizeQueryResults: XCTestCase {
     
     XCTAssertEqual(records?["QUERY_ROOT"]?["hero(episode:JEDI)"] as? Reference, Reference(key: "2001"))
     
-    guard let hero = records?["2001"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["2001"])
     XCTAssertEqual(hero["name"] as? String, "R2-D2")
     XCTAssertEqual(hero["friends"] as? [Reference], [Reference(key: "2001.friends.0"), Reference(key: "2001.friends.1"), Reference(key: "2001.friends.2")])
     
-    guard let luke = records?["2001.friends.0"] else { XCTFail(); return }
+    let luke = try XCTUnwrap(records?["2001.friends.0"])
     XCTAssertEqual(luke["name"] as? String, "Luke Skywalker")
   }
   
@@ -156,7 +156,7 @@ class NormalizeQueryResults: XCTestCase {
     
     let (_, records) = try response.parseResult().await()
     
-    guard let hero = records?["QUERY_ROOT.hero"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero"])
     XCTAssertEqual(hero["__typename"] as? String, "Droid")
     XCTAssertEqual(hero["name"] as? String, "R2-D2")
     XCTAssertEqual(hero["appearsIn"] as? [String], ["NEWHOPE", "EMPIRE", "JEDI"])
@@ -173,7 +173,7 @@ class NormalizeQueryResults: XCTestCase {
     
     let (_, records) = try response.parseResult().await()
     
-    guard let hero = records?["QUERY_ROOT.hero"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero"])
     XCTAssertEqual(hero["primaryFunction"] as? String, "Astromech")
   }
   
@@ -188,7 +188,7 @@ class NormalizeQueryResults: XCTestCase {
     
     let (_, records) = try response.parseResult().await()
     
-    guard let hero = records?["QUERY_ROOT.hero"] else { XCTFail(); return }
+    let hero = try XCTUnwrap(records?["QUERY_ROOT.hero"])
     XCTAssertEqual(hero["homePlanet"] as? String, "Tatooine")
   }
   
@@ -209,7 +209,7 @@ class NormalizeQueryResults: XCTestCase {
     
     let (_, records) = try response.parseResult().await()
     
-    guard let luke = records?["QUERY_ROOT.hero.friends.0"] else { XCTFail(); return }
+    let luke = try XCTUnwrap(records?["QUERY_ROOT.hero.friends.0"])
     XCTAssertEqual(luke["height(unit:METER)"] as? Double, 1.72)
   }
   
@@ -230,7 +230,7 @@ class NormalizeQueryResults: XCTestCase {
     
     let (_, records) = try response.parseResult().await()
     
-    guard let han = records?["QUERY_ROOT.hero.friends.0"] else { XCTFail(); return }
+    let han = try XCTUnwrap(records?["QUERY_ROOT.hero.friends.0"])
     XCTAssertEqual(han["height(unit:FOOT)"] as? Double, 5.905512)
   }
 }

--- a/Tests/ApolloTests/ParseQueryResponseTests.swift
+++ b/Tests/ApolloTests/ParseQueryResponseTests.swift
@@ -193,10 +193,8 @@ class ParseQueryResponseTests: XCTestCase {
     
     let (result, _) = try response.parseResult().await()
     
-    guard let droid = result.data?.hero?.asDroid else {
-      XCTFail("Wrong type")
-      return
-    }
+    let droid = try XCTUnwrap(result.data?.hero?.asDroid,
+                              "Wrong type")
     
     XCTAssertEqual(droid.primaryFunction, "Astromech")
   }
@@ -212,10 +210,8 @@ class ParseQueryResponseTests: XCTestCase {
 
     let (result, _) = try response.parseResult().await()
 
-    guard let human = result.data?.hero?.asHuman else {
-      XCTFail("Wrong type")
-      return
-    }
+    let human = try XCTUnwrap(result.data?.hero?.asHuman,
+                              "Wrong type")
     
     XCTAssertEqual(human.height, 1.72)
   }
@@ -264,10 +260,8 @@ class ParseQueryResponseTests: XCTestCase {
     
     let (result, _) = try response.parseResult().await()
     
-    guard let droid = result.data?.hero?.fragments.heroDetails.asDroid else {
-      XCTFail("Wrong type")
-      return
-    }
+    let droid = try XCTUnwrap(result.data?.hero?.fragments.heroDetails.asDroid,
+                              "Wrong type")
     
     XCTAssertEqual(droid.primaryFunction, "Astromech")
   }
@@ -283,10 +277,8 @@ class ParseQueryResponseTests: XCTestCase {
 
     let (result, _) = try response.parseResult().await()
 
-    guard let human = result.data?.hero?.fragments.heroDetails.asHuman else {
-      XCTFail("Wrong type")
-      return
-    }
+    let human = try XCTUnwrap(result.data?.hero?.fragments.heroDetails.asHuman,
+                              "Wrong type")
     
     XCTAssertEqual(human.height, 1.72)
   }

--- a/Tests/ApolloTests/QueryFromJSONBuildingTests.swift
+++ b/Tests/ApolloTests/QueryFromJSONBuildingTests.swift
@@ -11,10 +11,8 @@ class QueryFromJSONBuildingTests: XCTestCase {
 
     let data = try HeroDetailsWithFragmentQuery.Data(jsonObject: jsonObject)
 
-    guard let human = data.hero?.fragments.heroDetails.asHuman else {
-      XCTFail("Wrong type")
-      return
-    }
+    let human = try XCTUnwrap(data.hero?.fragments.heroDetails.asHuman,
+                              "Wrong type")
     
     XCTAssertEqual(human.height, 1.72)
   }

--- a/Tests/ApolloTests/ReadFieldValueTests.swift
+++ b/Tests/ApolloTests/ReadFieldValueTests.swift
@@ -63,10 +63,8 @@ class ReadFieldValueTests: XCTestCase {
     let object: JSONObject = ["name": 10]
     let field = GraphQLField("name", type: .nonNull(.scalar(String.self)))
 
-    guard let value = try readFieldValue(field, from: object) as? String else {
-      XCTFail("Wrong type, name should be a String!")
-      return
-    }
+    let value = try XCTUnwrap(try readFieldValue(field, from: object) as? String,
+                              "Wrong type, name should be a String!")
 
     XCTAssertEqual(value, "10")
   }
@@ -121,10 +119,8 @@ class ReadFieldValueTests: XCTestCase {
     let object: JSONObject = ["name": 10]
     let field = GraphQLField("name", type: .scalar(String.self))
 
-    guard let value = try readFieldValue(field, from: object) as? String else {
-      XCTFail("Wrong type, name should be a String!")
-      return
-    }
+    let value = try XCTUnwrap(try readFieldValue(field, from: object) as? String,
+                              "Wrong type, name should be a String!")
 
     XCTAssertEqual(value, "10")
   }


### PR DESCRIPTION
Apple added a way to have your tests error out if something doesn't unwrap in Xcode 11 called [`XCTUnwrap`](https://developer.apple.com/documentation/xctest/3380195-xctunwrap) - thanks to @basthomas for reminding me this existed, and inspiring me to clean all this up. 