### PR TITLE
Sneak in CLI 2.26.0

### DIFF
--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -30,7 +30,7 @@ struct CLIDownloader {
   }
   
   /// The URL string for getting the current version of the CLI
-  static let downloadURLString = "https://44151-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.25.0/apollo-v2.25.0-darwin-x64.tar.gz"
+  static let downloadURLString = "https://46555-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.26.0/apollo-v2.26.0-darwin-x64.tar.gz"
   
   /// Downloads the appropriate Apollo CLI in a zip file.
   ///

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -25,7 +25,7 @@ struct CLIExtractor {
     }
   }
   
-  static let expectedSHASUM = "5224c3788d0a131483bd1ed640444e0b1becf3ab33e9ce4aef6b0579bd4d7712"
+  static let expectedSHASUM = "efc67e140096bb3414a385c5da32dfa0d9a6172ac081f0351998c62b5d3db502"
   
   /// Checks to see if the CLI has already been extracted and is the correct version, and extracts or re-extracts as necessary
   ///

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-ZIP_FILE_DOWNLOAD_URL="https://44151-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.25.0/apollo-v2.25.0-darwin-x64.tar.gz"
+ZIP_FILE_DOWNLOAD_URL="https://46555-65563448-gh.circle-artifacts.com/0/oclif-pack/apollo-v2.26.0/apollo-v2.26.0-darwin-x64.tar.gz"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
 IS_RETRY="false"
@@ -58,7 +58,7 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="5224c3788d0a131483bd1ed640444e0b1becf3ab33e9ce4aef6b0579bd4d7712"
+  EXPECTED_SHASUM="efc67e140096bb3414a385c5da32dfa0d9a6172ac081f0351998c62b5d3db502"
   update_shasum
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then


### PR DESCRIPTION
Was about to put out a new release when I saw the tooling team managed to get another minor release out. Doesn't appear to have any major Swift changes, but worth staying up to date. 