### PR TITLE
Update download link and SHASUM for version 2.25.0 of the CLI

### DIFF
--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -30,7 +30,7 @@ struct CLIDownloader {
   }
   
   /// The URL string for getting the current version of the CLI
-  static let downloadURLString = "https://41516-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.22.1/apollo-v2.22.1-darwin-x64.tar.gz"
+  static let downloadURLString = "https://44151-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.25.0/apollo-v2.25.0-darwin-x64.tar.gz"
   
   /// Downloads the appropriate Apollo CLI in a zip file.
   ///

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -25,7 +25,7 @@ struct CLIExtractor {
     }
   }
   
-  static let expectedSHASUM = "bf98280b7164fbb2cd6fa04a9e7869d59798b9717ebee7650c365b920f566c59"
+  static let expectedSHASUM = "5224c3788d0a131483bd1ed640444e0b1becf3ab33e9ce4aef6b0579bd4d7712"
   
   /// Checks to see if the CLI has already been extracted and is the correct version, and extracts or re-extracts as necessary
   ///

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-ZIP_FILE_DOWNLOAD_URL="https://41516-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.22.1/apollo-v2.22.1-darwin-x64.tar.gz"
+ZIP_FILE_DOWNLOAD_URL="https://44151-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.25.0/apollo-v2.25.0-darwin-x64.tar.gz"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
 IS_RETRY="false"
@@ -55,7 +55,7 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="bf98280b7164fbb2cd6fa04a9e7869d59798b9717ebee7650c365b920f566c59"
+  EXPECTED_SHASUM="5224c3788d0a131483bd1ed640444e0b1becf3ab33e9ce4aef6b0579bd4d7712"
   update_shasum
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -3,6 +3,9 @@
 # Exit on all errors, undeclared variables and pipefailures.
 set -euo pipefail
 
+# Advertisement!
+echo "Have you tried our new Swift Package Manager wrapper around codegen? It's now available in beta! See docs at https://www.apollographql.com/docs/ios/swift-scripting/. Note that when this comes out of beta, this Bash script will be deprecated, so give it a try today!"
+
 # Get the path to the script directory
 SCRIPT_DIR="$(dirname "$0")"
 


### PR DESCRIPTION
This does not cause changes in the codegen at the moment, but figured it's worth keeping this up to date. 