### PR TITLE
Make GraphQLQueryWatcher Query Public

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -3,7 +3,7 @@ import Dispatch
 /// A `GraphQLQueryWatcher` is responsible for watching the store, and calling the result handler with a new result whenever any of the data the previous result depends on changes.
 public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, ApolloStoreSubscriber {
   weak var client: ApolloClientProtocol?
-  let query: Query
+  public let query: Query
   let resultHandler: GraphQLResultHandler<Query.Data>
 
   private var context = 0


### PR DESCRIPTION
Allow the using app to access the query on
the watcher.

It makes our life a lot easier to be able to access the query on watchers so we can update the cache for things we are watching if we know they changed.