### PR TITLE
Don't compare a boolean value to true

### DIFF
--- a/docs/source/tutorial/tutorial-authentication.mdx
+++ b/docs/source/tutorial/tutorial-authentication.mdx
@@ -250,7 +250,7 @@ Then, add a new method to determine what to do when the "Book now!" button is ta
     return
   }
     
-  if launch.isBooked == true {
+  if launch.isBooked {
     print("Cancel trip!")
   } else {
     print("Book trip!")


### PR DESCRIPTION
Comparing boolean values inside `if` statement to `true` is usually redundant.

A similar change was already made in the iOSTutorial repository. https://github.com/apollographql/iOSTutorial/commit/65994719cc2b1ccd544c3d984ea88acedd511227