### PR TITLE
add request to GraphQLHTTPResponseError for easier debugging

### DIFF
--- a/Sources/Apollo/GraphQLHTTPResponseError.swift
+++ b/Sources/Apollo/GraphQLHTTPResponseError.swift
@@ -22,6 +22,8 @@ public struct GraphQLHTTPResponseError: Error, LocalizedError {
     }
   }
 
+  /// Request sent to server
+  public let request: URLRequest
   /// The body of the response.
   public let body: Data?
   /// Information about the response as provided by the server.
@@ -29,9 +31,11 @@ public struct GraphQLHTTPResponseError: Error, LocalizedError {
   public let kind: ErrorKind
   private let serializationFormat = JSONSerializationFormat.self
 
-  public init(body: Data? = nil,
+  public init(request: URLRequest,
+              body: Data? = nil,
               response: HTTPURLResponse,
               kind: ErrorKind) {
+    self.request = request
     self.body = body
     self.response = response
     self.kind = kind

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -173,7 +173,8 @@ public class HTTPNetworkTransport {
       }
 
       guard httpResponse.isSuccessful else {
-        let unsuccessfulError = GraphQLHTTPResponseError(body: data,
+        let unsuccessfulError = GraphQLHTTPResponseError(request: request,
+                                                         body: data,
                                                          response: httpResponse,
                                                          kind: .errorResponse)
         self.handleErrorOrRetry(operation: operation,
@@ -186,7 +187,8 @@ public class HTTPNetworkTransport {
       }
 
       guard let data = data else {
-        let error = GraphQLHTTPResponseError(body: nil,
+        let error = GraphQLHTTPResponseError(request: request,
+                                             body: nil,
                                              response: httpResponse,
                                              kind: .invalidResponse)
         self.handleErrorOrRetry(operation: operation,
@@ -200,7 +202,7 @@ public class HTTPNetworkTransport {
 
       do {
         guard let body = try self.serializationFormat.deserialize(data: data) as? JSONObject else {
-          throw GraphQLHTTPResponseError(body: data, response: httpResponse, kind: .invalidResponse)
+          throw GraphQLHTTPResponseError(request: request, body: data, response: httpResponse, kind: .invalidResponse)
         }
 
         let graphQLResponse = GraphQLResponse(operation: operation, body: body)

--- a/Tests/ApolloTests/ErrorGenerationTests.swift
+++ b/Tests/ApolloTests/ErrorGenerationTests.swift
@@ -33,7 +33,8 @@ class ErrorGenerationTests: XCTestCase {
     let data = try XCTUnwrap(json.data(using: .utf8),
                              "Couldn't create json data")
     
-    let httpResponseError = GraphQLHTTPResponseError(body: data,
+    let httpResponseError = GraphQLHTTPResponseError(request: URLRequest(url: URL(string: "http://localhost:8080/graphql")!),
+                                                     body: data,
                                                      response: response,
                                                      kind: .errorResponse)
     XCTAssertEqual(httpResponseError.graphQLErrors?.count, 1)
@@ -68,7 +69,8 @@ class ErrorGenerationTests: XCTestCase {
     let data = try XCTUnwrap(json.data(using: .utf8),
                              "Couldn't create json data")
     
-    let httpResponseError = GraphQLHTTPResponseError(body: data,
+    let httpResponseError = GraphQLHTTPResponseError(request: URLRequest(url: URL(string: "http://localhost:8080/graphql")!),
+                                                     body: data,
                                                      response: response,
                                                      kind: .errorResponse)
     XCTAssertEqual(httpResponseError.graphQLErrors?.count, 2)
@@ -87,7 +89,8 @@ class ErrorGenerationTests: XCTestCase {
                              "Couldn't create text data")
 
     
-    let httpResponseError = GraphQLHTTPResponseError(body: data,
+    let httpResponseError = GraphQLHTTPResponseError(request: URLRequest(url: URL(string: "http://localhost:8080/graphql")!),
+                                                     body: data,
                                                      response: response,
                                                      kind: .errorResponse)
     
@@ -101,7 +104,8 @@ class ErrorGenerationTests: XCTestCase {
                                    httpVersion: nil,
                                    headerFields: nil)!
     
-    let httpResponseError = GraphQLHTTPResponseError(body: nil,
+    let httpResponseError = GraphQLHTTPResponseError(request: URLRequest(url: URL(string: "http://localhost:8080/graphql")!),
+                                                     body: nil,
                                                      response: response,
                                                      kind: .errorResponse)
     


### PR DESCRIPTION
Was trying to trace some problems with auth and it was very useful to see what we actually send to server (headers in particular)