### PR TITLE
Remove Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,0 @@
-github "stephencelis/SQLite.swift" ~> 0.12.2
-github "daltoniam/Starscream" ~> 3.1.1


### PR DESCRIPTION
We don't actually need this because Xcode uses SPM to get these deps. Specifying the Cartfile causes Carthage to get the dependencies, but Xcode will fetch and use the SPM dependencies instead.

@eliperkins and I spent a long time trying to debug why changing the version of something in the Cartfile in our fork wasn't working and then we realized it was this issue.