### PR TITLE
Fixing some weirdness with circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
     environment:
       DESTINATION: platform=tvOS Simulator,OS=13.3,name=Apple TV
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: appletvsimulator13.3
+      CIRCLE_XCODE_SDK: appletvsimulator13.2
     steps:
       - common_test_steps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,6 @@ jobs:
     steps:
       - common_test_steps
 
-  iOS11_4:
-    macos:
-      xcode: "11.3.0"
-    environment:
-      DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
-      CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.2
-    steps:
-      - common_test_steps
-
   tvOS13_0:
     macos:
       xcode: "11.3.0"
@@ -114,16 +104,6 @@ jobs:
     steps:
       - common_test_steps
 
-  SQLiteiOS11_4:
-    macos:
-      xcode: "11.3.0"
-    environment:
-      DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
-      CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.2
-    steps:
-      - common_test_steps
-
   WebSocketmacOS10_15:
     macos:
       xcode: "11.3.0"
@@ -154,16 +134,6 @@ jobs:
     steps:
       - common_test_steps
 
-  WebSocketiOS11_4:
-    macos:
-      xcode: "11.3.0"
-    environment:
-      DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
-      CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.2
-    steps:
-      - common_test_steps
-
   CocoaPodsTrunk:
     macos:
       xcode: "11.3.0"
@@ -186,8 +156,6 @@ workflows:
           name: Apollo iOS 13.3
       - iOS12_4:
           name: Apollo iOS 12.4
-      - iOS11_4:
-          name: Apollo iOS 11.4
       - tvOS13_0:
           name: Apollo tvOS 13.0
       - SQLitemacOS10_15:
@@ -196,32 +164,25 @@ workflows:
           name: ApolloSQLite iOS 13.3
       - SQLiteiOS12_4:
           name: ApolloSQLite iOS 12.4
-      - SQLiteiOS11_4:
-          name: ApolloSQLite iOS 11.4
       - WebSocketmacOS10_15:
           name: ApolloWebSocket macOS 10.15
       - WebSocketiOS13_1:
           name: ApolloWebSocket iOS 13.3
       - WebSocketiOS12_4:
           name: ApolloWebSocket iOS 12.4
-      - WebSocketiOS11_4:
-          name: ApolloWebSocket iOS 11.4
       - CocoaPodsTrunk:
           name: Push Podspec to CocoaPods Trunk
           requires:
             - Apollo macOS 10.15
             - Apollo iOS 13.3
             - Apollo iOS 12.4
-            - Apollo iOS 11.4
             - Apollo tvOS 13.0
             - ApolloSQLite macOS 10.15
             - ApolloSQLite iOS 13.3
             - ApolloSQLite iOS 12.4
-            - ApolloSQLite iOS 11.4
             - ApolloWebSocket macOS 10.15
             - ApolloWebSocket iOS 13.3
             - ApolloWebSocket iOS 12.4
-            - ApolloWebSocket iOS 11.4
           filters:
             # Only build semver tags
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,13 @@ jobs:
     steps:
       - common_test_steps
 
-  tvOS13_0:
+  tvOS13_3:
     macos:
       xcode: "11.3.0"
     environment:
-      DESTINATION: platform=tvOS Simulator,OS=13.0,name=Apple TV
+      DESTINATION: platform=tvOS Simulator,OS=13.3,name=Apple TV
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: appletvsimulator13.0
+      CIRCLE_XCODE_SDK: appletvsimulator13.3
     steps:
       - common_test_steps
 
@@ -156,8 +156,8 @@ workflows:
           name: Apollo iOS 13.3
       - iOS12_4:
           name: Apollo iOS 12.4
-      - tvOS13_0:
-          name: Apollo tvOS 13.0
+      - tvOS13_3:
+          name: Apollo tvOS 13.3
       - SQLitemacOS10_15:
           name: ApolloSQLite macOS 10.15
       - SQLiteiOS13_1:
@@ -176,7 +176,7 @@ workflows:
             - Apollo macOS 10.15
             - Apollo iOS 13.3
             - Apollo iOS 12.4
