### PR TITLE
SwiftUI previews fix

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCLI.swift
+++ b/Sources/ApolloCodegenLib/ApolloCLI.swift
@@ -1,7 +1,9 @@
 import Foundation
 
+// Only available on macOS
+#if os(macOS)
+
 /// Wrapper for calling the bundled node-based Apollo CLI.
-@available(OSX, message: "Only available on macOS")
 public struct ApolloCLI {
   
   /// Creates an instance of `ApolloCLI`, downloading and extracting if needed
@@ -47,3 +49,5 @@ public struct ApolloCLI {
     return try Basher.run(command: command, from: folder)
   }
 }
+
+#endif

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -1,7 +1,9 @@
 import Foundation
 
+// Only available on macOS
+#if os(macOS)
+
 /// A class to facilitate running code generation
-@available(OSX, message: "Only available on macOS")
 public class ApolloCodegen {
   
   /// Errors which can happen with code generation
@@ -42,3 +44,5 @@ public class ApolloCodegen {
     return try cli.runApollo(with: options.arguments, from: folder)
   }
 }
+
+#endif

--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -1,7 +1,9 @@
 import Foundation
 
+// Only available on macOS
+#if os(macOS)
+
 /// A wrapper to facilitate downloading a schema with the Apollo node CLI
-@available(OSX, message: "Only available on macOS")
 public struct ApolloSchemaDownloader {
   
   /// Runs code generation from the given folder with the passed-in options
@@ -19,3 +21,5 @@ public struct ApolloSchemaDownloader {
     return try cli.runApollo(with: options.arguments)
   }
 }
+
+#endif

--- a/Sources/ApolloCodegenLib/Basher.swift
+++ b/Sources/ApolloCodegenLib/Basher.swift
@@ -1,7 +1,9 @@
 import Foundation
 
+// Only available on macOS
+#if os(macOS)
+
 /// Bash command runner
-@available(OSX, message: "Only available on macOS")
 public struct Basher {
   
   public enum BashError: Error, LocalizedError {
@@ -65,3 +67,5 @@ public struct Basher {
     return output
   }
 }
+
+#endif

--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -1,7 +1,9 @@
 import Foundation
 
+// Only available on macOS
+#if os(macOS)
+
 /// Helper for downloading the CLI Zip file so we don't have to include it in the repo.
-@available(OSX, message: "Only available on macOS")
 struct CLIDownloader {
   
   enum CLIDownloaderError: Error, LocalizedError {
@@ -118,3 +120,5 @@ struct CLIDownloader {
     }
   }
 }
+
+#endif

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -1,7 +1,9 @@
 import Foundation
 
+// Only available on macOS
+#if os(macOS)
+
 /// Helper for extracting and validating the node-based Apollo CLI from a zip.
-@available(OSX, message: "Only available on macOS")
 struct CLIExtractor {
   
   // MARK: - Extracting the binary
@@ -122,3 +124,5 @@ struct CLIExtractor {
     }
   }
 }
+
+#endif


### PR DESCRIPTION
Hello @designatednerd  👋 
Thank you for your amazing work on this library! I had the [same issue reported here](https://github.com/apollographql/apollo-ios/issues/1039) and decided to try to help out.

This PR fixes an issue that started with the inclusion of `ApolloCodegenLib` in `0.23.0`, where all SwiftUI previews for files in targets that also import Apollo stopped working with the following error: 
```
use of unresolved identifier 'Process'

Compile /Users/peck/Library/Developer/Xcode/DerivedData/practice-ffshylstkbdpuwdygwokyrmihofw/SourcePackages/checkouts/apollo-ios/Sources/ApolloCodegenLib/Basher.swift:
/Users/peck/Library/Developer/Xcode/DerivedData/practice-ffshylstkbdpuwdygwokyrmihofw/SourcePackages/checkouts/apollo-ios/Sources/ApolloCodegenLib/Basher.swift:27:16: error: use of unresolved identifier 'Process'
    let task = Process()
```
In my case, I have Apollo as a dependency using SPM. I don't know if this issue is reproducible with cocoapods or other dependency managers.

This happens because `ApolloCodegenLib` is meant to be built only on macOS, and this check is only enforced with a runtime `@available` annotation instead of a compile-time `#if os(macOS)`.
I looked for a way to specify a specific platform per-target directly in the SPM manifest, but according to [this PR in the SPM repo](https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md) there is no way for now (and he recommends to strip away the platform specific code using `#if`): 
> Platform-specific targets or products: Consider that a package supports multiple platforms but has a product that should be only built for Linux. There is no way to express this intent and the build system may end up trying to build such targets on all platforms. A simple workaround is to use #if to conditionalize the source code of the target. Another use case comes up when you want to keep deployment target of a certain target lower than other targets in a package. A workaround is factoring out the target into its own package. A proper solution to this problem will be explored in a separate proposal, which should provide target-level settings.

This PR applies the suggestion specified above. I'm sorry it is not below 20 lines and I'm not really following the contributor guide, but this seems an "innocuous" bug fix. 😄 

I don't know how to test this behavior with SwiftUI previews to be honest.