### PR TITLE
Make `clientName` and `clientVersion` get-only protocol requirements

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -377,8 +377,7 @@ public class HTTPNetworkTransport {
                                                sendQueryDocument: sendQueryDocument,
                                                autoPersistQuery: autoPersistQueries)
     var request = URLRequest(url: self.url)
-    request.setValue(self.clientName, forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName)
-    request.setValue(self.clientVersion, forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion)
+    self.addClientHeaders(to: &request)
     
     // We default to json, but this can be changed below if needed.
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -377,7 +377,7 @@ public class HTTPNetworkTransport {
                                                sendQueryDocument: sendQueryDocument,
                                                autoPersistQuery: autoPersistQueries)
     var request = URLRequest(url: self.url)
-    self.addClientHeaders(to: &request)
+    self.addApolloClientHeaders(to: &request)
     
     // We default to json, but this can be changed below if needed.
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -23,12 +23,12 @@ public protocol NetworkTransport: class {
 public extension NetworkTransport {
   
   /// The field name for the Apollo Client Name header
-  var headerFieldNameApolloClientName: String {
+  static var headerFieldNameApolloClientName: String {
     return "apollographql-client-name"
   }
   
   /// The field name for the Apollo Client Version header
-  var headerFieldNameApolloClientVersion: String {
+  static var headerFieldNameApolloClientVersion: String {
     return "apollographql-client-version"
   }
   
@@ -74,8 +74,8 @@ public extension NetworkTransport {
   /// Adds the Apollo client headers for this instance of `NetworkTransport` to the given request
   /// - Parameter request: A mutable URLRequest to add the headers to.
   func addApolloClientHeaders(to request: inout URLRequest) {
-    request.setValue(self.clientName, forHTTPHeaderField: self.headerFieldNameApolloClientName)
-    request.setValue(self.clientVersion, forHTTPHeaderField: self.headerFieldNameApolloClientVersion)
+    request.setValue(self.clientName, forHTTPHeaderField: Self.headerFieldNameApolloClientName)
+    request.setValue(self.clientVersion, forHTTPHeaderField: Self.headerFieldNameApolloClientVersion)
   }
 }
 

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -22,13 +22,13 @@ public protocol NetworkTransport: class {
 
 public extension NetworkTransport {
   
-  /// The header field name for the Client Name
-  var headerFieldNameClientName: String {
+  /// The field name for the Apollo Client Name header
+  var headerFieldNameApolloClientName: String {
     return "apollographql-client-name"
   }
   
-  /// The header field name for the client version
-  var headerFieldNameClientVersion: String {
+  /// The field name for the Apollo Client Version header
+  var headerFieldNameApolloClientVersion: String {
     return "apollographql-client-version"
   }
   
@@ -63,11 +63,11 @@ public extension NetworkTransport {
     return version
   }
   
-  /// Adds the client headers for this instance of `NetworkTransport` to the given request
+  /// Adds the Apollo client headers for this instance of `NetworkTransport` to the given request
   /// - Parameter request: A mutable URLRequest to add the headers to.
-  func addClientHeaders(to request: inout URLRequest) {
-    request.setValue(self.clientName, forHTTPHeaderField: self.headerFieldNameClientName)
-    request.setValue(self.clientVersion, forHTTPHeaderField: self.headerFieldNameClientVersion)
+  func addApolloClientHeaders(to request: inout URLRequest) {
+    request.setValue(self.clientName, forHTTPHeaderField: self.headerFieldNameApolloClientName)
+    request.setValue(self.clientVersion, forHTTPHeaderField: self.headerFieldNameApolloClientVersion)
   }
 }
 

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -12,10 +12,10 @@ public protocol NetworkTransport: class {
   func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
   
   /// The name of the client to send as the `"apollographql-client-name"` header.
-  var clientName: String { get set }
+  var clientName: String { get }
   
   /// The version of the client to send as the `"apollographql-client-version"` header
-  var clientVersion: String { get set }
+  var clientVersion: String { get }
 }
 
 public extension NetworkTransport {

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -5,7 +5,7 @@ public protocol NetworkTransport: class {
   
   /// Send a GraphQL operation to a server and return a response.
   ///
-  /// Note: The `clientName` and `clientVersion` should be sent with any URL request which needs headers so your client can be identified by tools like Apollo Graph Manager. The `addClientHeaders` method is provided below to do this for you automatically, and this is handled for you by batteries-included versions of `NetworkTransport`. 
+  /// Note if you're implementing this yourself rather than using one of the batteries-included versions of `NetworkTransport` (which handle this for you): The `clientName` and `clientVersion` should be sent with any URL request which needs headers so your client can be identified by tools meant to see what client is using which request. The `addApolloClientHeaders` method is provided below to do this for you if you're using Apollo Graph Manager.
   ///
   /// - Parameters:
   ///   - operation: The operation to send.
@@ -13,10 +13,10 @@ public protocol NetworkTransport: class {
   /// - Returns: An object that can be used to cancel an in progress request.
   func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
   
-  /// The name of the client to send as the `"apollographql-client-name"` header.
+  /// The name of the client to send as a header value.
   var clientName: String { get }
   
-  /// The version of the client to send as the `"apollographql-client-version"` header
+  /// The version of the client to send as a header value.
   var clientVersion: String { get }
 }
 

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -21,12 +21,12 @@ public protocol NetworkTransport: class {
 public extension NetworkTransport {
   
   /// The header field name for the Client Name
-  static var headerFieldNameClientName: String {
+  var headerFieldNameClientName: String {
     return "apollographql-client-name"
   }
   
   /// The header field name for the client version
-  static var headerFieldNameClientVersion: String {
+  var headerFieldNameClientVersion: String {
     return "apollographql-client-version"
   }
   
@@ -59,6 +59,13 @@ public extension NetworkTransport {
     }
     
     return version
+  }
+  
+  /// Adds the client headers for this instance of `NetworkTransport` to the given request
+  /// - Parameter request: A mutable URLRequest to add the headers to.
+  func addClientHeaders(to request: inout URLRequest) {
+    request.setValue(self.clientName, forHTTPHeaderField: self.headerFieldNameClientName)
+    request.setValue(self.clientVersion, forHTTPHeaderField: self.headerFieldNameClientVersion)
   }
 }
 

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -41,6 +41,10 @@ public extension NetworkTransport {
     return "\(identifier)-apollo-ios"
   }
   
+  var clientName: String {
+    return Self.defaultClientName
+  }
+  
   /// The default client version to use when setting up the `clientVersion` property.
   static var defaultClientVersion: String {
     var version = String()
@@ -61,6 +65,10 @@ public extension NetworkTransport {
     }
     
     return version
+  }
+  
+  var clientVersion: String {
+    return Self.defaultClientVersion
   }
   
   /// Adds the Apollo client headers for this instance of `NetworkTransport` to the given request

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -5,6 +5,8 @@ public protocol NetworkTransport: class {
   
   /// Send a GraphQL operation to a server and return a response.
   ///
+  /// Note: The `clientName` and `clientVersion` should be sent with any URL request which needs headers so your client can be identified by tools like Apollo Graph Manager. The `addClientHeaders` method is provided below to do this for you automatically, and this is handled for you by batteries-included versions of `NetworkTransport`. 
+  ///
   /// - Parameters:
   ///   - operation: The operation to send.
   ///   - completionHandler: A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred.

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -23,7 +23,7 @@ public class SplitNetworkTransport {
     if httpVersion == websocketVersion {
       return httpVersion
     } else {
-      return "SPLIT_HTTPVERSION_\(httpVersion)_WEBSOCKETNAME_\(websocketVersion)"
+      return "SPLIT_HTTPVERSION_\(httpVersion)_WEBSOCKETVERSION_\(websocketVersion)"
     }
   }
   

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -8,34 +8,22 @@ public class SplitNetworkTransport {
   private let webSocketNetworkTransport: NetworkTransport
   
   public var clientName: String {
-    get {
-      let httpName = self.httpNetworkTransport.clientName
-      let websocketName = self.webSocketNetworkTransport.clientName
-      if httpName == websocketName {
-        return httpName
-      } else {
-        return "SPLIT_HTTPNAME_\(httpName)_WEBSOCKETNAME_\(websocketName)"
-      }
-    }
-    set {
-      self.httpNetworkTransport.clientName = newValue
-      self.webSocketNetworkTransport.clientName = newValue
+    let httpName = self.httpNetworkTransport.clientName
+    let websocketName = self.webSocketNetworkTransport.clientName
+    if httpName == websocketName {
+      return httpName
+    } else {
+      return "SPLIT_HTTPNAME_\(httpName)_WEBSOCKETNAME_\(websocketName)"
     }
   }
 
   public var clientVersion: String {
-    get {
-      let httpVersion = self.httpNetworkTransport.clientVersion
-      let websocketVersion = self.webSocketNetworkTransport.clientVersion
-      if httpVersion == websocketVersion {
-        return httpVersion
-      } else {
-        return "SPLIT_HTTPVERSION_\(httpVersion)_WEBSOCKETNAME_\(websocketVersion)"
-      }
-    }
-    set {
-      self.httpNetworkTransport.clientVersion = newValue
-      self.webSocketNetworkTransport.clientVersion = newValue
+    let httpVersion = self.httpNetworkTransport.clientVersion
+    let websocketVersion = self.webSocketNetworkTransport.clientVersion
+    if httpVersion == websocketVersion {
+      return httpVersion
+    } else {
+      return "SPLIT_HTTPVERSION_\(httpVersion)_WEBSOCKETNAME_\(websocketVersion)"
     }
   }
   

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -50,14 +50,14 @@ public class WebSocketTransport {
   /// NOTE: Setting this won't override immediately if the socket is still connected, only on reconnection.
   public var clientName: String {
     didSet {
-      self.websocket.request.setValue(self.clientName, forHTTPHeaderField: "apollographql-client-name")
+      self.addClientHeaders(to: &self.websocket.request)
     }
   }
   
   /// NOTE: Setting this won't override immediately if the socket is still connected, only on reconnection.
   public var clientVersion: String {
     didSet {
-      self.websocket.request.setValue(self.clientVersion, forHTTPHeaderField: "apollographql-client-version")
+      self.addClientHeaders(to: &self.websocket.request)
     }
   }
   
@@ -84,8 +84,7 @@ public class WebSocketTransport {
     self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
     self.clientName = clientName
     self.clientVersion = clientVersion
-    self.websocket.request.setValue(self.clientName, forHTTPHeaderField: WebSocketTransport.headerFieldNameClientName)
-    self.websocket.request.setValue(self.clientVersion, forHTTPHeaderField: WebSocketTransport.headerFieldNameClientVersion)
+    self.addClientHeaders(to: &self.websocket.request)
     self.websocket.delegate = self
     self.websocket.connect()
     self.websocket.callbackQueue = processingQueue

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -50,14 +50,14 @@ public class WebSocketTransport {
   /// NOTE: Setting this won't override immediately if the socket is still connected, only on reconnection.
   public var clientName: String {
     didSet {
-      self.addClientHeaders(to: &self.websocket.request)
+      self.addApolloClientHeaders(to: &self.websocket.request)
     }
   }
   
   /// NOTE: Setting this won't override immediately if the socket is still connected, only on reconnection.
   public var clientVersion: String {
     didSet {
-      self.addClientHeaders(to: &self.websocket.request)
+      self.addApolloClientHeaders(to: &self.websocket.request)
     }
   }
   
@@ -84,7 +84,7 @@ public class WebSocketTransport {
     self.websocket = WebSocketTransport.provider.init(request: request, protocols: protocols)
     self.clientName = clientName
     self.clientVersion = clientVersion
-    self.addClientHeaders(to: &self.websocket.request)
+    self.addApolloClientHeaders(to: &self.websocket.request)
     self.websocket.delegate = self
     self.websocket.connect()
     self.websocket.callbackQueue = processingQueue

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -273,13 +273,13 @@ class HTTPTransportTests: XCTestCase {
     let request = try XCTUnwrap(mockSession.lastRequest,
                                 "last request should not be nil")
     
-    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientName),
+    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameClientName),
                                    "Client name on last request was nil!")
     
     XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
     XCTAssertEqual(clientName, network.clientName)
     
-    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameClientVersion),
+    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameClientVersion),
                                       "Client version on last request was nil!")
     
     XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -273,13 +273,13 @@ class HTTPTransportTests: XCTestCase {
     let request = try XCTUnwrap(mockSession.lastRequest,
                                 "last request should not be nil")
     
-    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameApolloClientName),
+    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameApolloClientName),
                                    "Client name on last request was nil!")
     
     XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
     XCTAssertEqual(clientName, network.clientName)
     
-    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameApolloClientVersion),
+    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: HTTPNetworkTransport.headerFieldNameApolloClientVersion),
                                       "Client version on last request was nil!")
     
     XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -273,13 +273,13 @@ class HTTPTransportTests: XCTestCase {
     let request = try XCTUnwrap(mockSession.lastRequest,
                                 "last request should not be nil")
     
-    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameClientName),
+    let clientName = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameApolloClientName),
                                    "Client name on last request was nil!")
     
     XCTAssertFalse(clientName.isEmpty, "Client name was empty!")
     XCTAssertEqual(clientName, network.clientName)
     
-    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameClientVersion),
+    let clientVersion = try XCTUnwrap(request.value(forHTTPHeaderField: network.headerFieldNameApolloClientVersion),
                                       "Client version on last request was nil!")
     
     XCTAssertFalse(clientVersion.isEmpty, "Client version was empty!")

--- a/Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift
+++ b/Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift
@@ -40,38 +40,35 @@ class SplitNetworkTransportTests: XCTestCase {
     webSocketNetworkTransport: self.webSocketTransport
   )
   
-  
-  func testGettingSplitClientName() {
+  func testGettingSplitClientNameWithDifferentNames() {
     let splitName = self.splitTransport.clientName
     XCTAssertTrue(splitName.hasPrefix("SPLIT_"))
     XCTAssertTrue(splitName.contains(self.httpName))
     XCTAssertTrue(splitName.contains(self.webSocketName))
   }
   
-  func testGettingSplitClientVersion() {
+  func testGettingSplitClientVersionWithDifferentVersions() {
     let splitVersion = self.splitTransport.clientVersion
     XCTAssertTrue(splitVersion.hasPrefix("SPLIT_"))
     XCTAssertTrue(splitVersion.contains(self.httpVersion))
     XCTAssertTrue(splitVersion.contains(self.webSocketVersion))
   }
 
-  func testSettingSplitClientName() {
+  func testGettingSplitClientNameWithTheSameNames() {
     let splitName = "TestSplitClientName"
     
-    self.splitTransport.clientName = splitName
+    self.webSocketTransport.clientName = splitName
+    self.httpTransport.clientName = splitName
     
     XCTAssertEqual(self.splitTransport.clientName, splitName)
-    XCTAssertEqual(self.webSocketTransport.clientName, splitName)
-    XCTAssertEqual(self.httpTransport.clientName, splitName)
   }
   
-  func testSettingSplitClientVersion() {
+  func testGettingSplitClientVersionWithTheSameVersions() {
     let splitVersion = "TestSplitClientVersion"
     
-    self.splitTransport.clientVersion = splitVersion
+    self.webSocketTransport.clientVersion = splitVersion
+    self.httpTransport.clientVersion = splitVersion
     
     XCTAssertEqual(self.splitTransport.clientVersion, splitVersion)
-    XCTAssertEqual(self.webSocketTransport.clientVersion, splitVersion)
-    XCTAssertEqual(self.httpTransport.clientVersion, splitVersion)
   }
 }


### PR DESCRIPTION
**BREAKING CHANGE** 

This has been much-discussed in #877 and #917, and it's clear that for people implementing their own `NetworkTransport` method rather than using one of ours, having to provide a setter for this is really annoying. If implementers still want to make the property get/set, they can (and we do with `HTTPNetworkTransport`). 

Also added a convenience method to add the headers to any `URLRequest`, and added a note to the `send` method that these should probably be sent along if you want to use monitoring tools like Apollo Graph Manager.