### PR TITLE
RFC: Add Bazel build configurations for Apollo iOS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,56 @@
+licenses(["notice"])
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+swift_library(
+    name = "ApolloCore",
+    module_name = "ApolloCore",
+    srcs = ["//Sources:ApolloCoreFiles"],
+    deps = []
+)
+
+swift_library(
+    name = "Apollo",
+    module_name = "Apollo",
+    srcs = ["//Sources:ApolloFiles"],
+    deps = ["ApolloCore"]
+)
+
+swift_library(
+    name = "ApolloCodegenLib",
+    module_name = "ApolloCodegenLib",
+    srcs = ["//Sources:ApolloCodegenLibFiles"],
+    deps = [
+        "ApolloCore",
+        "@Stencil//:Stencil",
+    ]
+)
+
+swift_library(
+    name = "ApolloSQLite",
+    module_name = "ApolloSQLite",
+    srcs = ["//Sources:ApolloSQLiteFiles"],
+    deps = [
+        "Apollo",
+        "@SQLite//:SQLite",
+    ]
+)
+
+swift_library(
+    name = "ApolloWebSocket",
+    module_name = "ApolloWebSocket",
+    srcs = ["//Sources:ApolloWebSocketFiles"],
+    deps = [
+        "Apollo",
+        "ApolloCore",
+        "@Starscream//:Starscream",
+    ]
+)

--- a/Sources/BUILD
+++ b/Sources/BUILD
@@ -1,0 +1,29 @@
+filegroup(
+    name = "ApolloCoreFiles",
+    srcs = glob(["ApolloCore/*.swift"]),
+    visibility = ["//:__pkg__"],
+)
+
+filegroup(
+    name = "ApolloFiles",
+    srcs = glob(["Apollo/*.swift"]),
+    visibility = ["//:__pkg__"],
+)
+
+filegroup(
+    name = "ApolloCodegenLibFiles",
+    srcs = glob(["ApolloCodegenLib/*.swift"]),
+    visibility = ["//:__pkg__"],
+)
+
+filegroup(
+    name = "ApolloSQLiteFiles",
+    srcs = glob(["ApolloSQLite/*.swift"]),
+    visibility = ["//:__pkg__"],
+)
+
+filegroup(
+    name = "ApolloWebSocketFiles",
+    srcs = glob(["ApolloWebSocket/*.swift"]),
+    visibility = ["//:__pkg__"],
+)

