### PR TITLE
Add background-compatible `URLSessionClient` class

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		9B21FD772422C8CC00998B5C /* TestFileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B21FD762422C8CC00998B5C /* TestFileHelper.swift */; };
 		9B21FD782424305700998B5C /* ExpectedEnumWithDifferentCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B68F05F2416F80C00E97318 /* ExpectedEnumWithDifferentCases.swift */; };
 		9B21FD792424305E00998B5C /* ExpectedEnumWithSanitizedCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B68F063241703B200E97318 /* ExpectedEnumWithSanitizedCases.swift */; };
+		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
+		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
+		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
 		9B518C87235F819E004C426D /* CLIDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B518C85235F8125004C426D /* CLIDownloader.swift */; };
 		9B518C8C235F8B5F004C426D /* ApolloFilePathHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B518C8A235F8B05004C426D /* ApolloFilePathHelper.swift */; };
 		9B518C8D235F8B9E004C426D /* CLIDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B518C88235F8AD4004C426D /* CLIDownloaderTests.swift */; };
@@ -365,6 +368,9 @@
 		9B21FD742422C29D00998B5C /* GraphQLFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLFileTests.swift; sourceTree = "<group>"; };
 		9B21FD762422C8CC00998B5C /* TestFileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFileHelper.swift; sourceTree = "<group>"; };
 		9B4AA8AD239EFDC9003E1300 /* Apollo-Target-CodegenTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenTests.xcconfig"; sourceTree = "<group>"; };
+		9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClient.swift; sourceTree = "<group>"; };
+		9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBinAPI.swift; sourceTree = "<group>"; };
+		9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClientTests.swift; sourceTree = "<group>"; };
 		9B518C85235F8125004C426D /* CLIDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDownloader.swift; sourceTree = "<group>"; };
 		9B518C88235F8AD4004C426D /* CLIDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDownloaderTests.swift; sourceTree = "<group>"; };
 		9B518C8A235F8B05004C426D /* ApolloFilePathHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloFilePathHelper.swift; sourceTree = "<group>"; };
@@ -727,6 +733,7 @@
 				C3279FC52345233000224790 /* TestCustomRequestCreator.swift */,
 				9B64F6752354D219002D1BB5 /* URL+QueryDict.swift */,
 				9B21FD762422C8CC00998B5C /* TestFileHelper.swift */,
+				9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */,
 			);
 			name = TestHelpers;
 			sourceTree = "<group>";
@@ -1169,6 +1176,7 @@
 				9FF90A6B1DDDEB420034C3B6 /* ReadFieldValueTests.swift */,
 				C338DF1622DD9DE9006AF33E /* RequestCreatorTests.swift */,
 				9F19D8451EED8D3B00C57247 /* ResultOrPromiseTests.swift */,
+				9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */,
 				5BB2C0222380836100774170 /* VersionNumberTests.swift */,
 				C304EBD322DDC7B200748F72 /* a.txt */,
 				C35D43BE22DDD3C100BCBABE /* b.txt */,
@@ -1203,6 +1211,7 @@
 				C377CCAA22D7992E00572E03 /* MultipartFormData.swift */,
 				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
 				9BEDC79D22E5D2CF00549BF6 /* RequestCreator.swift */,
+				9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -1997,6 +2006,7 @@
 				5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */,
 				9FE941D01E62C771007CDD89 /* Promise.swift in Sources */,
 				9BA1245E22DE116B00BF1D24 /* Result+Helpers.swift in Sources */,
+				9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */,
 				9FC750631D2A59F600458D91 /* ApolloClient.swift in Sources */,
 				9BA3130E2302BEA5007B7FC5 /* DispatchQueue+Optional.swift in Sources */,
 				9F86B6901E65533D00B885FF /* GraphQLResponseGenerator.swift in Sources */,
@@ -2013,6 +2023,7 @@
 				9FC9A9C81E2EFE6E0023C4D5 /* CacheKeyForFieldTests.swift in Sources */,
 				9F91CF8F1F6C0DB2008DD0BE /* MutatingResultsTests.swift in Sources */,
 				F82E62E122BCD223000C311B /* AutomaticPersistedQueriesTests.swift in Sources */,
