### PR TITLE
Swift Scripting Docs targetRootURL Possible Typo

### DIFF
--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -214,7 +214,7 @@ Now you can create a new empty `.graphql` file in your Xcode project, give it th
 2. Set up your `ApolloCodegenOptions` object. In this case, we'll use the constructor that [sets defaults for you automatically](./api/ApolloCodegenLib/structs/ApolloCodegenOptions#methods): 
 
     ```swift:title=main.swift
-    let options = ApolloCodegenOptions(targetRootURL: targetRootURL)
+    let options = ApolloCodegenOptions(targetRootURL: targetURL)
     ```
 
     This creates a single file called `API.swift` in the target's root folder. 


### PR DESCRIPTION
In the `ApolloCodegenOptions` section of the codegen tutorial, the `targetRootURL` parameter of `ApolloCodegenOptions` was set to `targetRootURL`, which I believe hasn't been referred to anywhere else.  I believe this is meant to be `targetURL`, which has been used in previous steps.

So far, this has been incredibly useful though & I've been able to get some code generated entirely in Swift, so I'm a happy bunny!  🐰 