### PR TITLE
Update Roadmap for Spring 2020

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document is meant to give the community some idea of where we're going with the iOS SDK in the short and longer term. 
 
-This document was last updated on October 2, 2019. 
+This document was last updated on Feburary 4, 2020. 
 
 ^ If that's more than three months ago, please file an issue asking [@designatednerd](https://github.com/designatednerd) to update this document. 😃
 
@@ -11,17 +11,15 @@ This document was last updated on October 2, 2019.
 
 These are things we plan to be working on **within the next 3 months**.
 
-- **More up-to-date documentation**: We'll be going through the docs in greater detail to make sure everything is up to snuff. We're also planning to significantly beef up the docs on the community-contributed `ApolloSQLite` and `ApolloWebSocket` libraries, which are a bit anemic. If there's anything in particular you see that definitely needs to be updated, please open an issue!
+- **Swift Codegen Rewrite**: As outlined in much greater detail in the [RFC issue](https://github.com/apollographql/apollo-ios/issues/939), this will happen in several phases:
+    
+    - **Run existing codegen with Swift instead of Bash**. This will allow for more type-safe and easier to troubleshoot scripts. 
+    - **Start generating code with Swift instead of Typescript**. This will allow much easier community contribution to code generation, and allow us to take on a bunch of improvements like `Hashable`, `Equatable`, and potentially `Identifiable` without having to fight with Typescript to do it.
+    - **Add immutable caching to new generated code**. Caching is currently heavily tied into our existing parsing mechanism. We're going to separate that out in two phases: The first will allow caching that *cannot* be changed by the consumer.
+    - **Add mutable caching to new generated code**. This is the final stage of updating caching: Allowing caching that *can* be changed by the consumer.
+    - **Remove Old Codegen**. Once all this is built, older codegen will be deprecated. 
 
-- **Better examples**: Right now most of our iOS sample code is out of date. We'll be working on some new sample apps to give some better examples of what you can do with the Apollo client and its libraries, and we'll be updating these examples more frequently.
-
-- **Swift Code, Generated In Swift**: As described in the [call for suggestions](https://github.com/apollographql/apollo-ios/issues/682), we're going to move the "generation" bit of codegen from Typescript into Swift.
-
-  There are several advantages of this, but the biggest one is opening up the ability of our mostly-Swift devs to contribute to Codegen improvements without having to deal with TypeScript and all of its fun edge cases. 
-
-  We're also taking this as an opportunity to make a number of things Swiftier, particularly inlcuding using `Codable` for parsing, and making everything conform to `Hashable` and `Equatable` (and potentially taking a look at (`Identifiable` for Swift 5.1 support)
-
-  You can follow this effort through the [Swift Codegen GitHub project](https://github.com/apollographql/apollo-ios/projects/2).
+    You can follow this effort through the [Swift Codegen GitHub project](https://github.com/apollographql/apollo-ios/projects/2).
 
 - **General bug-bashing**: There's still a few outstanding general issues and small feature requests I'd like to address, and we'll be dealing with any new issues as they come up.
 
@@ -33,10 +31,6 @@ These are things we plan to be working on **beyond the next 3 months**.
 We're very open to any help we can get on these if your goals would be advanced by making these things work better sooner.
 
 - **Dependency Manager test suite**. We've seen a few issues around things that work well for at least one of the three major iOS dependency managers, but causes problems in others. We plan to make a repo that we can use to automatically test for common issues against new versions of the library on CocoaPods, Carthage, and Swift Package Manager *before* they're released.
-
-- **Better caching**. Right now there are a few issues around cache eviction and expiration for the `InMemoryNormalizedCache` (namely, they don't happen automatically), and some architectural issues around where we're locking to ensure thread-safe access to caches. 
-
-  These aren't affecting the majority of users at the moment, but as we grow, we need to make sure these tools scale better. 
 
 - **Wrapper libraries**. A very highly voted suggestion in our fall 2019 developer survey was wrapper libraries for concurrency helpers like RxSwift, Combine, and PromiseKit. 
 


### PR DESCRIPTION
This pulls in a high-level summary of the Swift Codegen rewrite from #939 to the official `ROADMAP.md` document.