### PR TITLE
Added option to generate a custom scalar with a prefix.

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -55,7 +55,7 @@ public struct ApolloCodegenOptions {
   /// Enum to select how to handle properties using a custom scalar from the schema.
   public enum CustomScalarFormat: Equatable {
     /// Uses a default type instead of a custom scalar.
-    case `default`
+    case none
     /// Use your own types for custom scalars.
     case passthrough
     /// Use your own types for custom scalars with a prefix.
@@ -102,7 +102,7 @@ public struct ApolloCodegenOptions {
               only: URL? = nil,
               operationIDsURL: URL? = nil,
               outputFormat: OutputFormat,
-              customScalarFormat: CustomScalarFormat = .default,
+              customScalarFormat: CustomScalarFormat = .none,
               suppressSwiftMultilineStringLiterals: Bool = false,
               urlToSchemaFile: URL,
               downloadTimeout: Double = 30.0) {
@@ -180,11 +180,12 @@ public struct ApolloCodegenOptions {
     }
     
     switch customScalarFormat {
-    case .default:
+    case .none:
       break
     case .passthrough:
       arguments.append("--passthroughCustomScalars")
     case .passthroughWithPrefix(let prefix):
+      arguments.append("--passthroughCustomScalars")
       arguments.append("--customScalarsPrefix='\(prefix)'")
     }
     

--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -52,6 +52,16 @@ public struct ApolloCodegenOptions {
     }
   }
   
+  /// Enum to select how to handle properties using a custom scalar from the schema.
+  public enum CustomScalarFormat: Equatable {
+    /// Uses a default type instead of a custom scalar.
+    case `default`
+    /// Use your own types for custom scalars.
+    case passthrough
+    /// Use your own types for custom scalars with a prefix.
+    case passthroughWithPrefix(String)
+  }
+  
   let codegenEngine: CodeGenerationEngine
   let includes: String
   let mergeInFieldsFromFragmentSpreads: Bool
@@ -61,7 +71,7 @@ public struct ApolloCodegenOptions {
   let omitDeprecatedEnumCases: Bool
   let operationIDsURL: URL?
   let outputFormat: OutputFormat
-  let passthroughCustomScalars: Bool
+  let customScalarFormat: CustomScalarFormat
   let suppressSwiftMultilineStringLiterals: Bool
   let urlToSchemaFile: URL
   
@@ -79,7 +89,7 @@ public struct ApolloCodegenOptions {
   ///  - only: [optional] Parse all input files, but only output generated code for the file at this URL if non-nil. Defaults to nil.
   ///  - operationIDsURL: [optional] Path to an operation id JSON map file. If specified, also stores the operation ids (hashes) as properties on operation types. Defaults to nil.
   ///  - outputFormat: The `OutputFormat` enum option to use to output generated code.
-  ///  - passthroughCustomScalars: Set true to use your own types for custom scalars. Defaults to false.
+  ///  - customScalarFormat: How to handle properties using a custom scalar from the schema.
   ///  - suppressSwiftMultilineStringLiterals: Don't use multi-line string literals when generating code. Defaults to false.
   ///  - urlToSchemaFile: The URL to your schema file.
   ///  - downloadTimeout: The maximum time to wait before indicating that the download timed out, in seconds. Defaults to 30 seconds.
@@ -92,7 +102,7 @@ public struct ApolloCodegenOptions {
               only: URL? = nil,
               operationIDsURL: URL? = nil,
               outputFormat: OutputFormat,
-              passthroughCustomScalars: Bool = false,
+              customScalarFormat: CustomScalarFormat = .default,
               suppressSwiftMultilineStringLiterals: Bool = false,
               urlToSchemaFile: URL,
               downloadTimeout: Double = 30.0) {
@@ -105,7 +115,7 @@ public struct ApolloCodegenOptions {
     self.only = only
     self.operationIDsURL = operationIDsURL
     self.outputFormat = outputFormat
-    self.passthroughCustomScalars = passthroughCustomScalars
+    self.customScalarFormat = customScalarFormat
     self.suppressSwiftMultilineStringLiterals = suppressSwiftMultilineStringLiterals
     self.urlToSchemaFile = urlToSchemaFile
     self.downloadTimeout = downloadTimeout
@@ -169,8 +179,13 @@ public struct ApolloCodegenOptions {
       arguments.append("--omitDeprecatedEnumCases")
     }
     
-    if self.passthroughCustomScalars {
+    switch customScalarFormat {
+    case .default:
+      break
+    case .passthrough:
       arguments.append("--passthroughCustomScalars")
+    case .passthroughWithPrefix(let prefix):
+      arguments.append("--customScalarsPrefix='\(prefix)'")
     }
     
     if self.mergeInFieldsFromFragmentSpreads {
@@ -187,7 +202,7 @@ public struct ApolloCodegenOptions {
     case .multipleFiles(let folderURL):
       arguments.append("'\(folderURL.path)'")
     }
-    
+        
     return arguments
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -42,7 +42,7 @@ class ApolloCodegenTests: XCTestCase {
       XCTFail("Nope, this should be a single file!")
     }
     XCTAssertFalse(options.omitDeprecatedEnumCases)
-    XCTAssertFalse(options.passthroughCustomScalars)
+    XCTAssertEqual(options.customScalarFormat, .default)
     XCTAssertEqual(options.urlToSchemaFile, schema)
     XCTAssertEqual(options.modifier, .public)
     
@@ -64,6 +64,7 @@ class ApolloCodegenTests: XCTestCase {
     let only = sourceRoot.appendingPathComponent("only.graphql")
     let operationIDsURL = sourceRoot.appendingPathComponent("operationIDs.json")
     let namespace = "ANameSpace"
+    let prefix = "MyPrefix"
     
     let options = ApolloCodegenOptions(codegenEngine: .swiftExperimental,
                                        includes: "*.graphql",
@@ -74,7 +75,7 @@ class ApolloCodegenTests: XCTestCase {
                                        only: only,
                                        operationIDsURL: operationIDsURL,
                                        outputFormat: .multipleFiles(inFolderAtURL: output),
-                                       passthroughCustomScalars: true,
+                                       customScalarFormat: .passthroughWithPrefix(prefix),
                                        urlToSchemaFile: schema)
     XCTAssertEqual(options.includes, "*.graphql")
     XCTAssertFalse(options.mergeInFieldsFromFragmentSpreads)
@@ -87,7 +88,7 @@ class ApolloCodegenTests: XCTestCase {
     case .multipleFiles(let folderURL):
       XCTAssertEqual(folderURL, output)
     }
-    XCTAssertTrue(options.passthroughCustomScalars)
+    XCTAssertEqual(options.customScalarFormat, .passthroughWithPrefix(prefix))
     XCTAssertEqual(options.urlToSchemaFile, schema)
     XCTAssertTrue(options.omitDeprecatedEnumCases)
     XCTAssertEqual(options.modifier, .internal)
@@ -103,7 +104,7 @@ class ApolloCodegenTests: XCTestCase {
       "--only='\(only.path)'",
       "--operationIdsPath='\(operationIDsURL.path)'",
       "--omitDeprecatedEnumCases",
-      "--passthroughCustomScalars",
+      "--customScalarsPrefix='\(prefix)'",
       "'\(output.path)'",
     ])
   }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -42,7 +42,7 @@ class ApolloCodegenTests: XCTestCase {
       XCTFail("Nope, this should be a single file!")
     }
     XCTAssertFalse(options.omitDeprecatedEnumCases)
-    XCTAssertEqual(options.customScalarFormat, .default)
+    XCTAssertEqual(options.customScalarFormat, .none)
     XCTAssertEqual(options.urlToSchemaFile, schema)
     XCTAssertEqual(options.modifier, .public)
     
@@ -104,6 +104,7 @@ class ApolloCodegenTests: XCTestCase {
       "--only='\(only.path)'",
       "--operationIdsPath='\(operationIDsURL.path)'",
       "--omitDeprecatedEnumCases",
+      "--passthroughCustomScalars",
       "--customScalarsPrefix='\(prefix)'",
       "'\(output.path)'",
     ])


### PR DESCRIPTION
Fixes #1214 

Added an option to `ApolloCodegenOptions` to take a `CustomScalarFormat` enum which can be either `default`, `passthrough` or `passthroughWithPrefix(String)`