### PR TITLE
Fix a typo in the guard clause

### DIFF
--- a/docs/source/tutorial/tutorial-detail-view.md
+++ b/docs/source/tutorial/tutorial-detail-view.md
@@ -174,7 +174,7 @@ private func loadLaunchDetails() {
   guard
     let launchID = self.launchID,
     launchID != self.launch?.id else {
-      // This is the launch we're alrady displaying, or the ID is nil.
+      // This is the launch we're already displaying, or the ID is nil.
       return
   }
     


### PR DESCRIPTION
Fixes a typo in the `loadLaunchDetails()` function on "Complete the detail view" page of the tutorial.