### PR TITLE
Bring Swift Scripting out of Beta

### DIFF
--- a/SwiftScripts/Sources/Codegen/main.swift
+++ b/SwiftScripts/Sources/Codegen/main.swift
@@ -8,8 +8,8 @@ let parentFolderOfScriptFile = FileFinder.findParentFolder()
 // Use that to calculate the source root
 let sourceRootURL = parentFolderOfScriptFile
     .apollo.parentFolderURL() // Sources
-    .apollo.parentFolderURL()  // SwiftScripts
-    .apollo.parentFolderURL()  // apollo-ios
+    .apollo.parentFolderURL() // SwiftScripts
+    .apollo.parentFolderURL() // apollo-ios
 
 // In a typical app, you'll only need to do this for one target, so you'd
 // set these up directly within this file. Here, we're using more than one

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -224,8 +224,8 @@ One of the convenience wrappers available to you in the target is `ApolloSchemaD
 3. Set up your `ApolloSchemaOptions` object. In this case, we'll use the [default arguments for all the constructor parameters that take them](./api/ApolloCodegenLib/structs/ApolloSchemaOptions#methods), and only pass in the endpoint to download from and the folder to put the downloaded file into: 
 
     ```swift:title=main.swift
-    let options = ApolloSchemaOptions(endpointURL: endpoint,
-                                      outputFolderURL: output)
+    let schemaDownloadOptions = ApolloSchemaOptions(endpointURL: endpoint,
+                                                    outputFolderURL: output)
     ```
     
     With these defaults, this will download a JSON file called `schema.json`. 
@@ -235,7 +235,7 @@ One of the convenience wrappers available to you in the target is `ApolloSchemaD
     ```swift:title=main.swift
     do {
       try ApolloSchemaDownloader.run(with: cliFolderURL,
-                                     options: options)
+                                     options: schemaDownloadOptions)
     } catch {
       exit(1)
     }
@@ -319,7 +319,7 @@ Here, for example, is what this looks like in a file for one of the queries in o
 2. Set up your `ApolloCodegenOptions` object. In this case, we'll use the constructor that [sets defaults for you automatically](./api/ApolloCodegenLib/structs/ApolloCodegenOptions#methods): 
 
     ```swift:title=main.swift
-    let options = ApolloCodegenOptions(targetRootURL: targetURL)
+    let codegenOptions = ApolloCodegenOptions(targetRootURL: targetURL)
     ```
 
     This creates a single file called `API.swift` in the target's root folder. 
@@ -330,7 +330,7 @@ Here, for example, is what this looks like in a file for one of the queries in o
     do {
         try ApolloCodegen.run(from: targetURL,
                               with: cliFolderURL,
-                              options: options)
+                              options: codegenOptions)
     } catch {
         exit(1)
     }

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -256,7 +256,7 @@ One of the convenience wrappers available to you in the target is `ApolloSchemaD
 
 Note the warning: This isn't relevant for schema downloading, but it *is* relevant for generating code: In order to generate code, you need both the schema and some kind of operation.
 
-## Using codegen to create a `.graphql` file with an operation
+## Creating a `.graphql` file with an operation
 
 Because you've already [downloaded a schema](#downloading-a-schema), you can now proceed to creating an operation. The easiest and most common type of operation to create is a Query. 
 
@@ -299,9 +299,9 @@ Here, for example, is what this looks like in a file for one of the queries in o
 
 <img alt="Launch list file" src="screenshot/graphql_file_launchlist.png" class="screenshot"/>
 
-## Generating code for a target
+## Generating Swift code for a target
 
->**Before you start**: Remember, you need to have a locally downloaded copy of your schema and at least one `.graphql` file containing an operation in your file tree. If you don't have **both** of these, code generation will fail. [Read the section above](#using-codegen-to-create-a-graphql-file-with-an-operation) if you don't have an operation set up!
+>**Before you start**: Remember, you need to have a locally downloaded copy of your schema and at least one `.graphql` file containing an operation in your file tree. If you don't have **both** of these, code generation will fail. [Read the section above](#creating-a-graphql-file-with-an-operation) if you don't have an operation set up!
 
 1. Specify the URL for the root of the target you're generating code for:
 

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -1,9 +1,7 @@
 ---
 title: Swift scripting
-sidebar_title: Swift scripting (beta)
+sidebar_title: Swift scripting
 ---
-
-⚠️ **This functionality is in beta.** ⚠️
 
 Apollo Client for iOS enables you to use Swift scripting to perform certain operations that otherwise require the command line. This document guides you through setting up a Swift Package Manager executable and then using it to: 
 

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -63,7 +63,7 @@ To begin, let's set up a Swift Package Manager executable:
     ```swift:title=Package.swift
     .package(name: "Apollo",
              url: "https://github.com/apollographql/apollo-ios.git", 
-             .upToNextMinor(from: "0.27.0"))
+             .upToNextMinor(from: "0.29.0"))
     ```
   **NOTE**: The version should be identical to the version you're using in your main project.
 

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -10,6 +10,31 @@ Apollo Client for iOS enables you to use Swift scripting to perform certain oper
 - Download a schema
 - Generate Swift code for your model object based on your schema and operations
 
