### PR TITLE
Fix for concurrent fetching bugs

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		9B518C87235F819E004C426D /* CLIDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B518C85235F8125004C426D /* CLIDownloader.swift */; };
 		9B518C8C235F8B5F004C426D /* ApolloFilePathHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B518C8A235F8B05004C426D /* ApolloFilePathHelper.swift */; };
 		9B518C8D235F8B9E004C426D /* CLIDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B518C88235F8AD4004C426D /* CLIDownloaderTests.swift */; };
+		9B554CC4247DC29A002F452A /* TaskData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B554CC3247DC29A002F452A /* TaskData.swift */; };
 		9B5A1EFC243528AA00F066BB /* InputObjectGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5A1EFB243528AA00F066BB /* InputObjectGenerationTests.swift */; };
 		9B5A1EFD24352AC100F066BB /* ExpectedReviewInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B68F06C241C646700E97318 /* ExpectedReviewInput.swift */; };
 		9B5A1EFE24352AED00F066BB /* ExpectedColorInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B68F06A241C643000E97318 /* ExpectedColorInput.swift */; };
@@ -399,6 +400,7 @@
 		9B518C85235F8125004C426D /* CLIDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDownloader.swift; sourceTree = "<group>"; };
 		9B518C88235F8AD4004C426D /* CLIDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDownloaderTests.swift; sourceTree = "<group>"; };
 		9B518C8A235F8B05004C426D /* ApolloFilePathHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloFilePathHelper.swift; sourceTree = "<group>"; };
+		9B554CC3247DC29A002F452A /* TaskData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskData.swift; sourceTree = "<group>"; };
 		9B5A1EE3243284F300F066BB /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		9B5A1EFB243528AA00F066BB /* InputObjectGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectGenerationTests.swift; sourceTree = "<group>"; };
 		9B5A1EFF2435356400F066BB /* ExpectedColorInputNoModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedColorInputNoModifier.swift; sourceTree = "<group>"; };
@@ -1287,6 +1289,7 @@
 				9F69FFA81D42855900E000B1 /* NetworkTransport.swift */,
 				9BEDC79D22E5D2CF00549BF6 /* RequestCreator.swift */,
 				9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */,
+				9B554CC3247DC29A002F452A /* TaskData.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -2112,6 +2115,7 @@
 				54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */,
 				9FC9A9C51E2D6CE70023C4D5 /* GraphQLSelectionSet.swift in Sources */,
 				9BDE43DD22C6705300FD7C7F /* GraphQLHTTPResponseError.swift in Sources */,
+				9B554CC4247DC29A002F452A /* TaskData.swift in Sources */,
 				9FCDFD231E33A0D8007519DC /* AsynchronousOperation.swift in Sources */,
 				9BA1244A22D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift in Sources */,
 				9B708AAD2305884500604A11 /* ApolloClientProtocol.swift in Sources */,

--- a/Sources/Apollo/Atomic.swift
+++ b/Sources/Apollo/Atomic.swift
@@ -27,6 +27,12 @@ public class Atomic<T> {
       _value = newValue
     }
   }
