### PR TITLE
Workaround CLI argument parsing issue

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCLI.swift
+++ b/Sources/ApolloCodegenLib/ApolloCLI.swift
@@ -38,13 +38,13 @@ public struct ApolloCLI {
   public func runApollo(with arguments: [String],
                         from folder: URL? = nil) throws -> String {
     // Add the binary folder URL to $PATH so the script can find pre-compiled `node`
-    let command = "export PATH=$PATH:\(self.binaryFolderURL.path)" +
+    let command = "export PATH=$PATH:'\(self.binaryFolderURL.path)'" +
       // Log out the version for debugging purposes
-      " && \(self.scriptPath) --version" +
+      " && '\(self.scriptPath)' --version" +
       // Set the final command to log out the passed-in arguments for debugging purposes
       " && set -x" +
       // Actually run the script with the given options.
-      " && \(self.scriptPath) \(arguments.joined(separator: " "))"
+      " && '\(self.scriptPath)' \(arguments.joined(separator: " "))"
     
     return try Basher.run(command: command, from: folder)
   }

--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -55,7 +55,7 @@ public struct ApolloSchemaOptions {
       arguments.append("--key=\(key)")
     }
     
-    arguments.append(outputURL.path)
+    arguments.append("'\(outputURL.path)'")
     
     return arguments
   }

--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -47,15 +47,15 @@ public struct ApolloSchemaOptions {
       "--endpoint=\(self.endpointURL.absoluteString)"
     ]
     
-    if let header = self.header {
-      arguments.append("--header=\(header)")
-    }
-    
     if let key = self.apiKey {
       arguments.append("--key=\(key)")
     }
     
     arguments.append("'\(outputURL.path)'")
+    
+    if let header = self.header {
+      arguments.append("--header=\(header)")
+    }
     
     return arguments
   }

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -99,7 +99,7 @@ struct CLIExtractor {
     try self.validateZipFileSHASUM(at: zipFileURL, expected: expectedSHASUM)
     
     CodegenLogger.log("Extracting CLI from zip file. This may take a second...")
-    _ = try Basher.run(command: "tar xzf \(zipFileURL.path) -C \(cliFolderURL.path)", from: nil)
+    _ = try Basher.run(command: "tar xzf '\(zipFileURL.path)' -C '\(cliFolderURL.path)'", from: nil)
     
     let apolloFolderURL = ApolloFilePathHelper.apolloFolderURL(fromCLIFolder: cliFolderURL)
     let binaryFolderURL = ApolloFilePathHelper.binaryFolderURL(fromApollo: apolloFolderURL)

--- a/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
@@ -27,7 +27,7 @@ class ApolloSchemaTests: XCTestCase {
     XCTAssertEqual(options.arguments, [
         "client:download-schema",
         "--endpoint=http://localhost:8080/graphql",
-        expectedOutputURL.path
+        "'\(expectedOutputURL.path)'"
     ])
   }
   
@@ -54,7 +54,7 @@ class ApolloSchemaTests: XCTestCase {
         "--endpoint=http://localhost:8080/graphql",
         "--header=\(header)",
         "--key=\(apiKey)",
-        expectedOutputURL.path
+        "'\(expectedOutputURL.path)'"
     ])
   }
   

--- a/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
@@ -52,9 +52,9 @@ class ApolloSchemaTests: XCTestCase {
     XCTAssertEqual(options.arguments, [
         "client:download-schema",
         "--endpoint=http://localhost:8080/graphql",
-        "--header=\(header)",
         "--key=\(apiKey)",
-        "'\(expectedOutputURL.path)'"
+        "'\(expectedOutputURL.path)'",
+        "--header=\(header)"
     ])
   }
   

--- a/Tests/ApolloCodegenTests/CodegenTestHelper.swift
+++ b/Tests/ApolloCodegenTests/CodegenTestHelper.swift
@@ -44,7 +44,7 @@ struct CodegenTestHelper {
     self.sourceRootURL()
       .appendingPathComponent("Tests")
       .appendingPathComponent("ApolloCodegenTests")
-      .appendingPathComponent("scripts")
+      .appendingPathComponent("scripts directory")
   }
   
   static func apolloFolderURL() -> URL {


### PR DESCRIPTION
Due to an underlying issue with the Oclif framework that the Apollo CLI uses, the `schema:download` command (at least) fails when `--header` arguments are not placed at the end of the command, such as when specifying a non-default output path. The ApolloCodegenLib places the output path after the header argument, so the schema download always fails.

This PR just moves the header argument to the end of the bash command by reordering the array of arguments in `ApolloSchemaOptions#arguments`.

See also:
https://github.com/apollographql/apollo-tooling/issues/844#issuecomment-547143805