-            - Apollo tvOS 13.0
+            - Apollo tvOS 13.3
             - ApolloSQLite macOS 10.15
             - ApolloSQLite iOS 13.3
             - ApolloSQLite iOS 12.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=13.3,name=iPhone 11
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -60,7 +60,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -70,7 +70,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -100,7 +100,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=13.3,name=iPhone 11
       CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -110,7 +110,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -120,7 +120,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -140,7 +140,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=13.3,name=iPhone 11
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -150,7 +150,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 
@@ -160,7 +160,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.3
+      CIRCLE_XCODE_SDK: iphonesimulator13.2
     steps:
       - common_test_steps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - common_test_steps
 
-  iOS13_1:
+  iOS13_3:
     macos:
       xcode: "11.3.0"
     environment:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - common_test_steps
 
-  SQLiteiOS13_1:
+  SQLiteiOS13_3:
     macos:
       xcode: "11.3.0"
     environment:
@@ -114,7 +114,7 @@ jobs:
     steps:
       - common_test_steps
 
-  WebSocketiOS13_1:
+  WebSocketiOS13_3:
     macos:
       xcode: "11.3.0"
     environment:
@@ -152,7 +152,7 @@ workflows:
     jobs:
       - macOS10_15:
           name: Apollo macOS 10.15
-      - iOS13_1:
+      - iOS13_3:
           name: Apollo iOS 13.3
       - iOS12_4:
           name: Apollo iOS 12.4
@@ -160,13 +160,13 @@ workflows:
           name: Apollo tvOS 13.3
       - SQLitemacOS10_15:
           name: ApolloSQLite macOS 10.15
-      - SQLiteiOS13_1:
+      - SQLiteiOS13_3:
           name: ApolloSQLite iOS 13.3
       - SQLiteiOS12_4:
           name: ApolloSQLite iOS 12.4
       - WebSocketmacOS10_15:
           name: ApolloWebSocket macOS 10.15
-      - WebSocketiOS13_1:
+      - WebSocketiOS13_3:
           name: ApolloWebSocket iOS 13.3
       - WebSocketiOS12_4:
           name: ApolloWebSocket iOS 12.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ commands:
       - run:
           name: "Pull Submodules"
           command: |
-            git submodule init
-            git submodule update --remote
+            git submodule update --init
       - run:
           command: ./scripts/install-or-update-starwars-server.sh
           name: Install/Update StarWars Server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
 jobs:
   macOS10_15:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=macOS,arch=x86_64
       CIRCLE_XCODE_SCHEME: Apollo
@@ -46,7 +46,7 @@ jobs:
 
   iOS13_1:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=13.1,name=iPhone 11
       CIRCLE_XCODE_SCHEME: Apollo
@@ -56,7 +56,7 @@ jobs:
 
   iOS12_4:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: Apollo
@@ -66,7 +66,7 @@ jobs:
 
   iOS11_4:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: Apollo
@@ -76,7 +76,7 @@ jobs:
 
   tvOS13_0:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=tvOS Simulator,OS=13.0,name=Apple TV
       CIRCLE_XCODE_SCHEME: Apollo
@@ -86,7 +86,7 @@ jobs:
 
   SQLitemacOS10_15:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=macOS,arch=x86_64
       CIRCLE_XCODE_SCHEME: ApolloSQLite
@@ -96,7 +96,7 @@ jobs:
 
   SQLiteiOS13_1:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=13.1,name=iPhone 11
       CIRCLE_XCODE_SCHEME: ApolloSQLite
@@ -106,7 +106,7 @@ jobs:
 
   SQLiteiOS12_4:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: ApolloSQLite
@@ -116,7 +116,7 @@ jobs:
 
   SQLiteiOS11_4:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: ApolloSQLite
@@ -126,7 +126,7 @@ jobs:
 
   WebSocketmacOS10_15:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=macOS,arch=x86_64
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
@@ -136,7 +136,7 @@ jobs:
 
   WebSocketiOS13_1:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=13.1,name=iPhone 11
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
@@ -146,7 +146,7 @@ jobs:
 
   WebSocketiOS12_4:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
