### PR TITLE
Add code generation for interface and union enums

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -26,6 +26,14 @@
 		9B455CEB2492FB03002255A9 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CEA2492FB03002255A9 /* String+SHA.swift */; };
 		9B3D70F92488340400D8BAF4 /* ASTUnionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */; };
 		9B3D70FA2488340C00D8BAF4 /* ASTInterfaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */; };
+		9B3D70FC2488388300D8BAF4 /* InterfaceEnumGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70FB2488388300D8BAF4 /* InterfaceEnumGenerator.swift */; };
+		9B3D70FE2488388E00D8BAF4 /* UnionEnumGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70FD2488388E00D8BAF4 /* UnionEnumGenerator.swift */; };
+		9B3D71012488429E00D8BAF4 /* ExpectedCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71002488429E00D8BAF4 /* ExpectedCharacterType.swift */; };
+		9B3D71032488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71022488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift */; };
+		9B3D7105248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D7104248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift */; };
+		9B3D71072488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */; };
+		9B3D710924884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D710824884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift */; };
+		9B3D710B24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D710A24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift */; };
 		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
 		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
 		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
@@ -411,6 +419,14 @@
 		9B3D70F5248832AE00D8BAF4 /* API.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = API.json; sourceTree = "<group>"; };
 		9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTInterfaceType.swift; sourceTree = "<group>"; };
 		9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTUnionType.swift; sourceTree = "<group>"; };
+		9B3D70FB2488388300D8BAF4 /* InterfaceEnumGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceEnumGenerator.swift; sourceTree = "<group>"; };
+		9B3D70FD2488388E00D8BAF4 /* UnionEnumGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionEnumGenerator.swift; sourceTree = "<group>"; };
+		9B3D71002488429E00D8BAF4 /* ExpectedCharacterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedCharacterType.swift; sourceTree = "<group>"; };
+		9B3D71022488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntefaceEnumGenerationTests.swift; sourceTree = "<group>"; };
+		9B3D7104248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedSanitizedCharacterType.swift; sourceTree = "<group>"; };
+		9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoCasesCharacterType.swift; sourceTree = "<group>"; };
+		9B3D710824884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoModifierCharacterType.swift; sourceTree = "<group>"; };
+		9B3D710A24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedEpisodeEnumWithoutModifier.swift; sourceTree = "<group>"; };
 		9B4AA8AD239EFDC9003E1300 /* Apollo-Target-CodegenTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenTests.xcconfig"; sourceTree = "<group>"; };
 		9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClient.swift; sourceTree = "<group>"; };
 		9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBinAPI.swift; sourceTree = "<group>"; };
@@ -813,6 +829,17 @@
 				9B455CEA2492FB03002255A9 /* String+SHA.swift */,
 			);
 			name = Extensions;
+            sourceTree = "<group>";
+        };
+		9B3D70FF2488428A00D8BAF4 /* InterfaceObject */ = {
+			isa = PBXGroup;
+			children = (
+				9B3D71002488429E00D8BAF4 /* ExpectedCharacterType.swift */,
+				9B3D7104248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift */,
+				9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */,
+				9B3D710824884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift */,
+			);
+			name = InterfaceObject;
 			sourceTree = "<group>";
 		};
 		9B6835472463486200337AE6 /* ApolloCore */ = {
@@ -829,6 +856,7 @@
 		9B68F0512415B17B00E97318 /* ExpectedOutputs */ = {
 			isa = PBXGroup;
 			children = (
+				9B3D70FF2488428A00D8BAF4 /* InterfaceObject */,
 				9B68F069241C641600E97318 /* InputObject */,
 				9B68F05E2416BEA300E97318 /* Enum */,
 			);
@@ -840,6 +868,7 @@
 			children = (
 				9B68F0522415B1C800E97318 /* ExpectedEpisodeEnum.swift */,
 				9B68F0562416B5F700E97318 /* ExpectedEpisodeEnumNoDescription.swift */,
+				9B3D710A24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift */,
 				9B68F0582416BA7700E97318 /* ExpectedEnumWithNoCases.swift */,
 				9B68F05A2416BCF100E97318 /* ExpectedEnumOmittingDeprecatedCases.swift */,
 				9B68F05C2416BDCF00E97318 /* ExpectedEnumWithDeprecatedCases.swift */,
@@ -988,6 +1017,7 @@
 				9B68F03A240D8D1800E97318 /* CodegenExtensionTests.swift */,
 				9B68F04E2413271D00E97318 /* EnumGenerationTests.swift */,
 				9B5A1EFB243528AA00F066BB /* InputObjectGenerationTests.swift */,
+				9B3D71022488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift */,
 				9BAEEC0D234BB95B00808306 /* FileManagerExtensionsTests.swift */,
 				9B68F0542416B33300E97318 /* LineByLineComparison.swift */,
 				9BD681352405F725000874CB /* JSONTests.swift */,
@@ -1077,6 +1107,8 @@
 				9B68F03E240F3B0E00E97318 /* CodeGenerator.swift */,
 				9B68F04924130D6500E97318 /* EnumGenerator.swift */,
 				9B68F0612417002900E97318 /* InputObjectGenerator.swift */,
+				9B3D70FB2488388300D8BAF4 /* InterfaceEnumGenerator.swift */,
+				9B3D70FD2488388E00D8BAF4 /* UnionEnumGenerator.swift */,
 			);
 			name = Output;
 			sourceTree = "<group>";
@@ -1995,9 +2027,11 @@
 				9B0E4718240AF6D70093BDA7 /* ASTVariableType.swift in Sources */,
 				9B0E471C240B167C0093BDA7 /* String+Apollo.swift in Sources */,
 				9BAEEBF32346DDAD00808306 /* CodegenLogger.swift in Sources */,
+				9B3D70FE2488388E00D8BAF4 /* UnionEnumGenerator.swift in Sources */,
 				9B518C8C235F8B5F004C426D /* ApolloFilePathHelper.swift in Sources */,
 				9B518C87235F819E004C426D /* CLIDownloader.swift in Sources */,
 				9B3D70FA2488340C00D8BAF4 /* ASTInterfaceType.swift in Sources */,
+				9B3D71012488429E00D8BAF4 /* ExpectedCharacterType.swift in Sources */,
 				9BAEEBF123467E0A00808306 /* ApolloCLI.swift in Sources */,
 				9BD6812B2405F410000874CB /* ASTFragment.swift in Sources */,
 				9B68F04A24130D6500E97318 /* EnumGenerator.swift in Sources */,
@@ -2013,6 +2047,8 @@
 				9B0E471E240B239D0093BDA7 /* ASTEnumValue.swift in Sources */,
 				9B7B6F5A233C287200F32205 /* ApolloCodegenOptions.swift in Sources */,
 				9BAEEBF52346E90700808306 /* CLIExtractor.swift in Sources */,
+				9BCB58602407593C002F766E /* OptionalBoolean.swift in Sources */,
+				9B3D70FC2488388300D8BAF4 /* InterfaceEnumGenerator.swift in Sources */,
 				9BD6813B2405FA56000874CB /* ASTOperation.swift in Sources */,
 				9BD681292405F149000874CB /* ASTTypeUsed.swift in Sources */,
 				9BD6812F2405F665000874CB /* JSON.swift in Sources */,
@@ -2076,7 +2112,9 @@
 			files = (
 				9B68F0572416B5F700E97318 /* ExpectedEpisodeEnumNoDescription.swift in Sources */,
 				9B21FD782424305700998B5C /* ExpectedEnumWithDifferentCases.swift in Sources */,
+				9B3D710B24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift in Sources */,
 				9B6835342460B47900337AE6 /* ASTVariableType+TestHelpers.swift in Sources */,
+				9B3D71032488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift in Sources */,
 				9B5A1F002435356400F066BB /* ExpectedColorInputNoModifier.swift in Sources */,
 				9B68F04F2413271D00E97318 /* EnumGenerationTests.swift in Sources */,
 				9BAEEC10234BB95B00808306 /* FileManagerExtensionsTests.swift in Sources */,
@@ -2084,6 +2122,7 @@
 				9B68F0532415B1C800E97318 /* ExpectedEpisodeEnum.swift in Sources */,
 				9BAEEC17234C275600808306 /* ApolloSchemaTests.swift in Sources */,
 				9B5A1EFC243528AA00F066BB /* InputObjectGenerationTests.swift in Sources */,
+				9B3D7105248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift in Sources */,
 				9B0E471A240AFA060093BDA7 /* VariableToSwiftTypeTests.swift in Sources */,
 				9B8C3FB5248DA3E000707B13 /* URLExtensionsTests.swift in Sources */,
 				9BAEEC12234BBA9200808306 /* CodegenTestHelper.swift in Sources */,
@@ -2094,7 +2133,9 @@
 				9B68F05B2416BCF100E97318 /* ExpectedEnumOmittingDeprecatedCases.swift in Sources */,
 				9B68F03B240D8D1800E97318 /* CodegenExtensionTests.swift in Sources */,
 				9B683538246310D400337AE6 /* ExpectedReviewInputNoModifier.swift in Sources */,
+				9B3D71072488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift in Sources */,
 				9BD681422406F516000874CB /* ASTParsingTests.swift in Sources */,
+				9B3D710924884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift in Sources */,
 				9B68F0552416B33300E97318 /* LineByLineComparison.swift in Sources */,
 				9BAEEC15234C132600808306 /* CLIExtractorTests.swift in Sources */,
 				9B5A1EFE24352AED00F066BB /* ExpectedColorInput.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -34,6 +34,11 @@
 		9B3D71072488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */; };
 		9B3D710924884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D710824884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift */; };
 		9B3D710B24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D710A24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift */; };
+		9B3D710F24884D7500D8BAF4 /* ExpectedSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D710E24884D7500D8BAF4 /* ExpectedSearchResultType.swift */; };
+		9B3D711124884E1B00D8BAF4 /* UnionEnumGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711024884E1B00D8BAF4 /* UnionEnumGenerationTests.swift */; };
+		9B3D711324889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711224889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift */; };
+		9B3D711524889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711424889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift */; };
+		9B3D711724889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711624889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift */; };
 		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
 		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
 		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
@@ -427,6 +432,11 @@
 		9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoCasesCharacterType.swift; sourceTree = "<group>"; };
 		9B3D710824884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoModifierCharacterType.swift; sourceTree = "<group>"; };
 		9B3D710A24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedEpisodeEnumWithoutModifier.swift; sourceTree = "<group>"; };
