### PR TITLE
Update swift-tools to 5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   xcode_version:
     type: string
-    default: "11.3.1"
+    default: "11.4.0"
   ios_current_version:
     type: string
     default: "13.3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ parameters:
     default: "11.4.0"
   ios_current_version:
     type: string
-    default: "13.3"
+    default: "13.4"
   ios_previous_version:
     type: string
     default: "12.4"
   ios_sdk:
     type: string
-    default: "iphonesimulator13.2"
+    default: "iphonesimulator13.4"
   macos_version: # The user-facing version string for macOS builds
     type: string
     default: "10.15"
@@ -21,10 +21,10 @@ parameters:
     default: "macosx10.15"
   tvos_version: # The user-facing version string of tvOS builds
     type: string
-    default: "13.3"
+    default: "13.4"
   tvos_sdk:
     type: string
-    default: "appletvsimulator13.2"
+    default: "appletvsimulator13.4"
 
 commands:
   common_test_steps:

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -1779,7 +1779,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/SwiftScripts\"\nswift run Codegen -t \"GitHub\"\n";
+			shellScript = "cd \"${SRCROOT}/SwiftScripts\"\nxcrun -sdk macosx swift run Codegen -t \"GitHub\"\n";
 		};
 		9FCE2D061E6C251100E34457 /* Generate Apollo Client API */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -1793,7 +1793,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/SwiftScripts\"\nswift run Codegen -t \"StarWars\"\n";
+			shellScript = "cd \"${SRCROOT}/SwiftScripts\"\nxcrun -sdk macosx swift run Codegen -t \"StarWars\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/SwiftScripts/Package.swift
+++ b/SwiftScripts/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,20 +6,28 @@ import PackageDescription
 let package = Package(
     name: "Codegen",
     dependencies: [
-        .package(path: ".."),
+        .package(name: "Apollo", path: ".."),
         .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.0.1"),
         .package(url: "https://github.com/designatednerd/SourceDocs.git", .branch("master"))
     ],
     targets: [
-        .target(
-            name: "Codegen",
-            dependencies: ["ApolloCodegenLib", "SwiftToolsSupport-auto"]),
+        .target(name: "Codegen",
+                dependencies: [
+                    .product(name: "ApolloCodegenLib", package: "Apollo"),
+                    .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+                ]),
         .target(name: "SchemaDownload",
-                dependencies: ["ApolloCodegenLib"]),
+                dependencies: [
+                    .product(name: "ApolloCodegenLib", package: "Apollo"),
+                ]),
         .target(name: "DocumentationGenerator",
-                dependencies: ["ApolloCodegenLib", "SourceDocsLib"]),
-        .testTarget(
-            name: "CodegenTests",
-            dependencies: ["Codegen"]),
+                dependencies: [
+                    .product(name: "ApolloCodegenLib", package: "Apollo"),
+                    .product(name: "SourceDocsLib", package: "SourceDocs"),
+                ]),
+        .testTarget(name: "CodegenTests",
+                    dependencies: [
+                        "Codegen"
+                    ]),
     ]
 )

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -245,16 +245,15 @@ Now, you're able to generate code from a debuggable Swift Package Manager execut
 1. Select the target in your project or workspace you want to run code generation, and go to the `Build Phases` tab. 
 
 2. Create a new Run Script Build Phase by selecting the **+** button in the upper left-hand corner:
+   ![New run script build phase dialog](screenshot/new_run_script_phase.png)
 
-  ![New run script build phase dialog](screenshot/new_run_script_phase.png)
-
-3. Update the build phase run script to `cd` into the folder where your executable's code lives, then run `swift run`. 
+3. Update the build phase run script to `cd` into the folder where your executable's code lives, then run `swift run` (using `xcrun` so that you can ensure it runs with the correct SDK, no matter what type of project you're building): 
 
     ```
     cd "${SRCROOT}"/Codegen
-    swift run
+    xcrun -sdk macosx swift run
     ```
-    
+
     >**Note**: If your package ever seems to have problems with caching, run `swift package clean` before `swift run` for a totally clean build. It is not recommended to do this by default, because it substantially increases build time.
     
 4. Build your target.

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -37,7 +37,9 @@ To begin, let's set up a Swift Package Manager executable:
 
     ```swift
     .target(name: "Codegen",
-            dependencies: ["ApolloCodegenLib"])
+            dependencies: [                    
+                .product(name: "ApolloCodegenLib", package: "Apollo"),
+            ])
     ```
     
 6. In `main.swift`, import the Codegen lib at the top of the file:


### PR DESCRIPTION
In this PR: 
- Updated `swift-tools` to 5.2 for the Codegen project
- Fixed issue where trying to run SPM from a run script build phase for iOS used the wrong swift
- Updated documentation for setting up a project using swift scripting to use workaround
- Updated documentation for new way of specifying a dependency in `swift-tools` 5.2