+## Conceptual background
+
+Apollo's code generation requires both of the following to run:
+
+* Your **schema**, which defines what it's *possible* for you to request from or send to your server
+* One or more **operations**, which define what you are *actually* requesting from the server
+
+If you're missing either of these, codegen can't run. If you define operations but no schema, the operations can't be validated. If you define a schema but no operations, there's nothing to validate or generate code for. 
+
+Or, more succinctly:
+
+```
+schema + operations = code
+```
+
+Each operation you define can be one of the following:
+
+- A **query**, which is a one-time request for specific data
+- A **mutation**, which changes data on the server and then receives updated data back
+- A **subscription**, which allows you to listen for changes to a particular object or type of object
+
+Code generation takes your operations and compares them to the schema to confirm that they're valid. If an operation _isn't_ valid, the whole process errors out. If all operations are valid, codegen generates Swift code that gives you end-to-end type safety for each operation. 
+
+The rest of this guide will help you set up a Swift Package Manager executable that will live alongside your main `xcodeproj` and which can be used either from your main `xcodeproj` or on its own to download a schema, generate code, or both.
+
 ## Setup
 
 To begin, let's set up a Swift Package Manager executable:
@@ -232,27 +257,6 @@ One of the convenience wrappers available to you in the target is `ApolloSchemaD
 Note the warning: This isn't relevant for schema downloading, but it *is* relevant for generating code: In order to generate code, you need both the schema and some kind of operation.
 
 ## Using codegen to create a `.graphql` file with an operation
-
-Code generation requires both of the following to run:
-
-* Your **schema**, which defines what it's *possible* for you to request from or send to your server
-* One or more **operations**, which define what you are *actually* requesting from the server
-
-If you're missing either of these, codegen can't run. If you define operations but no schema, the operations can't be validated. If you define a schema but no operations, there's nothing to validate or generate code for. 
-
-Or, more succinctly:
-
-```
-schema + operations = code
-```
-
-Each operation you define can be one of the following:
-
-- A **query**, which is a one-time request for specific data
-- A **mutation**, which changes data on the server and then receives updated data back
-- A **subscription**, which allows you to listen for changes to a particular object or type of object
-
-Code generation takes your operations and compares them to the schema to confirm that they're valid. If an operation _isn't_ valid, the whole process errors out. If all operations are valid, codegen generates Swift code that gives you end-to-end type safety for each operation. 
 
 Because you've already [downloaded a schema](#downloading-a-schema), you can now proceed to creating an operation. The easiest and most common type of operation to create is a Query. 
 

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -118,17 +118,17 @@ Here's how you obtain the parent folder of the script, then use that to get back
 ```swift:title=main.swift
 let parentFolderOfScriptFile = FileFinder.findParentFolder()
 let sourceRootURL = parentFolderOfScriptFile
-  .deletingLastPathComponent() // Result: Sources folder
-  .deletingLastPathComponent() // Result: Codegen folder
-  .deletingLastPathComponent() // Result: MyProject source root folder
+  .apollo.parentFolder() // Result: Sources folder
+  .apollo.parentFolder() // Result: Codegen folder
+  .apollo.parentFolder() // Result: MyProject source root folder
 ```
 
 You can use this to get the URL of the folder you plan to download the CLI to: 
 
 ```swift:title=main.swift
 let cliFolderURL = sourceRootURL
-  .appendingPathComponent("Codegen")
-  .appendingPathComponent("ApolloCLI")
+  .apollo.childFolderURL(folderName: "Codegen")
+  .apollo.childFolderURL(folderName: "ApolloCLI")
 ```
 
 This would put the folder to download the CLI here in your filesystem: 
@@ -187,10 +187,10 @@ One of the convenience wrappers available to you in the target is `ApolloSchemaD
 
     ```swift:title=main.swift
     let output = sourceRootURL
-        .appendingPathComponent("MyProject")
+        .apollo.childFolderURL(folderName:"MyProject")
     ```
     
-    You might want to make sure the folder exists before proceeding:
+    Note that particularly if you're not just downloading the schema into your target's folder, you will want to make sure the folder exists before proceeding:
     
     ```swift:title=main.swift
     try FileManager
@@ -303,7 +303,7 @@ Here, for example, is what this looks like in a file for one of the queries in o
 
     ```swift:title=main.swift
     let targetURL = sourceRootURL
-                    .appendingPathComponent("MyProject")
+        .apollo.childFolderURL(folderName: "MyProject")
     ```
 
     Again, you might want to make sure the folder exists before proceeding:

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Advertisement!
-echo "Have you tried our new Swift Package Manager wrapper around codegen? It's now available in beta! See docs at https://www.apollographql.com/docs/ios/swift-scripting/. Note that when this comes out of beta, this Bash script will be deprecated, so give it a try today!"
+echo "Have you tried our new Swift Package Manager wrapper around codegen? It's now out of beta and ready to go! See docs at https://www.apollographql.com/docs/ios/swift-scripting/. This Bash script will be deprecated soon, so give it a try today!"
 
 # Get the path to the script directory
 SCRIPT_DIR="$(dirname "$0")"


### PR DESCRIPTION
In this PR:
- Promoted swift scripting to the final version
- Made some edits to make the whole Swift Scripting doc more readable and put some conceptual stuff up front
- Updated a bunch of instructions to use more user-friendly extensions so users can tell what's happening more easily
- Added a full example script developers can use as a reference.
- Updated the warning on the bash script - this probably will be deprecated in the next version or two. 

Would LOVE feedback on this - I think the scripting stuff is now to a point of maturity that I can rip the beta tag off it, and I hope the changes to the scripting doc make things clearer. 