### PR TITLE
improve HTTPNetworkTransportRetryDelegate to enable returning custom error

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -74,7 +74,7 @@ public protocol HTTPNetworkTransportRetryDelegate: HTTPNetworkTransportDelegate 
   ///   - error: The received error
   ///   - request: The URLRequest which generated the error
   ///   - response: [Optional] Any response received when the error was generated
-  ///   - retryHandler: A closure indicating whether the operation should be retried. Asyncrhonous to allow for re-authentication or other async operations to complete.
+  ///   - continueHandler: A closure indicating whether the operation should be retried. Asyncrhonous to allow for re-authentication or other async operations to complete.
   func networkTransport(_ networkTransport: HTTPNetworkTransport,
                         receivedError error: Error,
                         for request: URLRequest,

--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -67,7 +67,7 @@ public protocol HTTPNetworkTransportRetryDelegate: HTTPNetworkTransportDelegate 
                         retryHandler: @escaping (_ shouldRetry: Bool) -> Void)
   
   /// Called when an error has been received after a request has been sent to the server to see if an operation should be retried or not.
-  /// NOTE: Don't just call the `retryHandler` with `true` all the time, or you can potentially wind up in an infinite loop of errors
+  /// NOTE: Don't just call the `continueHandler` with `.retry` all the time, or you can potentially wind up in an infinite loop of errors
   ///
   /// - Parameters:
   ///   - networkTransport: The network transport which received the error

