### PR TITLE
Fix bash paths with spaces

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCLI.swift
+++ b/Sources/ApolloCodegenLib/ApolloCLI.swift
@@ -38,13 +38,13 @@ public struct ApolloCLI {
   public func runApollo(with arguments: [String],
                         from folder: URL? = nil) throws -> String {
     // Add the binary folder URL to $PATH so the script can find pre-compiled `node`
-    let command = "export PATH=$PATH:\(self.binaryFolderURL.path)" +
+    let command = "export PATH=$PATH:'\(self.binaryFolderURL.path)'" +
       // Log out the version for debugging purposes
-      " && \(self.scriptPath) --version" +
+      " && '\(self.scriptPath)' --version" +
       // Set the final command to log out the passed-in arguments for debugging purposes
       " && set -x" +
       // Actually run the script with the given options.
-      " && \(self.scriptPath) \(arguments.joined(separator: " "))"
+      " && '\(self.scriptPath)' \(arguments.joined(separator: " "))"
     
     return try Basher.run(command: command, from: folder)
   }

--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -55,7 +55,7 @@ public struct ApolloSchemaOptions {
       arguments.append("--key=\(key)")
     }
     
-    arguments.append(outputURL.path)
+    arguments.append("'\(outputURL.path)'")
     
     return arguments
   }

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -99,7 +99,7 @@ struct CLIExtractor {
     try self.validateZipFileSHASUM(at: zipFileURL, expected: expectedSHASUM)
     
     CodegenLogger.log("Extracting CLI from zip file. This may take a second...")
-    _ = try Basher.run(command: "tar xzf \(zipFileURL.path) -C \(cliFolderURL.path)", from: nil)
+    _ = try Basher.run(command: "tar xzf '\(zipFileURL.path)' -C '\(cliFolderURL.path)'", from: nil)
     
     let apolloFolderURL = ApolloFilePathHelper.apolloFolderURL(fromCLIFolder: cliFolderURL)
     let binaryFolderURL = ApolloFilePathHelper.binaryFolderURL(fromApollo: apolloFolderURL)

--- a/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
@@ -27,7 +27,7 @@ class ApolloSchemaTests: XCTestCase {
     XCTAssertEqual(options.arguments, [
         "client:download-schema",
         "--endpoint=http://localhost:8080/graphql",
-        expectedOutputURL.path
+        "'\(expectedOutputURL.path)'"
     ])
   }
   
@@ -54,7 +54,7 @@ class ApolloSchemaTests: XCTestCase {
         "--endpoint=http://localhost:8080/graphql",
         "--header=\(header)",
         "--key=\(apiKey)",
-        expectedOutputURL.path
+        "'\(expectedOutputURL.path)'"
     ])
   }
   

--- a/Tests/ApolloCodegenTests/CodegenTestHelper.swift
+++ b/Tests/ApolloCodegenTests/CodegenTestHelper.swift
@@ -44,7 +44,7 @@ struct CodegenTestHelper {
     self.sourceRootURL()
       .appendingPathComponent("Tests")
       .appendingPathComponent("ApolloCodegenTests")
-      .appendingPathComponent("scripts")
+      .appendingPathComponent("scripts directory")
   }
   
   static func apolloFolderURL() -> URL {


### PR DESCRIPTION
The `Basher.run` command is failing when it contains paths with spaces. This change encloses string interpolated paths in single quotes to allow paths with spaces to work with the bash script.

Changed `CodegenTestHelper.cliFolderURL` to use a path with a space in it (changed `"scripts"` to `"scripts directory"`) to test this change.