### PR TITLE
Cancel existing operation in a watcher before starting a new one

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -34,6 +34,8 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
 
   func fetch(cachePolicy: CachePolicy) {
+    // Cancel anything already in flight before starting a new fetch
+    fetching?.cancel()
     fetching = client?.fetch(query: query, cachePolicy: cachePolicy, context: &context, queue: .main) { [weak self] result in
       guard let `self` = self else { return }
 

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -385,9 +385,6 @@ class FetchQueryTests: XCTestCase {
   }
   
   func testThreadedCache() throws {
-    #if canImport(ApolloSQLite)
-      print("THIS ONLY TESTS THE IN-MEMORY CACHE")
-    #else
     let cache = InMemoryNormalizedCache()
     
     let networkTransport1 = MockNetworkTransport(body: [
@@ -479,6 +476,5 @@ class FetchQueryTests: XCTestCase {
     for watcher in watchers {
       watcher.cancel()
     }
-    #endif
   }
 }


### PR DESCRIPTION
Thanks to @RolandasRazma for the suggestion in #1011 - this removes the hack needed to make things pass added in #1010. 

There's still some pretty significant thread safety issues going on here as pointed out by @cysp, but I think there's a BIG rabbit hole there, and I'd at least like to remove the dirty hack ASAP. 