### PR TITLE
Create folder for downloading CLI if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ package-lock.json
 scripts/apollo
 scripts/apollo.tar.gz
 SwiftScripts/ApolloCLI
+Tests/ApolloCodegenTests/scripts

--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -67,6 +67,8 @@ struct CLIDownloader {
   ///   - zipFileURL: The URL where downloaded data should be saved.
   ///   - timeout: The maximum time to wait before indicating that the download timed out, in seconds.
   private static func download(to zipFileURL: URL, timeout: Double) throws {
+    try FileManager.default.apollo_createContainingFolderIfNeeded(for: zipFileURL)
+    
     CodegenLogger.log("Downloading zip file with the CLI...")
     let semaphore = DispatchSemaphore(value: 0)
     var errorToThrow: Error? = CLIDownloaderError.downloadTimedOut(after: timeout)

--- a/Tests/ApolloCodegenTests/CLIDownloaderTests.swift
+++ b/Tests/ApolloCodegenTests/CLIDownloaderTests.swift
@@ -21,6 +21,17 @@ class CLIDownloaderTests: XCTestCase {
     XCTAssertEqual(try FileManager.default.apollo_shasum(at: zipFileURL), CLIExtractor.expectedSHASUM)    
   }
   
+  func testDownloadingToFolderThatDoesntAlreadyExistWorks() throws {
+    let scriptsURL = CodegenTestHelper.cliFolderURL()
+    try FileManager.default.apollo_deleteFolder(at: scriptsURL)
+    
+    XCTAssertFalse(FileManager.default.apollo_folderExists(at: scriptsURL))
+    
+    try CLIDownloader.downloadIfNeeded(cliFolderURL: scriptsURL, timeout: 90.0)
+    
+    XCTAssertTrue(FileManager.default.apollo_folderExists(at: scriptsURL))
+  }
+  
   func testTimeoutThrowsCorrectError() throws {
     let scriptsURL = CodegenTestHelper.cliFolderURL()
     

--- a/Tests/ApolloCodegenTests/CodegenTestHelper.swift
+++ b/Tests/ApolloCodegenTests/CodegenTestHelper.swift
@@ -15,15 +15,16 @@ struct CodegenTestHelper {
   static var timeout: Double = 90.0
   
   static func sourceRootURL() -> URL {
-    let parentFolder = FileFinder.findParentFolder()
-    return parentFolder
+    FileFinder.findParentFolder()
         .deletingLastPathComponent() // Tests
         .deletingLastPathComponent() // apollo-ios
   }
   
   static func cliFolderURL() -> URL {
-    let sourceRoot = self.sourceRootURL()
-    return sourceRoot.appendingPathComponent("scripts")
+    self.sourceRootURL()
+      .appendingPathComponent("Tests")
+      .appendingPathComponent("ApolloCodegenTests")
+      .appendingPathComponent("scripts")
   }
   
   static func apolloFolderURL() -> URL {

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -74,7 +74,11 @@ You can use this to get the URL of the folder you plan to download the CLI to:
 let cliFolderURL = sourceRootURL
   .appendingPathComponent("Codegen")
   .appendingPathComponent("ApolloCLI")
-```    
+```
+
+>**Note**: We recommend adding this folder to your `.gitignore`, because otherwise you'll be adding the zip file and a ton of JS code to your repo. 
+>
+> If you're on versions prior to `0.24.0`, throw an empty `.keep` file and force-add it to git to preserve the folder structure. Versions after `0.24.0` automatically create the folder being downloaded to if it doesn't exist.
 
 Now, with access to both the `sourceRootURL` and the `cliFolderURL`, it's time to use your script to do neat stuff for you!
 


### PR DESCRIPTION
Related to #1057, this PR creates the folder the CLI is being downloaded to if it doesn't already exist. I've also thrown a note into the documentation indicating that the folder the CLI is downloaded to should be in `.gitignore`, and that after `0.24.0` is out it will be auto-created with a workaround for prior versions.