### PR TITLE
SQLCipher support

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
     ss.dependency 'SQLite.swift', '~>0.12.2'
   end
   
+  # Cache persistance storage mechanism extended with encryption mechanism
   s.subspec 'SQLiteCipher' do |ss|
     ss.source_files = 'Sources/ApolloSQLite/*.swift'
     ss.dependency 'Apollo/Core'

--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -34,6 +34,13 @@ Pod::Spec.new do |s|
     ss.dependency 'Apollo/Core'
     ss.dependency 'SQLite.swift', '~>0.12.2'
   end
+  
+  s.subspec 'SQLiteCipher' do |ss|
+    ss.source_files = 'Sources/ApolloSQLite/*.swift'
+    ss.dependency 'Apollo/Core'
+    ss.dependency 'SQLCipher', '~>4.2.0'
+    ss.dependency 'SQLite.swift/SQLCipher', '> 0.12.0'
+  end
 
   # Websocket and subscription support based on Starscream
   s.subspec 'WebSocket' do |ss|

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -31,6 +31,12 @@ public final class SQLiteNormalizedCache {
     try self.createTableIfNeeded()
   }
 
+  public init(db: Connection, shouldVacuumOnClear: Bool = false) throws {
+    self.shouldVacuumOnClear = shouldVacuumOnClear
+    self.db = db
+    try self.createTableIfNeeded()
+  }
+  
   private func recordCacheKey(forFieldCacheKey fieldCacheKey: CacheKey) -> CacheKey {
     let components = fieldCacheKey.components(separatedBy: ".")
     var updatedComponents = [String]()


### PR DESCRIPTION
Hello there :) 
Based on this discussion https://github.com/apollographql/apollo-ios/issues/1117
I thought that I will give it a shot and try to introduce SQLCipher integration.

Usage is quite simple. 
`pod 'Apollo/SQLiteCipher'`

      private lazy var store: ApolloStore = {
        do {
            let db = try Connection(.uri(temporarySQLiteFileURL().absoluteString), readonly: false)
            try db.rekey("secret") //To set DB encryption secret
            try db.key("secret") //To open DB
            
            let cache = try SQLiteNormalizedCache(db: db)
            return ApolloStore(cache: cache)
        } catch {
            print(error)
        }
        
        return ApolloStore(cache: InMemoryNormalizedCache())
    }()

Apollo.podspec modification is a result of this issue:
https://github.com/stephencelis/SQLite.swift/issues/570
It is impossible to integrate those two: 
`pod 'Apollo/SQLite'`
`pod 'SQLite.swift/SQLCipher'`
Cause the result is normal SQLiteDB which is unable to use Cipher encryption. Probably it is conflicting somehow with normal SQLite implementation.

I did not introduce SPM packged denepdency - not sure how to handle this part to be honest.