### PR TITLE
Workaround CLI argument parsing issue

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -53,6 +53,8 @@ public struct ApolloSchemaOptions {
     
     arguments.append(outputURL.path)
     
+		// Header argument must be last in the CLI command due to an underlying issue in the Oclif framework.
+		// See: https://github.com/apollographql/apollo-tooling/issues/844#issuecomment-547143805
     if let header = self.header {
       arguments.append("--header=\(header)")
     }

--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -47,15 +47,15 @@ public struct ApolloSchemaOptions {
       "--endpoint=\(self.endpointURL.absoluteString)"
     ]
     
-    if let header = self.header {
-      arguments.append("--header=\(header)")
-    }
-    
     if let key = self.apiKey {
       arguments.append("--key=\(key)")
     }
     
     arguments.append(outputURL.path)
+    
+    if let header = self.header {
+      arguments.append("--header=\(header)")
+    }
     
     return arguments
   }

--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -53,8 +53,8 @@ public struct ApolloSchemaOptions {
     
     arguments.append(outputURL.path)
     
-		// Header argument must be last in the CLI command due to an underlying issue in the Oclif framework.
-		// See: https://github.com/apollographql/apollo-tooling/issues/844#issuecomment-547143805
+    // Header argument must be last in the CLI command due to an underlying issue in the Oclif framework.
+    // See: https://github.com/apollographql/apollo-tooling/issues/844#issuecomment-547143805
     if let header = self.header {
       arguments.append("--header=\(header)")
     }

--- a/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
@@ -52,9 +52,9 @@ class ApolloSchemaTests: XCTestCase {
     XCTAssertEqual(options.arguments, [
         "client:download-schema",
         "--endpoint=http://localhost:8080/graphql",
-        "--header=\(header)",
         "--key=\(apiKey)",
-        expectedOutputURL.path
+        expectedOutputURL.path,
+				"--header=\(header)"
     ])
   }
   

--- a/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
@@ -54,7 +54,7 @@ class ApolloSchemaTests: XCTestCase {
         "--endpoint=http://localhost:8080/graphql",
         "--key=\(apiKey)",
         expectedOutputURL.path,
-				"--header=\(header)"
+        "--header=\(header)"
     ])
   }
   


### PR DESCRIPTION
Due to an underlying issue with the Oclif framework that the Apollo CLI uses, the `schema:download` command (at least) fails when `--header` arguments are not placed at the end of the command, such as when specifying a non-default output path. The ApolloCodegenLib places the output path after the header argument, so the schema download always fails.

This PR just moves the header argument to the end of the bash command by reordering the array of arguments in `ApolloSchemaOptions#arguments`.

See also:
https://github.com/apollographql/apollo-tooling/issues/844#issuecomment-547143805