### PR TITLE
Make GraphQLResponse a generic on the response type instead of on the operation type

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -78,10 +78,10 @@ public class ApolloClient {
     }
   }
 
-  private func handleOperationResult<Operation>(shouldPublishResultToStore: Bool,
+  private func handleOperationResult<Data: GraphQLSelectionSet>(shouldPublishResultToStore: Bool,
                                                 context: UnsafeMutableRawPointer?,
-                                                _ result: Result<GraphQLResponse<Operation>, Error>,
-                                                resultHandler: @escaping GraphQLResultHandler<Operation.Data>) {
+                                                _ result: Result<GraphQLResponse<Data>, Error>,
+                                                resultHandler: @escaping GraphQLResultHandler<Data>) {
     switch result {
     case .failure(let error):
       resultHandler(.failure(error))

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -79,9 +79,9 @@ public class ApolloClient {
   }
 
   private func handleOperationResult<Data: GraphQLSelectionSet>(shouldPublishResultToStore: Bool,
-                                                context: UnsafeMutableRawPointer?,
-                                                _ result: Result<GraphQLResponse<Data>, Error>,
-                                                resultHandler: @escaping GraphQLResultHandler<Data>) {
+                                                                context: UnsafeMutableRawPointer?,
+                                                                _ result: Result<GraphQLResponse<Data>, Error>,
+                                                                resultHandler: @escaping GraphQLResultHandler<Data>) {
     switch result {
     case .failure(let error):
       resultHandler(.failure(error))

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -133,10 +133,10 @@ public class HTTPNetworkTransport {
     self.requestCreator = requestCreator
   }
 
-  private func send<Operation>(operation: Operation,
+  private func send<Operation: GraphQLOperation>(operation: Operation,
                                isPersistedQueryRetry: Bool,
                                files: [GraphQLFile]?,
-                               completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+                               completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     let request: URLRequest
     do {
       request = try self.createRequest(for: operation,
@@ -231,10 +231,10 @@ public class HTTPNetworkTransport {
     return task
   }
 
-  private func handleGraphQLErrorsOrComplete<Operation>(operation: Operation,
+  private func handleGraphQLErrorsOrComplete<Operation: GraphQLOperation>(operation: Operation,
                                                         files: [GraphQLFile]?,
-                                                        response: GraphQLResponse<Operation>,
-                                                        completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) {
+                                                        response: GraphQLResponse<Operation.Data>,
+                                                        completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
     guard
       let delegate = self.delegate as? HTTPNetworkTransportGraphQLErrorDelegate,
       let graphQLErrors = response.parseErrorsOnlyFast(),
@@ -261,12 +261,12 @@ public class HTTPNetworkTransport {
     })
   }
 
-  private func handleGraphQLErrorsIfNeeded<Operation>(operation: Operation,
+  private func handleGraphQLErrorsIfNeeded<Operation: GraphQLOperation>(operation: Operation,
                                                       files: [GraphQLFile]?,
                                                       for request: URLRequest,
                                                       body: JSONObject,
                                                       errors: [GraphQLError],
-                                                      completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation>, Error>) -> Void) {
+                                                      completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
 
     let errorMessages = errors.compactMap { $0.message }
     if self.enableAutoPersistedQueries,
@@ -283,12 +283,12 @@ public class HTTPNetworkTransport {
     }
   }
 
-  private func handleErrorOrRetry<Operation>(operation: Operation,
+  private func handleErrorOrRetry<Operation: GraphQLOperation>(operation: Operation,
                                              files: [GraphQLFile]?,
                                              error: Error,
                                              for request: URLRequest,
                                              response: URLResponse?,
-                                             completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) {
+                                             completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
     guard
       let delegate = self.delegate,
       let retrier = delegate as? HTTPNetworkTransportRetryDelegate else {
@@ -439,7 +439,7 @@ public class HTTPNetworkTransport {
 
 extension HTTPNetworkTransport: NetworkTransport {
 
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+  public func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     return send(operation: operation,
                 isPersistedQueryRetry: false,
                 files: nil,
@@ -451,9 +451,9 @@ extension HTTPNetworkTransport: NetworkTransport {
 
 extension HTTPNetworkTransport: UploadingNetworkTransport {
 
-  public func upload<Operation>(operation: Operation,
+  public func upload<Operation: GraphQLOperation>(operation: Operation,
                                 files: [GraphQLFile],
-                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     return send(operation: operation,
                 isPersistedQueryRetry: false,
                 files: files,

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -134,9 +134,9 @@ public class HTTPNetworkTransport {
   }
 
   private func send<Operation: GraphQLOperation>(operation: Operation,
-                               isPersistedQueryRetry: Bool,
-                               files: [GraphQLFile]?,
-                               completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
+                                                 isPersistedQueryRetry: Bool,
+                                                 files: [GraphQLFile]?,
+                                                 completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     let request: URLRequest
     do {
       request = try self.createRequest(for: operation,
@@ -262,11 +262,11 @@ public class HTTPNetworkTransport {
   }
 
   private func handleGraphQLErrorsIfNeeded<Operation: GraphQLOperation>(operation: Operation,
-                                                      files: [GraphQLFile]?,
-                                                      for request: URLRequest,
-                                                      body: JSONObject,
-                                                      errors: [GraphQLError],
-                                                      completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
+                                                                        files: [GraphQLFile]?,
+                                                                        for request: URLRequest,
+                                                                        body: JSONObject,
+                                                                        errors: [GraphQLError],
+                                                                        completionHandler: @escaping (_ results: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
 
     let errorMessages = errors.compactMap { $0.message }
     if self.enableAutoPersistedQueries,
@@ -284,11 +284,11 @@ public class HTTPNetworkTransport {
   }
 
   private func handleErrorOrRetry<Operation: GraphQLOperation>(operation: Operation,
-                                             files: [GraphQLFile]?,
-                                             error: Error,
-                                             for request: URLRequest,
-                                             response: URLResponse?,
-                                             completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
+                                                               files: [GraphQLFile]?,
+                                                               error: Error,
+                                                               for request: URLRequest,
+                                                               response: URLResponse?,
+                                                               completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) {
     guard
       let delegate = self.delegate,
       let retrier = delegate as? HTTPNetworkTransportRetryDelegate else {
@@ -452,8 +452,8 @@ extension HTTPNetworkTransport: NetworkTransport {
 extension HTTPNetworkTransport: UploadingNetworkTransport {
 
   public func upload<Operation: GraphQLOperation>(operation: Operation,
-                                files: [GraphQLFile],
-                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
+                                                  files: [GraphQLFile],
+                                                  completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     return send(operation: operation,
                 isPersistedQueryRetry: false,
                 files: files,

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -11,7 +11,7 @@ public protocol NetworkTransport: class {
   ///   - operation: The operation to send.
   ///   - completionHandler: A closure to call when a request completes. On `success` will contain the response received from the server. On `failure` will contain the error which occurred.
   /// - Returns: An object that can be used to cancel an in progress request.
-  func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+  func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable
 
   /// The name of the client to send as a header value.
   var clientName: String { get }
@@ -91,5 +91,5 @@ public protocol UploadingNetworkTransport: NetworkTransport {
   ///   - files: An array of `GraphQLFile` objects to send.
   ///   - completionHandler: The completion handler to execute when the request completes or errors
   /// - Returns: An object that can be used to cancel an in progress request.
-  func upload<Operation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable
+  func upload<Operation: GraphQLOperation>(operation: Operation, files: [GraphQLFile], completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable
 }

--- a/Sources/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Sources/ApolloTestSupport/MockNetworkTransport.swift
@@ -11,7 +11,7 @@ public final class MockNetworkTransport: NetworkTransport {
     self.body = body
   }
 
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+  public func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     DispatchQueue.global(qos: .default).async {
       completionHandler(.success(GraphQLResponse(operation: operation, body: self.body)))
     }

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -42,7 +42,7 @@ public class SplitNetworkTransport {
 
 extension SplitNetworkTransport: NetworkTransport {
 
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+  public func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     if operation.operationType == .subscription {
       return webSocketNetworkTransport.send(operation: operation, completionHandler: completionHandler)
     } else {
@@ -55,9 +55,9 @@ extension SplitNetworkTransport: NetworkTransport {
 
 extension SplitNetworkTransport: UploadingNetworkTransport {
 
-  public func upload<Operation>(operation: Operation,
+  public func upload<Operation: GraphQLOperation>(operation: Operation,
                                 files: [GraphQLFile],
-                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>, Error>) -> Void) -> Cancellable {
+                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     return httpNetworkTransport.upload(operation: operation,
                                        files: files,
                                        completionHandler: completionHandler)

--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -56,8 +56,8 @@ extension SplitNetworkTransport: NetworkTransport {
 extension SplitNetworkTransport: UploadingNetworkTransport {
 
   public func upload<Operation: GraphQLOperation>(operation: Operation,
-                                files: [GraphQLFile],
-                                completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
+                                                  files: [GraphQLFile],
+                                                  completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>, Error>) -> Void) -> Cancellable {
     return httpNetworkTransport.upload(operation: operation,
                                        files: files,
                                        completionHandler: completionHandler)

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -273,7 +273,7 @@ public class WebSocketTransport {
 // MARK: - HTTPNetworkTransport conformance
 
 extension WebSocketTransport: NetworkTransport {
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation>,Error>) -> Void) -> Cancellable {
+  public func send<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (_ result: Result<GraphQLResponse<Operation.Data>,Error>) -> Void) -> Cancellable {
     if let error = self.error.value {
       completionHandler(.failure(error))
       return EmptyCancellable()

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -35,7 +35,7 @@ class HTTPTransportTests: XCTestCase {
     return transport
   }()
   
-  private func validateHeroNameQueryResponse<Operation: GraphQLOperation>(result: Result<GraphQLResponse<Operation>, Error>,
+  private func validateHeroNameQueryResponse<Data: GraphQLSelectionSet>(result: Result<GraphQLResponse<Data>, Error>,
                                                                           expectation: XCTestExpectation,
                                                                           file: StaticString = #file,
                                                                           line: UInt = #line) {

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -36,9 +36,9 @@ class HTTPTransportTests: XCTestCase {
   }()
   
   private func validateHeroNameQueryResponse<Data: GraphQLSelectionSet>(result: Result<GraphQLResponse<Data>, Error>,
-                                                                          expectation: XCTestExpectation,
-                                                                          file: StaticString = #file,
-                                                                          line: UInt = #line) {
+                                                                        expectation: XCTestExpectation,
+                                                                        file: StaticString = #file,
+                                                                        line: UInt = #line) {
     defer {
       expectation.fulfill()
     }


### PR DESCRIPTION
It looks like there's little reasons to have `GraphQLResponse` be tied to the operation type, instead of more simply to the response type (`.Data`)

I was interested in this change as I use a query wrapper class around the `GraphQLOperation` generated by the codegen. This wrapper allows me to easily set context for my `NetworkTransport` that receives the operation through Apollo. While it shares the same response type as the wrapped operation, it is of a different type and this was not playing well with the `GraphQLResponse`

This slightly changes the public API of `NetworkTransport` as well, but all the changes are straightforward.