### PR TITLE
Add watchOS 3.0 availability for urlSession(:task:didFinishCollecting:)

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -109,7 +109,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     self.clearAllTasks()
   }
   
-  @available(OSX 10.12, iOS 10.0, tvOS 10.0, *)
+  @available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
   open func urlSession(_ session: URLSession,
                        task: URLSessionTask,
                        didFinishCollecting metrics: URLSessionTaskMetrics) {


### PR DESCRIPTION
I've updated to the latest version of Apollo iOS today on a project I have in the works 🎉.

However, when set up via SPM on a watchOS-only project, the main Apollo library wouldn't build because of this error:

```
/path/to/apollo-ios/Sources/Apollo/URLSessionClient.swift:115:53: error: 'URLSessionTaskMetrics' is only available in watchOS 3.0 or newer
                       didFinishCollecting metrics: URLSessionTaskMetrics) {
                                                    ^
/path/to/apollo-ios/Sources/Apollo/URLSessionClient.swift:113:13: note: add @available attribute to enclosing instance method
  open func urlSession(_ session: URLSession,
            ^
/path/to/apollo-ios/Sources/Apollo/URLSessionClient.swift:11:12: note: add @available attribute to enclosing class
open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate {
```

In this PR, I've opted for adding `watchOS 3.0` to the existing `@available` attribute on the instance method.