### PR TITLE
Add ability to set the SSLTrustValidator for websocket

### DIFF
--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -63,8 +63,11 @@ public class WebSocketTransport {
   }
 
   public var security: SSLTrustValidator? {
-    didSet {
-      websocket.security = security
+    get {
+      return websocket.security
+    }
+    set {
+      websocket.security = newValue
     }
   }
 

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -61,7 +61,13 @@ public class WebSocketTransport {
       self.addApolloClientHeaders(to: &self.websocket.request)
     }
   }
-  
+
+  public var security: SSLTrustValidator? {
+    didSet {
+      websocket.security = security
+    }
+  }
+
   /// Determines whether a SOCKS proxy is enabled on the underlying request.
   /// Mostly useful for debugging with tools like Charles Proxy.
   /// Note: Will return `false` from the getter and no-op the setter for implementations that do not conform to `SOCKSProxyable`.


### PR DESCRIPTION
A use case could be SSL Pinning.

Alternatively this can go into the initializer if it makes more sense there.