### PR TITLE
Update intro pages of docs

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -7,7 +7,9 @@ description: A strongly-typed, caching GraphQL client for iOS, written in Swift
 
 It allows you to execute queries and mutations against a GraphQL server and returns results as query-specific Swift types. This means you don't have to deal with parsing JSON, or passing around dictionaries and making clients cast values to the right type manually. You also don't have to write model types yourself, because these are generated from the GraphQL definitions your UI uses.
 
-As the generated types are query-specific, you're only able to access data you actually specify as part of a query. If you don't ask for a field, you won't be able to access the corresponding property. In effect, this means you can now rely on the Swift type checker to make sure errors in data access show up at compile time. With our Xcode integration, you can conveniently work with your UI code and corresponding GraphQL definitions side by side, and it will even validate your query documents, and show errors inline.
+As the generated types are query-specific, you're only able to access data you actually specify as part of a query. If you don't ask for a field in a particular query, you won't be able to access the corresponding property on the returned data structure.
+
+In effect, this means you can now rely on the Swift type checker to make sure errors in data access show up at compile time. With our Xcode integration, you can conveniently work with your UI code and corresponding GraphQL definitions side by side, and it will even validate your query documents, and show errors inline.
 
 Apollo iOS does more than simply run your queries against a GraphQL server, however. It normalizes query results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run. This means your UI is always internally consistent, and can be kept fully up-to-date with the state on the server with the minimum number of queries required.
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -17,7 +17,7 @@ This combination of immutable models, one way data flow, and automatic consisten
 
 ## Getting Started
 
-[Front Page](https://github.com/apollographql/frontpage-ios-app) is the iOS version of the simple "Hello World" app that lives on our [developer site](http://dev.apollodata.com).
+We have a [detailed iOS tutorial](./tutorial/tutorial-introduction) walking you through how to build an app called [RocketResever](https://github.com/apollographql/iOSTutorial), which talks to the backend built in the [Fullstack Tutorial](https://www.apollographql.com/docs/tutorial/introduction/).
 
 If you have questions or would like to contribute, please join our iOS channel on [Spectrum](https://spectrum.chat/apollo/apollo-ios).
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -28,6 +28,6 @@ We're excited about the prospects of further [unifying the clients for JavaScrip
 ## Other resources
 
 - [GraphQL.org](http://graphql.org) for an introduction and reference to the GraphQL itself, partially written and maintained by the Apollo team.
-- [Our website](http://www.apollodata.com/) to learn about Apollo open-source and commercial tools.
-- [Our blog](https://dev-blog.apollodata.com) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
+- [Our website](http://www.apollographql.com/) to learn about Apollo open-source and commercial tools.
+- [Our blog](https://www.apollographql.com/blog/) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
 - [Our Twitter](https://twitter.com/apollographql) for in-the-moment news.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -21,11 +21,11 @@ We have a [detailed iOS tutorial](./tutorial/tutorial-introduction) walking you 
 
 If you have questions or would like to contribute, please join our iOS channel on [Spectrum](https://spectrum.chat/apollo/apollo-ios).
 
-[Apollo Android](https://github.com/apollographql/apollo-android) is a GraphQL client for native Android apps written in Java.
+## Related platforms
+
+[Apollo Android](https://github.com/apollographql/apollo-android) is a GraphQL client for native Android apps written in Java and Kotlin, and offers Kotlin Multi-Platform integration as well.
 
 Apollo Client for JavaScript's [React integration](https://apollographql.com/docs/react) works with [React Native](https://facebook.github.io/react-native/) on both iOS and Android.
-
-We're excited about the prospects of further [unifying the clients for JavaScript, iOS, and Android](https://blog.apollographql.com/one-graphql-client-for-javascript-ios-and-android-64993c1b7991), including sharing a cache between native and React Native.
 
 ## Other resources
 

--- a/docs/source/tutorial/tutorial-introduction.md
+++ b/docs/source/tutorial/tutorial-introduction.md
@@ -2,11 +2,11 @@
 title: "0. Introduction"
 ---
 
-Welcome! This tutorial demonstrates adding the Apollo iOS SDK to an app to communicate with a GraphQL server. It was prepared with the following tools:
+Welcome! This tutorial demonstrates adding the Apollo iOS SDK to an app to communicate with a GraphQL server. It is confirmed to work with the following tools:
 
-- Xcode 11.4
+- Xcode 11.5
 - Swift 5.2
-- Apollo iOS SDK 0.25.0
+- Apollo iOS SDK 0.28.0
 
 The tutorial assumes that you're using a Mac with Xcode installed. It also assumes some prior experience with iOS development.
 


### PR DESCRIPTION
@martinbonnin pointed out some wildly out of date stuff on the front page of the iOS docs as he was adapting some stuff for Android. I've updated links and wording to better reflect what we've got currently. 

I also updated the intro page for the tutorial to indicate it works with Xcode 11.5 and Apollo 0.28.0 while I was poking around in the docs.