### PR TITLE
Remove documentation about private Cartfile

### DIFF
--- a/docs/shared/carthage-installation-panel.mdx
+++ b/docs/shared/carthage-installation-panel.mdx
@@ -6,18 +6,12 @@ import {
 
 <ExpansionPanel title="Carthage Installation">
 
-Since Carthage [does not allow choosing which schemes in a repo to build](https://github.com/Carthage/Carthage/issues/1874), we've moved our dependencies to a [`Cartfile.private`](https://github.com/apollographql/apollo-ios/blob/master/Cartfile.private) file so that those dependencies are not forced on people using only the `Apollo` framework and not either of our optional frameworks, `ApolloSQLite` or `ApolloWebSocket`. 
-
-This makes setup a hair more complicated if you *are* using those, but is a big help in preventing dependency conflicts if you're not. 
-
 <ExpansionPanelList>
 <ExpansionPanelListItem number="1">
 
 <h4>Set up your `Cartfile`</h4>
 
 Add `github "apollographql/apollo-ios"` to your Cartfile. 
-  - If you also plan on using the `ApolloSQLite` framework, you should also add `github "stephencelis/SQLite.swift"`. You may want to lock it to the version specified in `Cartfile.private` to prevent dependency conflicts. 
-  - If you also plan on using the `ApolloWebSocket` framework, you should also add `github "daltoniam/Starscream"`. You may want to lock it to the version specified in `Cartfile.private` to prevent dependency conflicts.
 
 </ExpansionPanelListItem>
 <ExpansionPanelListItem number="2">


### PR DESCRIPTION
The Carthage installation docs instruct people to manually add the SQLite and Starscream packages to their project Cartfiles because Apollo uses a private Cartfile. However, [this commit](https://github.com/apollographql/apollo-ios/commit/bb3568c273e667c888ae5204328f608ed03942fb) made Apollo's Cartfile public, making these installation steps unnecessary.