### PR TITLE
Update Roadmap, Add Workaround for Tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This document is meant to give the community some idea of where we're going with the iOS SDK in the short and longer term. 
 
-This document was last updated on Feburary 4, 2020. 
+This document was last updated on June 16, 2020. 
 
 ^ If that's more than three months ago, please file an issue asking [@designatednerd](https://github.com/designatednerd) to update this document. 😃
 
@@ -11,15 +11,20 @@ This document was last updated on Feburary 4, 2020.
 
 These are things we plan to be working on **within the next 3 months**.
 
-- **Swift Codegen Rewrite**: As outlined in much greater detail in the [RFC issue](https://github.com/apollographql/apollo-ios/issues/939), this will happen in several phases:
+- **Swift Codegen Rewrite, Continued**: As outlined in much greater detail in the [RFC issue](https://github.com/apollographql/apollo-ios/issues/939), we're rewriting our code generation. This has taken somewhat longer than expected, but the following phases are still in progress:
     
-    - **Run existing codegen with Swift instead of Bash**. This will allow for more type-safe and easier to troubleshoot scripts. 
     - **Start generating code with Swift instead of Typescript**. This will allow much easier community contribution to code generation, and allow us to take on a bunch of improvements like `Hashable`, `Equatable`, and potentially `Identifiable` without having to fight with Typescript to do it.
     - **Add immutable caching to new generated code**. Caching is currently heavily tied into our existing parsing mechanism. We're going to separate that out in two phases: The first will allow caching that *cannot* be changed by the consumer.
     - **Add mutable caching to new generated code**. This is the final stage of updating caching: Allowing caching that *can* be changed by the consumer.
     - **Remove Old Codegen**. Once all this is built, older codegen will be deprecated. 
 
     You can follow this effort through the [Swift Codegen GitHub project](https://github.com/apollographql/apollo-ios/projects/2).
+    
+- **Updated Networking Architecture**: We've seen some significant limitations of using a delegate-based system crop up, particularly in terms of flexibility. We'll be outlining and working on a new architecture that uses something somewhat similar to [Apollo Link](https://github.com/apollographql/apollo-link) on the web and [ApolloInterceptor](https://github.com/apollographql/apollo-android/blob/master/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java) on Android, to allow you to intercept and modify both outgoing network requests and the responses to those requests.
+  
+    Please keep an eye out for an RFC coming later this summer with significantly more detail in the [Issues tab](https://github.com/apollographql/apollo-ios/issues). 
+    
+- **New Apple Software Support**: It's that time of year! We'll be carefully working with betas of Xcode 12, iOS 14, and other related software to make sure everything still works on those versions. Check back after WWDC for updates on whether there are new technologies we plan to support. 
 
 - **General bug-bashing**: There's still a few outstanding general issues and small feature requests I'd like to address, and we'll be dealing with any new issues as they come up.
 
@@ -34,4 +39,4 @@ We're very open to any help we can get on these if your goals would be advanced 
 
 - **Wrapper libraries**. A very highly voted suggestion in our fall 2019 developer survey was wrapper libraries for concurrency helpers like RxSwift, Combine, and PromiseKit. 
 
-  Note that we are **not** locked into any particular set of other dependencies to support yet, but we anticipate these will be wrappers in a separate repository that have Apollo as a dependency. As individual wrappers move into nearer-term work, we'll outline which specific ones we'll be supporting.
+    Note that we are **not** locked into any particular set of other dependencies to support yet, but we anticipate these will be wrappers in a separate repository that have Apollo as a dependency. As individual wrappers move into nearer-term work, we'll outline which specific ones we'll be supporting.

--- a/Tests/ApolloTests/URLSessionClientTests.swift
+++ b/Tests/ApolloTests/URLSessionClientTests.swift
@@ -180,7 +180,15 @@ class URLSessionClientLiveTests: XCTestCase {
           XCTAssertFalse(data.isEmpty)
           do {
             let httpBinResponse = try HTTPBinResponse(data: data)
-            XCTAssertEqual(httpBinResponse.url, response.url?.absoluteString)
+            // WORKAROUND: HTTPBin started randomly returning http instead of https
+            // in this field, replace until addressed. Issue: https://github.com/postmanlabs/httpbin/issues/615
+            var responseURLString = httpBinResponse.url
+            if !responseURLString.contains("https") {
+              let droppedHTTP = String(responseURLString.dropFirst(4))
+              responseURLString = "https" + droppedHTTP
+            }
+            
+            XCTAssertEqual(responseURLString, response.url?.absoluteString)
             XCTAssertEqual(httpBinResponse.args?["index"], "\(index)")
           } catch {
             XCTFail("Parsing error: \(error) for url \(response.url!)")


### PR DESCRIPTION
In this PR: 
- Updated the roadmap for Summer 2020 to reflect the (excruciatingly slow) progress I've made on codegen.
- Added a workaround for [an issue with `httpbin.org` that's causing some tests to arbitrarily fail](https://github.com/postmanlabs/httpbin/issues/615). 