### PR TITLE
Expose HTTPNetworkDelegate publicly as weak var

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -99,10 +99,12 @@ public class HTTPNetworkTransport {
   let useGETForQueries: Bool
   let enableAutoPersistedQueries: Bool
   let useGETForPersistedQueryRetry: Bool
-  let delegate: HTTPNetworkTransportDelegate?
   private let requestCreator: RequestCreator
   private let sendOperationIdentifiers: Bool
-  
+
+  /// A delegate which can conform to any or all of `HTTPNetworkTransportPreflightDelegate`, `HTTPNetworkTransportTaskCompletedDelegate`, and `HTTPNetworkTransportRetryDelegate`.
+  public weak var delegate: HTTPNetworkTransportDelegate?
+
   public lazy var clientName = HTTPNetworkTransport.defaultClientName
   public lazy var clientVersion = HTTPNetworkTransport.defaultClientVersion
   


### PR DESCRIPTION
Had a good [discussion in Spectrum about why this was set as an internal `let` rather than a `public weak var`](https://spectrum.chat/apollo/apollo-ios/delegate-in-httpnetworktransport~ea1545c2-f8dd-4442-844c-13aaaeaefed3), which would allow the delegate to be set after initialization.

Having dug back through the history of the code, there really wasn't a good reason not to do it that way, so I've gone ahead and made the change. 

This is a **potentially breaking change** - in theory switching this to a `weak var` mostly helps prevent retain cycles, but if you weren't holding on to the delegate already, this could theoretically result in the delegate getting autoreleased in places it wasn't before.