### PR TITLE
Add some error descriptions

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -13,11 +13,24 @@ import ApolloCore
 /// when for background sessions.
 open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate {
   
-  public enum URLSessionClientError: Error {
+  public enum URLSessionClientError: Error, LocalizedError {
     case noHTTPResponse(request: URLRequest?)
     case sessionBecameInvalidWithoutUnderlyingError
     case dataForRequestNotFound(request: URLRequest?)
     case networkError(data: Data, response: HTTPURLResponse?, underlying: Error)
+    
+    public var errorDescription: String? {
+      switch self {
+      case .noHTTPResponse(let request):
+        return "The request did not receive an HTTP response. Request: \(String(describing: request))"
+      case .sessionBecameInvalidWithoutUnderlyingError:
+        return "The URL session became invalid, but no underlying error was returned."
+      case .dataForRequestNotFound(let request):
+        return "URLSessionClient was not able to locate the stored data for request \(String(describing: request))"
+      case .networkError(_, _, let underlyingError):
+        return "A network error occurred: \(underlyingError.localizedDescription)"
+      }
+    }
   }
   
   /// A completion block to be called when the raw task has completed, with the raw information from the session

--- a/Sources/ApolloCodegenLib/String+Apollo.swift
+++ b/Sources/ApolloCodegenLib/String+Apollo.swift
@@ -3,8 +3,15 @@ import Foundation
 import ApolloCore
 #endif
 
-enum ApolloStringError: Error {
+enum ApolloStringError: Error, LocalizedError {
   case expectedSuffixMissing(_ suffix: String)
+  
+  var errorDescription: String? {
+    switch self {
+    case .expectedSuffixMissing(let suffix):
+      return "Expected \"\(self)\" to have suffix \"\(suffix)\", but it did not. Cannot drop a suffix that doesn't exist!"
+    }
+  }
 }
 
 extension ApolloExtension where Base == String {


### PR DESCRIPTION
In this PR: 

- Added `LocalizedError` support to `URLSessionError`, addressing #1293. 
- Also looked for other places that needed `LocalizedError` added, found and addressed one. 