### PR TITLE
Fix package dependency syntax

### DIFF
--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -28,8 +28,7 @@ To begin, let's set up a Swift Package Manager executable:
 4. Update the `dependencies` section to grab the Apollo iOS library:
 
     ```swift
-    .package(url: "https://github.com/apollographql/apollo-ios.git", 
-             from: "0.22.0")
+    .package(name: "Apollo", url: "https://github.com/apollographql/apollo-ios.git", from: "0.23.0")
     ```
   **NOTE**: The version should be identical to the version you're using in your main project. 
 


### PR DESCRIPTION
@designatednerd I went ahead and made the PR related to #1102 in case you'd like to have it merged as I will probably be offline for a few hours.

One thing I'd like to ask though, is whether it would make sense to have the officially suggested syntax pointing to an exact version rather then a range and updating the docs as new versions are released, as in:

```swift
.package(name: "Apollo", url: "https://github.com/apollographql/apollo-ios.git", .exact("0.24.0"))
```
 I ask for a few reasons:
- You point out right below that the version should be an exact match to the one in the main project, but the unaware user may end up mixing things? That would also make it more in line with [**the iOS SDK setup docs**](https://github.com/apollographql/apollo-ios/blame/master/docs/shared/spm-installation-panel.mdx#L28) which favour the version to be up to the next minor only?
- It makes it easier to debug opened issues, since you'd know the exact version installed instead of having to guess or depend on the reporter double-checking it?
- It avoids propagating new bugs to people that setup their projects earlier and end up pulling a later version in the range (even if minor) which contains a bug?

Let me know if any of this makes sense and whether I should update the PR to make it align with these points.

Cheers!