### PR TITLE
Fix memory leaks in Promise whenAll

### DIFF
--- a/Sources/Apollo/Promise.swift
+++ b/Sources/Apollo/Promise.swift
@@ -3,6 +3,7 @@ import Dispatch
 func whenAll<Value>(_ promises: [Promise<Value>], notifyOn queue: DispatchQueue = .global()) -> Promise<[Value]> {
   return Promise { (fulfill, reject) in
     let group = DispatchGroup()
+    var rejected = false
 
     for promise in promises {
       group.enter()
@@ -11,11 +12,15 @@ func whenAll<Value>(_ promises: [Promise<Value>], notifyOn queue: DispatchQueue 
         group.leave()
       }.catch { error in
         reject(error)
+        rejected = true
+        group.leave()
       }
     }
 
     group.notify(queue: queue) {
-      fulfill(promises.map { $0.result!.value! })
+      if !rejected {
+        fulfill(promises.map { $0.result!.value! })
+      }
     }
   }
 }

--- a/Sources/Apollo/ResultOrPromise.swift
+++ b/Sources/Apollo/ResultOrPromise.swift
@@ -19,6 +19,7 @@ func whenAll<Value>(_ resultsOrPromises: [ResultOrPromise<Value>], notifyOn queu
 
   return .promise(Promise { (fulfill, reject) in
     let group = DispatchGroup()
+    var rejected = false
 
     for resultOrPromise in resultsOrPromises {
       group.enter()
@@ -27,11 +28,15 @@ func whenAll<Value>(_ resultsOrPromises: [ResultOrPromise<Value>], notifyOn queu
         group.leave()
       }.catch { error in
         reject(error)
+        rejected = true
+        group.leave()
       }
     }
 
     group.notify(queue: queue) {
-      fulfill(resultsOrPromises.map { $0.result!.value! })
+      if !rejected {
+        fulfill(resultsOrPromises.map { $0.result!.value! })
+      }
     }
   })
 }

--- a/Tests/ApolloTests/PromiseTests.swift
+++ b/Tests/ApolloTests/PromiseTests.swift
@@ -249,4 +249,34 @@ class PromiseTests: XCTestCase {
     
     waitForExpectations(timeout: 1)
   }
+
+  func testWhenAllRejectsWhenAnyOfThePromisesRejectsAsync_doesNotCreateMemoryLeak() throws {
+    var executeReject: ((Error) -> Void)?
+
+    var promises: [Promise<String>] = [Promise(fulfilled: "foo"),
+                                       Promise<String> { _, reject in executeReject = reject },
+                                       Promise(fulfilled: "bar")]
+    weak var weakPromise0 = promises[0]
+    weak var weakPromise1 = promises[1]
+    weak var weakPromise2 = promises[2]
+
+    let expectation = self.expectation(description: "whenAll catch handler invoked")
+
+    whenAll(promises).catch { error in
+      XCTAssert(error is TestError)
+
+      expectation.fulfill()
+    }
+
+    promises = []
+    executeReject?(TestError())
+    executeReject = nil
+
+    waitForExpectations(timeout: 1)
+
+    XCTAssertNil(weakPromise0)
+    XCTAssertNil(weakPromise1)
+    XCTAssertNil(weakPromise2)
+  }
+
 }


### PR DESCRIPTION
When any of the promises reject, we were calling reject, but never leaving the `DispatchGroup`. This means the `notify` block was never being scheduled. This _is_ what we wanted, but the unintended consequence of that is that the `notify` block was then retained indefinitely, and the `group.notify` block is retaining the `promises` or the `resultOrPromises`. This way, the notify block gets called and releases it's reference to the `promises`, but if any rejects occured, it does not call `fulfill`.

@designatednerd I was seeing memory leaks in my application and was able to track it down to this. I wrote a unit test for `Promise`, but unit testing memory leaks of value semantic entities is impossible, so I can't provide a unit test for `ResultOrPromise`. I tested the fix with my app, and the memory leaks are gone now.