+  
+  public func mutate(block: (inout T) -> Void) {
+    lock.lock()
+    block(&_value)
+    lock.unlock()
+  }
 }
 
 public extension Atomic where T == Int {

--- a/Sources/Apollo/TaskData.swift
+++ b/Sources/Apollo/TaskData.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public class TaskData {
+  
+  public let rawCompletion: URLSessionClient.RawCompletion?
+  public let completionBlock: URLSessionClient.Completion
+  private(set) var data: Data = Data()
+  private(set) var response: HTTPURLResponse? = nil
+  
+  init(rawCompletion: URLSessionClient.RawCompletion?,
+       completionBlock: @escaping URLSessionClient.Completion) {
+    self.rawCompletion = rawCompletion
+    self.completionBlock = completionBlock
+  }
+  
+  func append(additionalData: Data) {
+    self.data.append(additionalData)
+  }
+  
+  func responseReceived(response: URLResponse) {
+    if let httpResponse = response as? HTTPURLResponse {
+      self.response = httpResponse
+    }
+  }
+}

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -77,12 +77,14 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                         rawTaskCompletionHandler: RawCompletion? = nil,
                         completion: @escaping Completion) -> URLSessionTask {
     let dataTask = self.session.dataTask(with: request)
+    let identifier = dataTask.taskIdentifier
     if let rawCompletion = rawTaskCompletionHandler {
-      self.rawCompletions.value[dataTask.taskIdentifier] = rawCompletion
+      self.rawCompletions.value[identifier] = rawCompletion
     }
     
-    self.completionBlocks.value[dataTask.taskIdentifier] = completion
-    self.datas.value[dataTask.taskIdentifier] = Data()
+    
+    self.completionBlocks.value[identifier] = completion
+    self.datas.value[identifier] = Data()
     dataTask.resume()
     
     return dataTask

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -41,6 +41,10 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                               delegateQueue: callbackQueue)
   }
   
+  deinit {
+    self.clearAllTasks()
+  }
+  
   /// Clears underlying dictionaries of any data related to a particular task identifier.
   ///
   /// - Parameter identifier: The identifier of the task to clear.

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -68,7 +68,6 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                         rawTaskCompletionHandler: RawCompletion? = nil,
                         completion: @escaping Completion) -> URLSessionTask {
     let task = self.session.dataTask(with: request)
-    print("Task ID: \(task.taskIdentifier)")
     let taskData = TaskData(rawCompletion: rawTaskCompletionHandler,
                             completionBlock: completion)
     

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -206,6 +206,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                        didReceive data: Data) {
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
+        assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")
         return
       }
       

--- a/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
+++ b/Tests/ApolloCacheDependentTests/StarWarsServerTests.swift
@@ -9,15 +9,17 @@ protocol TestConfig {
 }
 
 class DefaultConfig: TestConfig {
+  let transport =  HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql")!)
   func network() -> HTTPNetworkTransport {
-    return HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql")!)
+    return transport
   }
 }
 
 class APQsConfig: TestConfig {
+  let transport = HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql")!,
+                                       enableAutoPersistedQueries: true)
   func network() -> HTTPNetworkTransport {
-    return HTTPNetworkTransport(url: URL(string: "http://localhost:8080/graphql")!,
-                                enableAutoPersistedQueries: true)
+    return transport
   }
 }
 

