### PR TITLE
Add a missing import of DetailUISetupPanel

### DIFF
--- a/docs/source/tutorial/tutorial-detail-view.md
+++ b/docs/source/tutorial/tutorial-detail-view.md
@@ -2,6 +2,8 @@
 title: "6. Complete the detail view"
 ---
 
+import DetailUISetupPanel from "./components/detail_ui_setup_panel.mdx"
+
 To get more information to show on the detail page, you have a couple of options: 
 
 - You could request all the details you want to display for every single launch in the `LaunchList` query, and then pass that retrieved object on to the `DetailViewController`. 


### PR DESCRIPTION
Adds a missing import for collapsed `DetailUISetupPanel` section.

The ["6. Complete the detail view"](https://www.apollographql.com/docs/ios/tutorial/tutorial-detail-view/) section of tutorial doesn't render collapsed panel because of missing import.

<img width="812" alt="Screenshot 2020-04-09 07 31 13" src="https://user-images.githubusercontent.com/123158/78861221-8e268a80-7a34-11ea-83fa-06235217cf25.png">
