### PR TITLE
Enclose bash argument values in quotes to allow spaces

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -149,8 +149,8 @@ public struct ApolloCodegenOptions {
       "codegen:generate",
       "--target=\(self.codegenEngine.targetForApolloTools)",
       "--addTypename",
-      "--includes=\(self.includes)",
-      "--localSchemaFile=\(self.urlToSchemaFile.path)"
+      "--includes='\(self.includes)'",
+      "--localSchemaFile='\(self.urlToSchemaFile.path)'"
     ]
     
     if let namespace = self.namespace {
@@ -158,11 +158,11 @@ public struct ApolloCodegenOptions {
     }
 
     if let only = only {
-      arguments.append("--only=\(only.path)")
+      arguments.append("--only='\(only.path)'")
     }
     
     if let idsURL = self.operationIDsURL {
-      arguments.append("--operationIdsPath=\(idsURL.path)")
+      arguments.append("--operationIdsPath='\(idsURL.path)'")
     }
     
     if self.omitDeprecatedEnumCases {
@@ -183,9 +183,9 @@ public struct ApolloCodegenOptions {
     
     switch self.outputFormat {
     case .singleFile(let fileURL):
-      arguments.append(fileURL.path)
+      arguments.append("'\(fileURL.path)'")
     case .multipleFiles(let folderURL):
-      arguments.append(folderURL.path)
+      arguments.append("'\(folderURL.path)'")
     }
     
     return arguments

--- a/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaOptions.swift
@@ -56,7 +56,7 @@ public struct ApolloSchemaOptions {
     // Header argument must be last in the CLI command due to an underlying issue in the Oclif framework.
     // See: https://github.com/apollographql/apollo-tooling/issues/844#issuecomment-547143805
     if let header = self.header {
-      arguments.append("--header=\(header)")
+      arguments.append("--header='\(header)'")
     }
     
     return arguments

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -50,10 +50,10 @@ class ApolloCodegenTests: XCTestCase {
       "codegen:generate",
       "--target=swift",
       "--addTypename",
-      "--includes=./**/*.graphql",
-      "--localSchemaFile=\(schema.path)",
+      "--includes='./**/*.graphql'",
+      "--localSchemaFile='\(schema.path)'",
       "--mergeInFieldsFromFragmentSpreads",
-      output.path,
+      "'\(output.path)'",
     ])
   }
   
@@ -97,14 +97,14 @@ class ApolloCodegenTests: XCTestCase {
       "codegen:generate",
       "--target=json",
       "--addTypename",
-      "--includes=*.graphql",
-      "--localSchemaFile=\(schema.path)",
+      "--includes='*.graphql'",
+      "--localSchemaFile='\(schema.path)'",
       "--namespace=\(namespace)",
-      "--only=\(only.path)",
-      "--operationIdsPath=\(operationIDsURL.path)",
+      "--only='\(only.path)'",
+      "--operationIdsPath='\(operationIDsURL.path)'",
       "--omitDeprecatedEnumCases",
       "--passthroughCustomScalars",
-      output.path,
+      "'\(output.path)'",
     ])
   }
   

--- a/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaTests.swift
@@ -54,7 +54,7 @@ class ApolloSchemaTests: XCTestCase {
         "--endpoint=http://localhost:8080/graphql",
         "--key=\(apiKey)",
         "'\(expectedOutputURL.path)'",
-        "--header=\(header)"
+        "--header='\(header)'"
     ])
   }
   


### PR DESCRIPTION
Following on from https://github.com/apollographql/apollo-ios/pull/1092 – I found a few more places where enclosing bash argument values in quotes is advisable.