@@ -156,7 +156,7 @@ jobs:
 
   WebSocketiOS11_4:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
@@ -166,7 +166,7 @@ jobs:
 
   CocoaPodsTrunk:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.0"
     steps:
       - checkout
       # TODO: Remove when Circle updates the version of CP installed on their

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
     macos:
       xcode: "11.3.0"
     environment:
-      DESTINATION: platform=iOS Simulator,OS=13.1,name=iPhone 11
+      DESTINATION: platform=iOS Simulator,OS=13.3,name=iPhone 11
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -60,7 +60,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -70,7 +70,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: Apollo
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -98,9 +98,9 @@ jobs:
     macos:
       xcode: "11.3.0"
     environment:
-      DESTINATION: platform=iOS Simulator,OS=13.1,name=iPhone 11
+      DESTINATION: platform=iOS Simulator,OS=13.3,name=iPhone 11
       CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -110,7 +110,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -120,7 +120,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: ApolloSQLite
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -138,9 +138,9 @@ jobs:
     macos:
       xcode: "11.3.0"
     environment:
-      DESTINATION: platform=iOS Simulator,OS=13.1,name=iPhone 11
+      DESTINATION: platform=iOS Simulator,OS=13.3,name=iPhone 11
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -150,7 +150,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=12.2,name=iPhone XS
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -160,7 +160,7 @@ jobs:
     environment:
       DESTINATION: platform=iOS Simulator,OS=11.4,name=iPhone 8
       CIRCLE_XCODE_SCHEME: ApolloWebSocket
-      CIRCLE_XCODE_SDK: iphonesimulator13.1
+      CIRCLE_XCODE_SDK: iphonesimulator13.3
     steps:
       - common_test_steps
 
@@ -183,7 +183,7 @@ workflows:
       - macOS10_15:
           name: Apollo macOS 10.15
       - iOS13_1:
-          name: Apollo iOS 13.1
+          name: Apollo iOS 13.3
       - iOS12_4:
           name: Apollo iOS 12.4
       - iOS11_4:
@@ -193,7 +193,7 @@ workflows:
       - SQLitemacOS10_15:
           name: ApolloSQLite macOS 10.15
       - SQLiteiOS13_1:
-          name: ApolloSQLite iOS 13.1
+          name: ApolloSQLite iOS 13.3
       - SQLiteiOS12_4:
           name: ApolloSQLite iOS 12.4
       - SQLiteiOS11_4:
@@ -201,7 +201,7 @@ workflows:
       - WebSocketmacOS10_15:
           name: ApolloWebSocket macOS 10.15
       - WebSocketiOS13_1:
-          name: ApolloWebSocket iOS 13.1
+          name: ApolloWebSocket iOS 13.3
       - WebSocketiOS12_4:
           name: ApolloWebSocket iOS 12.4
       - WebSocketiOS11_4:
@@ -210,16 +210,16 @@ workflows:
           name: Push Podspec to CocoaPods Trunk
           requires:
             - Apollo macOS 10.15
-            - Apollo iOS 13.1
+            - Apollo iOS 13.3
             - Apollo iOS 12.4
             - Apollo iOS 11.4
             - Apollo tvOS 13.0
             - ApolloSQLite macOS 10.15
-            - ApolloSQLite iOS 13.1
+            - ApolloSQLite iOS 13.3
             - ApolloSQLite iOS 12.4
             - ApolloSQLite iOS 11.4
             - ApolloWebSocket macOS 10.15
-            - ApolloWebSocket iOS 13.1
+            - ApolloWebSocket iOS 13.3
             - ApolloWebSocket iOS 12.4
             - ApolloWebSocket iOS 11.4
           filters:


### PR DESCRIPTION
Suddenly some WebSocket tests that build fine on a local 11.3 weren't building at all on an 11.1 image. Not sure what's going on there but we should update to the 11.3 image anyway.