### PR TITLE
More CLI fixes

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCLI.swift
+++ b/Sources/ApolloCodegenLib/ApolloCLI.swift
@@ -13,6 +13,12 @@ public struct ApolloCLI {
   ///   - timeout: The maximum time to wait before indicating that the download timed out, in seconds.
   public static func createCLI(cliFolderURL: URL, timeout: Double) throws -> ApolloCLI {
     try CLIDownloader.downloadIfNeeded(cliFolderURL: cliFolderURL, timeout: timeout)
+    
+    if !(try CLIExtractor.validateSHASUMOfDownloadedFile(in: cliFolderURL)) {
+      CodegenLogger.log("Downloaded zip file has incorrect SHASUM, forcing redownolad")
+      try CLIDownloader.forceRedownload(cliFolderURL: cliFolderURL, timeout: timeout)
+    }
+    
     let binaryFolderURL = try CLIExtractor.extractCLIIfNeeded(from: cliFolderURL)
     return ApolloCLI(binaryFolderURL: binaryFolderURL)
   }

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -78,6 +78,22 @@ struct CLIExtractor {
     return true
   }
   
+  static func validateSHASUMOfDownloadedFile(in cliFolderURL: URL, expected: String = CLIExtractor.expectedSHASUM) throws -> Bool {
+    let zipFileURL = ApolloFilePathHelper.zipFileURL(fromCLIFolder: cliFolderURL)
+    
+    do {
+      try self.validateZipFileSHASUM(at: zipFileURL)
+      return true
+    } catch {
+      switch error {
+      case CLIExtractorError.zipFileHasInvalidSHASUM:
+        return false
+      default:
+        throw error
+      }
+    }
+  }
+  
   /// Writes the SHASUM of the extracted version of the CLI to a file for faster checks to ensure we have the correct version.
   ///
   /// - Parameter apolloFolderURL: The URL to the extracted apollo folder.
@@ -119,7 +135,7 @@ struct CLIExtractor {
   /// - Parameter expected: The expected SHASUM. Defaults to the real expected SHASUM. This parameter exists mostly for testing.
   static func validateZipFileSHASUM(at zipFileURL: URL, expected: String = CLIExtractor.expectedSHASUM) throws {
     let shasum = try FileManager.default.apollo.shasum(at: zipFileURL)
-    print("SHASUM: \(shasum)")
+    print("SHASUM of downloaded file: \(shasum)")
     guard shasum == expected else {
       throw CLIExtractorError.zipFileHasInvalidSHASUM(expectedSHASUM: expected, gotSHASUM: shasum)
     }

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-ZIP_FILE_DOWNLOAD_URL="https://install.apollographql.com/legacy-cli/darwin/2.28.0"
+ZIP_FILE_DOWNLOAD_URL="https://install.apollographql.com/legacy-cli/darwin/2.28.3"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
 IS_RETRY="false"
@@ -58,7 +58,7 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="060d893aea4ebc2effa74b20433f5d0f586b31fec0d0f73c210ee152c032185e"
+  EXPECTED_SHASUM="cb2f4b9f53eb8443661e7658e407a3837da3d781649f8bc66a1c6cf7d32acef1"
   update_shasum
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then


### PR DESCRIPTION
In this PR:
 
- Update the CLI URL and SHASUM for the shell script to match those from #1284 
- Add a check in the Swift script that ensures the downloaded zip file has the correct SHASUM, and forces a redownload if it doesn't.

Will need to add some tests for the swift script after the holiday weekend, but wanted to get people unblocked first.