### PR TITLE
make parts of GraphQLGetTransformer and MultipartFormData public

### DIFF
--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct GraphQLGETTransformer {
+public struct GraphQLGETTransformer {
 
   let body: GraphQLMap
   let url: URL
@@ -10,7 +10,7 @@ struct GraphQLGETTransformer {
   /// - Parameters:
   ///   - body: The GraphQLMap to transform from the body of a `POST` request
   ///   - url: The base url to append the query to.
-  init(body: GraphQLMap, url: URL) {
+  public init(body: GraphQLMap, url: URL) {
     self.body = body
     self.url = url
   }
@@ -18,7 +18,7 @@ struct GraphQLGETTransformer {
   /// Creates the get URL.
   ///
   /// - Returns: [optional] The created get URL or nil if the provided information couldn't be used to access the appropriate parameters.
-  func createGetURL() -> URL? {
+  public func createGetURL() -> URL? {
     guard var components = URLComponents(string: self.url.absoluteString) else {
       return nil
     }

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -17,7 +17,7 @@ public class MultipartFormData {
   /// A Carriage Return Line Feed character, which will be seen as a newline on both unix and Windows servers.
   static let CRLF = "\r\n"
 
-  let boundary: String
+  public let boundary: String
 
   private var bodyParts: [BodyPart]
 
@@ -89,7 +89,7 @@ public class MultipartFormData {
   /// Encodes everything into the final form data to send to a server.
   ///
   /// - Returns: The final form data to send to a server.
-  func encode() throws -> Data {
+  public func encode() throws -> Data {
     var data = Data()
 
     for p in self.bodyParts {


### PR DESCRIPTION
This allows creating NetworkTransport subclasses outside of the Apollo module that still make use of GraphQLGETTransformer and MultipartFormData.
A use case for doing this (and my actual use case) is replacing the use of URLSessionTask in HTTPNetworkTransport.swift with another networking library, such as Alamofire (ex. AlamofireNetworkTransport.swift)