### PR TITLE
Add ability to get to Starscream's underlying SOCKS proxy property.

### DIFF
--- a/Sources/ApolloWebSocket/ApolloWebSocket.swift
+++ b/Sources/ApolloWebSocket/ApolloWebSocket.swift
@@ -19,13 +19,34 @@ public protocol ApolloWebSocketClient: WebSocketClient {
   var callbackQueue: DispatchQueue { get set }
 }
 
+public protocol SOCKSProxyable {
+  
+  /// Determines whether a SOCKS proxy is enabled on the underlying request.
+  /// Mostly useful for debugging with tools like Charles Proxy.
+  var enableSOCKSProxy: Bool { get set }
+}
+
 // MARK: - WebSocket
 
 /// Included implementation of an `ApolloWebSocketClient`, based on `Starscream`'s `WebSocket`.
-public class ApolloWebSocket: WebSocket, ApolloWebSocketClient {
+public class ApolloWebSocket: WebSocket, ApolloWebSocketClient, SOCKSProxyable {
+  
+  private var stream: FoundationStream!
+  
+  public var enableSOCKSProxy: Bool {
+    get {
+      return self.stream.enableSOCKSProxy
+    }
+    set {
+      self.stream.enableSOCKSProxy = newValue
+    }
+  }
+
   required public convenience init(request: URLRequest, protocols: [String]? = nil) {
+    let stream = FoundationStream()
     self.init(request: request,
               protocols: protocols,
-              stream: FoundationStream())
+              stream: stream)
+    self.stream = stream
   }
 }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -61,6 +61,28 @@ public class WebSocketTransport {
       self.addApolloClientHeaders(to: &self.websocket.request)
     }
   }
+  
+  /// Determines whether a SOCKS proxy is enabled on the underlying request.
+  /// Mostly useful for debugging with tools like Charles Proxy.
+  /// Note: Will return `false` from the getter and no-op the setter for implementations that do not conform to `SOCKSProxyable`.
+  public var enableSOCKSProxy: Bool {
+    get {
+      guard let socket = self.websocket as? SOCKSProxyable else {
+        // If it's not proxyable, then the proxy can't be enabled
+        return false
+      }
+      
+      return socket.enableSOCKSProxy
+    }
+    set {
+      guard var socket = self.websocket as? SOCKSProxyable else {
+        // If it's not proxyable, there's nothing to do here.
+        return
+      }
+      
+      socket.enableSOCKSProxy = newValue
+    }
+  }
 
   /// Designated initializer
   ///


### PR DESCRIPTION
Addresses #1104. Definitely glad I went this way - it's not just that you have to set it on the web socket, you have to set it on the underlying stream. Ouch. 

Anyway that's all abstracted away now so yay. 