--- a/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
@@ -22,9 +22,10 @@ class APQsConfig: TestConfig {
 }
 
 class APQsWithGetMethodConfig: TestConfig, HTTPNetworkTransportRetryDelegate{
+  
   var alreadyRetried = false
-  func networkTransport(_ networkTransport: HTTPNetworkTransport, receivedError error: Error, for request: URLRequest, response: URLResponse?, retryHandler: @escaping (Bool) -> Void) {
-    retryHandler(!alreadyRetried)
+  func networkTransport(_ networkTransport: HTTPNetworkTransport, receivedError error: Error, for request: URLRequest, response: URLResponse?, continueHandler: @escaping (HTTPNetworkTransport.ContinueAction) -> Void) {
+    continueHandler(!alreadyRetried ? .retry : .fail(error))
     alreadyRetried = true
   }
   

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -190,17 +190,14 @@ class HTTPTransportTests: XCTestCase {
     self.wait(for: [expectation], timeout: 10)
   }
   
-  func testRetryDelegateReturnsCorrectError() throws {
-    
+  func testRetryDelegateReturnsApolloError() throws {
     class MockRetryDelegate: HTTPNetworkTransportRetryDelegate {
-      var mockError: Error?
-      
       func networkTransport(_ networkTransport: HTTPNetworkTransport,
                             receivedError error: Error,
                             for request: URLRequest,
                             response: URLResponse?,
                             continueHandler: @escaping (HTTPNetworkTransport.ContinueAction) -> Void) {
-        continueHandler(.fail(mockError ?? error))
+        continueHandler(.fail(error))
       }
     }
     
@@ -223,28 +220,42 @@ class HTTPTransportTests: XCTestCase {
     }
     
     wait(for: [expectationErrorResponse], timeout: 1)
-    
+  }
+  
+  func testRetryDelegateReturnsCustomError() throws {
     enum MockError: Error, Equatable {
       case customError
     }
     
-    mockRetryDelegate.mockError = MockError.customError
+    class MockRetryDelegate: HTTPNetworkTransportRetryDelegate {
+      func networkTransport(_ networkTransport: HTTPNetworkTransport,
+                            receivedError error: Error,
+                            for request: URLRequest,
+                            response: URLResponse?,
+                            continueHandler: @escaping (HTTPNetworkTransport.ContinueAction) -> Void) {
+        continueHandler(.fail(MockError.customError))
+      }
+    }
     
-    let expectationCustomError = self.expectation(description: "Send operation completed")
+    let mockRetryDelegate = MockRetryDelegate()
+    
+    let transport = HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql_non_existant")!)
+    transport.delegate = mockRetryDelegate
+    
+    let expectationErrorResponse = self.expectation(description: "Send operation completed")
     
     let _ = transport.send(operation: HeroNameQuery()) { result in
       switch result {
       case .success:
         XCTFail()
-        expectationCustomError.fulfill()
+        expectationErrorResponse.fulfill()
       case .failure(let error):
         XCTAssertTrue(error is MockError)
-        expectationCustomError.fulfill()
+        expectationErrorResponse.fulfill()
       }
     }
     
-    wait(for: [expectationCustomError], timeout: 1)
-    
+    wait(for: [expectationErrorResponse], timeout: 1)
   }
   
   func testEquality() {

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -214,12 +214,11 @@ class HTTPTransportTests: XCTestCase {
     let _ = transport.send(operation: HeroNameQuery()) { result in
       switch result {
       case .success:
-        XCTAssertTrue(false)
+        XCTFail()
         expectationErrorResponse.fulfill()
       case .failure(let error):
         XCTAssertTrue(error is GraphQLHTTPResponseError)
         expectationErrorResponse.fulfill()
-        break
       }
     }
     
@@ -236,12 +235,11 @@ class HTTPTransportTests: XCTestCase {
     let _ = transport.send(operation: HeroNameQuery()) { result in
       switch result {
       case .success:
-        XCTAssertTrue(false)
+        XCTFail()
         expectationCustomError.fulfill()
       case .failure(let error):
         XCTAssertTrue(error is MockError)
         expectationCustomError.fulfill()
-        break
       }
     }
     

--- a/Tests/ApolloTests/HTTPTransportTests.swift
+++ b/Tests/ApolloTests/HTTPTransportTests.swift
@@ -340,9 +340,9 @@ extension HTTPTransportTests: HTTPNetworkTransportRetryDelegate {
                         receivedError error: Error,
                         for request: URLRequest,
                         response: URLResponse?,
-                        retryHandler: @escaping (Bool) -> Void) {
+                        continueHandler: @escaping (HTTPNetworkTransport.ContinueAction) -> Void) {
     guard let graphQLError = error as? GraphQLHTTPResponseError else {
-      retryHandler(false)
+      continueHandler(.fail(error))
       return
     }
     
@@ -352,12 +352,12 @@ extension HTTPTransportTests: HTTPNetworkTransportRetryDelegate {
       if retryCount > 1 {
         self.shouldModifyURLInWillSend = false
       }
-      retryHandler(true)
+      continueHandler(.retry)
     case .invalidResponse:
-      retryHandler(false)
+      continueHandler(.fail(error))
     case .persistedQueryNotFound,
          .persistedQueryNotSupported:
-      retryHandler(false)
+      continueHandler(.fail(error))
     }
   }
 }

--- a/docs/source/api/Apollo/protocols/HTTPNetworkTransportRetryDelegate.md
+++ b/docs/source/api/Apollo/protocols/HTTPNetworkTransportRetryDelegate.md
@@ -9,14 +9,14 @@ public protocol HTTPNetworkTransportRetryDelegate: HTTPNetworkTransportDelegate
 > Methods which will be called if an error is receieved at the network level.
 
 ## Methods
-### `networkTransport(_:receivedError:for:response:retryHandler:)`
+### `networkTransport(_:receivedError:for:response:continueHandler:)`
 
 ```swift
 func networkTransport(_ networkTransport: HTTPNetworkTransport,
                       receivedError error: Error,
                       for request: URLRequest,
                       response: URLResponse?,
-                      retryHandler: @escaping (_ shouldRetry: Bool) -> Void)
+                      continueHandler: @escaping (_ action: HTTPNetworkTransport.ContinueAction) -> Void)
 ```
 
 > Called when an error has been received after a request has been sent to the server to see if an operation should be retried or not.
@@ -27,7 +27,7 @@ func networkTransport(_ networkTransport: HTTPNetworkTransport,
 >   - error: The received error
 >   - request: The URLRequest which generated the error
 >   - response: [Optional] Any response received when the error was generated
->   - retryHandler: A closure indicating whether the operation should be retried. Asyncrhonous to allow for re-authentication or other async operations to complete.
+>   - continueHandler: A closure indicating whether the operation should be retried. Asyncrhonous to allow for re-authentication or other async operations to complete.
 
 #### Parameters
 


### PR DESCRIPTION
solves use case described in https://github.com/apollographql/apollo-ios/issues/1121 where delegate might want to return different error depending on logic