### PR TITLE
Add workaround for SPM name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ scripts/apollo
 scripts/apollo.tar.gz
 SwiftScripts/ApolloCLI
 Tests/ApolloCodegenTests/scripts
+Tests/ApolloCodegenTests/scripts directory

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		9B518C85235F8125004C426D /* CLIDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDownloader.swift; sourceTree = "<group>"; };
 		9B518C88235F8AD4004C426D /* CLIDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDownloaderTests.swift; sourceTree = "<group>"; };
 		9B518C8A235F8B05004C426D /* ApolloFilePathHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloFilePathHelper.swift; sourceTree = "<group>"; };
+		9B5A1EE3243284F300F066BB /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		9B60204E23FDFA9F00D0C8E0 /* SQLiteCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteCacheTests.swift; sourceTree = "<group>"; };
 		9B64F6752354D219002D1BB5 /* URL+QueryDict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+QueryDict.swift"; sourceTree = "<group>"; };
 		9B68F03A240D8D1800E97318 /* CodegenExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodegenExtensionTests.swift; sourceTree = "<group>"; };
@@ -1088,6 +1089,7 @@
 		9FC7503A1D2A532C00458D91 = {
 			isa = PBXGroup;
 			children = (
+				9B5A1EE3243284F300F066BB /* Package.swift */,
 				9FC750461D2A532C00458D91 /* Apollo */,
 				9B7B6F50233C26E400F32205 /* ApolloCodegenLib */,
 				9B7BDACC23FDEBE300ACD198 /* ApolloSQLite */,

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -36,40 +36,72 @@ let package = Package(
       dependencies: []),
     .target(
       name: "ApolloCodegenLib",
-      dependencies: ["Stencil"]),
+      dependencies: [
+        .product(name: "Stencil", package: "Stencil"),
+      ]),
     .target(
       name: "ApolloSQLite",
-      dependencies: ["Apollo", "SQLite"]),
+      dependencies: [
+        "Apollo",
+        .product(name: "SQLite", package: "SQLite.swift"),
+      ]),
     .target(
       name: "ApolloSQLiteTestSupport",
-      dependencies: ["ApolloSQLite", "ApolloTestSupport"]),
+      dependencies: [
+        "ApolloSQLite",
+        "ApolloTestSupport"
+      ]),
 	.target(
       name: "ApolloWebSocket",
-      dependencies: ["Apollo","Starscream"]),
+      dependencies: [
+        "Apollo",
+        .product(name: "Starscream", package: "Starscream"),
+      ]),
     .target(
       name: "ApolloTestSupport",
-      dependencies: ["Apollo"]),
+      dependencies: [
+        "Apollo",
+      ]),
     .target(
       name: "GitHubAPI",
-      dependencies: ["Apollo"]),
+      dependencies: [
+        "Apollo",
+      ]),
     .target(
       name: "StarWarsAPI",
-      dependencies: ["Apollo"]),
+      dependencies: [
+        "Apollo",
+      ]),
 
     .testTarget(
       name: "ApolloTests",
-      dependencies: ["ApolloTestSupport", "StarWarsAPI"]),
+      dependencies: [
+        "ApolloTestSupport",
+        "StarWarsAPI",
+      ]),
     .testTarget(
       name: "ApolloCacheDependentTests",
-      dependencies: ["ApolloSQLiteTestSupport", "StarWarsAPI"]),
+      dependencies: [
+        "ApolloSQLiteTestSupport",
+        "StarWarsAPI",
+      ]),
     .testTarget(
       name: "ApolloCodegenTests",
-      dependencies: ["ApolloCodegenLib"]),
+      dependencies: [
+        "ApolloCodegenLib"
+      ]),
     .testTarget(
       name: "ApolloSQLiteTests",
-      dependencies: ["ApolloSQLiteTestSupport", "StarWarsAPI"]),
+      dependencies: [
+        "ApolloSQLiteTestSupport",
+        "StarWarsAPI"
+      ]),
     .testTarget(
       name: "ApolloWebsocketTests",
-      dependencies: ["ApolloWebSocket", "ApolloTestSupport", "StarWarsAPI"]),
+      dependencies: [
+        "ApolloWebSocket",
+        "ApolloTestSupport",
+        "StarWarsAPI",
+      ]),
     ]
 )

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -28,10 +28,13 @@ To begin, let's set up a Swift Package Manager executable:
 4. Update the `dependencies` section to grab the Apollo iOS library:
 
     ```swift
-    .package(url: "https://github.com/apollographql/apollo-ios.git", 
-             from: "0.22.0")
+    .package(name: "Apollo",
+             url: "https://github.com/apollographql/apollo-ios.git", 
+             .upToNextMinor(from: "0.24.0"))
     ```
-  **NOTE**: The version should be identical to the version you're using in your main project. 
+  **NOTE**: The version should be identical to the version you're using in your main project. \
+
+  **ALSO NOTE**: Having to specify the name is a workaround for [SR-12110](https://bugs.swift.org/browse/SR-12210). Hopefully once that's fixed, SPM should pick up the name automatically. 
 
 5. For the main executable target in the `targets` section, add `ApolloCodegenLib` as a dependency: 
 


### PR DESCRIPTION
This PR addresses issues pointed out in #1102 and #1105. 

The issue is that for some reason Swift 5.2 is not picking up on `Package.swift`'s name property correctly for use with a `product` in a dependency. I have not been able to figure out why - I tried renaming the package to `Apolloooo` temporarily and while `Package.resolved` picked that up, it still caused the same error. 

I've added details on to [SR-12210](https://bugs.swift.org/browse/SR-12210), which appears to be the same issue. 

The workaround for the moment is to manually specify the name of the dependency, which is easy if obnoxious. I've updated our documentation to reflect this recommendation. 

Also in this PR: 
- Updated `Package.swift` for main lib to use `swift-tools-version` 5.2 and use style accordingly
- Added `Package.swift` to the main `.xcodeproj` because I'm sick of having to hunt for it manually 😆 
- Updated `gitignore` to also ignore new folder for testing codegen lib downloads