+				9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */,
 				9F19D8461EED8D3B00C57247 /* ResultOrPromiseTests.swift in Sources */,
 				9F533AB31E6C4A4200CBE097 /* BatchedLoadTests.swift in Sources */,
 				C3279FC72345234D00224790 /* TestCustomRequestCreator.swift in Sources */,
@@ -2030,6 +2041,7 @@
 				9FF90A711DDDEB420034C3B6 /* ReadFieldValueTests.swift in Sources */,
 				9F295E311E27534800A24949 /* NormalizeQueryResults.swift in Sources */,
 				9FF90A731DDDEB420034C3B6 /* ParseQueryResponseTests.swift in Sources */,
+				9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */,
 				9BF1A94F22CA5784005292C2 /* HTTPTransportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate {
+  
+  public enum URLSessionClientError: Error {
+    case sessionBecameInvalidWithoutUnderlyingError
+    case dataForTaskNotFound(taskIdentifier: Int)
+  }
+  
+  public typealias Completion = (Result<(Data, HTTPURLResponse?), Error>) -> Void
+  
+  private var completionBlocks = [Int: Completion]()
+  private var datas = [Int: Data]()
+  private var responses = [Int: HTTPURLResponse]()
+  
+  open private(set) var session: URLSession!
+  
+  public init(sessionConfiguration: URLSessionConfiguration = .default,
+              callbackQueue: OperationQueue? = .main) {
+    super.init()
+    self.session = URLSession(configuration: sessionConfiguration,
+                              delegate: self,
+                              delegateQueue: callbackQueue)
+  }
+  
+  private func clearTask(with identifier: Int) {
+    self.completionBlocks.removeValue(forKey: identifier)
+    self.datas.removeValue(forKey: identifier)
+    self.responses.removeValue(forKey: identifier)
+  }
+  
+  private func clearAllTasks() {
+    self.completionBlocks.removeAll()
+    self.datas.removeAll()
+    self.responses.removeAll()
+  }
+  
+  @discardableResult
+  open func sendRequest(_ request: URLRequest, completion: @escaping Completion) -> URLSessionTask {
+    let dataTask = self.session.dataTask(with: request)
+    self.completionBlocks[dataTask.taskIdentifier] = completion
+    self.datas[dataTask.taskIdentifier] = Data()
+    dataTask.resume()
+    
+    return dataTask
+  }
+  
+  open func cancel(task: URLSessionTask) {
+    let taskID = task.taskIdentifier
+    self.clearTask(with: taskID)
+    task.cancel()
+  }
+  
+  // MARK: - URLSessionDelegate
+  
+  open func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+    let finalError = error ?? URLSessionClientError.sessionBecameInvalidWithoutUnderlyingError
+    for block in completionBlocks.values {
+      block(.failure(finalError))
+    }
+    
+    self.clearAllTasks()
+  }
+  
+  @available(OSX 10.12, iOS 10.0, *)
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       didFinishCollecting metrics: URLSessionTaskMetrics) {
+    // No default implementation
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       didReceive challenge: URLAuthenticationChallenge,
+                       completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    completionHandler(.performDefaultHandling, nil)
+  }
+  
+  
+  #if os(iOS) || os(tvOS) || os(watchOS)
+  open func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    // No default implementation
+  }
+  #endif
+  
+  // MARK: - NSURLSessionTaskDelegate
+  
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       didReceive challenge: URLAuthenticationChallenge,
+                       completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    completionHandler(.performDefaultHandling, nil)
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       taskIsWaitingForConnectivity task: URLSessionTask) {
+    // No default implementation
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       didCompleteWithError error: Error?) {
+    defer {
+      self.clearTask(with: task.taskIdentifier)
+    }
+    
+    guard let completion = self.completionBlocks.removeValue(forKey: task.taskIdentifier) else {
+      // No completion block, the task has likely been cancelled. Bail out.
+      return
+    }
+    
+    
+    if let finalError = error {
+      completion(.failure(finalError))
+    } else {
+      let taskIdentifier = task.taskIdentifier
+      guard let data = self.datas[taskIdentifier] else {
+        // Data is immediately created for a task on creation, so if it's not there, something's gone wrong.
+        completion(.failure(URLSessionClientError.dataForTaskNotFound(taskIdentifier: taskIdentifier)))
+        return
+      }
+      
+      let response = self.responses[taskIdentifier]
+      completion(.success((data, response)))
+    }
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       needNewBodyStream completionHandler: @escaping (InputStream?) -> Void) {
+    completionHandler(nil)
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       didSendBodyData bytesSent: Int64,
+                       totalBytesSent: Int64,
+                       totalBytesExpectedToSend: Int64) {
+    // No default implementation
+  }
+  
+  @available(iOS 11.0, OSXApplicationExtension 10.13, *)
+  public func urlSession(_ session: URLSession,
+                         task: URLSessionTask,
+                         willBeginDelayedRequest request: URLRequest,
+                         completionHandler: @escaping (URLSession.DelayedRequestDisposition, URLRequest?) -> Void) {
+    completionHandler(.continueLoading, request)
+  }
+  
+  public func urlSession(_ session: URLSession,
+                         task: URLSessionTask,
+                         willPerformHTTPRedirection response: HTTPURLResponse,
+                         newRequest request: URLRequest,
+                         completionHandler: @escaping (URLRequest?) -> Void) {
+    completionHandler(request)
+  }
+  
+  // MARK: - URLSessionDataDelegate
+  
+  open func urlSession(_ session: URLSession,
+                       dataTask: URLSessionDataTask,
+                       didReceive data: Data) {
+    self.datas[dataTask.taskIdentifier]?.append(data)
+  }
+  
+  @available(iOS 9.0, OSXApplicationExtension 10.11, *)
+  open func urlSession(_ session: URLSession,
+                       dataTask: URLSessionDataTask,
+                       didBecome streamTask: URLSessionStreamTask) {
+    // No default implementation
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       dataTask: URLSessionDataTask,
+                       didBecome downloadTask: URLSessionDownloadTask) {
+    // No default implementation
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       dataTask: URLSessionDataTask,
+                       willCacheResponse proposedResponse: CachedURLResponse,
+                       completionHandler: @escaping (CachedURLResponse?) -> Void) {
+    completionHandler(proposedResponse)
+  }
+  
+  open func urlSession(_ session: URLSession,
+                       dataTask: URLSessionDataTask,
+                       didReceive response: URLResponse,
+                       completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+    defer {
+      completionHandler(.allow)
+    }
+    
+    if let httpResponse = response as? HTTPURLResponse {
+      self.responses[dataTask.taskIdentifier] = httpResponse
+    }
+  }
+}

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -159,19 +159,19 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     // No default implementation
   }
   
-  @available(iOS 11.0, OSXApplicationExtension 10.13, *)
-  public func urlSession(_ session: URLSession,
-                         task: URLSessionTask,
-                         willBeginDelayedRequest request: URLRequest,
-                         completionHandler: @escaping (URLSession.DelayedRequestDisposition, URLRequest?) -> Void) {
+  @available(iOS 11.0, OSXApplicationExtension 10.13, OSX 10.13, *)
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       willBeginDelayedRequest request: URLRequest,
+                       completionHandler: @escaping (URLSession.DelayedRequestDisposition, URLRequest?) -> Void) {
     completionHandler(.continueLoading, request)
   }
   
-  public func urlSession(_ session: URLSession,
-                         task: URLSessionTask,
-                         willPerformHTTPRedirection response: HTTPURLResponse,
-                         newRequest request: URLRequest,
-                         completionHandler: @escaping (URLRequest?) -> Void) {
+  open func urlSession(_ session: URLSession,
+                       task: URLSessionTask,
+                       willPerformHTTPRedirection response: HTTPURLResponse,
+                       newRequest request: URLRequest,
+                       completionHandler: @escaping (URLRequest?) -> Void) {
     completionHandler(request)
   }
   

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -2,6 +2,12 @@ import Foundation
 
 /// A class to handle URL Session calls that will support background execution,
 /// but still (mostly) use callbacks for its primary method of communication.
+///
+/// **NOTE:** Delegate methods implemented here are not documented inline because
+/// Apple has their own documentation for them. Please consult Apple's
+/// documentation for how the delegate methods work and what needs to be overridden
+/// and handled within your app, particularly in regards to what needs to be called
+/// when for background sessions.
 open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate {
   
   public enum URLSessionClientError: Error {

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -102,7 +102,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     self.clearAllTasks()
   }
   
-  @available(OSX 10.12, iOS 10.0, *)
+  @available(OSX 10.12, iOS 10.0, tvOS 10.0, *)
   open func urlSession(_ session: URLSession,
                        task: URLSessionTask,
                        didFinishCollecting metrics: URLSessionTaskMetrics) {
@@ -187,7 +187,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     // No default implementation
   }
   
-  @available(iOS 11.0, OSXApplicationExtension 10.13, OSX 10.13, *)
+  @available(iOS 11.0, OSXApplicationExtension 10.13, OSX 10.13, tvOS 11.0, watchOS 4.0, *)
   open func urlSession(_ session: URLSession,
                        task: URLSessionTask,
                        willBeginDelayedRequest request: URLRequest,

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -230,12 +230,12 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   // MARK: - Tests
   
   func testRequestBody() throws {
-    let mockSession = MockURLSession()
-    let network = HTTPNetworkTransport(url: URL(string: endpoint)!, session: mockSession)
+    let mockClient = MockURLSessionClient()
+    let network = HTTPNetworkTransport(url: URL(string: endpoint)!, client: mockClient)
     let query = HeroNameQuery()
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -247,12 +247,12 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testRequestBodyWithVariable() throws {
-    let mockSession = MockURLSession()
-    let network = HTTPNetworkTransport(url: URL(string: endpoint)!, session: mockSession)
+    let mockClient = MockURLSessionClient()
+    let network = HTTPNetworkTransport(url: URL(string: endpoint)!, client: mockClient)
     let query = HeroNameQuery(episode: .jedi)
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     XCTAssertEqual(request.url?.host, network.url.host)
     XCTAssertEqual(request.httpMethod, "POST")
@@ -264,14 +264,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   
   func testRequestBodyForAPQsWithVariable() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        enableAutoPersistedQueries: true)
     let query = HeroNameQuery(episode: .empire)
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
 
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -283,14 +283,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
 
   func testMutationRequestBodyForAPQs() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        enableAutoPersistedQueries: true)
     let mutation = CreateAwesomeReviewMutation()
     let _ = network.send(operation: mutation) { _ in }
 
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
 
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -302,15 +302,15 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testQueryStringForAPQsUseGetMethod() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        enableAutoPersistedQueries: true,
                                        useGETForPersistedQueryRetry: true)
     let query = HeroNameQuery()
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     XCTAssertEqual(request.url?.host, network.url.host)
     
@@ -320,15 +320,15 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testQueryStringForAPQsUseGetMethodWithVariable() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        enableAutoPersistedQueries: true,
                                        useGETForPersistedQueryRetry: true)
     let query = HeroNameQuery(episode: .empire)
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
 
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -340,14 +340,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testUseGETForQueriesRequest() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        useGETForQueries: true)
     let query = HeroNameQuery()
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -359,12 +359,12 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testNotUseGETForQueriesRequest() throws {
-    let mockSession = MockURLSession()
-    let network = HTTPNetworkTransport(url: URL(string: endpoint)!, session: mockSession)
+    let mockClient = MockURLSessionClient()
+    let network = HTTPNetworkTransport(url: URL(string: endpoint)!, client: mockClient)
     let query = HeroNameQuery()
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -376,14 +376,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testNotUseGETForQueriesAPQsRequest() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        enableAutoPersistedQueries: true)
     let query = HeroNameQuery(episode: .empire)
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
 
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -395,15 +395,15 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testUseGETForQueriesAPQsRequest() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        useGETForQueries: true,
                                        enableAutoPersistedQueries: true)
     let query = HeroNameQuery(episode: .empire)
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     
     XCTAssertEqual(request.url?.host, network.url.host)
@@ -415,15 +415,15 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   }
   
   func testNotUseGETForQueriesAPQsGETRequest() throws {
-    let mockSession = MockURLSession()
+    let mockClient = MockURLSessionClient()
     let network = HTTPNetworkTransport(url: URL(string: endpoint)!,
-                                       session: mockSession,
+                                       client: mockClient,
                                        enableAutoPersistedQueries: true,
                                        useGETForPersistedQueryRetry: true)
     let query = HeroNameQuery(episode: .empire)
     let _ = network.send(operation: query) { _ in }
     
-    let request = try XCTUnwrap(mockSession.lastRequest,
+    let request = try XCTUnwrap(mockClient.lastRequest,
                                 "last request should not be nil")
     XCTAssertEqual(request.url?.host, network.url.host)
     XCTAssertEqual(request.httpMethod, "GET")

--- a/Tests/ApolloTests/HTTPBinAPI.swift
+++ b/Tests/ApolloTests/HTTPBinAPI.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum HTTPBinAPI {
+    static let baseURL = URL(string: "https://httpbin.org/")!
+    enum Endpoint {
+        case bytes(count: Int)
+        case get
+        case headers
+        case image
+        case post
+        
+        var toString: String {
+            
+            switch self {
+            case .bytes(let count):
+                return "bytes/\(count)"
+            case .get:
+                return "get"
+            case .headers:
+                return "headers"
+            case .image:
+                return "image/jpeg"
+            case .post:
+                return "post"
+            }
+        }
+        
+        var toURL: URL {
+            HTTPBinAPI.baseURL.appendingPathComponent(self.toString)
+        }
+    }
+}
+
+struct HTTPBinResponse: Codable {
+    
+    let headers: [String: String]
+    let url: String
+    let json: [String: String]?
+    
+    init(data: Data) throws {
+        self = try JSONDecoder().decode(Self.self, from: data)
+    }
+}

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -127,9 +127,16 @@ class URLSessionClientLiveTests: XCTestCase {
       
       switch result {
       case .failure(let error):
-        let nsError = error as NSError
-        XCTAssertEqual(nsError.domain, NSURLErrorDomain)
-        XCTAssertEqual(nsError.code, NSURLErrorCancelled)
+        switch error {
+        case URLSessionClient.URLSessionClientError.networkError(let data, let httpResponse, let underlying):
+          XCTAssertTrue(data.isEmpty)
+          XCTAssertNil(httpResponse)          
+          let nsError = underlying as NSError
+          XCTAssertEqual(nsError.domain, NSURLErrorDomain)
+          XCTAssertEqual(nsError.code, NSURLErrorCancelled)
+        default:
+          XCTFail("Unexpected error: \(error)")
+        }
       case .success:
         XCTFail("Task succeeded when it should have been cancelled!")
       }

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -24,7 +24,7 @@ class URLSessionClientLiveTests: XCTestCase {
         XCTFail("Unexpected error: \(error)")
       case .success(let (data, httpResponse)):
         XCTAssertFalse(data.isEmpty)
-        XCTAssertEqual(request.url, httpResponse?.url)
+        XCTAssertEqual(request.url, httpResponse.url)
       }
     }
     
@@ -44,10 +44,15 @@ class URLSessionClientLiveTests: XCTestCase {
         XCTFail("Unexpected error: \(error)")
       case .success(let (data, httpResponse)):
         XCTAssertFalse(data.isEmpty)
-        XCTAssertEqual(httpResponse!.allHeaderFields["Content-Type"] as! String, "image/jpeg")
-        let image = UIImage(data: data)
-        XCTAssertNotNil(image)
-        XCTAssertEqual(request.url, httpResponse?.url)
+        XCTAssertEqual(httpResponse.allHeaderFields["Content-Type"] as! String, "image/jpeg")
+        #if os(macOS)
+          let image = NSImage(data: data)
+          XCTAssertNotNil(image)
+        #else
+          let image = UIImage(data: data)
+          XCTAssertNotNil(image)
+        #endif
+        XCTAssertEqual(request.url, httpResponse.url)
       }
     }
     
@@ -71,7 +76,7 @@ class URLSessionClientLiveTests: XCTestCase {
         XCTAssertEqual(data.count,
                        randomInt,
                        "Expected \(randomInt) bytes, got \(data.count)")
-        XCTAssertEqual(request.url, response?.url)
+        XCTAssertEqual(request.url, response.url)
       }
     }
     
@@ -97,7 +102,7 @@ class URLSessionClientLiveTests: XCTestCase {
       case .failure(let error):
         XCTFail("Unexpected error: \(error)")
       case .success(let (data, httpResponse)):
-        XCTAssertEqual(request.url, httpResponse?.url)
+        XCTAssertEqual(request.url, httpResponse.url)
         
         do {
           let parsed = try HTTPBinResponse(data: data)
@@ -123,7 +128,7 @@ class URLSessionClientLiveTests: XCTestCase {
     
     self.client.cancel(task: task)
     
-    self.wait(for: [expectation], timeout: 10)
+    self.wait(for: [expectation], timeout: 5)
     
   }
 }

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import Apollo
+
+class URLSessionClientLiveTests: XCTestCase {
+  
+  lazy var client = URLSessionClient()
+  
+  private func request(for endpoint: HTTPBinAPI.Endpoint) -> URLRequest {
+    URLRequest(url: endpoint.toURL,
+               cachePolicy: URLRequest.CachePolicy.reloadIgnoringCacheData,
+               timeoutInterval: 30)
+  }
+  
+  func testBasicGet() {
+    let request = self.request(for: .get)
+    let expectation = self.expectation(description: "Basic GET request completed")
+    self.client.sendRequest(request) { result in
+      defer {
+        expectation.fulfill()
+      }
+      
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      case .success(let (data, httpResponse)):
+        XCTAssertFalse(data.isEmpty)
+        XCTAssertEqual(request.url, httpResponse?.url)
+      }
+    }
+    
+    self.wait(for: [expectation], timeout: 10)
+  }
+  
+  func testGettingImage() {
+    let request = self.request(for: .image)
+    let expectation = self.expectation(description: "GET request for image completed")
+    self.client.sendRequest(request) { result in
+      defer {
+        expectation.fulfill()
+      }
+      
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      case .success(let (data, httpResponse)):
+        XCTAssertFalse(data.isEmpty)
+        XCTAssertEqual(httpResponse!.allHeaderFields["Content-Type"] as! String, "image/jpeg")
+        let image = UIImage(data: data)
+        XCTAssertNotNil(image)
+        XCTAssertEqual(request.url, httpResponse?.url)
+      }
+    }
+    
+    self.wait(for: [expectation], timeout: 10)
+  }
+  
+  func testGettingBytes() throws {
+    let randomInt = Int.random(in: 1...102_400) // 102400 is max from HTTPBin
+    let request = self.request(for: .bytes(count: randomInt))
+    
+    let expectation = self.expectation(description: "GET request for a random amount of data completed")
+    self.client.sendRequest(request) { result in
+      defer {
+        expectation.fulfill()
+      }
+      
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      case .success(let (data, response)):
+        XCTAssertEqual(data.count,
+                       randomInt,
+                       "Expected \(randomInt) bytes, got \(data.count)")
+        XCTAssertEqual(request.url, response?.url)
+      }
+    }
+    
+    self.wait(for: [expectation], timeout: 10)
+  }
+  
+  func testPostingJSON() throws {
+    let testJSON = ["key": "value"]
+    let data = try JSONSerialization.data(withJSONObject: testJSON, options: .prettyPrinted)
+    
+    var request = self.request(for: .post)
+    request.httpBody = data
+    request.httpMethod = GraphQLHTTPMethod.POST.rawValue
+    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    
+    let expectation = self.expectation(description: "POST request with JSON completed")
+    self.client.sendRequest(request) { result in
+      defer {
+        expectation.fulfill()
+      }
+      
+      switch result {
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      case .success(let (data, httpResponse)):
+        XCTAssertEqual(request.url, httpResponse?.url)
+        
+        do {
+          let parsed = try HTTPBinResponse(data: data)
+          XCTAssertEqual(parsed.json, testJSON)
+        } catch {
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+    }
+    
+    self.wait(for: [expectation], timeout: 10)
+  }
+  
+  func testCancelling() throws {
+    let request = self.request(for: .bytes(count: 102400)) // 102400 is max from HTTPBin
+    
+    let expectation = self.expectation(description: "Cancelled task completed anyway")
+    expectation.isInverted = true
+    let task = self.client.sendRequest(request) { result in
+      // This shouldn't get hit since we cancel the task immediately
+      expectation.fulfill()
+    }
+    
+    self.client.cancel(task: task)
+    
+    self.wait(for: [expectation], timeout: 10)
+    
+  }
+}

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -35,10 +35,20 @@ The available implementations are:
 
 The initializer for `HTTPNetworkTransport` has several properties which can allow you to get better information and finer-grained control of your HTTP requests and responses:
 
-- `session` allows you to pass in a custom `URLSession` to set up anything which needs to be done for every single request without alteration. This defaults to `URLSession.shared`. 
+- `client` allows you to pass in a [subclass of `URLSessionClient`](#the-urlsessionclient-class) to handle managing a background-compatible URL session, and set up anything which needs to be done for every single request without alteration. 
 - `sendOperationIdentifiers` allows you send operation identifiers along with your requests. **NOTE:** To send operation identifiers, Apollo types must be generated with `operationIdentifier`s or sending data will crash. Due to this restriction, this option defaults to `false`.
 - `useGETForQueries` sends all requests of `query` type using `GET` instead of `POST`. This defaults to `false` to preserve existing behavior in older versions of the client. 
 - `delegate` Can conform to one or many of several sub-protocols for `HTTPNetworkTransportDelegate`, detailed below.
+
+### The URLSessionClient class
+
+Since `URLSession` only supports use in the background using the delegate-based API, we have created our own `URLSessionClient` which handles the basics of setup for that. 
+
+One thing to be aware of: Because setting up a delegate is only possible in the initializer for `URLSession`, you can only pass in a `URLSessionConfiguration`, **not** an existing `URLSession`, to this class's initializer. 
+
+By default, instances of `URLSessionClient` use `URLSessionConfiguration.default` to set up their URL session, and instances of `HTTPNetworkTransport` use the default initializer for `URLSessionClient`.
+
+The `URLSessionClient` class and most of its methods are `open` so you can subclass it if you need to override any of the delegate methods for the `URLSession` delegates we're using or you need to handle additional delegate scenarios.  
 
 ### Using `HTTPNetworkTransportDelegate`
 


### PR DESCRIPTION
**I WOULD LOVE FEEDBACK ON THIS, LOVE IT OR HATE IT. ESPECIALLY IF YOU HATE IT**

I've started noodling around with some major changes to our networking stack and I managed to get one piece done in a way that's _relatively_ straightforward: Making our networking compatible with background URL sessions. 

I'm planning to put together a longer RFC on the stuff I'm noodling with (basically: Switching to an interceptor pattern instead of a delegate pattern) in the next week, but this is enough of a drop-in replacement for something we're already using that I think it can go straight in. 

In this PR: 

- Added a delegate-based class for `URLSession` handling to allow things to work in the background (background sessions only work with the delegate-based API because Apple hates us all). This is `open` and contains `open` default implementations for methods on all delegates we're implementing so that they can easily be subclassed. 
- **BREAKING**: Updated the initializer for `HTTPNetworkTransport` to take the `URLSessionClient` class rather than a `URLSession` directly. This is basically because there's no way to set the delegate on a URLSession except in the initializer (I suspect to prevent a session from going from background to foreground).
- Updated mocking tools to use the new `URLSessionClient`. 
- Updated instructions for advanced client usage. 

A few notes: 
- I've tried to keep this as straightforward as possible so that other changes I want to make to our stack won't have to touch this - it's purely for actually dealing with communicating with the network. 
- This'll likely be annoying for people who are sharing a single session with non-Apollo API classes, but like I said, there's not really a way around it if we can't update the delegate on an existing session.
- The `RawCompletion` stuff is basically a workaround to keep our `HTTPNetworkTransportTaskCompletedDelegate` working while I work on an alternative system. Hopefully the system I'm working on will eliminate the need for that, but it's definitely not something I can just drop completely yet. 
- Note that if you call `cancel(task:)` on `URLSessionClient`, you will not receive an error callback that your task was cancelled, since the intent is obviously to cancel. If you really love getting `NSURLErrorCancelled`, you'll still get that callback if you call `cancel()` directly on the task. 