### PR TITLE
Apollo Codegen Lib Should Only Compile on macOS

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCLI.swift
+++ b/Sources/ApolloCodegenLib/ApolloCLI.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Wrapper for calling the bundled node-based Apollo CLI.
+@available(OSX, message: "Only available on macOS")
 public struct ApolloCLI {
   
   /// Creates an instance of `ApolloCLI`, downloading and extracting if needed

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// A class to facilitate running code generation
+@available(OSX, message: "Only available on macOS")
 public class ApolloCodegen {
   
   /// Errors which can happen with code generation

--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// A wrapper to facilitate downloading a schema with the Apollo node CLI
+@available(OSX, message: "Only available on macOS")
 public struct ApolloSchemaDownloader {
   
   /// Runs code generation from the given folder with the passed-in options

--- a/Sources/ApolloCodegenLib/Basher.swift
+++ b/Sources/ApolloCodegenLib/Basher.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Bash command runner
+@available(OSX, message: "Only available on macOS")
 public struct Basher {
   
   public enum BashError: Error, LocalizedError {

--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Helper for downloading the CLI Zip file so we don't have to include it in the repo.
+@available(OSX, message: "Only available on macOS")
 struct CLIDownloader {
   
   enum CLIDownloaderError: Error, LocalizedError {

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Helper for extracting and validating the node-based Apollo CLI from a zip.
+@available(OSX, message: "Only available on macOS")
 struct CLIExtractor {
   
   // MARK: - Extracting the binary


### PR DESCRIPTION
This PR adds `@available` guards to make sure things that can't compile on other platforms won't accidentally compile on other platforms. Relates to #1039.