### PR TITLE
Fix a typo in a comment

### DIFF
--- a/docs/source/tutorial/tutorial-mutations.md
+++ b/docs/source/tutorial/tutorial-mutations.md
@@ -300,7 +300,7 @@ private func loadLaunchDetails(forceReload: Bool = false) {
   guard
     let launchID = self.launchID,
     (forceReload || launchID != self.launch?.id) else {
-      // This is the launch we're alrady displaying, or the ID is nil.
+      // This is the launch we're already displaying, or the ID is nil.
       return
   }
         


### PR DESCRIPTION
Fixes a typo on [Define additional mutations](https://www.apollographql.com/docs/ios/tutorial/tutorial-mutations/) page of tutorial.