--- a/SwiftScripts/BUILD
+++ b/SwiftScripts/BUILD
@@ -1,0 +1,27 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "SchemaDownload",
+    srcs = glob(["Sources/SchemaDownload/**/*.swift"]),
+    deps = [
+        "//:ApolloCodegenLib",
+    ],
+)
+
+swift_binary(
+    name = "Codegen",
+    srcs = glob(["Sources/Codegen/**/*.swift"]),
+    deps = [
+        "//:ApolloCodegenLib",
+        "@swift-tools-support-core//:TSCUtility",
+    ],
+)
+
+swift_binary(
+    name = "DocumentGenerator",
+    srcs = glob(["Sources/DocumentGenerator/**/*.swift"]),
+    deps = [
+        "//:ApolloCodegenLib",
+        "@swift-tools-support-core//:TSCUtility",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,98 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+git_repository(
+  name = "build_bazel_rules_apple",
+  remote = "https://github.com/bazelbuild/rules_apple.git",
+  commit = "12ac0738c56f8a15c714a7e09ec87a1bbdbcada9",
+  shallow_since = "1592940289 -0700"
+)
+
+git_repository(
+  name = "build_bazel_rules_swift",
+  remote = "https://github.com/bazelbuild/rules_swift.git",
+  commit = "8ecb09641ee0ba5efd971ffff8dd6cbee6ea7dd3",
+  shallow_since = "1584545517 -0700"
+)
+
+git_repository(
+  name = "build_bazel_apple_support",
+  remote = "https://github.com/bazelbuild/apple_support.git",
+  commit = "501b4afb27745c4813a88ffa28acd901408014e4",
+  shallow_since = "1577729628 -0800"
+)
+
+git_repository(
+  name = "bazel_skylib",
+  remote = "https://github.com/bazelbuild/bazel-skylib.git",
+  commit = "d35e8d7bc6ad7a3a53e9a1d2ec8d3a904cc54ff7",
+  shallow_since = "1593183852 +0200"
+)
+
+new_git_repository(
+  name = "Stencil",
+  remote = "https://github.com/stencilproject/Stencil.git",
+  commit = "124df01d3c5defdce07872fe1828c764bb969b38",
+  shallow_since = "1590711283 +0200",
+  build_file = "Stencil.BUILD",
+)
+
+new_git_repository(
+  name = "PathKit",
+  remote = "https://github.com/kylef/PathKit.git",
+  commit = "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+  shallow_since = "1553800707 +0000",
+  build_file = "PathKit.BUILD",
+)
+
+new_git_repository(
+  name = "SQLite",
+  remote = "https://github.com/stephencelis/SQLite.swift.git",
+  commit = "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
+  shallow_since = "1561117027 +0300",
+  build_file = "SQLite.BUILD",
+)
+
+new_git_repository(
+  name = "Starscream",
+  remote = "https://github.com/daltoniam/Starscream",
+  commit = "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
+  shallow_since = "1571027770 +0300",
+  build_file = "Starscream.BUILD",
+)
+
+new_git_repository(
+  name = "swift-tools-support-core",
+  remote = "https://github.com/apple/swift-tools-support-core",
+  commit = "25fc6eaec5d9f79b79419c5bdaa04e434cbcd568",
+  shallow_since = "1593886283 -0700",
+  build_file = "swift-tools-support-core.BUILD",
+)
+
+load(
+  "@build_bazel_rules_swift//swift:repositories.bzl",
+  "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+  "@build_bazel_apple_support//lib:repositories.bzl",
+  "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
+load(
+  "@com_google_protobuf//:protobuf_deps.bzl",
+  "protobuf_deps",
+)
+
+protobuf_deps()
+
+http_file(
+  name = "xctestrunner",
+  executable = 1,
+  sha256 = "890faff3f6d5321712ffb7a09ba3614eabca93977221e86d058c7842fdbad6b6",
+  urls = ["https://github.com/google/xctestrunner/releases/download/0.2.13/ios_test_runner.par"],
+)

--- a/external/PathKit.BUILD
+++ b/external/PathKit.BUILD
@@ -1,0 +1,18 @@
+
+licenses(["notice"])
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+swift_library(
+    name = "PathKit",
+    module_name = "PathKit",
+    srcs = glob(["Sources/*.swift"]),
+)

--- a/external/SQLite.BUILD
+++ b/external/SQLite.BUILD
@@ -1,0 +1,38 @@
+
+licenses(["notice"])
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+objc_library(
+    name = "SQLiteObjc",
+    hdrs = [
+        "Sources/SQLiteObjc/include/SQLiteObjc.h",
+    ],
+    includes = ["Sources/SQLiteObjc/include"],
+    srcs = [
+        "Sources/SQLiteObjc/fts3_tokenizer.h",
+        "Sources/SQLiteObjc/SQLiteObjc.m",
+    ],
+    enable_modules = True,
+    module_name = "SQLiteObjc",
+    visibility = ["//:__pkg__"]
+)
+
+swift_library(
+    name = "SQLite",
+    module_name = "SQLite",
+    swiftc_inputs = ["Sources/SQLite/SQLite.h"],
+    copts = ["-import-objc-header", "$(location Sources/SQLite/SQLite.h)"],
+    srcs = glob(["Sources/SQLite/**/*.swift"]),
+    deps = [
+        "SQLiteObjc",
+    ],
+)

--- a/external/Starscream.BUILD
+++ b/external/Starscream.BUILD
@@ -1,0 +1,19 @@
+
+licenses(["notice"])
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+swift_library(
+    name = "Starscream",
+    module_name = "Starscream",
+    srcs = glob(["Sources/Starscream/**/*.swift"]),
+    deps = [],
+)

--- a/external/Stencil.BUILD
+++ b/external/Stencil.BUILD
@@ -1,0 +1,21 @@
+
+licenses(["notice"])
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+swift_library(
+    name = "Stencil",
+    module_name = "Stencil",
+    srcs = glob(["Sources/*.swift"]),
+    deps = [
+        "@PathKit//:PathKit",
+    ]
+)

--- a/external/swift-tools-support-core.BUILD
+++ b/external/swift-tools-support-core.BUILD
@@ -1,0 +1,50 @@
+
+licenses(["notice"])
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+cc_library(
+    name = "TSCclibc",
+    hdrs = glob(["Sources/TSCclibc/include/*.h"]),
+    includes = ["Sources/TSCclibc/include"],
+    srcs = [
+        "Sources/TSCclibc/libc.c",
+        "Sources/TSCclibc/process.c",
+    ],
+    visibility = ["//:__pkg__"]
+)
+
+swift_library(
+    name = "TSCLibc",
+    module_name = "TSCLibc",
+    srcs = glob(["Sources/TSCLibc/**/*.swift"]),
+    deps = [
+        "TSCclibc",
+    ],
+)
+
+swift_library(
+    name = "TSCBasic",
+    module_name = "TSCBasic",
+    srcs = glob(["Sources/TSCBasic/**/*.swift"]),
+    deps = [
+        "TSCLibc",
+    ],
+)
+
+swift_library(
+    name = "TSCUtility",
+    module_name = "TSCUtility",
+    srcs = glob(["Sources/TSCUtility/**/*.swift"]),
+    deps = [
+        "TSCBasic",
+    ],
+)


### PR DESCRIPTION
I plan to add some Bazel support for Apollo iOS, including runtime BUILD
files and some bzl macros that can download schema and generate code
from the schema.

Before that, this PR added relevant BUILD configuration to build Apollo
/ ApolloCore / ApolloWebSocket / ApolloSQLite.

I am not sure what SwiftScripts do, and whether these will work as
expected, since Bazel sandbox the binary therefore the path finding
logic will be incorrect.

For the codegen part, I need to figure out a few things:

 1. It seems OK to wrap the node / run with sh_binary, with additional
    shell scripts (run-bundled-codegen.sh messes with Bazel sandbox and
    I am not happy to just wrap that, mainly because it won't be
    properly cached (the downloaded tar.gz file)).

 2. I need to use http_archive most likely for the apollo cli tools (in
    node.js). However, the current link doesn't end with tar.gz, which
    Bazel doesn't like.

Hence, this PR upstreams some conservative changes. Please let me know
what you maintainers think.

The broad picture is to make integration with Bazel based iOS project
easier, and uses Bazel's cache for schema download, code generation etc.