+		9B3D710E24884D7500D8BAF4 /* ExpectedSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedSearchResultType.swift; sourceTree = "<group>"; };
+		9B3D711024884E1B00D8BAF4 /* UnionEnumGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionEnumGenerationTests.swift; sourceTree = "<group>"; };
+		9B3D711224889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedSanitizedSearchResultType.swift; sourceTree = "<group>"; };
+		9B3D711424889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoCasesSearchResultType.swift; sourceTree = "<group>"; };
+		9B3D711624889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoModifierSearchResultType.swift; sourceTree = "<group>"; };
 		9B4AA8AD239EFDC9003E1300 /* Apollo-Target-CodegenTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenTests.xcconfig"; sourceTree = "<group>"; };
 		9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClient.swift; sourceTree = "<group>"; };
 		9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBinAPI.swift; sourceTree = "<group>"; };
@@ -831,7 +841,7 @@
 			name = Extensions;
             sourceTree = "<group>";
         };
-		9B3D70FF2488428A00D8BAF4 /* InterfaceObject */ = {
+		9B3D70FF2488428A00D8BAF4 /* InterfaceEnum */ = {
 			isa = PBXGroup;
 			children = (
 				9B3D71002488429E00D8BAF4 /* ExpectedCharacterType.swift */,
@@ -839,7 +849,18 @@
 				9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */,
 				9B3D710824884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift */,
 			);
-			name = InterfaceObject;
+			name = InterfaceEnum;
+			sourceTree = "<group>";
+		};
+		9B3D710D24884CE500D8BAF4 /* UnionEnum */ = {
+			isa = PBXGroup;
+			children = (
+				9B3D710E24884D7500D8BAF4 /* ExpectedSearchResultType.swift */,
+				9B3D711224889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift */,
+				9B3D711424889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift */,
+				9B3D711624889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift */,
+			);
+			name = UnionEnum;
 			sourceTree = "<group>";
 		};
 		9B6835472463486200337AE6 /* ApolloCore */ = {
@@ -856,7 +877,8 @@
 		9B68F0512415B17B00E97318 /* ExpectedOutputs */ = {
 			isa = PBXGroup;
 			children = (
-				9B3D70FF2488428A00D8BAF4 /* InterfaceObject */,
+				9B3D710D24884CE500D8BAF4 /* UnionEnum */,
+				9B3D70FF2488428A00D8BAF4 /* InterfaceEnum */,
 				9B68F069241C641600E97318 /* InputObject */,
 				9B68F05E2416BEA300E97318 /* Enum */,
 			);
@@ -1022,6 +1044,7 @@
 				9B68F0542416B33300E97318 /* LineByLineComparison.swift */,
 				9BD681352405F725000874CB /* JSONTests.swift */,
 				9B8C3FB4248DA3E000707B13 /* URLExtensionsTests.swift */,
+				9B3D711024884E1B00D8BAF4 /* UnionEnumGenerationTests.swift */,
 				9B0E4719240AFA060093BDA7 /* VariableToSwiftTypeTests.swift */,
 				9BAEEC0C234BB95B00808306 /* Info.plist */,
 			);
@@ -2112,6 +2135,7 @@
 			files = (
 				9B68F0572416B5F700E97318 /* ExpectedEpisodeEnumNoDescription.swift in Sources */,
 				9B21FD782424305700998B5C /* ExpectedEnumWithDifferentCases.swift in Sources */,
+				9B3D710F24884D7500D8BAF4 /* ExpectedSearchResultType.swift in Sources */,
 				9B3D710B24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift in Sources */,
 				9B6835342460B47900337AE6 /* ASTVariableType+TestHelpers.swift in Sources */,
 				9B3D71032488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift in Sources */,
@@ -2134,8 +2158,12 @@
 				9B68F03B240D8D1800E97318 /* CodegenExtensionTests.swift in Sources */,
 				9B683538246310D400337AE6 /* ExpectedReviewInputNoModifier.swift in Sources */,
 				9B3D71072488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift in Sources */,
+				9B3D711724889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift in Sources */,
+				9B3D711324889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift in Sources */,
 				9BD681422406F516000874CB /* ASTParsingTests.swift in Sources */,
+				9B3D711124884E1B00D8BAF4 /* UnionEnumGenerationTests.swift in Sources */,
 				9B3D710924884A1500D8BAF4 /* ExpectedNoModifierCharacterType.swift in Sources */,
+				9B3D711524889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift in Sources */,
 				9B68F0552416B33300E97318 /* LineByLineComparison.swift in Sources */,
 				9BAEEC15234C132600808306 /* CLIExtractorTests.swift in Sources */,
 				9B5A1EFE24352AED00F066BB /* ExpectedColorInput.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		9B455CE62492D0A3002255A9 /* OptionalBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */; };
 		9B455CE72492D0A3002255A9 /* Collection+Apollo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */; };
 		9B455CEB2492FB03002255A9 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CEA2492FB03002255A9 /* String+SHA.swift */; };
+		9B3D70F92488340400D8BAF4 /* ASTUnionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */; };
+		9B3D70FA2488340C00D8BAF4 /* ASTInterfaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */; };
 		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
 		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
 		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
@@ -406,6 +408,9 @@
 		9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalBoolean.swift; sourceTree = "<group>"; };
 		9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+Apollo.swift"; sourceTree = "<group>"; };
 		9B455CEA2492FB03002255A9 /* String+SHA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SHA.swift"; sourceTree = "<group>"; };
+		9B3D70F5248832AE00D8BAF4 /* API.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = API.json; sourceTree = "<group>"; };
+		9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTInterfaceType.swift; sourceTree = "<group>"; };
+		9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTUnionType.swift; sourceTree = "<group>"; };
 		9B4AA8AD239EFDC9003E1300 /* Apollo-Target-CodegenTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenTests.xcconfig"; sourceTree = "<group>"; };
 		9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClient.swift; sourceTree = "<group>"; };
 		9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBinAPI.swift; sourceTree = "<group>"; };
@@ -956,9 +961,11 @@
 				9B0E471D240B239D0093BDA7 /* ASTEnumValue.swift */,
 				9BD6813C2405FAB7000874CB /* ASTField.swift */,
 				9BD6812A2405F410000874CB /* ASTFragment.swift */,
+				9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */,
 				9BD681392405F95B000874CB /* ASTOperation.swift */,
 				9BD681262405F0CB000874CB /* ASTOutput.swift */,
 				9BD681282405F149000874CB /* ASTTypeUsed.swift */,
+				9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */,
 				9B0E4717240AF6D70093BDA7 /* ASTVariableType.swift */,
 				9BD6813F2406F31A000874CB /* FlexibleDecoder.swift */,
 			);
@@ -1021,6 +1028,9 @@
 		9BCF0CE923FC9F060031D2A2 /* StarWarsAPI */ = {
 			isa = PBXGroup;
 			children = (
+				9B3D70F5248832AE00D8BAF4 /* API.json */,
+				9BCF0CFC23FC9F060031D2A2 /* API.swift */,
+				9BCF0CFB23FC9F060031D2A2 /* schema.json */,
 				9BCF0CEA23FC9F060031D2A2 /* TestFolder */,
 				9BCF0CED23FC9F060031D2A2 /* HeroAndFriendsNames.graphql */,
 				9BCF0CEE23FC9F060031D2A2 /* HeroFriendsOfFriends.graphql */,
@@ -1036,8 +1046,6 @@
 				9BCF0CF823FC9F060031D2A2 /* operationIDs.json */,
 				9BCF0CF923FC9F060031D2A2 /* CharacterAndSubTypesFragments.graphql */,
 				9BCF0CFA23FC9F060031D2A2 /* HeroTypeDependentAliasedField.graphql */,
-				9BCF0CFB23FC9F060031D2A2 /* schema.json */,
-				9BCF0CFC23FC9F060031D2A2 /* API.swift */,
 				9BCF0CFD23FC9F060031D2A2 /* SubscribeReview.graphql */,
 				9BCF0CFE23FC9F060031D2A2 /* HeroParentTypeDependentField.graphql */,
 				9BCF0CFF23FC9F060031D2A2 /* Info.plist */,
@@ -1989,11 +1997,14 @@
 				9BAEEBF32346DDAD00808306 /* CodegenLogger.swift in Sources */,
 				9B518C8C235F8B5F004C426D /* ApolloFilePathHelper.swift in Sources */,
 				9B518C87235F819E004C426D /* CLIDownloader.swift in Sources */,
+				9B3D70FA2488340C00D8BAF4 /* ASTInterfaceType.swift in Sources */,
 				9BAEEBF123467E0A00808306 /* ApolloCLI.swift in Sources */,
 				9BD6812B2405F410000874CB /* ASTFragment.swift in Sources */,
 				9B68F04A24130D6500E97318 /* EnumGenerator.swift in Sources */,
 				9B68F06524198D1000E97318 /* InputObjectGenerator.swift in Sources */,
 				9B7B6F69233C2C0C00F32205 /* FileManager+Apollo.swift in Sources */,
+				9B3D70F92488340400D8BAF4 /* ASTUnionType.swift in Sources */,
+				AE1CFBD0245EBA25002C8CEE /* ApolloExtension.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				9B68F068241ADA9D00E97318 /* Dictionary+Apollo.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -19,16 +19,10 @@
 		9B21FD772422C8CC00998B5C /* TestFileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B21FD762422C8CC00998B5C /* TestFileHelper.swift */; };
 		9B21FD782424305700998B5C /* ExpectedEnumWithDifferentCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B68F05F2416F80C00E97318 /* ExpectedEnumWithDifferentCases.swift */; };
 		9B21FD792424305E00998B5C /* ExpectedEnumWithSanitizedCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B68F063241703B200E97318 /* ExpectedEnumWithSanitizedCases.swift */; };
-		9B455CDF2492D05E002255A9 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6CB23D238077B60007259D /* Atomic.swift */; };
-		9B455CE52492D0A3002255A9 /* ApolloExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE22492D0A3002255A9 /* ApolloExtension.swift */; };
-		9B455CE62492D0A3002255A9 /* OptionalBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */; };
-		9B455CE72492D0A3002255A9 /* Collection+Apollo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */; };
-		9B455CEB2492FB03002255A9 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CEA2492FB03002255A9 /* String+SHA.swift */; };
 		9B3D70F92488340400D8BAF4 /* ASTUnionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */; };
 		9B3D70FA2488340C00D8BAF4 /* ASTInterfaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */; };
 		9B3D70FC2488388300D8BAF4 /* InterfaceEnumGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70FB2488388300D8BAF4 /* InterfaceEnumGenerator.swift */; };
 		9B3D70FE2488388E00D8BAF4 /* UnionEnumGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D70FD2488388E00D8BAF4 /* UnionEnumGenerator.swift */; };
-		9B3D71012488429E00D8BAF4 /* ExpectedCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71002488429E00D8BAF4 /* ExpectedCharacterType.swift */; };
 		9B3D71032488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71022488448F00D8BAF4 /* IntefaceEnumGenerationTests.swift */; };
 		9B3D7105248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D7104248847D400D8BAF4 /* ExpectedSanitizedCharacterType.swift */; };
 		9B3D71072488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71062488495900D8BAF4 /* ExpectedNoCasesCharacterType.swift */; };
@@ -39,6 +33,12 @@
 		9B3D711324889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711224889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift */; };
 		9B3D711524889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711424889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift */; };
 		9B3D711724889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D711624889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift */; };
+		9B3FB4F124D9ED01002C8B1B /* ExpectedCharacterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3D71002488429E00D8BAF4 /* ExpectedCharacterType.swift */; };
+		9B455CDF2492D05E002255A9 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6CB23D238077B60007259D /* Atomic.swift */; };
+		9B455CE52492D0A3002255A9 /* ApolloExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE22492D0A3002255A9 /* ApolloExtension.swift */; };
+		9B455CE62492D0A3002255A9 /* OptionalBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */; };
+		9B455CE72492D0A3002255A9 /* Collection+Apollo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */; };
+		9B455CEB2492FB03002255A9 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CEA2492FB03002255A9 /* String+SHA.swift */; };
 		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
 		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
 		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