--- a/Tests/ApolloTests/HTTPBinAPI.swift
+++ b/Tests/ApolloTests/HTTPBinAPI.swift
@@ -1,43 +1,59 @@
 import Foundation
 
 enum HTTPBinAPI {
-    static let baseURL = URL(string: "https://httpbin.org/")!
-    enum Endpoint {
-        case bytes(count: Int)
-        case get
-        case headers
-        case image
-        case post
-        
-        var toString: String {
-            
-            switch self {
-            case .bytes(let count):
-                return "bytes/\(count)"
-            case .get:
-                return "get"
-            case .headers:
-                return "headers"
-            case .image:
-                return "image/jpeg"
-            case .post:
-                return "post"
-            }
-        }
-        
-        var toURL: URL {
-            HTTPBinAPI.baseURL.appendingPathComponent(self.toString)
-        }
+  static let baseURL = URL(string: "https://httpbin.org")!
+  enum Endpoint {
+    case bytes(count: Int)
+    case get
+    case getWithIndex(index: Int)
+    case headers
+    case image
+    case post
+    
+    var toString: String {
+      
+      switch self {
+      case .bytes(let count):
+        return "bytes/\(count)"
+      case .get,
+           .getWithIndex:
+        return "get"
+      case .headers:
+        return "headers"
+      case .image:
+        return "image/jpeg"
+      case .post:
+        return "post"
+      }
     }
+    
+    var queryParams: [URLQueryItem]? {
+      switch self {
+      case .getWithIndex(let index):
+        return [URLQueryItem(name: "index", value: "\(index)")]
+      default:
+        return nil
+      }
+    }
+    
+    var toURL: URL {
+      var components = URLComponents(url: HTTPBinAPI.baseURL, resolvingAgainstBaseURL: false)!
+      components.path = "/\(self.toString)"
+      components.queryItems = self.queryParams
+      
+      return components.url!
+    }
+  }
 }
 
 struct HTTPBinResponse: Codable {
-    
-    let headers: [String: String]
-    let url: String
-    let json: [String: String]?
-    
-    init(data: Data) throws {
-        self = try JSONDecoder().decode(Self.self, from: data)
-    }
+  
+  let headers: [String: String]
+  let url: String
+  let json: [String: String]?
+  let args: [String: String]?
+  
+  init(data: Data) throws {
+    self = try JSONDecoder().decode(Self.self, from: data)
+  }
 }

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -165,7 +165,7 @@ class URLSessionClientLiveTests: XCTestCase {
   
   func testMultipleSimultaneousRequests() {
     let expectation = self.expectation(description: "request sent, response received")
-    let iterations = 9 // Seems like httpbin freaks out if you send more than this in one go
+    let iterations = 20
     expectation.expectedFulfillmentCount = iterations
     DispatchQueue.concurrentPerform(iterations: iterations, execute: { index in
       let request = self.request(for: .getWithIndex(index: index))

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class URLSessionClientLiveTests: XCTestCase {
   
-  lazy var client = URLSessionClient()
+  let client = URLSessionClient()
   
   private func request(for endpoint: HTTPBinAPI.Endpoint) -> URLRequest {
     URLRequest(url: endpoint.toURL,

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -167,10 +167,12 @@ class URLSessionClientLiveTests: XCTestCase {
     let expectation = self.expectation(description: "request sent, response received")
     let iterations = 20
     expectation.expectedFulfillmentCount = iterations
+    let taskIDs = Atomic<[Int]>([])
+    
     DispatchQueue.concurrentPerform(iterations: iterations, execute: { index in
       let request = self.request(for: .getWithIndex(index: index))
 
-      self.client.sendRequest(request) { result in
+      let task = self.client.sendRequest(request) { result in
         switch result {
         case .success((let data, let response)):
           XCTAssertEqual(response.url, request.url)
@@ -190,8 +192,17 @@ class URLSessionClientLiveTests: XCTestCase {
           expectation.fulfill()
         }
       }
+      
+      taskIDs.mutate { $0.append(task.taskIdentifier) }
     })
     
     self.wait(for: [expectation], timeout: 30)
+    
+    // Were the correct number of tasks created?
+    XCTAssertEqual(taskIDs.value.count, iterations)
+    
+    // Using a set to unique, are all task IDs different values?)
+    let set = Set(taskIDs.value)
+    XCTAssertEqual(set.count, iterations)
   }
 }


### PR DESCRIPTION
~So, turns out a fairly large assumption I made (`URLSessionTask` identifers are unique) is basically incorrect in a sufficiently concurrent set of requests. This means when using the task identifier as a key in a dictionary, you may wind up with multiple requests having the same task identifier, and the dictionaries lose their mind.~

~This PR updates the underlying dictionaries in `URLSessionClient` to key off the `URLSessionTask` itself rather than just the identifier.~

~This is a *partial* fix for #1210 - there's still something going on there that I can't put my finger on, but I wanted to at least get this merged for the next version since it does fix what is definitely incorrect behavior~

Welp, looks like our locking behavior wasn't doing what I was expecting it to do, and it was having all sorts of weird side effects, including effing up the task identifier generation - shout out to @davedelong and @bdash for spotting what I was doing wrong and offering better suggestions.

This should now be an *actual* fix for #1210 and/or #1226. 