### PR TITLE
Allow to clear the cache synchronously

### DIFF
--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -32,9 +32,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
 
   public func clear(callbackQueue: DispatchQueue?,
                     completion: ((Result<Void, Error>) -> Void)?) {
-    self.recordsLock.lock()
-    self.records.clear()
-    self.recordsLock.unlock()
+    clearImmediately()
 
     guard let completion = completion else {
       return
@@ -43,5 +41,11 @@ public final class InMemoryNormalizedCache: NormalizedCache {
     DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
                                                    action: completion,
                                                    result: .success(()))
+  }
+
+  public func clearImmediately() {
+    self.recordsLock.lock()
+    self.records.clear()
+    self.recordsLock.unlock()
   }
 }

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -29,4 +29,7 @@ public protocol NormalizedCache {
   ///   - completion: [optional] A completion closure to fire when the clear function has completed.
   func clear(callbackQueue: DispatchQueue?,
              completion: ((Result<Void, Error>) -> Void)?)
+
+  // Clears all records synchronously
+  func clearImmediately() throws
 }

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -148,7 +148,7 @@ extension SQLiteNormalizedCache: NormalizedCache {
   public func clear(callbackQueue: DispatchQueue?, completion: ((Swift.Result<Void, Error>) -> Void)?) {
     let result: Swift.Result<Void, Error>
     do {
-      try self.clearRecords()
+      try clearImmediately()
       result = .success(())
     } catch {
       result = .failure(error)
@@ -157,5 +157,9 @@ extension SQLiteNormalizedCache: NormalizedCache {
     DispatchQueue.apollo_returnResultAsyncIfNeeded(on: callbackQueue,
                                                    action: completion,
                                                    result: result)
+  }
+
+  public func clearImmediately() throws {
+    try clearRecords()
   }
 }

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -44,6 +44,10 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
                                                      result: .success(()))
     }
   }
+  
+  func clearImmediatly() {
+    records.clear()
+  }
 }
 
 class BatchedLoadTests: XCTestCase {  

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -45,7 +45,7 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     }
   }
   
-  func clearImmediatly() {
+  func clearImmediately() {
     records.clear()
   }
 }


### PR DESCRIPTION
I don't really understand why the existing methods have completion blocks while all the work is done synchronously on the caller thread. This gives the impression that the work is being offloaded to another queue which is not the case. I guess the protocol should not be concerned with the existing implementations. That said I've not replaced the existing methods for backward compatibility.

I had a need for synchronous cache clearance to ensure that everything is done right when the user logs out.