@@ -417,10 +417,6 @@
 		9B1CCDD82360F02C007C9032 /* Bundle+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Helpers.swift"; sourceTree = "<group>"; };
 		9B21FD742422C29D00998B5C /* GraphQLFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLFileTests.swift; sourceTree = "<group>"; };
 		9B21FD762422C8CC00998B5C /* TestFileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFileHelper.swift; sourceTree = "<group>"; };
-		9B455CE22492D0A3002255A9 /* ApolloExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloExtension.swift; sourceTree = "<group>"; };
-		9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalBoolean.swift; sourceTree = "<group>"; };
-		9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+Apollo.swift"; sourceTree = "<group>"; };
-		9B455CEA2492FB03002255A9 /* String+SHA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SHA.swift"; sourceTree = "<group>"; };
 		9B3D70F5248832AE00D8BAF4 /* API.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = API.json; sourceTree = "<group>"; };
 		9B3D70F6248833CB00D8BAF4 /* ASTInterfaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTInterfaceType.swift; sourceTree = "<group>"; };
 		9B3D70F82488340400D8BAF4 /* ASTUnionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTUnionType.swift; sourceTree = "<group>"; };
@@ -437,6 +433,10 @@
 		9B3D711224889DB200D8BAF4 /* ExpectedSanitizedSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedSanitizedSearchResultType.swift; sourceTree = "<group>"; };
 		9B3D711424889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoCasesSearchResultType.swift; sourceTree = "<group>"; };
 		9B3D711624889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedNoModifierSearchResultType.swift; sourceTree = "<group>"; };
+		9B455CE22492D0A3002255A9 /* ApolloExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloExtension.swift; sourceTree = "<group>"; };
+		9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalBoolean.swift; sourceTree = "<group>"; };
+		9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+Apollo.swift"; sourceTree = "<group>"; };
+		9B455CEA2492FB03002255A9 /* String+SHA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SHA.swift"; sourceTree = "<group>"; };
 		9B4AA8AD239EFDC9003E1300 /* Apollo-Target-CodegenTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenTests.xcconfig"; sourceTree = "<group>"; };
 		9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClient.swift; sourceTree = "<group>"; };
 		9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBinAPI.swift; sourceTree = "<group>"; };
@@ -830,17 +830,6 @@
 			name = TestHelpers;
 			sourceTree = "<group>";
 		};
-		9B455CE82492D0A7002255A9 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				9B455CE22492D0A3002255A9 /* ApolloExtension.swift */,
-				9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */,
-				9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */,
-				9B455CEA2492FB03002255A9 /* String+SHA.swift */,
-			);
-			name = Extensions;
-            sourceTree = "<group>";
-        };
 		9B3D70FF2488428A00D8BAF4 /* InterfaceEnum */ = {
 			isa = PBXGroup;
 			children = (
@@ -861,6 +850,17 @@
 				9B3D711624889EF200D8BAF4 /* ExpectedNoModifierSearchResultType.swift */,
 			);
 			name = UnionEnum;
+			sourceTree = "<group>";
+		};
+		9B455CE82492D0A7002255A9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9B455CE22492D0A3002255A9 /* ApolloExtension.swift */,
+				9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */,
+				9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */,
+				9B455CEA2492FB03002255A9 /* String+SHA.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		9B6835472463486200337AE6 /* ApolloCore */ = {
@@ -2054,14 +2054,12 @@
 				9B518C8C235F8B5F004C426D /* ApolloFilePathHelper.swift in Sources */,
 				9B518C87235F819E004C426D /* CLIDownloader.swift in Sources */,
 				9B3D70FA2488340C00D8BAF4 /* ASTInterfaceType.swift in Sources */,
-				9B3D71012488429E00D8BAF4 /* ExpectedCharacterType.swift in Sources */,
 				9BAEEBF123467E0A00808306 /* ApolloCLI.swift in Sources */,
 				9BD6812B2405F410000874CB /* ASTFragment.swift in Sources */,
 				9B68F04A24130D6500E97318 /* EnumGenerator.swift in Sources */,
 				9B68F06524198D1000E97318 /* InputObjectGenerator.swift in Sources */,
 				9B7B6F69233C2C0C00F32205 /* FileManager+Apollo.swift in Sources */,
 				9B3D70F92488340400D8BAF4 /* ASTUnionType.swift in Sources */,
-				AE1CFBD0245EBA25002C8CEE /* ApolloExtension.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				9B68F068241ADA9D00E97318 /* Dictionary+Apollo.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,
@@ -2070,7 +2068,6 @@
 				9B0E471E240B239D0093BDA7 /* ASTEnumValue.swift in Sources */,
 				9B7B6F5A233C287200F32205 /* ApolloCodegenOptions.swift in Sources */,
 				9BAEEBF52346E90700808306 /* CLIExtractor.swift in Sources */,
-				9BCB58602407593C002F766E /* OptionalBoolean.swift in Sources */,
 				9B3D70FC2488388300D8BAF4 /* InterfaceEnumGenerator.swift in Sources */,
 				9BD6813B2405FA56000874CB /* ASTOperation.swift in Sources */,
 				9BD681292405F149000874CB /* ASTTypeUsed.swift in Sources */,
@@ -2134,6 +2131,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B68F0572416B5F700E97318 /* ExpectedEpisodeEnumNoDescription.swift in Sources */,
+				9B3FB4F124D9ED01002C8B1B /* ExpectedCharacterType.swift in Sources */,
 				9B21FD782424305700998B5C /* ExpectedEnumWithDifferentCases.swift in Sources */,
 				9B3D710F24884D7500D8BAF4 /* ExpectedSearchResultType.swift in Sources */,
 				9B3D710B24884B2100D8BAF4 /* ExpectedEpisodeEnumWithoutModifier.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ASTInterfaceType.swift
+++ b/Sources/ApolloCodegenLib/ASTInterfaceType.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// Represents an interface type
+struct ASTInterfaceType: Codable, Equatable {
+  
+  // The name of the interface type
+  let name: String
+  
+  // The names of the types which conform to this interface
+  let types: [String]
+  
+  /// Initializer for testing
+  init(name: String,
+       types: [String]) {
+    self.name = name
+    self.types = types
+  }
+}

--- a/Sources/ApolloCodegenLib/ASTOutput.swift
+++ b/Sources/ApolloCodegenLib/ASTOutput.swift
@@ -8,6 +8,12 @@ struct ASTOutput: Codable, Equatable {
   /// An array of all fragments to generate code for.
   let fragments: [ASTFragment]
   
-  /// An array of "all" types used <-- TODO: Figure out why some are not in here
+  /// An array of all input types used
   let typesUsed: [ASTTypeUsed]
+  
+  /// An array of Union types used
+  let unionTypes: [ASTUnionType]
+  
+  /// An array of Interface types used
+  let interfaceTypes: [ASTInterfaceType]
 }

--- a/Sources/ApolloCodegenLib/ASTUnionType.swift
+++ b/Sources/ApolloCodegenLib/ASTUnionType.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Represents a union type
+struct ASTUnionType: Codable, Equatable {
+  
+  /// The name of the union type
+  let name: String
+  
+  /// The names of the types represented by the union type
+  let types: [String]
+  
+  /// Initializer for testing
+  init(name: String,
+       types: [String]) {
+    self.name = name
+    self.types = types
+  }
+}

--- a/Sources/ApolloCodegenLib/InterfaceEnumGenerator.swift
+++ b/Sources/ApolloCodegenLib/InterfaceEnumGenerator.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Stencil
+
+public class InterfaceEnumGenerator {
+  public struct SanitizedInterfaceObject {
+    
+    // The name of the enum.
+    let name: String
+    
+    // The variable declaration of the enum
+    let nameVariableDeclaration: String
+  
+    // The variable usage of the enum
+    let nameVariableUsage: String
+    
+    let cases: [SanitizedCase]
+    public struct SanitizedCase {
+      // The name of the case
+      let name: String
+      
+      // The declaration of the case
+      let variableDeclaration: String
+      
+      // The usage of the case
+      let variableUsage: String
+      
+      public init(name: String,
+                  variableDeclaration: String,
+                  variableUsage: String) {
+        self.name = name
+        self.variableDeclaration = variableDeclaration
+        self.variableUsage = variableUsage
+      }
+    }
+    
+    init(from interfaceType: ASTInterfaceType) {
+      self.name = "\(interfaceType.name)Type"
+      self.nameVariableDeclaration = self.name.apollo.sanitizedVariableDeclaration
+      self.nameVariableUsage = self.name.apollo.sanitizedVariableUsage
+      self.cases = interfaceType.types.map {
+        SanitizedCase(name: $0,
+                      variableDeclaration: $0.apollo.sanitizedVariableDeclaration,
+                      variableUsage: $0.apollo.sanitizedVariableUsage)
+      }
+    }
+  }
+  
+  public enum InterfaceEnumContextKey: String {
+    case type
+    case cases
+    case modifier
+  }
+  
+  /// Designated initializer
+  public init() { }
+  
+  func run(interfaceType: ASTInterfaceType, options: ApolloCodegenOptions) throws -> String {
+    
+    let sanitized = SanitizedInterfaceObject(from: interfaceType)
+    
+    let context: [InterfaceEnumContextKey: Any] = [
+      .type: sanitized,
+      .cases: sanitized.cases,
+      .modifier: options.modifier.prefixValue
+    ]
+    
+    return try Environment().renderTemplate(string: self.interfaceEnumTemplate,
+                                            context: context.apollo_toStringKeyedDict)
+  }
+  
+  /// A stencil template to use to render interface enums.
+  ///
+  /// Variable to allow custom modifications, but MODIFY AT YOUR OWN RISK.
+  open var interfaceEnumTemplate: String {
+    """
+    {{ modifier }}enum {{ type.name }}: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+      {{ modifier }}typealias RawValue = String
+
+      {% for case in type.cases %}case {{ case.variableDeclaration }}
+      {% endfor %}/// Type conforming to `{{ type.name }}` not defined at the time this enum was generated
+      case __unknown(String)
+
+      {{ modifier }}var rawValue: String {
+        switch self {
+        {% for case in cases %}case .{{ case.variableUsage }}: return "{{ case.name }}"
+        {% endfor %}case .__unknown(let value): return value
+        }
+      }
+
+      {{ modifier }}init(rawValue: String) {
+        switch rawValue {
+        {% for case in cases %}case "{{ case.name }}": self = .{{ case.variableUsage }}
+        {% endfor %}default: self = .__unknown(rawValue)
+        }
+      }
+
+      {{ modifier }}static var allCases: [{{ type.name }}] {
+        [{% for case in cases %}
+          .{{ case.variableUsage }},{% endfor %}
+        ]
+      }
+    }
+    """
+  }
+}

--- a/Sources/ApolloCodegenLib/InterfaceEnumGenerator.swift
+++ b/Sources/ApolloCodegenLib/InterfaceEnumGenerator.swift
@@ -65,7 +65,7 @@ public class InterfaceEnumGenerator {
     ]
     
     return try Environment().renderTemplate(string: self.interfaceEnumTemplate,
-                                            context: context.apollo_toStringKeyedDict)
+                                            context: context.apollo.toStringKeyedDict)
   }
   
   /// A stencil template to use to render interface enums.

--- a/Sources/ApolloCodegenLib/UnionEnumGenerator.swift
+++ b/Sources/ApolloCodegenLib/UnionEnumGenerator.swift
@@ -1,9 +1,105 @@
-//
-//  UnionEnumGenerator.swift
-//  ApolloCodegenLib
-//
-//  Created by Ellen Shapiro on 6/3/20.
-//  Copyright © 2020 Apollo GraphQL. All rights reserved.
-//
-
 import Foundation
+import Stencil
+
+public class UnionEnumGenerator {
+  public struct SanitizedUnionObject {
+    
+    // The name of the enum.
+    let name: String
+    
+    // The variable declaration of the enum
+    let nameVariableDeclaration: String
+  
+    // The variable usage of the enum
+    let nameVariableUsage: String
+    
+    let cases: [SanitizedCase]
+    public struct SanitizedCase {
+      // The name of the case
+      let name: String
+      
+      // The declaration of the case
+      let variableDeclaration: String
+      
+      // The usage of the case
+      let variableUsage: String
+      
+      public init(name: String,
+                  variableDeclaration: String,
+                  variableUsage: String) {
+        self.name = name
+        self.variableDeclaration = variableDeclaration
+        self.variableUsage = variableUsage
+      }
+    }
+    
+    init(from unionType: ASTUnionType) {
+      self.name = "\(unionType.name)Type"
+      self.nameVariableDeclaration = self.name.apollo.sanitizedVariableDeclaration
+      self.nameVariableUsage = self.name.apollo.sanitizedVariableUsage
+      self.cases = unionType.types.map {
+        SanitizedCase(name: $0,
+                      variableDeclaration: $0.apollo.sanitizedVariableDeclaration,
+                      variableUsage: $0.apollo.sanitizedVariableUsage)
+      }
+    }
+  }
+  
+  public enum InterfaceEnumContextKey: String {
+    case type
+    case cases
+    case modifier
+  }
+  
+  /// Designated initializer
+  public init() { }
+  
+  func run(unionType: ASTUnionType, options: ApolloCodegenOptions) throws -> String {
+    
+    let sanitized = SanitizedUnionObject(from: unionType)
+    
+    let context: [InterfaceEnumContextKey: Any] = [
+      .type: sanitized,
+      .cases: sanitized.cases,
+      .modifier: options.modifier.prefixValue
+    ]
+    
+    return try Environment().renderTemplate(string: self.unionEnumTemplate,
+                                            context: context.apollo_toStringKeyedDict)
+  }
+  
+  /// A stencil template to use to render interface enums.
+  ///
+  /// Variable to allow custom modifications, but MODIFY AT YOUR OWN RISK.
+  open var unionEnumTemplate: String {
+    """
+    {{ modifier }}enum {{ type.name }}: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+      {{ modifier }}typealias RawValue = String
+
+      {% for case in type.cases %}case {{ case.variableDeclaration }}
+      {% endfor %}/// Type which is a member of `{{ type.name }}` not defined at the time this enum was generated
+      case __unknown(String)
+
+      {{ modifier }}var rawValue: String {
+        switch self {
+        {% for case in cases %}case .{{ case.variableUsage }}: return "{{ case.name }}"
+        {% endfor %}case .__unknown(let value): return value
+        }
+      }
+
+      {{ modifier }}init(rawValue: String) {
+        switch rawValue {
+        {% for case in cases %}case "{{ case.name }}": self = .{{ case.variableUsage }}
+        {% endfor %}default: self = .__unknown(rawValue)
+        }
+      }
+
+      {{ modifier }}static var allCases: [{{ type.name }}] {
+        [{% for case in cases %}
+          .{{ case.variableUsage }},{% endfor %}
+        ]
+      }
+    }
+    """
+  }
+}

--- a/Sources/ApolloCodegenLib/UnionEnumGenerator.swift
+++ b/Sources/ApolloCodegenLib/UnionEnumGenerator.swift
@@ -1,0 +1,9 @@
+//
+//  UnionEnumGenerator.swift
+//  ApolloCodegenLib
+//
+//  Created by Ellen Shapiro on 6/3/20.
+//  Copyright © 2020 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation

--- a/Sources/ApolloCodegenLib/UnionEnumGenerator.swift
+++ b/Sources/ApolloCodegenLib/UnionEnumGenerator.swift
@@ -65,7 +65,7 @@ public class UnionEnumGenerator {
     ]
     
     return try Environment().renderTemplate(string: self.unionEnumTemplate,
-                                            context: context.apollo_toStringKeyedDict)
+                                            context: context.apollo.toStringKeyedDict)
   }
   
   /// A stencil template to use to render interface enums.

--- a/Sources/StarWarsAPI/API.json
+++ b/Sources/StarWarsAPI/API.json
@@ -7085,5 +7085,25 @@
 				}
 			]
 		}
-	]
+	],
+  "unionTypes": [
+    {
+      "name": "SearchResult",
+      "types": [
+        "Human",
+        "Droid",
+        "Starship"
+      ]
+    }
+  ],
+  "interfaceTypes": [
+    {
+      "name": "Character",
+      "types": [
+        "Human",
+        "Droid",
+        "Alien"
+      ]
+    }
+  ]
 }

--- a/Sources/StarWarsAPI/API.json
+++ b/Sources/StarWarsAPI/API.json
@@ -7450,24 +7450,23 @@
 			]
 		}
 	],
-  "unionTypes": [
-    {
-      "name": "SearchResult",
-      "types": [
-        "Human",
-        "Droid",
-        "Starship"
-      ]
-    }
-  ],
-  "interfaceTypes": [
-    {
-      "name": "Character",
-      "types": [
-        "Human",
-        "Droid",
-        "Alien"
-      ]
-    }
-  ]
+	"unionTypes": [
+		{
+			"name": "SearchResult",
+			"types": [
+				"Human",
+				"Droid",
+				"Starship"
+			]
+		}
+	],
+	"interfaceTypes": [
+		{
+			"name": "Character",
+			"types": [
+				"Human",
+				"Droid"
+			]
+		}
+	]
 }

--- a/Sources/StarWarsAPI/API.json
+++ b/Sources/StarWarsAPI/API.json
@@ -100,7 +100,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "stars",
@@ -214,7 +215,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "stars",
@@ -325,7 +327,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -377,7 +380,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -477,7 +481,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "id",
@@ -547,7 +552,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "id",
@@ -665,7 +671,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "id",
@@ -735,7 +742,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "id",
@@ -835,7 +843,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "id",
@@ -905,7 +914,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -1005,7 +1015,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -1057,7 +1068,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -1161,7 +1173,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "friends",
@@ -1195,7 +1208,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -1244,7 +1258,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "friends",
@@ -1278,7 +1293,8 @@
 													}
 												}
 											},
-											"isConditional": false
+											"isConditional": false,
+											"isDeprecated": false
 										},
 										{
 											"responseName": "name",
@@ -1355,7 +1371,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "appearsIn",
@@ -1454,7 +1471,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "appearsIn",
@@ -1543,7 +1561,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -1632,7 +1651,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -1735,7 +1755,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -1843,7 +1864,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -1937,7 +1959,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -2061,7 +2084,8 @@
 									"variableName": "includeDetails",
 									"inverted": false
 								}
-							]
+							],
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -2130,7 +2154,8 @@
 											"variableName": "includeDetails",
 											"inverted": false
 										}
-									]
+									],
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -2231,7 +2256,8 @@
 											"variableName": "includeDetails",
 											"inverted": false
 										}
-									]
+									],
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -2385,7 +2411,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -2435,7 +2462,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -2525,7 +2553,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "friends",
@@ -2566,7 +2595,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -2609,7 +2639,8 @@
 													}
 												}
 											},
-											"isConditional": false
+											"isConditional": false,
+											"isDeprecated": false
 										},
 										{
 											"responseName": "name",
@@ -2711,7 +2742,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "friends",
@@ -2759,7 +2791,8 @@
 											"variableName": "includeFriendsDetails",
 											"inverted": false
 										}
-									]
+									],
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -2821,7 +2854,8 @@
 													"variableName": "includeFriendsDetails",
 													"inverted": false
 												}
-											]
+											],
+											"isDeprecated": false
 										},
 										{
 											"responseName": "name",
@@ -2956,7 +2990,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -2999,7 +3034,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -3057,7 +3093,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -3169,7 +3206,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -3214,7 +3252,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -3274,7 +3313,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -3390,7 +3430,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						}
 					],
 					"fragmentSpreads": [
@@ -3417,7 +3458,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -3533,7 +3575,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "friends",
@@ -3567,7 +3610,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "id",
@@ -3619,7 +3663,8 @@
 													}
 												}
 											},
-											"isConditional": false
+											"isConditional": false,
+											"isDeprecated": false
 										},
 										{
 											"responseName": "name",
@@ -3723,7 +3768,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -3819,7 +3865,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "id",
@@ -3933,7 +3980,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -4033,7 +4081,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "id",
@@ -4151,7 +4200,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -4272,7 +4322,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -4315,7 +4366,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -4367,7 +4419,8 @@
 													}
 												}
 											},
-											"isConditional": false
+											"isConditional": false,
+											"isDeprecated": false
 										},
 										{
 											"responseName": "name",
@@ -4410,7 +4463,8 @@
 															}
 														}
 													},
-													"isConditional": false
+													"isConditional": false,
+													"isDeprecated": false
 												},
 												{
 													"responseName": "name",
@@ -4487,7 +4541,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -4539,7 +4594,8 @@
 													}
 												}
 											},
-											"isConditional": false
+											"isConditional": false,
+											"isDeprecated": false
 										},
 										{
 											"responseName": "name",
@@ -4582,7 +4638,8 @@
 															}
 														}
 													},
-													"isConditional": false
+													"isConditional": false,
+													"isDeprecated": false
 												},
 												{
 													"responseName": "name",
@@ -4713,7 +4770,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						}
 					],
 					"fragmentSpreads": [],
@@ -4738,7 +4796,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "property",
@@ -4778,7 +4837,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "property",
@@ -4843,7 +4903,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -4895,7 +4956,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "appearsIn",
@@ -4928,6 +4990,275 @@
 			"fragmentsReferenced": [],
 			"sourceWithFragments": "query SameHeroTwice {\n  hero {\n    __typename\n    name\n  }\n  r2: hero {\n    __typename\n    appearsIn\n  }\n}",
 			"operationId": "2a8ad85a703add7d64622aaf6be76b58a1134caf28e4ff6b34dd00ba89541364"
+		},
+		{
+			"filePath": "file:///Users/ellen/Desktop/Work/Apollo/apollo-ios/Sources/StarWarsAPI/Search.graphql",
+			"operationName": "Search",
+			"operationType": "query",
+			"rootType": "Query",
+			"variables": [
+				{
+					"name": "term",
+					"type": "String",
+					"typeNode": {
+						"kind": "NamedType",
+						"name": {
+							"kind": "Name",
+							"value": "String"
+						}
+					}
+				}
+			],
+			"source": "query Search($term: String) {\n  search(text: $term) {\n    __typename\n    ... on Human {\n      id\n      name\n    }\n    ... on Droid {\n      id\n      name\n    }\n    ... on Starship {\n      id\n      name\n    }\n  }\n}",
+			"fields": [
+				{
+					"responseName": "search",
+					"fieldName": "search",
+					"type": "[SearchResult]",
+					"typeNode": {
+						"kind": "ListType",
+						"type": {
+							"kind": "NamedType",
+							"name": {
+								"kind": "Name",
+								"value": "SearchResult"
+							}
+						}
+					},
+					"args": [
+						{
+							"name": "text",
+							"value": {
+								"kind": "Variable",
+								"variableName": "term"
+							},
+							"type": "String",
+							"typeNode": {
+								"kind": "NamedType",
+								"name": {
+									"kind": "Name",
+									"value": "String"
+								}
+							}
+						}
+					],
+					"isConditional": false,
+					"isDeprecated": false,
+					"fields": [
+						{
+							"responseName": "__typename",
+							"fieldName": "__typename",
+							"type": "String!",
+							"typeNode": {
+								"kind": "NonNullType",
+								"type": {
+									"kind": "NamedType",
+									"name": {
+										"kind": "Name",
+										"value": "String"
+									}
+								}
+							},
+							"isConditional": false,
+							"isDeprecated": false
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": [
+						{
+							"typeCondition": "Human",
+							"possibleTypes": [
+								"Human"
+							],
+							"fields": [
+								{
+									"responseName": "__typename",
+									"fieldName": "__typename",
+									"type": "String!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "String"
+											}
+										}
+									},
+									"isConditional": false,
+									"isDeprecated": false
+								},
+								{
+									"responseName": "id",
+									"fieldName": "id",
+									"type": "ID!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "ID"
+											}
+										}
+									},
+									"isConditional": false,
+									"description": "The ID of the human",
+									"isDeprecated": false
+								},
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "String"
+											}
+										}
+									},
+									"isConditional": false,
+									"description": "What this human calls themselves",
+									"isDeprecated": false
+								}
+							],
+							"fragmentSpreads": []
+						},
+						{
+							"typeCondition": "Droid",
+							"possibleTypes": [
+								"Droid"
+							],
+							"fields": [
+								{
+									"responseName": "__typename",
+									"fieldName": "__typename",
+									"type": "String!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "String"
+											}
+										}
+									},
+									"isConditional": false,
+									"isDeprecated": false
+								},
+								{
+									"responseName": "id",
+									"fieldName": "id",
+									"type": "ID!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "ID"
+											}
+										}
+									},
+									"isConditional": false,
+									"description": "The ID of the droid",
+									"isDeprecated": false
+								},
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "String"
+											}
+										}
+									},
+									"isConditional": false,
+									"description": "What others call this droid",
+									"isDeprecated": false
+								}
+							],
+							"fragmentSpreads": []
+						},
+						{
+							"typeCondition": "Starship",
+							"possibleTypes": [
+								"Starship"
+							],
+							"fields": [
+								{
+									"responseName": "__typename",
+									"fieldName": "__typename",
+									"type": "String!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "String"
+											}
+										}
+									},
+									"isConditional": false,
+									"isDeprecated": false
+								},
+								{
+									"responseName": "id",
+									"fieldName": "id",
+									"type": "ID!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "ID"
+											}
+										}
+									},
+									"isConditional": false,
+									"description": "The ID of the starship",
+									"isDeprecated": false
+								},
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!",
+									"typeNode": {
+										"kind": "NonNullType",
+										"type": {
+											"kind": "NamedType",
+											"name": {
+												"kind": "Name",
+												"value": "String"
+											}
+										}
+									},
+									"isConditional": false,
+									"description": "The name of the starship",
+									"isDeprecated": false
+								}
+							],
+							"fragmentSpreads": []
+						}
+					]
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query Search($term: String) {\n  search(text: $term) {\n    __typename\n    ... on Human {\n      id\n      name\n    }\n    ... on Droid {\n      id\n      name\n    }\n    ... on Starship {\n      id\n      name\n    }\n  }\n}",
+			"operationId": "73536da2eec4d83e6e1003e674cb2299d9da2798f7bd310e57339a6bcd713b77"
 		},
 		{
 			"filePath": "file:///Users/ellen/Desktop/Work/Apollo/apollo-ios/Sources/StarWarsAPI/Starship.graphql",
@@ -4982,7 +5313,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5128,7 +5460,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5265,7 +5598,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "episode",
@@ -5397,7 +5731,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5479,7 +5814,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5545,7 +5881,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5608,7 +5945,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -5681,7 +6019,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -5727,7 +6066,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5801,7 +6141,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -5844,7 +6185,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -5920,7 +6262,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -5974,7 +6317,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "primaryFunction",
@@ -6025,7 +6369,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "height",
@@ -6094,7 +6439,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -6172,7 +6518,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -6250,7 +6597,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				}
 			],
 			"fragmentSpreads": [],
@@ -6275,7 +6623,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "friends",
@@ -6309,7 +6658,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "appearsIn",
@@ -6359,7 +6709,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -6411,7 +6762,8 @@
 											}
 										}
 									},
-									"isConditional": false
+									"isConditional": false,
+									"isDeprecated": false
 								},
 								{
 									"responseName": "name",
@@ -6474,7 +6826,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "friends",
@@ -6508,7 +6861,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -6567,7 +6921,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "appearsIn",
@@ -6625,7 +6980,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -6668,7 +7024,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -6726,7 +7083,8 @@
 									}
 								}
 							},
-							"isConditional": false
+							"isConditional": false,
+							"isDeprecated": false
 						},
 						{
 							"responseName": "name",
@@ -6796,7 +7154,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -6866,7 +7225,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -6921,7 +7281,8 @@
 							}
 						}
 					},
-					"isConditional": false
+					"isConditional": false,
+					"isDeprecated": false
 				},
 				{
 					"responseName": "name",
@@ -7053,7 +7414,8 @@
 								"value": "Int"
 							}
 						}
-					}
+					},
+					"description": ""
 				},
 				{
 					"name": "green",
@@ -7067,7 +7429,8 @@
 								"value": "Int"
 							}
 						}
-					}
+					},
+					"description": ""
 				},
 				{
 					"name": "blue",
@@ -7081,7 +7444,8 @@
 								"value": "Int"
 							}
 						}
-					}
+					},
+					"description": ""
 				}
 			]
 		}

--- a/Sources/StarWarsAPI/API.swift
+++ b/Sources/StarWarsAPI/API.swift
@@ -5647,6 +5647,301 @@ public final class SameHeroTwiceQuery: GraphQLQuery {
   }
 }
 
+public final class SearchQuery: GraphQLQuery {
+  /// The raw GraphQL definition of this operation.
+  public let operationDefinition: String =
+    """
+    query Search($term: String) {
+      search(text: $term) {
+        __typename
+        ... on Human {
+          id
+          name
+        }
+        ... on Droid {
+          id
+          name
+        }
+        ... on Starship {
+          id
+          name
+        }
+      }
+    }
+    """
+
+  public let operationName: String = "Search"
+
+  public let operationIdentifier: String? = "73536da2eec4d83e6e1003e674cb2299d9da2798f7bd310e57339a6bcd713b77"
+
+  public var term: String?
+
+  public init(term: String? = nil) {
+    self.term = term
+  }
+
+  public var variables: GraphQLMap? {
+    return ["term": term]
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["Query"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("search", arguments: ["text": GraphQLVariable("term")], type: .list(.object(Search.selections))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(search: [Search?]? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Query", "search": search.flatMap { (value: [Search?]) -> [ResultMap?] in value.map { (value: Search?) -> ResultMap? in value.flatMap { (value: Search) -> ResultMap in value.resultMap } } }])
+    }
+
+    public var search: [Search?]? {
+      get {
+        return (resultMap["search"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Search?] in value.map { (value: ResultMap?) -> Search? in value.flatMap { (value: ResultMap) -> Search in Search(unsafeResultMap: value) } } }
+      }
+      set {
+        resultMap.updateValue(newValue.flatMap { (value: [Search?]) -> [ResultMap?] in value.map { (value: Search?) -> ResultMap? in value.flatMap { (value: Search) -> ResultMap in value.resultMap } } }, forKey: "search")
+      }
+    }
+
+    public struct Search: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Human", "Droid", "Starship"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLTypeCase(
+            variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections, "Starship": AsStarship.selections],
+            default: [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            ]
+          )
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public static func makeHuman(id: GraphQLID, name: String) -> Search {
+        return Search(unsafeResultMap: ["__typename": "Human", "id": id, "name": name])
+      }
+
+      public static func makeDroid(id: GraphQLID, name: String) -> Search {
+        return Search(unsafeResultMap: ["__typename": "Droid", "id": id, "name": name])
+      }
+
+      public static func makeStarship(id: GraphQLID, name: String) -> Search {
+        return Search(unsafeResultMap: ["__typename": "Starship", "id": id, "name": name])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var asHuman: AsHuman? {
+        get {
+          if !AsHuman.possibleTypes.contains(__typename) { return nil }
+          return AsHuman(unsafeResultMap: resultMap)
+        }
+        set {
+          guard let newValue = newValue else { return }
+          resultMap = newValue.resultMap
+        }
+      }
+
+      public struct AsHuman: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Human"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(id: GraphQLID, name: String) {
+          self.init(unsafeResultMap: ["__typename": "Human", "id": id, "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The ID of the human
+        public var id: GraphQLID {
+          get {
+            return resultMap["id"]! as! GraphQLID
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+
+        /// What this human calls themselves
+        public var name: String {
+          get {
+            return resultMap["name"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "name")
+          }
+        }
+      }
+
+      public var asDroid: AsDroid? {
+        get {
+          if !AsDroid.possibleTypes.contains(__typename) { return nil }
+          return AsDroid(unsafeResultMap: resultMap)
+        }
+        set {
+          guard let newValue = newValue else { return }
+          resultMap = newValue.resultMap
+        }
+      }
+
+      public struct AsDroid: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Droid"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(id: GraphQLID, name: String) {
+          self.init(unsafeResultMap: ["__typename": "Droid", "id": id, "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The ID of the droid
+        public var id: GraphQLID {
+          get {
+            return resultMap["id"]! as! GraphQLID
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+
+        /// What others call this droid
+        public var name: String {
+          get {
+            return resultMap["name"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "name")
+          }
+        }
+      }
+
+      public var asStarship: AsStarship? {
+        get {
+          if !AsStarship.possibleTypes.contains(__typename) { return nil }
+          return AsStarship(unsafeResultMap: resultMap)
+        }
+        set {
+          guard let newValue = newValue else { return }
+          resultMap = newValue.resultMap
+        }
+      }
+
+      public struct AsStarship: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Starship"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(id: GraphQLID, name: String) {
+          self.init(unsafeResultMap: ["__typename": "Starship", "id": id, "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The ID of the starship
+        public var id: GraphQLID {
+          get {
+            return resultMap["id"]! as! GraphQLID
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "id")
+          }
+        }
+
+        /// The name of the starship
+        public var name: String {
+          get {
+            return resultMap["name"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "name")
+          }
+        }
+      }
+    }
+  }
+}
+
 public final class StarshipQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
   public let operationDefinition: String =

--- a/Sources/StarWarsAPI/Search.graphql
+++ b/Sources/StarWarsAPI/Search.graphql
@@ -1,0 +1,16 @@
+query Search($term: String) {
+  search(text: $term) {
+    ... on Human {
+      id
+      name
+    }
+    ... on Droid {
+      id
+      name
+    }
+    ... on Starship {
+      id
+      name
+    }
+  }
+}

--- a/Sources/StarWarsAPI/operationIDs.json
+++ b/Sources/StarWarsAPI/operationIDs.json
@@ -123,6 +123,10 @@
     "name": "SameHeroTwice",
     "source": "query SameHeroTwice {\n  hero {\n    __typename\n    name\n  }\n  r2: hero {\n    __typename\n    appearsIn\n  }\n}"
   },
+  "73536da2eec4d83e6e1003e674cb2299d9da2798f7bd310e57339a6bcd713b77": {
+    "name": "Search",
+    "source": "query Search($term: String) {\n  search(text: $term) {\n    __typename\n    ... on Human {\n      id\n      name\n    }\n    ... on Droid {\n      id\n      name\n    }\n    ... on Starship {\n      id\n      name\n    }\n  }\n}"
+  },
   "a3734516185da9919e3e66d74fe92b60d65292a1943dc54913f7332637dfdd2a": {
     "name": "Starship",
     "source": "query Starship {\n  starship(id: 3000) {\n    __typename\n    name\n    coordinates\n  }\n}"

--- a/SwiftScripts/Sources/Codegen/ArgumentSetup.swift
+++ b/SwiftScripts/Sources/Codegen/ArgumentSetup.swift
@@ -4,12 +4,15 @@ import TSCUtility
 
 enum Target {
     case starWars
+    case starWarsSwiftCodegen
     case gitHub
     
     init?(name: String) {
         switch name {
         case "StarWars":
             self = .starWars
+        case "StarWars-SwiftCodegen":
+            self = .starWarsSwiftCodegen
         case "GitHub":
             self = .gitHub
         default:
@@ -23,7 +26,8 @@ enum Target {
             return sourceRootURL
                 .apollo.childFolderURL(folderName: "Sources")
                 .apollo.childFolderURL(folderName: "GitHubAPI")
-        case .starWars:
+        case .starWars,
+             .starWarsSwiftCodegen:
             return sourceRootURL
                 .apollo.childFolderURL(folderName: "Sources")
                 .apollo.childFolderURL(folderName: "StarWarsAPI")
@@ -35,6 +39,15 @@ enum Target {
         switch self {
         case .starWars:
             return ApolloCodegenOptions(targetRootURL: targetRootURL)
+        case .starWarsSwiftCodegen:
+            let jsonOutputFileURL = try!  targetRootURL.apollo.childFileURL(fileName: "API.json")
+            let operationIDsURL = try! targetRootURL.apollo.childFileURL(fileName: "operationIDs.json")
+            let json = try! targetRootURL.apollo.childFileURL(fileName: "schema.json")
+            
+            return ApolloCodegenOptions(codegenEngine: .swiftExperimental,
+                                        operationIDsURL: operationIDsURL,
+                                        outputFormat: .singleFile(atFileURL: jsonOutputFileURL),
+                                        urlToSchemaFile: json)
         case .gitHub:
             let json = try! targetRootURL.apollo.childFileURL(fileName: "schema.docs.graphql")
             let outputFileURL = try!  targetRootURL.apollo.childFileURL(fileName: "API.swift")

--- a/Tests/ApolloCodegenTests/ASTParsingTests.swift
+++ b/Tests/ApolloCodegenTests/ASTParsingTests.swift
@@ -34,12 +34,58 @@ class ASTParsingTests: XCTestCase {
       XCTAssertEqual(output.operations.count, 36)
       XCTAssertEqual(output.fragments.count, 15)
       XCTAssertEqual(output.typesUsed.count, 3)
+      XCTAssertEqual(output.unionTypes.count, 1)
+      XCTAssertEqual(output.interfaceTypes.count, 1)
     } catch {
       CodegenTestHelper.handleFileLoadError(error)
     }
   }
   
-  func testParsingASTTypes() throws {
+  func testParsingASTUnionTypes() throws {
+    let output: ASTOutput
+    do {
+      output = try loadAST(from: starWarsJSONURL)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+      return
+    }
+    
+    let types = output.unionTypes
+    XCTAssertEqual(types.count, 1)
+    
+    let type = try XCTUnwrap(types.first)
+    
+    XCTAssertEqual(type.name, "SearchResult")
+    XCTAssertEqual(type.types, [
+      "Human",
+      "Droid",
+      "Starship"
+    ])
+  }
+  
+  func testParsingASTInterfaceTypes() throws {
+    let output: ASTOutput
+    do {
+      output = try loadAST(from: starWarsJSONURL)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+      return
+    }
+    
+    let types = output.interfaceTypes
+    XCTAssertEqual(types.count, 1)
+    
+    let type = try XCTUnwrap(types.first)
+    
+    XCTAssertEqual(type.name, "Character")
+    XCTAssertEqual(type.types, [
+      "Human",
+      "Droid",
+      "Alien"
+    ])
+  }
+  
+  func testParsingASTInputTypes() throws {
     let output: ASTOutput
     do {
       output = try loadAST(from: starWarsJSONURL)

--- a/Tests/ApolloCodegenTests/ASTParsingTests.swift
+++ b/Tests/ApolloCodegenTests/ASTParsingTests.swift
@@ -31,7 +31,7 @@ class ASTParsingTests: XCTestCase {
   func testLoadingStarWarsJSON() throws {
     do {
       let output = try loadAST(from: starWarsJSONURL)
-      XCTAssertEqual(output.operations.count, 36)
+      XCTAssertEqual(output.operations.count, 37)
       XCTAssertEqual(output.fragments.count, 15)
       XCTAssertEqual(output.typesUsed.count, 3)
       XCTAssertEqual(output.unionTypes.count, 1)
@@ -81,7 +81,6 @@ class ASTParsingTests: XCTestCase {
     XCTAssertEqual(type.types, [
       "Human",
       "Droid",
-      "Alien"
     ])
   }
   

--- a/Tests/ApolloCodegenTests/ASTParsingTests.swift
+++ b/Tests/ApolloCodegenTests/ASTParsingTests.swift
@@ -178,9 +178,9 @@ class ASTParsingTests: XCTestCase {
     ])
     
     XCTAssertEqual(colorFields.map { $0.description }, [
-      nil,
-      nil,
-      nil,
+      "",
+      "",
+      "",
     ])
   }
   
@@ -280,7 +280,7 @@ mutation CreateAwesomeReview {\n  createReview(episode: JEDI, review: {stars: 10
     ])
     
     XCTAssertEqual(innerFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false,
     ])
@@ -378,7 +378,7 @@ query HeroAndFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n   
     ])
     
     XCTAssertEqual(firstLevelFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false
     ])
@@ -429,7 +429,7 @@ query HeroAndFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n   
     ])
     
     XCTAssertEqual(secondLevelFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
     ])
     
@@ -544,7 +544,7 @@ query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $epi
     ])
     
     XCTAssertEqual(firstLevelFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false,
     ])
@@ -601,7 +601,7 @@ query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $epi
     ])
     
     XCTAssertEqual(secondLevelFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false
     ])
     
@@ -701,7 +701,7 @@ query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typen
     ])
     
     XCTAssertEqual(innerFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false
     ])
     
@@ -753,7 +753,7 @@ query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typen
     ])
     
     XCTAssertEqual(humanFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false
     ])
@@ -790,7 +790,7 @@ query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typen
     ])
     
     XCTAssertEqual(droidFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false
     ])
@@ -903,7 +903,7 @@ query TwoHeroes {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(epi
     ])
     
     XCTAssertEqual(r2Fields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
     ])
     
@@ -944,7 +944,7 @@ query TwoHeroes {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(epi
     ])
     
     XCTAssertEqual(lukeFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
     ])
     
@@ -1040,7 +1040,7 @@ query HeroNameConditionalInclusion($includeName: Boolean!) {\n  hero {\n    __ty
     ])
     
     XCTAssertEqual(innerFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false
     ])
     
@@ -1131,7 +1131,7 @@ query HeroNameConditionalExclusion($skipName: Boolean!) {\n  hero {\n    __typen
     ])
     
     XCTAssertEqual(innerFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false
     ])
     
@@ -1227,7 +1227,7 @@ query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  he
     ])
     
     XCTAssertEqual(innerFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false
     ])
     
@@ -1294,7 +1294,7 @@ query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  he
     ])
     
     XCTAssertEqual(humanFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false
     ])
@@ -1337,7 +1337,7 @@ query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  he
     ])
     
     XCTAssertEqual(droidFields.map { $0.isDeprecated }, [
-      nil,
+      false,
       false,
       false
     ])

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -153,6 +153,6 @@ class ApolloCodegenTests: XCTestCase {
     XCTAssertTrue(FileManager.default.apollo.folderExists(at: outputFolder))
     
     let contents = try FileManager.default.contentsOfDirectory(atPath: outputFolder.path)
-    XCTAssertEqual(contents.count, 17)
+    XCTAssertEqual(contents.count, 18)
   }
 }

--- a/Tests/ApolloCodegenTests/CodegenTestHelper.swift
+++ b/Tests/ApolloCodegenTests/CodegenTestHelper.swift
@@ -11,6 +11,19 @@ import XCTest
 
 struct CodegenTestHelper {
   
+  static func dummyOptions() -> ApolloCodegenOptions {    
+    let unusedURL = CodegenTestHelper.apolloFolderURL()
+    return ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: unusedURL),
+                                urlToSchemaFile: unusedURL)
+  }
+  
+  static func dummyOptionsNoModifier() -> ApolloCodegenOptions {
+    let unusedURL = CodegenTestHelper.apolloFolderURL()
+    return ApolloCodegenOptions(modifier: .none,
+                                outputFormat: .singleFile(atFileURL: unusedURL),
+                                urlToSchemaFile: unusedURL)
+  }
+  
   static func handleFileLoadError(_ error: Error,
                                   file: StaticString = #file,
                                   line: UInt = #line) {

--- a/Tests/ApolloCodegenTests/EnumGenerationTests.swift
+++ b/Tests/ApolloCodegenTests/EnumGenerationTests.swift
@@ -281,4 +281,44 @@ class EnumGenerationTests: XCTestCase {
       CodegenTestHelper.handleFileLoadError(error)
     }
   }
+  
+  func testGeneratingEnumWithoutModifier() {
+    let newHope = ASTEnumValue(name: "NEWHOPE",
+                               description: "Star Wars Episode IV: A New Hope, released in 1977.",
+                               isDeprecated: false)
+    let empire = ASTEnumValue(name: "EMPIRE",
+                              description: "Star Wars Episode V: The Empire Strikes Back, released in 1980.",
+                              isDeprecated: false)
+    let jedi = ASTEnumValue(name: "JEDI",
+                            description: "Star Wars Episode VI: Return of the Jedi, released in 1983.",
+                            isDeprecated: false)
+    
+    let episodeEnum = ASTTypeUsed(kind: .EnumType,
+                                  name: "EpisodeWithoutModifier",
+                                  description: "The episodes in the Star Wars trilogy",
+                                  values: [
+                                    newHope,
+                                    empire,
+                                    jedi
+                                  ],
+                                  fields: nil)
+    
+    let unusedURL = CodegenTestHelper.apolloFolderURL()
+    let options = ApolloCodegenOptions(modifier: .none,
+                                       outputFormat: .singleFile(atFileURL: unusedURL),
+                                       urlToSchemaFile: unusedURL)
+    
+    
+    do {
+      let output = try EnumGenerator().run(typeUsed: episodeEnum, options: options)
+      let expectedFileURL = CodegenTestHelper.sourceRootURL()
+        .appendingPathComponent("Tests")
+        .appendingPathComponent("ApolloCodegenTests")
+        .appendingPathComponent("ExpectedEpisodeEnumWithoutModifier.swift")
+      
+      LineByLineComparison.between(received: output, expectedFileURL: expectedFileURL)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+    }
+  }
 }

--- a/Tests/ApolloCodegenTests/EnumGenerationTests.swift
+++ b/Tests/ApolloCodegenTests/EnumGenerationTests.swift
@@ -11,13 +11,6 @@ import XCTest
 
 class EnumGenerationTests: XCTestCase {
   
-  private lazy var dummyOptions: ApolloCodegenOptions = {
-    let unusedURL = CodegenTestHelper.apolloFolderURL()
-    return ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: unusedURL),
-                                urlToSchemaFile: unusedURL)
-  }()
-  
-  
   func testTryingToGenerateWrongKindThrowsAppropriateError() throws {
     let wrongKind = ASTTypeUsed(kind: .InputObjectType,
                                 name: "InputObject",
@@ -30,7 +23,7 @@ class EnumGenerationTests: XCTestCase {
                                 ])
     
     do {
-      _ = try EnumGenerator().run(typeUsed: wrongKind, options: self.dummyOptions)
+      _ = try EnumGenerator().run(typeUsed: wrongKind, options: CodegenTestHelper.dummyOptions())
     } catch {
       switch error {
       case EnumGenerator.EnumGenerationError.kindIsNotAnEnum:
@@ -49,7 +42,7 @@ class EnumGenerationTests: XCTestCase {
                               values: nil,
                               fields: nil)
     do {
-      _ = try EnumGenerator().run(typeUsed: nilCases, options: self.dummyOptions)
+      _ = try EnumGenerator().run(typeUsed: nilCases, options: CodegenTestHelper.dummyOptions())
     } catch {
       switch error {
       case EnumGenerator.EnumGenerationError.enumHasNilCases:
@@ -84,7 +77,7 @@ class EnumGenerationTests: XCTestCase {
                                   fields: nil)
     
     do {
-      let output = try EnumGenerator().run(typeUsed: episodeEnum, options: self.dummyOptions)
+      let output = try EnumGenerator().run(typeUsed: episodeEnum, options: CodegenTestHelper.dummyOptions())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
@@ -117,7 +110,7 @@ class EnumGenerationTests: XCTestCase {
                                           ],
                                           fields: nil)
     do {
-      let output = try EnumGenerator().run(typeUsed: withoutDescriptions, options: self.dummyOptions)
+      let output = try EnumGenerator().run(typeUsed: withoutDescriptions, options: CodegenTestHelper.dummyOptions())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
@@ -146,7 +139,7 @@ class EnumGenerationTests: XCTestCase {
                                      ],
                                      fields: nil)
     do {
-      let output = try EnumGenerator().run(typeUsed: withDeprecated, options: self.dummyOptions)
+      let output = try EnumGenerator().run(typeUsed: withDeprecated, options: CodegenTestHelper.dummyOptions())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
@@ -201,7 +194,7 @@ class EnumGenerationTests: XCTestCase {
                                    fields: nil)
     
     do {
-      let output = try EnumGenerator().run(typeUsed: withoutCases, options: self.dummyOptions)
+      let output = try EnumGenerator().run(typeUsed: withoutCases, options: CodegenTestHelper.dummyOptions())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
@@ -231,7 +224,7 @@ class EnumGenerationTests: XCTestCase {
                                      fields: nil)
     
     do {
-      let output = try EnumGenerator().run(typeUsed: differentCases, options: self.dummyOptions)
+      let output = try EnumGenerator().run(typeUsed: differentCases, options: CodegenTestHelper.dummyOptions())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
@@ -270,7 +263,7 @@ class EnumGenerationTests: XCTestCase {
     
     
     do {
-      let output = try EnumGenerator().run(typeUsed: sanitizedCases, options: self.dummyOptions)
+      let output = try EnumGenerator().run(typeUsed: sanitizedCases, options: CodegenTestHelper.dummyOptions())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
@@ -303,14 +296,8 @@ class EnumGenerationTests: XCTestCase {
                                   ],
                                   fields: nil)
     
-    let unusedURL = CodegenTestHelper.apolloFolderURL()
-    let options = ApolloCodegenOptions(modifier: .none,
-                                       outputFormat: .singleFile(atFileURL: unusedURL),
-                                       urlToSchemaFile: unusedURL)
-    
-    
     do {
-      let output = try EnumGenerator().run(typeUsed: episodeEnum, options: options)
+      let output = try EnumGenerator().run(typeUsed: episodeEnum, options: CodegenTestHelper.dummyOptionsNoModifier())
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")

--- a/Tests/ApolloCodegenTests/ExpectedCharacterType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedCharacterType.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum CharacterType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  public typealias RawValue = String
+
+  case Human
+  case Droid
+  case Alien
+  /// Type conforming to `CharacterType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .Human: return "Human"
+    case .Droid: return "Droid"
+    case .Alien: return "Alien"
+    case .__unknown(let value): return value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "Human": self = .Human
+    case "Droid": self = .Droid
+    case "Alien": self = .Alien
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  public static var allCases: [CharacterType] {
+    [
+      .Human,
+      .Droid,
+      .Alien,
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedEpisodeEnumWithoutModifier.swift
+++ b/Tests/ApolloCodegenTests/ExpectedEpisodeEnumWithoutModifier.swift
@@ -1,0 +1,39 @@
+/// The episodes in the Star Wars trilogy
+enum EpisodeWithoutModifier: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  typealias RawValue = String
+
+  /// Star Wars Episode IV: A New Hope, released in 1977.
+  case NEWHOPE
+  /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
+  case EMPIRE
+  /// Star Wars Episode VI: Return of the Jedi, released in 1983.
+  case JEDI
+  /// An EpisodeWithoutModifier type not defined at the time this enum was generated
+  case __unknown(String)
+
+  var rawValue: String {
+    switch self {
+    case .NEWHOPE: return "NEWHOPE"
+    case .EMPIRE: return "EMPIRE"
+    case .JEDI: return "JEDI"
+    case .__unknown(let value): return value
+    }
+  }
+
+  init(rawValue: String) {
+    switch rawValue {
+    case "NEWHOPE": self = .NEWHOPE
+    case "EMPIRE": self = .EMPIRE
+    case "JEDI": self = .JEDI
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  static var allCases: [EpisodeWithoutModifier] {
+    [
+      .NEWHOPE,
+      .EMPIRE,
+      .JEDI,
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedNoCasesCharacterType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedNoCasesCharacterType.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum NoCasesCharacterType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  public typealias RawValue = String
+
+  /// Type conforming to `NoCasesCharacterType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .__unknown(let value): return value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  public static var allCases: [NoCasesCharacterType] {
+    [
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedNoCasesSearchResultType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedNoCasesSearchResultType.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum NoCasesSearchResultType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  public typealias RawValue = String
+
+  /// Type which is a member of `NoCasesSearchResultType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .__unknown(let value): return value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  public static var allCases: [NoCasesSearchResultType] {
+    [
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedNoModifierCharacterType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedNoModifierCharacterType.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum NoModifierCharacterType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  typealias RawValue = String
+
+  case Human
+  case Droid
+  case Alien
+  /// Type conforming to `NoModifierCharacterType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  var rawValue: String {
+    switch self {
+    case .Human: return "Human"
+    case .Droid: return "Droid"
+    case .Alien: return "Alien"
+    case .__unknown(let value): return value
+    }
+  }
+
+  init(rawValue: String) {
+    switch rawValue {
+    case "Human": self = .Human
+    case "Droid": self = .Droid
+    case "Alien": self = .Alien
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  static var allCases: [NoModifierCharacterType] {
+    [
+      .Human,
+      .Droid,
+      .Alien,
+    ]
+  }
+}
+

--- a/Tests/ApolloCodegenTests/ExpectedNoModifierSearchResultType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedNoModifierSearchResultType.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum NoModifierSearchResultType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  typealias RawValue = String
+
+  case Human
+  case Droid
+  case Starship
+  /// Type which is a member of `NoModifierSearchResultType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  var rawValue: String {
+    switch self {
+    case .Human: return "Human"
+    case .Droid: return "Droid"
+    case .Starship: return "Starship"
+    case .__unknown(let value): return value
+    }
+  }
+
+  init(rawValue: String) {
+    switch rawValue {
+    case "Human": self = .Human
+    case "Droid": self = .Droid
+    case "Starship": self = .Starship
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  static var allCases: [NoModifierSearchResultType] {
+    [
+      .Human,
+      .Droid,
+      .Starship,
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedSanitizedCharacterType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedSanitizedCharacterType.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum SanitizedCharacterType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  public typealias RawValue = String
+
+  case `case`
+  case `self`
+  case `Type`
+  case `Protocol`
+  /// Type conforming to `SanitizedCharacterType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .case: return "case"
+    case .`self`: return "self"
+    case .`Type`: return "Type"
+    case .`Protocol`: return "Protocol"
+    case .__unknown(let value): return value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "case": self = .case
+    case "self": self = .`self`
+    case "Type": self = .`Type`
+    case "Protocol": self = .`Protocol`
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  public static var allCases: [SanitizedCharacterType] {
+    [
+      .case,
+      .`self`,
+      .`Type`,
+      .`Protocol`,
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedSanitizedSearchResultType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedSanitizedSearchResultType.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum SanitizedSearchResultType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  public typealias RawValue = String
+
+  case `case`
+  case `self`
+  case `Type`
+  case `Protocol`
+  /// Type which is a member of `SanitizedSearchResultType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .case: return "case"
+    case .`self`: return "self"
+    case .`Type`: return "Type"
+    case .`Protocol`: return "Protocol"
+    case .__unknown(let value): return value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "case": self = .case
+    case "self": self = .`self`
+    case "Type": self = .`Type`
+    case "Protocol": self = .`Protocol`
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  public static var allCases: [SanitizedSearchResultType] {
+    [
+      .case,
+      .`self`,
+      .`Type`,
+      .`Protocol`,
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/ExpectedSearchResultType.swift
+++ b/Tests/ApolloCodegenTests/ExpectedSearchResultType.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum SearchResultType: RawRepresentable, Codable, Equatable, Hashable, CaseIterable {
+  public typealias RawValue = String
+
+  case Human
+  case Droid
+  case Starship
+  /// Type which is a member of `SearchResultType` not defined at the time this enum was generated
+  case __unknown(String)
+
+  public var rawValue: String {
+    switch self {
+    case .Human: return "Human"
+    case .Droid: return "Droid"
+    case .Starship: return "Starship"
+    case .__unknown(let value): return value
+    }
+  }
+
+  public init(rawValue: String) {
+    switch rawValue {
+    case "Human": self = .Human
+    case "Droid": self = .Droid
+    case "Starship": self = .Starship
+    default: self = .__unknown(rawValue)
+    }
+  }
+
+  public static var allCases: [SearchResultType] {
+    [
+      .Human,
+      .Droid,
+      .Starship,
+    ]
+  }
+}

--- a/Tests/ApolloCodegenTests/InputObjectGenerationTests.swift
+++ b/Tests/ApolloCodegenTests/InputObjectGenerationTests.swift
@@ -12,12 +12,6 @@ import XCTest
 
 class InputObjectGenerationTests: XCTestCase {
   
-  private lazy var dummyOptions: ApolloCodegenOptions = {
-    let unusedURL = CodegenTestHelper.apolloFolderURL()
-    return ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: unusedURL),
-                                urlToSchemaFile: unusedURL)
-  }()
-  
   private func colorInput(named name: String) -> ASTTypeUsed {
     let red = ASTTypeUsed.Field(name: "red",
                                 typeNode: .nonNullNamed("Int"),
@@ -67,7 +61,7 @@ class InputObjectGenerationTests: XCTestCase {
   
   func testGeneratingInputObjectWithNoOptionalProperties() {
     do {
-      let output = try InputObjectGenerator().run(typeUsed: self.colorInput(named: "ColorInput"), options: self.dummyOptions)
+      let output = try InputObjectGenerator().run(typeUsed: self.colorInput(named: "ColorInput"), options: CodegenTestHelper.dummyOptions())
 
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
@@ -105,7 +99,7 @@ class InputObjectGenerationTests: XCTestCase {
   
   func testGeneratingInputObjectWithOptionalProperties() {
     do {
-      let output = try InputObjectGenerator().run(typeUsed: self.reviewInput(named: "ReviewInput"), options: self.dummyOptions)
+      let output = try InputObjectGenerator().run(typeUsed: self.reviewInput(named: "ReviewInput"), options: CodegenTestHelper.dummyOptions())
 
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
@@ -121,12 +115,8 @@ class InputObjectGenerationTests: XCTestCase {
   }
   
   func testGeneratingInputObjectWithOptionalPropertiesAndNoModifier() {
-    let dummyURL = CodegenTestHelper.apolloFolderURL()
-    let options = ApolloCodegenOptions(modifier: .none,
-                                       outputFormat: .singleFile(atFileURL: dummyURL),
-                                       urlToSchemaFile: dummyURL)
     do {
-      let output = try InputObjectGenerator().run(typeUsed: self.reviewInput(named: "ReviewInputNoModifier"), options: options)
+      let output = try InputObjectGenerator().run(typeUsed: self.reviewInput(named: "ReviewInputNoModifier"), options: CodegenTestHelper.dummyOptionsNoModifier())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")

--- a/Tests/ApolloCodegenTests/IntefaceEnumGenerationTests.swift
+++ b/Tests/ApolloCodegenTests/IntefaceEnumGenerationTests.swift
@@ -12,12 +12,6 @@ import XCTest
 
 class InterfaceEnumGenerationTests: XCTestCase {
   
-  private lazy var dummyOptions: ApolloCodegenOptions = {
-    let unusedURL = CodegenTestHelper.apolloFolderURL()
-    return ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: unusedURL),
-                                urlToSchemaFile: unusedURL)
-  }()
-  
   func testGeneratingInterfaceEnum() {
     let interface = ASTInterfaceType(name: "Character",
                                      types: [
@@ -26,7 +20,7 @@ class InterfaceEnumGenerationTests: XCTestCase {
                                       "Alien"
                                      ])
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: self.dummyOptions)
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptions())
 
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
@@ -50,7 +44,7 @@ class InterfaceEnumGenerationTests: XCTestCase {
                                       "Protocol",
                                      ])
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: self.dummyOptions)
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptions())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
@@ -70,7 +64,7 @@ class InterfaceEnumGenerationTests: XCTestCase {
                                      types: [
                                      ])
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: self.dummyOptions)
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptions())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
@@ -93,13 +87,8 @@ class InterfaceEnumGenerationTests: XCTestCase {
                                       "Alien"
                                      ])
     
-    let unusedURL = CodegenTestHelper.apolloFolderURL()
-    let options = ApolloCodegenOptions(modifier: .none,
-                                       outputFormat: .singleFile(atFileURL: unusedURL),
-                                       urlToSchemaFile: unusedURL)
-    
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: options)
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptionsNoModifier())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")

--- a/Tests/ApolloCodegenTests/IntefaceEnumGenerationTests.swift
+++ b/Tests/ApolloCodegenTests/IntefaceEnumGenerationTests.swift
@@ -1,0 +1,117 @@
+//
+//  IntefaceObjectGenerationTests.swift
+//  ApolloCodegenTests
+//
+//  Created by Ellen Shapiro on 6/3/20.
+//  Copyright © 2020 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ApolloCodegenLib
+
+class InterfaceEnumGenerationTests: XCTestCase {
+  
+  private lazy var dummyOptions: ApolloCodegenOptions = {
+    let unusedURL = CodegenTestHelper.apolloFolderURL()
+    return ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: unusedURL),
+                                urlToSchemaFile: unusedURL)
+  }()
+  
+  func testGeneratingInterfaceEnum() {
+    let interface = ASTInterfaceType(name: "Character",
+                                     types: [
+                                      "Human",
+                                      "Droid",
+                                      "Alien"
+                                     ])
+    do {
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: self.dummyOptions)
+
+      let expectedFileURL = CodegenTestHelper.sourceRootURL()
+        .appendingPathComponent("Tests")
+        .appendingPathComponent("ApolloCodegenTests")
+        .appendingPathComponent("ExpectedCharacterType.swift")
+      
+      LineByLineComparison.between(received: output,
+                                   expectedFileURL: expectedFileURL,
+                                   trimImports: true)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+    }
+  }
+  
+  func testGeneratingInterfaceEnumWithSanitizedCaseNames() throws {
+    let interface = ASTInterfaceType(name: "SanitizedCharacter",
+                                     types: [
+                                      "case",
+                                      "self",
+                                      "Type",
+                                      "Protocol",
+                                     ])
+    do {
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: self.dummyOptions)
+      
+      let expectedFileURL = CodegenTestHelper.sourceRootURL()
+        .appendingPathComponent("Tests")
+        .appendingPathComponent("ApolloCodegenTests")
+        .appendingPathComponent("ExpectedSanitizedCharacterType.swift")
+      
+      LineByLineComparison.between(received: output,
+                                   expectedFileURL: expectedFileURL,
+                                   trimImports: true)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+    }
+  }
+  
+  func testGeneratingInterfaceEnumWithNoCases() {
+    let interface = ASTInterfaceType(name: "NoCasesCharacter",
+                                     types: [
+                                     ])
+    do {
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: self.dummyOptions)
+      
+      let expectedFileURL = CodegenTestHelper.sourceRootURL()
+        .appendingPathComponent("Tests")
+        .appendingPathComponent("ApolloCodegenTests")
+        .appendingPathComponent("ExpectedNoCasesCharacterType.swift")
+      
+      LineByLineComparison.between(received: output,
+                                   expectedFileURL: expectedFileURL,
+                                   trimImports: true)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+    }
+  }
+  
+  func testGeneratingEnumWithNoModifier() {
+    let interface = ASTInterfaceType(name: "NoModifierCharacter",
+                                     types: [
+                                      "Human",
+                                      "Droid",
+                                      "Alien"
+                                     ])
+    
+    let unusedURL = CodegenTestHelper.apolloFolderURL()
+    let options = ApolloCodegenOptions(modifier: .none,
+                                       outputFormat: .singleFile(atFileURL: unusedURL),
+                                       urlToSchemaFile: unusedURL)
+    
+    do {
+      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: options)
+      
+      let expectedFileURL = CodegenTestHelper.sourceRootURL()
+        .appendingPathComponent("Tests")
+        .appendingPathComponent("ApolloCodegenTests")
+        .appendingPathComponent("ExpectedNoModifierCharacterType.swift")
+      
+      LineByLineComparison.between(received: output,
+                                   expectedFileURL: expectedFileURL,
+                                   trimImports: true)
+    } catch {
+      CodegenTestHelper.handleFileLoadError(error)
+    }
+    
+  }
+}

--- a/Tests/ApolloCodegenTests/UnionEnumGenerationTests.swift
+++ b/Tests/ApolloCodegenTests/UnionEnumGenerationTests.swift
@@ -1,5 +1,5 @@
 //
-//  IntefaceObjectGenerationTests.swift
+//  UnionEnumGenerationTests.swift
 //  ApolloCodegenTests
 //
 //  Created by Ellen Shapiro on 6/3/20.
@@ -10,22 +10,22 @@ import Foundation
 import XCTest
 @testable import ApolloCodegenLib
 
-class InterfaceEnumGenerationTests: XCTestCase {
+class UnionEnumGenerationTests: XCTestCase {
   
-  func testGeneratingInterfaceEnum() {
-    let interface = ASTInterfaceType(name: "Character",
-                                     types: [
-                                      "Human",
-                                      "Droid",
-                                      "Alien"
-                                     ])
+  func testGeneratingUnionEnum() {
+    let union = ASTUnionType(name: "SearchResult",
+                             types: [
+                              "Human",
+                              "Droid",
+                              "Starship",
+                             ])
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptions())
-
+      let output = try UnionEnumGenerator().run(unionType: union, options: CodegenTestHelper.dummyOptions())
+      
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
-        .appendingPathComponent("ExpectedCharacterType.swift")
+        .appendingPathComponent("ExpectedSearchResultType.swift")
       
       LineByLineComparison.between(received: output,
                                    expectedFileURL: expectedFileURL,
@@ -35,8 +35,8 @@ class InterfaceEnumGenerationTests: XCTestCase {
     }
   }
   
-  func testGeneratingInterfaceEnumWithSanitizedCaseNames() throws {
-    let interface = ASTInterfaceType(name: "SanitizedCharacter",
+  func testGeneratingUnionEnumWithSanitizedCaseNames() {
+    let union = ASTUnionType(name: "SanitizedSearchResult",
                                      types: [
                                       "case",
                                       "self",
@@ -44,12 +44,12 @@ class InterfaceEnumGenerationTests: XCTestCase {
                                       "Protocol",
                                      ])
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptions())
+      let output = try UnionEnumGenerator().run(unionType: union, options: CodegenTestHelper.dummyOptions())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
-        .appendingPathComponent("ExpectedSanitizedCharacterType.swift")
+        .appendingPathComponent("ExpectedSanitizedSearchResultType.swift")
       
       LineByLineComparison.between(received: output,
                                    expectedFileURL: expectedFileURL,
@@ -59,17 +59,17 @@ class InterfaceEnumGenerationTests: XCTestCase {
     }
   }
   
-  func testGeneratingInterfaceEnumWithNoCases() {
-    let interface = ASTInterfaceType(name: "NoCasesCharacter",
-                                     types: [
-                                     ])
+  func testGeneratingUnionEnumWithNoCases() {
+    let union = ASTUnionType(name: "NoCasesSearchResult",
+                             types: [
+                             ])
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptions())
+      let output = try UnionEnumGenerator().run(unionType: union, options: CodegenTestHelper.dummyOptions())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
-        .appendingPathComponent("ExpectedNoCasesCharacterType.swift")
+        .appendingPathComponent("ExpectedNoCasesSearchResultType.swift")
       
       LineByLineComparison.between(received: output,
                                    expectedFileURL: expectedFileURL,
@@ -79,21 +79,21 @@ class InterfaceEnumGenerationTests: XCTestCase {
     }
   }
   
-  func testGeneratingInterfaceEnumWithNoModifier() {
-    let interface = ASTInterfaceType(name: "NoModifierCharacter",
-                                     types: [
-                                      "Human",
-                                      "Droid",
-                                      "Alien"
-                                     ])
+  func testGeneratingEnumWithNoModifier() {
+    let union = ASTUnionType(name: "NoModifierSearchResult",
+                             types: [
+                              "Human",
+                              "Droid",
+                              "Starship",
+                             ])
     
     do {
-      let output = try InterfaceEnumGenerator().run(interfaceType: interface, options: CodegenTestHelper.dummyOptionsNoModifier())
+      let output = try UnionEnumGenerator().run(unionType: union, options: CodegenTestHelper.dummyOptionsNoModifier())
       
       let expectedFileURL = CodegenTestHelper.sourceRootURL()
         .appendingPathComponent("Tests")
         .appendingPathComponent("ApolloCodegenTests")
-        .appendingPathComponent("ExpectedNoModifierCharacterType.swift")
+        .appendingPathComponent("ExpectedNoModifierSearchResultType.swift")
       
       LineByLineComparison.between(received: output,
                                    expectedFileURL: expectedFileURL,


### PR DESCRIPTION
NOTE: Draft until the JSON here gets finalized.

In Swift Codegen, we're going to be using enums to represent the possible types of unions and interfaces. This PR takes information returned from the server about what interface and union types are used and uses them to generate those enums. 

Also threw in an additional test on regular enums since we didn't have one covering modifiers.