### PR TITLE
Fix dependency declaration in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,9 @@ let package = Package(
         dependencies: []),
     .target(
       name: "Apollo",
-      dependencies: []),
+      dependencies: [
+        "ApolloCore",
+      ]),
     .target(
       name: "ApolloCodegenLib",
       dependencies: [
@@ -62,6 +64,7 @@ let package = Package(
       name: "ApolloWebSocket",
       dependencies: [
         "Apollo",
+        "ApolloCore",
         .product(name: "Starscream", package: "Starscream"),
       ]),
     .target(


### PR DESCRIPTION
I forgot to update this now that we're actually using `ApolloCore` from the `Apollo` and `ApolloWebSockets` libraries. This should fix some issues with compilation outlined in #1272. 