### PR TITLE
Avoid crash when evaluating optional variables

### DIFF
--- a/Sources/Apollo/GraphQLInputValue.swift
+++ b/Sources/Apollo/GraphQLInputValue.swift
@@ -27,6 +27,19 @@ extension JSONEncodable {
   }
 }
 
+extension Optional: GraphQLInputValue {
+  public func evaluate(with variables: [String: JSONEncodable]?) throws -> JSONValue {
+    switch self {
+    case .none:
+      return NSNull()
+    case .some(let wrapped as GraphQLInputValue):
+      return try wrapped.evaluate(with: variables)
+    default:
+      fatalError("Optional is only GraphQLInputValue if Wrapped is")
+    }
+  }
+}
+
 extension Dictionary: GraphQLInputValue {
   public func evaluate(with variables: [String: JSONEncodable]?) throws -> JSONValue {
     return try evaluate(with: variables) as JSONObject


### PR DESCRIPTION
This fixes #1255 by adding an extension method to `Optional` that implements `GraphQLInputValue.evaluate(with:)` by invoking that same method on the wrapped value. Without it, we'd be treating an optional `GraphQLVariable` as an optional `JSONEncodable`, which leads to a runtime crash because `GraphQLVariable` does not in fact conform to `JSONEncodable`.

All this should really be cleaned up by adopting conditional conformances (which weren't available when this was originally written), but that turns out to lead to quite the rabbit hole of issues so that'll have to wait.