### PR TITLE
Merges two parts of cancelTrip method together

### DIFF
--- a/docs/source/tutorial/tutorial-mutations.md
+++ b/docs/source/tutorial/tutorial-mutations.md
@@ -251,8 +251,13 @@ Network.shared.apollo.perform(mutation: CancelTripMutation(id: id)) { [weak self
   case .success(let graphQLResult):
     if let cancelResult = graphQLResult.data?.cancelTrip {
       if cancelResult.success {
-        // TODO
+        self.showAlert(title: "Trip cancelled",  
+                       message: cancelResult.message ?? "Your trip has been officially cancelled.")
+      } else {
+        self.showAlert(title: "Could not cancel trip", 
+                       message: cancelResult.message ?? "Unknown failure.")
       }
+    }
 
     if let errors = graphQLResult.errors {
       self.showAlertForErrors(errors)
@@ -261,19 +266,6 @@ Network.shared.apollo.perform(mutation: CancelTripMutation(id: id)) { [weak self
     self.showAlert(title: "Network Error",
                    message: error.localizedDescription)
   }
-}
-```
-
-
-In `cancelTrip(with id:)`, replace the `TODO` with code to handle what comes back in that mutation's `success` property: 
-
-```swift:title=DetailViewController.swift
-if cancelResult.success {
-  self.showAlert(title: "Trip cancelled",  
-                 message: cancelResult.message ?? "Your trip has been officially cancelled.")
-} else {
-  self.showAlert(title: "Could not cancel trip", 
-                 message: cancelResult.message ?? "Unknown failure.")
 }
 ```
 


### PR DESCRIPTION
The instructions for `cancelTrip` method consist of two parts. The first part has a `// TODO` placeholder, which a user needs to replace in the next step.

It may make sense to merge those two parts.

Also fixes https://github.com/apollographql/apollo-ios/pull/1137