### PR TITLE
Remove delegate from `HTTPNetworkTransport` initializer

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -117,14 +117,12 @@ public class HTTPNetworkTransport {
   ///   - useGETForQueries: If query operation should be sent using GET instead of POST. Defaults to false.
   ///   - enableAutoPersistedQueries: Whether to send persistedQuery extension. QueryDocument will be absent at 1st request, retry with QueryDocument if server respond PersistedQueryNotFound or PersistedQueryNotSupport. Defaults to false.
   ///   - useGETForPersistedQueryRetry: Whether to retry persistedQuery request with HttpGetMethod. Defaults to false.
-  ///   - delegate: [Optional] A delegate which can conform to any or all of `HTTPNetworkTransportPreflightDelegate`, `HTTPNetworkTransportTaskCompletedDelegate`, and `HTTPNetworkTransportRetryDelegate`. Defaults to nil.
   public init(url: URL,
               session: URLSession = .shared,
               sendOperationIdentifiers: Bool = false,
               useGETForQueries: Bool = false,
               enableAutoPersistedQueries: Bool = false,
               useGETForPersistedQueryRetry: Bool = false,
-              delegate: HTTPNetworkTransportDelegate? = nil,
               requestCreator: RequestCreator = ApolloRequestCreator()) {
     self.url = url
     self.session = session
@@ -132,7 +130,6 @@ public class HTTPNetworkTransport {
     self.useGETForQueries = useGETForQueries
     self.enableAutoPersistedQueries = enableAutoPersistedQueries
     self.useGETForPersistedQueryRetry = useGETForPersistedQueryRetry
-    self.delegate = delegate
     self.requestCreator = requestCreator
   }
 

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -473,5 +473,8 @@ class FetchQueryTests: XCTestCase {
     }
     self.wait(for: [expectation], timeout: 10)
     
+    for watcher in watchers {
+      watcher.cancel()
+    }
   }
 }

--- a/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
@@ -29,10 +29,11 @@ class APQsWithGetMethodConfig: TestConfig, HTTPNetworkTransportRetryDelegate{
   }
   
   func network() -> HTTPNetworkTransport {
-    return HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql")!,
+    let transport = HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql")!,
                                 enableAutoPersistedQueries: true,
-                                useGETForPersistedQueryRetry: true,
-                                delegate: self)
+                                useGETForPersistedQueryRetry: true)
+    transport.delegate = self
+    return transport
   }
   
 }

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -28,9 +28,12 @@ class HTTPTransportTests: XCTestCase {
   private var graphQlErrors = [GraphQLError]()
 
   private lazy var url = URL(string: "http://localhost:8080/graphql")!
-  private lazy var networkTransport = HTTPNetworkTransport(url: self.url,
-                                                           useGETForQueries: true,
-                                                           delegate: self)
+  private lazy var networkTransport: HTTPNetworkTransport = {
+    let transport = HTTPNetworkTransport(url: self.url,
+                                         useGETForQueries: true)
+    transport.delegate = self
+    return transport
+  }()
   
   private func validateHeroNameQueryResponse<Operation: GraphQLOperation>(result: Result<GraphQLResponse<Operation>, Error>,
                                                                           expectation: XCTestExpectation,
@@ -189,12 +192,10 @@ class HTTPTransportTests: XCTestCase {
   
   func testEquality() {
     let identicalTransport = HTTPNetworkTransport(url: self.url,
-                                                  useGETForQueries: true,
-                                                  delegate: self)
+                                                  useGETForQueries: true)
     XCTAssertEqual(self.networkTransport, identicalTransport)
     
-    let nonIdenticalTransport = HTTPNetworkTransport(url: self.url,
-                                                     delegate: self)
+    let nonIdenticalTransport = HTTPNetworkTransport(url: self.url)
     XCTAssertNotEqual(self.networkTransport, nonIdenticalTransport)
   }
 
@@ -208,7 +209,9 @@ class HTTPTransportTests: XCTestCase {
     let mockSession = MockURLSession()
     mockSession.response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
     mockSession.data = try JSONSerialization.data(withJSONObject: body, options: .prettyPrinted)
-    let network = HTTPNetworkTransport(url: url, session: mockSession, delegate: self)
+    let network = HTTPNetworkTransport(url: url,
+                                       session: mockSession)
+    network.delegate = self
     let expectation = self.expectation(description: "Send operation completed")
 
     let _ = network.send(operation: query) { result in
@@ -241,7 +244,9 @@ class HTTPTransportTests: XCTestCase {
     let mockSession = MockURLSession()
     mockSession.response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
     mockSession.data = try JSONSerialization.data(withJSONObject: body, options: .prettyPrinted)
-    let network = HTTPNetworkTransport(url: url, session: mockSession, delegate: self)
+    let network = HTTPNetworkTransport(url: url,
+                                       session: mockSession)
+    network.delegate = self
     let expectation = self.expectation(description: "Send operation completed")
 
     let _ = network.send(operation: query) { result in


### PR DESCRIPTION
Suggested by @RolandasRazma in #990, let's make this a fully breaking change to the delegate so people are more clearly ware of the change. 

Also I *think* I might have figured something out with one of the tests that keeps failing as part of #993, so I threw that fix in here. 