### PR TITLE
Use screenshot class and split query UI article into multiple sections

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -29,7 +29,9 @@ module.exports = {
             'tutorial/tutorial-create-project',
             'tutorial/tutorial-obtain-schema',
             'tutorial/tutorial-execute-query',
-            'tutorial/tutorial-query-ui'
+            'tutorial/tutorial-query-ui',
+            'tutorial/tutorial-pagination',
+            'tutorial/tutorial-detail-view'
           ],
           Usage:[
             'downloading-schema',

--- a/docs/source/tutorial/tutorial-create-project.md
+++ b/docs/source/tutorial/tutorial-create-project.md
@@ -10,19 +10,19 @@ In this step, you'll add the Apollo iOS SDK to a new project.
 
 2. Under the set of iOS templates, choose **Master-Detail App**:
 
-    ![select single view app template](images/master_detail_app.png)
+    <img src="images/master_detail_app.png" class="screenshot" alt="Select single view app template"/>
 
 4. Click **Next**. An options dialog for your app appears.
 
 5. Name the project **RocketReserver**. Make sure the language is **Swift** and the User Interface is **Storyboard**:
 
-    ![options for creating a new project](images/options_for_project.png)
-
+    <img src="images/options_for_project.png" class="screenshot" alt="Options for creating a new project"/>
+    
 6. Click **Next**. Select a location to save your new project and click **Finish**.
 
 Xcode creates and opens your new project, which has the following structure:
 
-<img alt="Initial project structure" src="images/initial_file_setup.png" width="300">
+<img alt="Initial project structure" class="screenshot" src="images/initial_file_setup.png" width="300">
 
 ## Add the Apollo iOS SDK to your project
 
@@ -32,21 +32,21 @@ Next, you'll add a dependency on the `apollo-ios` repo and Apollo libraries usin
 
 2. Specify `https://github.com/apollographql/apollo-ios.git` (don't forget the `.git`!) as the package repository:
 
-![choose a repo to add a dependency](images/choose_repo.png)
+    <img src="images/choose_repo.png" class="screenshot" alt="Choose a repo to add a dependency"/>
 
 3. Click **Next**. Xcode checks out the repository and analyzes the library. A package options dialog appears.
 
 4. Select **Up to Next Minor** from the Version dropdown (because the Apollo iOS SDK is still a `0.x` release, breaking changes _can_ occur between minor versions):
 
-    ![select next minor in drop-down](images/next_minor.png)
+    <img src="images/next_minor.png" class="screenshot" alt="Select next minor in dropdown"/>
 
 5. Click **Next**. A list of packages included in the library appears. For this tutorial, select the main **Apollo** target and the **ApolloWebSocket** target:
 
-    ![select the first and third targets](images/select_libs.png)
+    <img src="images/select_libs.png" class="screenshot" alt="Select the first and third targets"/>
 
 6. Click **Finish**. SPM fetches your dependencies. When it completes, you can see them in the project navigator:
 
-    ![screenshot of installed dependencies](images/installed_dependencies.png)
+    <img src="images/installed_dependencies.png" class="screenshot" alt="Screenshot of installed dependencies"/>
 
 > **Note:** Because SPM has not yet implemented [Target-Based Dependency Resolution](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md), you'll see the `SQLite` dependency even though you didn't select it.
 

--- a/docs/source/tutorial/tutorial-detail-view.md
+++ b/docs/source/tutorial/tutorial-detail-view.md
@@ -1,0 +1,234 @@
+---
+title: "6. Complete the detail view"
+---
+
+To get more information to show on the detail page, you have a couple of options: 
+
+- You could request all the details you want to display for every single launch in the `LaunchList` query, and then pass that retrieved object on to the `DetailViewController`. 
+- You could provide the identifier of an individual launch to a _different_ query to request all the details you want to display. 
+
+The first option *can* seem easier if there isn't a substantial difference in size between what you're requesting for the list versus the detail page. 
+
+However, remember that one of the advantages of GraphQL is that you can query for _exactly_ the data you need to display on a page. If you're not going to be displaying additional information, you can save bandwidth, execution time, and battery life by not asking for data until you need it.
+
+This is especially true when you have a *much* larger query for your detail view than for your list view. Passing the identifier and then fetching based on that is considered a best practice. Even though the amount of data in this case doesn't differ greatly, you'll build out a query to help fetch details based on the ID so you'll know how to do it in the future. 
+
+Create a new empty file and name it `LaunchDetails.graphql`. In this file, you'll add the details you want to display in the detail view. First, you'll want to go back to GraphiQL and make sure that your query works!
+
+Start by typing in the query name and passing in an ID. Then, try calling the singular `launch` method, which takes the ID as a property, and requesting the `id` back as the query result: 
+
+```graphql
+query LaunchDetails($id:ID) {
+  launch(id:$id) {
+    id  
+  }
+}
+```
+
+You'll see a warning in GraphiQL: 
+
+![variable dollar sign id of type ID was used in position expecting type ID exclamation point](images/graphiql_nullable_conflict.png)
+
+This bit can be confusing for Swift developers, because GraphQL's assumptions about nullability are different from Swift's: 
+
+* In Swift, if you don't annotate a property's type with either a question mark or an exclamation point, that property is non-nullable.
+
+* In GraphQL, if you don't annotate a field's type with an exclamation point, that field is considered *nullable*. This is becasue GraphQL fields are **nullable by default**.
+
+Keep this difference in mind when you switch between editing Swift and GraphQL files.
+
+Now, switch back to GraphiQL. Start by adding the properties you're already requesting in the `LaunchList` query, but use `LARGE` for the mission patch size since the patch will be displayed much larger:
+
+
+```graphql
+query LaunchDetails($id:ID!) {
+  launch(id: $id) {
+    id
+    site
+    mission {
+      name
+      missionPatch(size:LARGE)
+    }
+  }
+}
+```
+
+Next, look at the schema to see what other fields are available. For this example, we'll get the available fields on the `Launch`'s `rocket` field, and also whether the launch has been booked or not. Add the following below the closing brace for `mission`: 
+ 
+```graphQL
+rocket {
+  name
+  type
+}
+isBooked
+```
+
+At the bottom of GraphiQL's left panel, you'll see two tabs named "Query Variables" and "HTTP Headers". In "Query Variables", add the following:
+
+```
+{ "id": "25" }
+```
+
+This tells GraphiQL to fill in the value of the `$id` variable with the value `"25"` when it runs the query. Press the big play button, and you should get some results back for the launch with ID 25: 
+
+<img src="images/graphiql_detail_request.png" alt="Detail request returning JSON" class="screenshot">
+</img>
+
+Now that you've confirmed it worked, copy the query and paste it into your `LaunchDetails.graphql` file. Build the application so that codegen picks up this new file and generates a new query type for it. 
+
+Now that you know what you're planning to ask for, it's time to set up the UI for the detail screen. Go to `DetailViewController.swift`. First, add a place to hang on to the result of the query. Add the following property to the top of the class: 
+
+```swift
+private var launch: LaunchDetailsQuery.Data.Launch?
+```
+
+Next, delete the `self.detailDescriptionLabel` outlet and replace it with the following list of outlets:
+
+```swift
+@IBOutlet private var missionPatchImageView: UIImageView!
+@IBOutlet private var missionNameLabel: UILabel!
+@IBOutlet private var rocketNameLabel: UILabel!
+@IBOutlet private var launchSiteLabel: UILabel!
+@IBOutlet private var bookCancelButton: UIBarButtonItem!
+```
+
+Now in `Main.storyboard`, go to the **Detail Scene**. Delete the existing label. 
+
+This next (collapsed) section covers setting up constraints in detail to match the way things work in the sample application. You're welcome to use the five outlets listed above in an alternate setup if you'd prefer, but screenshots for the remainder of these tutorials are based on this section. 
+
+To follow the precise UI setup instructions, expand this panel:
+
+<DetailUISetupPanel />
+
+In the end, your detail view controller should look like this in the storyboard (or roughly like it in whatever alternate setup you've decided to use): 
+
+<img src="images/storyboard_final.png" alt="The storyboard's final look" class="screenshot">
+</img>
+
+Now it's time to hook everything up! Head back to `DetailViewController.swift` and update the `viewDidLoad` function to clear out anything from the storyboard before attempting to configure the view:
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+
+  self.missionNameLabel.text = "Loading..."
+  self.launchSiteLabel.text = nil
+  self.rocketNameLabel.text = nil
+  self.configureView()
+}
+```
+
+Delete the existing contents of `configureView()`. In their place, start by adding a check that we have something to display, and a place to display it:
+
+```swift
+guard
+  self.missionNameLabel != nil,
+  let launch = self.launch else {
+    return
+}
+```   
+    
+Next, it's time to display all the informaton you've gotten from your GraphQL server. Remember that GraphQL properties are nullable by default, so you'll often need to provide handling for when a given property is `nil`. 
+
+Add the following code below the `guard` statement you just added:
+   
+```swift 
+self.missionNameLabel.text = launch.mission?.name
+self.title = launch.mission?.name
+
+let placeholder = UIImage(named: "placeholder")!
+    
+if let missionPatch = launch.mission?.missionPatch {
+  self.missionPatchImageView.sd_setImage(with: URL(string: missionPatch)!, placeholderImage: placeholder)
+} else {
+  self.missionPatchImageView.image = placeholder
+}
+
+if let site = launch.site {
+  self.launchSiteLabel.text = "Launching from \(site)"
+} else {
+  self.launchSiteLabel.text = nil
+}
+    
+if 
+  let rocketName = launch.rocket?.name ,
+  let rocketType = launch.rocket?.type {
+    self.rocketNameLabel.text = "🚀 \(rocketName) (\(rocketType))"
+} else {
+  self.rocketNameLabel.text = nil
+}
+    
+if launch.isBooked {
+  self.bookCancelButton.title = "Cancel trip"
+  self.bookCancelButton.tintColor = .red
+} else {
+  self.bookCancelButton.title = "Book now!"
+  self.bookCancelButton.tintColor = self.view.tintColor
+}
+```
+
+Then, add a method to load the details using the `LaunchDetailsQuery` you created earlier:
+
+```swift
+private func loadLaunchDetails() {
+  guard
+    let launchID = self.launchID,
+    launchID != self.launch?.id else {
+      // This is the launch we're alrady displaying, or the ID is nil.
+      return
+  }
+    
+  Network.shared.apollo.fetch(query: LaunchDetailsQuery(id: launchID)) { [weak self] result in
+    guard let self = self else {
+      return
+    }
+    
+    switch result {
+    case .failure(let error):
+      print("NETWORK ERROR: \(error)")
+    case .success(let graphQLResult):
+      if let launch = graphQLResult.data?.launch {
+        self.launch = launch
+      }
+    
+      if let errors = graphQLResult.errors {
+        print("GRAPHQL ERRORS: \(errors)")
+      }
+    }
+  }
+}
+```
+
+Finally, update the `didSet` for `launchID` to load the launch details if we don't already have them: 
+
+```swift
+var launchID: GraphQLID? {
+  didSet {
+    self.loadLaunchDetails()
+  }
+}
+```
+
+and add a `didSet` on the `launch` property to load the UI once the launch is actually loaded. 
+
+```swift
+private var launch: LaunchDetailsQuery.Data.Launch? {
+  didSet {
+    self.configureView()
+  }
+}
+```
+
+Build and run the application. When you tap into the detail screen, you should now see the full details: 
+
+
+<img src="images/detail_loaded.png" alt="Final display of the detail screen" class="screenshot" width="300">
+</img>
+
+You'll notice that many of the more recent launches have a rocket type of `FT`. If you load more launches a couple times, you'll get to some rockets that have different rocket types: 
+
+
+<img src="images/detail_loaded_merlin_c.png" alt="Final display with different rocket type" class="screenshot" width="300">
+</img>
+
+You may have noticed that the detail view includes a `Book Now!` button, but there's no way to book a seat yet. To fix that, let's [learn how to make changes to objects in your graph with mutations](./tutorial-mutations).

--- a/docs/source/tutorial/tutorial-execute-query.md
+++ b/docs/source/tutorial/tutorial-execute-query.md
@@ -2,13 +2,11 @@
 title: "3. Execute your first query"
 ---
 
-## Constructing a query in GraphiQL
-
 The most common GraphQL operation is the **query**, which requests data from your graph in a structure that conforms to your server's schema. If you return to [the GraphiQL query explorer](https://n1kqy.sse.codesandbox.io/) for your server, you can see available queries in the Schema tab you opened earlier. 
 
 Click on the `launches` query at the top for details about it:
 
-![detail about launches query](images/launches_detail.png)
+<img src="images/launches_detail.png" class="screenshot" alt="Detail about launches query"/>
 
 In the right panel, you see both the query itself and information about what the query returns. You can use this information to write a query you'll eventually add to your app. 
 
@@ -23,7 +21,7 @@ The Apollo iOS SDK requires every query to have a name (even though this isn't r
 
 Next, between the query's curly braces, start typing `la`. An autocomplete box pops up and shows you options based on what's in the schema:
 
-![example of autocomplete](images/grapqhiql_autocomplete.png)
+<img src="images/grapqhiql_autocomplete.png" class="screenshot" alt="Example of autocomplete"/>
 
 GraphiQL is a great tool for building and verifying queries so you don't have to repeatedly rebuild your project in Xcode to try out changes.
 
@@ -40,7 +38,7 @@ query LaunchList {
 
 If you run this query by pressing the play button in GraphiQL, the query returns results as a JSON object on the right-hand side of the page: 
 
-![basic query JSON in GraphiQL](images/completed_basic_query.png)
+<img src="images/completed_basic_query.png" class="screenshot" alt="Query JSON in GraphiQL"/>
 
 This query executes successfully, but it doesn't include any information about the `launches`! That's because we didn't include the necessary field in our query.
 
@@ -61,7 +59,7 @@ query LaunchList {
 
 Run the query again, and you'll now see that in addition to the information you got back before, you're also getting a list of launches with their ID and site information: 
 
-![updated query JSON in GraphiQL](images/completed_id_query.png)
+<img src="images/completed_id_query.png" class="screenshot" alt="Updated query JSON in GraphiQL"/>
 
 ## Adding your query to Xcode
 
@@ -69,7 +67,7 @@ Now that your query is fetching the right data, head back to Xcode.
 
 1. Go to **File > New > File...** and select the **Empty** file template:
 
-![](images/empty_file_template.png)
+<img src="images/empty_file_template.png" class="screenshot" alt="Empty file template"/>
 
 2. Click **Next** and name the file `LaunchList.graphql`. Make sure it's saved at the same level as your `schema.json` file. As previously, don't add it to any target.
 

--- a/docs/source/tutorial/tutorial-obtain-schema.md
+++ b/docs/source/tutorial/tutorial-obtain-schema.md
@@ -2,16 +2,15 @@
 title: "2. Obtain your GraphQL schema"
 ---
 
-## Explore your server's schema
-
 This tutorial uses a modified version of the GraphQL server you build as part of [the Apollo full-stack tutorial](https://www.apollographql.com/docs/tutorial/introduction/). You can visit [`https://n1kqy.sse.codesandbox.io/`](https://n1kqy.sse.codesandbox.io/) to start it up and open the GraphiQL tool to explore its schema:
 
-![the GraphiQL query explorer](images/graphiql.png)
+<img src="images/graphiql.png" alt="The GraphiQL query explorer" class="screenshot">
+</img>
 
 The schema defines which GraphQL operations your server can execute. Click **Schema** on the right-hand side to view a list of types you can query (and the types of fields on those types) along with any possible mutations or subscriptions:
 
-![GraphiQL showing the schema](images/graphiql_show_schema.png)
-
+<img src="images/graphiql_show_schema.png" alt="GraphiQL showing the schema" class="screenshot">
+</img>
 
 ## Download your server's schema
 
@@ -21,25 +20,25 @@ To use the Apollo CLI from Xcode, add a **Run Script** build phase to your app:
 
 1. Select the `xcodeproj` file in the Project Navigator, and then select the `RocketReserver` application target: 
 
-    ![selecting the target](images/select_target.png)
+    <img src="images/select_target.png" alt="Selecting application target" class="screenshot"></img>
 
 2. A list of tabs appears. Select the **Build Phases** tab: 
 
-    ![the build phases menu item](images/build_phases.png)
+    <img src="images/build_phases.png" alt="Build phases menu item" class="screenshot"></img>
 
 3. Click the `+` button above the list of existing phases and select **New Run Script Phase**:
 
-    ![creating a new run script build phase](images/new_run_script_phase.png)
+    <img src="images/new_run_script_phase.png" alt="Creating a new run script build phase" class="screenshot" width="300"></img>
 
     This adds a new Run Script build phase to the bottom of your list of build phases.
     
 4. Drag the newly created phase up between "Dependencies" and "Compile Sources":
 
-    ![where to drag the run script](images/drag_run_script.png)
+    <img src="images/drag_run_script.png" alt="Where to drag the run script" class="screenshot"></img>
 
 5. Double-click the name of the build phase to rename it to **Apollo CLI**:
 
-    ![UI for renaming](images/rename_run_script.png)
+    <img src="images/rename_run_script.png" alt="UI for renaming" class="screenshot"></img>
 
 6. Expand the Apollo CLI phase. Paste the **Swift Package Manager Run Script** from [Adding a code generation build step](/installation/#adding-a-code-generation-build-step) into the text area. This script uses your schema to generate the code that the Apollo iOS SDK uses to interact with your server.
 
@@ -53,11 +52,11 @@ To use the Apollo CLI from Xcode, add a **Run Script** build phase to your app:
 
 8. Build your project to execute the script. In Finder, navigate to the folder that contains your `AppDelegate.swift` file. The folder should now include the downloaded `schema.json` file. Drag this file from Finder into Xcode:
 
-    ![where to drag the schema file](images/drag_schema_into_xcode.png)
+    <img src="images/drag_schema_into_xcode.png" alt="Where to drag the schema file" class="screenshot" width="300"></img>
 
     When Xcode offers to add the schema file, make sure **all targets are unchecked** to reduce the size of your application bundle: 
 
-    ![all targets unchecked in dialog](images/dont_add_to_target.png)
+    <img src="images/dont_add_to_target.png" alt="All targets unchecked in dialog" class="screenshot"></img>
 
     You don't need to add the schema to any targets, because it is only used to generate code that _is_ added to targets.
 

--- a/docs/source/tutorial/tutorial-pagination.md
+++ b/docs/source/tutorial/tutorial-pagination.md
@@ -1,0 +1,204 @@
+---
+title: "5. Paginate results"
+---
+
+As you might have noticed, the object returned from the `LaunchListQuery` is a `LaunchConnection`. This object has a list of launches, a pagination cursor, and a boolean to indicate whether more launches exist. 
+
+When using a cursor-based pagination system, it's important to remember that the cursor gives you a place where you can get all results after a certain spot, regardless of whether more items have been added in the interim. 
+
+You're going to use a second section in the TableView to allow your user to load more launches as long as they exist. But how will you know if they exist? First, you need to hang on to the most recently received `LaunchConnection` object.
+
+Add a variable to hold on to this object at the top of the file near your `launches` variable:
+
+```swift
+private var lastConnection: LaunchListQuery.Data.Launch?
+```
+
+Next, you're going to take advantage of a type from the Apollo library. Add the following to the top of the file:
+
+```swift
+import Apollo
+```
+
+Then, below `lastConnection`, add a variable to hang on to the most recent request: 
+
+```swift
+private var activeRequest: Cancellable?
+```
+
+Next, add a second case to your `ListSection` enum:
+
+```swift
+enum ListSection: Int, CaseIterable {
+  case launches
+  case loading
+}
+```
+
+This allows loading state to be displayed and selected in a separate section, keeping your `launches` section tied to the `launches` variable. 
+
+Next, in `tableView(_:, numberOfRowsInSection:)`, add handling for the `.loading` case, which returns `0` if there are no more launches to load: 
+
+```swift
+case .loading:
+  if self.lastConnection?.hasMore == false {
+    return 0
+  } else {
+    return 1
+  }
+```
+
+Remember here that if `lastConnection` is nil, there *are* more launches to load, since we haven't even loaded a first connection. 
+
+Next, add handling for the `.loading` case to `tableView(_, cellForRowAt:)`, showing a different message based on whether there's an active request or not:
+
+```swift
+case .loading:
+  if self.activeRequest == nil {
+    cell.textLabel?.text = "Tap to load more"
+  } else {
+    cell.textLabel?.text = "Loading..."
+  }
+```
+
+Next, you'll need to provide the cursor to your `LaunchListQuery`. The good news is that the `launches` API takes an optional `after` parameter, which accepts a cursor. 
+
+To pass a variable into a GraphQL query, you need to use syntax that defines that variable using a `$name` and its type. You can then pass the variable in as a parameter value to an API which takes a parameter.
+
+What does this look like in practice? Go to `LaunchList.graphql` and update just the first two lines to take and use the cursor as a parameter: 
+
+```graphql
+query LaunchList($cursor:String) {
+  launches(after:$cursor) {
+```
+
+Build the application so the code generation picks up on this new parameter. You'll see an error for a non-exhaustive switch, but this is something we'll fix shortly.
+
+Next, go back to `MasterViewController.swift` and update `loadLaunches()` to be `loadMoreLaunches(from cursor: String?)`, hanging on to the active request (and nil'ing it out when it completes), and updating the last received connection: 
+
+```swift
+private func loadMoreLaunches(from cursor: String?) {
+  self.activeRequest = Network.shared.apollo.fetch(query: LaunchListQuery(cursor: cursor)) { [weak self] result in
+    guard let self = self else {
+      return
+    }
+    
+    self.activeRequest = nil
+    defer {
+      self.tableView.reloadData()
+    }
+    
+    switch result {
+    case .success(let graphQLResult):
+      if let launchConnection = graphQLResult.data?.launches {
+        self.lastConnection = launchConnection
+        self.launches.append(contentsOf: launchConnection.launches.compactMap { $0 })
+      }
+    
+      if let errors = graphQLResult.errors {
+        let message = errors
+                        .map { $0.localizedDescription }
+                        .joined(separator: "\n")
+        self.showErrorAlert(title: "GraphQL Error(s)",
+                            message: message)
+    }
+    case .failure(let error):
+      self.showErrorAlert(title: "Network Error",
+                          message: error.localizedDescription)
+    }
+  }
+}
+```
+
+Then, add a new method to figure out if new launches need to be loaded:
+
+```swift
+private func loadMoreLaunchesIfTheyExist() {
+  guard let connection = self.lastConnection else {
+    // We don't have stored launch details, load from scratch
+    self.loadMoreLaunches(from: nil)
+    return
+  }
+    
+  guard connection.hasMore else {
+    // No more launches to fetch
+    return
+  }
+    
+  self.loadMoreLaunches(from: connection.cursor)
+}
+```
+
+Update `viewDidLoad` to use this new method rather than calling `loadMoreLaunches(from:)` directly:
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+  self.loadMoreLaunchesIfTheyExist()
+}
+```
+
+Next, you need to add some handling when the cell is tapped. Normally that's handled by `prepare(for segue:)`, but because you're going to be reloading things in the current view controller, you won't want the segue to perform at all. 
+
+Luckily, you can override the `shouldPerformSegue(withIdentifier:sender:)` method to say, "In this case, don't perform this segue, and take these other actions instead."
+
+Override this method, and add code that performs the segue for anything in the `.launches` section and _doesn't_ perform it (instead loading more launches if needed) for the `.loading` section:
+
+
+```swift
+override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
+  guard let selectedIndexPath = self.tableView.indexPathForSelectedRow else {
+    return false
+  }
+          
+  guard let listSection = ListSection(rawValue: selectedIndexPath.section) else {
+    assertionFailure("Invalid section")
+    return false
+  }
+        
+switch listSection {
+  case .launches:
+    return true
+  case .loading:
+    self.tableView.deselectRow(at: selectedIndexPath, animated: true)
+
+    if self.activeRequest == nil {
+      self.loadMoreLaunchesIfTheyExist()
+    } // else, let the active request finish loading
+
+    self.tableView.reloadRows(at: [selectedIndexPath], with: .automatic)
+    
+    // In either case, don't perform the segue
+    return false
+  }
+}
+```
+
+Finally, even though you've told the segue system that you don't need to perform the segue for anything in the `.loading` case, the _compiler_ still doesn't know that, and it requires you to handle the `.loading` case in `prepare(for segue:)`. 
+
+However, your code should theoretically never reach this point, so it's a good place to use an `assertionFailure` if you ever hit it during development. This both satisfies the compiler and warns you loudly and quickly if your assumption that something is handled in `shouldPerformSegue` is wrong. 
+
+Add the following to the `switch` statement in `prepare(for segue:)`
+
+```swift
+case .loading:
+  assertionFailure("Shouldn't have gotten here!")
+```
+
+Now, when you build and run and scroll down to the bottom of the list, you'll see a cell you can tap to load more rows: 
+
+
+<img src="images/tap_to_load_more.png" alt="Screenshot with loading cell" class="screenshot" width="300">
+</img>
+
+
+When you tap that cell, the rows will load and then redisplay. If you tap it several times, it reaches a point where the loading cell is no longer displayed, and the last launch was SpaceX's original FalconSat launch from Kwajalien Atoll:
+
+
+<img src="images/list_all_loaded.png" alt="List with all launches loaded and no loading cell" class="screenshot" width="300">
+</img>
+
+
+Congratulations, you've loaded all of the possible launches! But when you tap one, you still get the same boring detail page. 
+
+Next, you'll make the detail page a lot more interesting by taking the ID returned by one query and passing it to another.

--- a/docs/source/tutorial/tutorial-query-ui.mdx
+++ b/docs/source/tutorial/tutorial-query-ui.mdx
@@ -1,5 +1,5 @@
 ---
-title: Query-powered UI
+title: "4. Connect your queries to your UI"
 ---
 
 import DetailUISetupPanel from "./components/detail_ui_setup_panel.mdx"
@@ -29,7 +29,7 @@ var launches = [LaunchListQuery.Data.Launch.Launch]()
 
 Why the long name? Each query returns its own nested object structure to ensure that when you use the result of a particular query, you can't ask for a property that isn't present. Because this screen will be populated by the results of the `LaunchListQuery`, you need to display subtypes of that particular query.
 
-Next, add an enum that helps handle dealing with sections (we'll add additional items to the enum later): 
+Next, add an enum that helps handle dealing with sections (we'll add items to the enum later): 
 
 ```swift
 enum ListSection: Int, CaseIterable {
@@ -165,14 +165,14 @@ override func viewDidLoad() {
 Build and run the application. After the query completes, a list of launch sites appears: 
 
 
-<img src="images/list_sites_success.png" alt="List of launch sites" width="300">
+<img src="images/list_sites_success.png" alt="List of launch sites" class="screenshot" width="300">
 </img>
 
 
-However, if you attempt to tap one of the rows, the app displays the detail with the the placeholder text you can see in the storyboard rather than any actual information about the launch:
+However, if you attempt to tap one of the rows, the app displays the detail with the the placeholder text you can see in the storyboard, instead of any actual information about the launch:
 
 
-<img src="images/stock_detail_view.png" alt="Placeholder detail content" width="300">
+<img src="images/stock_detail_view.png" alt="Placeholder detail content" class="screenshot" width="300">
 </img>
 
 
@@ -258,28 +258,30 @@ if topAsDetailController.launchID == nil {
 Build and run, and tap on any of the launches. You'll now see the launch ID for the selected launch when you land on the page:
 
 
-<img src="images/detail_view_launch_id.png" alt="Empty screen with launch ID" width="300">
+<img src="images/detail_view_launch_id.png" alt="Empty screen with launch ID" class="screenshot" width="300">
 </img>
 
 The app is working! However, it doesn't provide much useful information. Let's fix that.
 
 ## Add more info to the list view
 
-Let's take advantage of one of the built-in styles for `UITableViewCell` to display more information without having to do much work. Go to `Main.storyboard`, select the **Master Scene** which includes the `TableView` and the default cell. 
+Let's take advantage of one of the built-in styles for `UITableViewCell` to display more information without having to do much work. Go to `Main.storyboard` and select the **Master Scene**, which includes the `TableView` and the default cell. 
 
-Expand the dropdowns in the left sidebar of Interface Builder until you get to **Cell**. Select that element, then go to the **Attributes Inspector** in the right sidebar of Xcode. At the top, there's a drop-down that allows you to select a style for your table view cell. Select **Subtitle**:
+Expand the dropdowns in the left sidebar of Interface Builder until you get to **Cell**. Select that element, then go to the **Attributes Inspector** in the right sidebar of Xcode. At the top, there's a dropdown that allows you to select a style for your table view cell. Select **Subtitle**:
 
-![](images/use_subtitle_style.png)
+<img src="images/use_subtitle_style.png" alt="Select subtitle style" class="screenshot">
+</img>
 
 While you're here, this is a good time to give the main `TableView` a name that better reflects what it's actually showing. Select the navigation item and rename it from `Master` to `Launches`:
 
-![](images/rename_master_launches.png)
+<img src="images/rename_master_launches.png" alt="Rename master" class="screenshot">
+</img>
 
 Go back to `LaunchList.graphql`. Your query is already fetching most of the information you want to display, but it would be nice to display both the name of the mission and an image of the patch. 
 
 Looking at the schema in GraphiQL, you can see that `Launch` has a property of `mission`, which allows you to get details of the mission. A mission has both a name and a `missionPatch` property, and the `missionPatch` can optionally take a parameter about what size something needs to be.
 
-Since loading a table view with large images can be a real performance hog, ask for the name and a small mission patch. Update your query to look like the following:
+Because loading a table view with large images can impact performance, ask for the name and a `SMALL` mission patch. Update your query to look like the following:
 
 ```graphql
 query LaunchList {
@@ -300,11 +302,11 @@ query LaunchList {
 
 When you recompile, if you look in `API.swift`, you'll see a new nested type, `Mission`, with the two properties you requested.
 
-Since `missionPatch` returns a URL string to an image that can be displayed, you'll want to have a fairly easy setup to display images based on URLs. 
+Because `missionPatch` returns a URL string to an image that can be displayed, you want to make it straightforward to display an image from its URL.
 
 To save time, go to **File > Swift Packages > Add Package Dependency...** and add a depenency on [SDWebImage](https://github.com/SDWebImage/SDWebImage). Paste in the URL to its git repo, `https://github.com/SDWebImage/SDWebImage.git`, and then select the main `SDWebImage` from the list of package products Xcode offers you once it resolves the repo. 
 
-Once SDWebImage has finished installing, go back to `MasterViewController.swift` and add the following import to the top of the file:
+When SDWebImage finishes installing, go back to `MasterViewController.swift` and add the following import to the top of the file:
 
 ```swift
 import SDWebImage
@@ -354,454 +356,10 @@ case .launches:
 Build and run the application, and you will see all the information for current launches populate: 
 
 
-<img src="images/launch_list_final.png" alt="Final launch list" width="300">
+<img src="images/launch_list_final.png" alt="Final launch list" class="screenshot" width="300">
 </img>
 
 
 If you scroll down, you'll see the list includes only about 20 launches. This is because the list of launches is **paginated**, and you've only fetched the first page. 
 
 Now it's time to learn how to use a cursor-based loading system to load the entire list of launches.
-
-## Use pagination to load additional launches
-
-As you might have noticed, the object returned from the `LaunchListQuery` is a `LaunchConnection`. This object has a list of launches, a pagination cursor, and a boolean to indicate whether more launches exist. 
-
-When using a cursor-based pagination system, it's important to remember that the cursor gives you a place where you can get all results after a certain spot, regardless of whether more items have been added in the interim. 
-
-You're going to use a second section in the TableView to allow your user to load more launches as long as they exist. But how will you know if they exist? First, you need to hang on to the most recently received `LaunchConnection` object.
-
-Add a variable to hold on to this object at the top of the file near your `launches` variable:
-
-```swift
-private var lastConnection: LaunchListQuery.Data.Launch?
-```
-
-Next, you're going to take advantage of a type from the Apollo library. Add the following to the top of the file:
-
-```swift
-import Apollo
-```
-
-Then, below `lastConnection`, add a variable to hang on to the most recent request: 
-
-```swift
-private var activeRequest: Cancellable?
-```
-
-Next, add a second case to your `ListSection` enum:
-
-```swift
-enum ListSection: Int, CaseIterable {
-  case launches
-  case loading
-}
-```
-
-This allows loading state to be displayed and selected in a separate section, keeping your `launches` section tied to the `launches` variable. 
-
-Next, in `tableView(_:, numberOfRowsInSection:)`, add handling for the `.loading` case, which returns `0` if there are no more launches to load: 
-
-```swift
-case .loading:
-  if self.lastConnection?.hasMore == false {
-    return 0
-  } else {
-    return 1
-  }
-```
-
-Remember here that if `lastConnection` is nil, there *are* more launches to load, since we haven't even loaded a first connection. 
-
-Next, add handling for the `.loading` case to `tableView(_, cellForRowAt:)`, showing a different message based on whether there's an active request or not:
-
-```swift
-case .loading:
-  if self.activeRequest == nil {
-    cell.textLabel?.text = "Tap to load more"
-  } else {
-    cell.textLabel?.text = "Loading..."
-  }
-```
-
-Next, you'll need to provide the cursor to your `LaunchListQuery`. The good news is that the `launches` API takes an optional `after` parameter, which accepts a cursor. 
-
-To pass a variable into a GraphQL query, you need to use syntax that defines that variable using a `$name` and its type. You can then pass the variable in as a parameter value to an API which takes a parameter.
-
-What does this look like in practice? Go to `LaunchList.graphql` and update just the first two lines to take and use the cursor as a parameter: 
-
-```graphql
-query LaunchList($cursor:String) {
-  launches(after:$cursor) {
-```
-
-Build the application so the code generation picks up on this new parameter. You'll see an error for a non-exhaustive switch, but this is something we'll fix shortly.
-
-Next, go back to `MasterViewController.swift` and update `loadLaunches()` to be `loadMoreLaunches(from cursor: String?)`, hanging on to the active request (and nil'ing it out when it completes), and updating the last received connection: 
-
-```swift
-private func loadMoreLaunches(from cursor: String?) {
-  self.activeRequest = Network.shared.apollo.fetch(query: LaunchListQuery(cursor: cursor)) { [weak self] result in
-    guard let self = self else {
-      return
-    }
-    
-    self.activeRequest = nil
-    defer {
-      self.tableView.reloadData()
-    }
-    
-    switch result {
-    case .success(let graphQLResult):
-      if let launchConnection = graphQLResult.data?.launches {
-        self.lastConnection = launchConnection
-        self.launches.append(contentsOf: launchConnection.launches.compactMap { $0 })
-      }
-    
-      if let errors = graphQLResult.errors {
-        let message = errors
-                        .map { $0.localizedDescription }
-                        .joined(separator: "\n")
-        self.showErrorAlert(title: "GraphQL Error(s)",
-                            message: message)
-    }
-    case .failure(let error):
-      self.showErrorAlert(title: "Network Error",
-                          message: error.localizedDescription)
-    }
-  }
-}
-```
-
-Then, add a new method to figure out if new launches need to be loaded:
-
-```swift
-private func loadMoreLaunchesIfTheyExist() {
-  guard let connection = self.lastConnection else {
-    // We don't have stored launch details, load from scratch
-    self.loadMoreLaunches(from: nil)
-    return
-  }
-    
-  guard connection.hasMore else {
-    // No more launches to fetch
-    return
-  }
-    
-  self.loadMoreLaunches(from: connection.cursor)
-}
-```
-
-Update `viewDidLoad` to use this new method rather than calling `loadMoreLaunches(from:)` directly:
-
-```swift
-override func viewDidLoad() {
-  super.viewDidLoad()
-  self.loadMoreLaunchesIfTheyExist()
-}
-```
-
-Next, you need to add some handling when the cell is tapped. Normally that's handled by `prepare(for segue:)`, but because you're going to be reloading things in the current view controller, you won't want the segue to perform at all. 
-
-Luckily, you can override the `shouldPerformSegue(withIdentifier:sender:)` method to say, "In this case, don't perform this segue, and take these other actions instead."
-
-Override this method, and add code that performs the segue for anything in the `.launches` section and _doesn't_ perform it (instead loading more launches if needed) for the `.loading` section:
-
-
-```swift
-override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
-  guard let selectedIndexPath = self.tableView.indexPathForSelectedRow else {
-    return false
-  }
-          
-  guard let listSection = ListSection(rawValue: selectedIndexPath.section) else {
-    assertionFailure("Invalid section")
-    return false
-  }
-        
-switch listSection {
-  case .launches:
-    return true
-  case .loading:
-    self.tableView.deselectRow(at: selectedIndexPath, animated: true)
-
-    if self.activeRequest == nil {
-      self.loadMoreLaunchesIfTheyExist()
-    } // else, let the active request finish loading
-
-    self.tableView.reloadRows(at: [selectedIndexPath], with: .automatic)
-    
-    // In either case, don't perform the segue
-    return false
-  }
-}
-```
-
-Finally, even though you've told the segue system that you don't need to perform the segue for anything in the `.loading` case, the _compiler_ still doesn't know that, and it requires you to handle the `.loading` case in `prepare(for segue:)`. 
-
-However, your code should theoretically never reach this point, so it's a good place to use an `assertionFailure` if you ever hit it during development. This both satisfies the compiler and warns you loudly and quickly if your assumption that something is handled in `shouldPerformSegue` is wrong. 
-
-Add the following to the `switch` statement in `prepare(for segue:)`
-
-```swift
-case .loading:
-  assertionFailure("Shouldn't have gotten here!")
-```
-
-Now, when you build and run and scroll down to the bottom of the list, you'll see a cell you can tap to load more rows: 
-
-
-<img src="images/tap_to_load_more.png" alt="Screenshot with loading cell" width="300">
-</img>
-
-
-When you tap that cell, the rows will load and then redisplay. If you tap it several times, it reaches a point where the loading cell is no longer displayed, and the last launch was SpaceX's original FalconSat launch from Kwajalien Atoll:
-
-
-<img src="images/list_all_loaded.png" alt="List with all launches loaded and no loading cell" width="300">
-</img>
-
-
-Congratulations, you've loaded all of the possible launches! But when you tap one, you still get the same boring detail page. 
-
-Next, you'll make the detail page a lot more interesting by taking the ID returned by one query and passing it to another.
-
-## Add more details to the detail view
-
-To get more information to show on the detail page, you have a couple of options: 
-
-- You could request all the details you want to display for every single launch in the `LaunchList` query, and then pass that retrieved object on to the `DetailViewController`. 
-- You could provide the identifier of an individual launch to a _different_ query to request all the details you want to display. 
-
-The first option *can* seem easier if there isn't a substantial difference in size between what you're requesting for the list versus the detail page. 
-
-However, remember that one of the advantages of GraphQL is that you can query for _exactly_ the data you need to display on a page. If you're not going to be displaying additional information, you can save bandwidth, execution time, and battery life by not asking for data until you need it.
-
-This is especially true when you have a *much* larger query for your detail view than for your list view. Passing the identifier and then fetching based on that is considered a best practice. Even though the amount of data in this case doesn't differ greatly, you'll build out a query to help fetch details based on the ID so you'll know how to do it in the future. 
-
-Create a new empty file and name it `LaunchDetails.graphql`. In this file, you'll add the details you want to display in the detail view. First, you'll want to go back to GraphiQL and make sure that your query works!
-
-Start by typing in the query name and passing in an ID. Then, try calling the singular `launch` method, which takes the ID as a property, and requesting the `id` back as the query result: 
-
-```graphql
-query LaunchDetails($id:ID) {
-  launch(id:$id) {
-    id  
-  }
-}
-```
-
-You'll see a warning in GraphiQL: 
-
-![variable dollar sign id of type ID was used in position expecting type ID exclamation point](images/graphiql_nullable_conflict.png)
-
-This bit can be confusing for Swift developers, because GraphQL's assumptions about nullability are different from Swift's: 
-
-* In Swift, if you don't annotate a property's type with either a question mark or an exclamation point, that property is non-nullable.
-
-* In GraphQL, if you don't annotate a field's type with an exclamation point, that field is considered *nullable*. This is becasue GraphQL fields are **nullable by default**.
-
-Keep this difference in mind when you switch between editing Swift and GraphQL files.
-
-Now, switch back to GraphiQL. Start by adding the properties you're already requesting in the `LaunchList` query, but use `LARGE` for the mission patch size since the patch will be displayed much larger:
-
-
-```graphql
-query LaunchDetails($id:ID!) {
-  launch(id: $id) {
-    id
-    site
-    mission {
-      name
-      missionPatch(size:LARGE)
-    }
-  }
-}
-```
-
-Next, look at the schema to see what other fields are available. For this example, we'll get the available fields on the `Launch`'s `rocket` field, and also whether the launch has been booked or not. Add the following below the closing brace for `mission`: 
- 
-```graphQL
-rocket {
-  name
-  type
-}
-isBooked
-```
-
-At the bottom of GraphiQL's left panel, you'll see two tabs named "Query Variables" and "HTTP Headers". In "Query Variables", add the following:
-
-```
-{ "id": "25" }
-```
-
-This tells GraphiQL to fill in the value of the `$id` variable with the value `"25"` when it runs the query. Press the big play button, and you should get some results back for the launch with ID 25: 
-
-![screenshot - detail request returning json](images/graphiql_detail_request.png)
-
-Now that you've confirmed it worked, copy the query and paste it into your `LaunchDetails.graphql` file. Build the application so that codegen picks up this new file and generates a new query type for it. 
-
-Now that you know what you're planning to ask for, it's time to set up the UI for the detail screen. Go to `DetailViewController.swift`. First, add a place to hang on to the result of the query. Add the following property to the top of the class: 
-
-```swift
-private var launch: LaunchDetailsQuery.Data.Launch?
-```
-
-Next, delete the `self.detailDescriptionLabel` outlet and replace it with the following list of outlets:
-
-```swift
-@IBOutlet private var missionPatchImageView: UIImageView!
-@IBOutlet private var missionNameLabel: UILabel!
-@IBOutlet private var rocketNameLabel: UILabel!
-@IBOutlet private var launchSiteLabel: UILabel!
-@IBOutlet private var bookCancelButton: UIBarButtonItem!
-```
-
-Now in `Main.storyboard`, go to the **Detail Scene**. Delete the existing label. 
-
-This next (collapsed) section covers setting up constraints in detail to match the way things work in the sample application. You're welcome to use the five outlets listed above in an alternate setup if you'd prefer, but screenshots for the remainder of these tutorials are based on this section. 
-
-To follow the precise UI setup instructions, expand this panel:
-
-<DetailUISetupPanel />
-
-In the end, your detail view controller should look like this in the storyboard (or roughly like it in whatever alternate setup you've decided to use): 
-
-![The storyboard's final look](images/storyboard_final.png)
-
-Now it's time to hook everything up! Head back to `DetailViewController.swift` and update the `viewDidLoad` function to clear out anything from the storyboard before attempting to configure the view:
-
-```swift
-override func viewDidLoad() {
-  super.viewDidLoad()
-
-  self.missionNameLabel.text = "Loading..."
-  self.launchSiteLabel.text = nil
-  self.rocketNameLabel.text = nil
-  self.configureView()
-}
-```
-
-Delete the existing contents of `configureView()`. In their place, start by adding a check that we have something to display, and a place to display it:
-
-```swift
-guard
-  self.missionNameLabel != nil,
-  let launch = self.launch else {
-    return
-}
-```   
-    
-Next, it's time to display all the informaton you've gotten from your GraphQL server. Remember that GraphQL properties are nullable by default, so you'll often need to provide handling for when a given property is `nil`. 
-
-Add the following code below the `guard` statement you just added:
-   
-```swift 
-self.missionNameLabel.text = launch.mission?.name
-self.title = launch.mission?.name
-
-let placeholder = UIImage(named: "placeholder")!
-    
-if let missionPatch = launch.mission?.missionPatch {
-  self.missionPatchImageView.sd_setImage(with: URL(string: missionPatch)!, placeholderImage: placeholder)
-} else {
-  self.missionPatchImageView.image = placeholder
-}
-
-if let site = launch.site {
-  self.launchSiteLabel.text = "Launching from \(site)"
-} else {
-  self.launchSiteLabel.text = nil
-}
-    
-if 
-  let rocketName = launch.rocket?.name ,
-  let rocketType = launch.rocket?.type {
-    self.rocketNameLabel.text = "🚀 \(rocketName) (\(rocketType))"
-} else {
-  self.rocketNameLabel.text = nil
-}
-    
-if launch.isBooked {
-  self.bookCancelButton.title = "Cancel trip"
-  self.bookCancelButton.tintColor = .red
-} else {
-  self.bookCancelButton.title = "Book now!"
-  self.bookCancelButton.tintColor = self.view.tintColor
-}
-```
-
-Then, add a method to load the details using the `LaunchDetailsQuery` you created earlier:
-
-```swift
-private func loadLaunchDetails() {
-  guard
-    let launchID = self.launchID,
-    launchID != self.launch?.id else {
-      // This is the launch we're alrady displaying, or the ID is nil.
-      return
-  }
-    
-  Network.shared.apollo.fetch(query: LaunchDetailsQuery(id: launchID)) { [weak self] result in
-    guard let self = self else {
-      return
-    }
-    
-    switch result {
-    case .failure(let error):
-      print("NETWORK ERROR: \(error)")
-    case .success(let graphQLResult):
-      if let launch = graphQLResult.data?.launch {
-        self.launch = launch
-      }
-    
-      if let errors = graphQLResult.errors {
-        print("GRAPHQL ERRORS: \(errors)")
-      }
-    }
-  }
-}
-```
-
-Finally, update the `didSet` for `launchID` to load the launch details if we don't already have them: 
-
-```swift
-var launchID: GraphQLID? {
-  didSet {
-    self.loadLaunchDetails()
-  }
-}
-```
-
-and add a `didSet` on the `launch` property to load the UI once the launch is actually loaded. 
-
-```swift
-private var launch: LaunchDetailsQuery.Data.Launch? {
-  didSet {
-    self.configureView()
-  }
-}
-```
-
-Build and run the application. When you tap into the detail screen, you should now see the full details: 
-
-
-<img src="images/detail_loaded.png" alt="Final display of the detail screen" width="300">
-</img>
-
-You'll notice that many of the more recent launches have a rocket type of `FT`. If you load more launches a couple times, you'll get to some rockets that have different rocket types: 
-
-
-<img src="images/detail_loaded_merlin_c.png" alt="Final display with different rocket type" width="300">
-</img>
-
-
-## Recap
-
-In this part of the tutorial, you have: 
-
-- Updated your query to get more information
-- Updated your app to pass information between screens
-- Created a second query to get more information than was necessary for the first query
-- Used all the data you've received from your queries to populate your user interface. 
-
-You may have noticed that the detail view includes a `Book Now!` button, but there's no way to book a seat yet. To fix that, let's [learn how to make changes to objects in your graph with mutations](./tutorial-mutations).


### PR DESCRIPTION
Before jumping into #932 , just wanted to take advantage of our new `screenshot` class for applicable images and get our existing tutorial sections into roughly equal-sized articles. 

