### PR TITLE
Update JS CLI to 2.30.1, remove now-unnecessary workaround

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -550,14 +550,14 @@
 		9BDE43D022C6655200FD7C7F /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		9BDE43DC22C6705300FD7C7F /* GraphQLHTTPResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponseError.swift; sourceTree = "<group>"; };
 		9BDE43DE22C6708600FD7C7F /* GraphQLHTTPRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPRequestError.swift; sourceTree = "<group>"; };
-		9BDF200B23FDC37600153E2B /* RepoURL.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RepoURL.graphql; sourceTree = "<group>"; };
 		9BDF200C23FDC37600153E2B /* GitHubAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitHubAPI.h; sourceTree = "<group>"; };
 		9BDF200D23FDC37600153E2B /* operationIdsPath.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = operationIdsPath.json; sourceTree = "<group>"; };
 		9BDF200E23FDC37600153E2B /* operationIDs.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = operationIDs.json; sourceTree = "<group>"; };
-		9BDF200F23FDC37600153E2B /* schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = schema.json; sourceTree = "<group>"; };
-		9BDF201023FDC37600153E2B /* Repository.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Repository.graphql; sourceTree = "<group>"; };
 		9BDF201123FDC37600153E2B /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		9BDF201223FDC37600153E2B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9BDF2EC824C100B600AC9A1E /* schema.docs.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = schema.docs.graphql; sourceTree = "<group>"; };
+		9BDF2ED124C100DF00AC9A1E /* RepoURL.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = RepoURL.graphql; sourceTree = "<group>"; };
+		9BDF2ED224C100DF00AC9A1E /* Repository.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = Repository.graphql; sourceTree = "<group>"; };
 		9BE071AC2368D08700FA5952 /* Collection+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Helpers.swift"; sourceTree = "<group>"; };
 		9BE071AE2368D34D00FA5952 /* Matchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchable.swift; sourceTree = "<group>"; };
 		9BE071B02368D3F500FA5952 /* Dictionary+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Helpers.swift"; sourceTree = "<group>"; };
@@ -1114,12 +1114,11 @@
 		9BDF200723FDC37600153E2B /* GitHubAPI */ = {
 			isa = PBXGroup;
 			children = (
-				9BDF200823FDC37600153E2B /* TestFolder */,
 				9BDF200C23FDC37600153E2B /* GitHubAPI.h */,
+				9BDF2ECD24C100DF00AC9A1E /* Queries */,
 				9BDF200D23FDC37600153E2B /* operationIdsPath.json */,
 				9BDF200E23FDC37600153E2B /* operationIDs.json */,
-				9BDF200F23FDC37600153E2B /* schema.json */,
-				9BDF201023FDC37600153E2B /* Repository.graphql */,
+				9BDF2EC824C100B600AC9A1E /* schema.docs.graphql */,
 				9BDF201123FDC37600153E2B /* API.swift */,
 				9BDF201223FDC37600153E2B /* Info.plist */,
 			);
@@ -1127,26 +1126,35 @@
 			path = Sources/GitHubAPI;
 			sourceTree = SOURCE_ROOT;
 		};
-		9BDF200823FDC37600153E2B /* TestFolder */ = {
+		9BDF2ECD24C100DF00AC9A1E /* Queries */ = {
 			isa = PBXGroup;
 			children = (
-				9BDF200923FDC37600153E2B /* TestFolder2 */,
+				9BDF2ECE24C100DF00AC9A1E /* TestFolder */,
+				9BDF2ED224C100DF00AC9A1E /* Repository.graphql */,
+			);
+			path = Queries;
+			sourceTree = "<group>";
+		};
+		9BDF2ECE24C100DF00AC9A1E /* TestFolder */ = {
+			isa = PBXGroup;
+			children = (
+				9BDF2ECF24C100DF00AC9A1E /* TestFolder2 */,
 			);
 			path = TestFolder;
 			sourceTree = "<group>";
 		};
-		9BDF200923FDC37600153E2B /* TestFolder2 */ = {
+		9BDF2ECF24C100DF00AC9A1E /* TestFolder2 */ = {
 			isa = PBXGroup;
 			children = (
-				9BDF200A23FDC37600153E2B /* TestFolder3 */,
+				9BDF2ED024C100DF00AC9A1E /* TestFolder3 */,
 			);
 			path = TestFolder2;
 			sourceTree = "<group>";
 		};
-		9BDF200A23FDC37600153E2B /* TestFolder3 */ = {
+		9BDF2ED024C100DF00AC9A1E /* TestFolder3 */ = {
 			isa = PBXGroup;
 			children = (
-				9BDF200B23FDC37600153E2B /* RepoURL.graphql */,
+				9BDF2ED124C100DF00AC9A1E /* RepoURL.graphql */,
 			);
 			path = TestFolder3;
 			sourceTree = "<group>";

--- a/Sources/Apollo/RequestCreator.swift
+++ b/Sources/Apollo/RequestCreator.swift
@@ -67,17 +67,8 @@ extension RequestCreator {
         preconditionFailure("To enable `autoPersistQueries`, Apollo types must be generated with operationIdentifiers")
       }
 
-      let hash: String
-      if operation.operationDefinition == operation.queryDocument {
-        // The codegen had everything it needed to generate the hash
-        hash = operationIdentifier
-      } else {
-        // The codegen needed more info for the correct hash - regenerate it.
-        hash = operation.queryDocument.apollo.sha256Hash
-      }
-
       body["extensions"] = [
-        "persistedQuery" : ["sha256Hash": hash, "version": 1]
+        "persistedQuery" : ["sha256Hash": operationIdentifier, "version": 1]
       ]
     }
 

--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -30,7 +30,7 @@ struct CLIDownloader {
   }
   
   /// The URL string for getting the current version of the CLI
-  static let downloadURLString = "https://install.apollographql.com/legacy-cli/darwin/2.28.3"
+  static let downloadURLString = "https://install.apollographql.com/legacy-cli/darwin/2.30.1"
   
   /// Downloads the appropriate Apollo CLI in a zip file.
   ///

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -25,7 +25,7 @@ struct CLIExtractor {
     }
   }
   
-  static let expectedSHASUM = "cb2f4b9f53eb8443661e7658e407a3837da3d781649f8bc66a1c6cf7d32acef1"
+  static let expectedSHASUM = "c2b1215eb8e82ec9d777f4b1590ed0f60960a23badadd889e4d129eb08866f14"
   
   /// Checks to see if the CLI has already been extracted and is the correct version, and extracts or re-extracts as necessary
   ///

--- a/Sources/GitHubAPI/API.swift
+++ b/Sources/GitHubAPI/API.swift
@@ -144,7 +144,7 @@ public final class RepositoryQuery: GraphQLQuery {
         }
 
         public struct Author: GraphQLSelectionSet {
-          public static let possibleTypes: [String] = ["EnterpriseUserAccount", "Organization", "User", "Bot", "Mannequin"]
+          public static let possibleTypes: [String] = ["Bot", "EnterpriseUserAccount", "Mannequin", "Organization", "User"]
 
           public static var selections: [GraphQLSelection] {
             return [
@@ -159,8 +159,16 @@ public final class RepositoryQuery: GraphQLQuery {
             self.resultMap = unsafeResultMap
           }
 
+          public static func makeBot(login: String) -> Author {
+            return Author(unsafeResultMap: ["__typename": "Bot", "login": login])
+          }
+
           public static func makeEnterpriseUserAccount(login: String) -> Author {
             return Author(unsafeResultMap: ["__typename": "EnterpriseUserAccount", "login": login])
+          }
+
+          public static func makeMannequin(login: String) -> Author {
+            return Author(unsafeResultMap: ["__typename": "Mannequin", "login": login])
           }
 
           public static func makeOrganization(login: String) -> Author {
@@ -169,14 +177,6 @@ public final class RepositoryQuery: GraphQLQuery {
 
           public static func makeUser(login: String) -> Author {
             return Author(unsafeResultMap: ["__typename": "User", "login": login])
-          }
-
-          public static func makeBot(login: String) -> Author {
-            return Author(unsafeResultMap: ["__typename": "Bot", "login": login])
-          }
-
-          public static func makeMannequin(login: String) -> Author {
-            return Author(unsafeResultMap: ["__typename": "Mannequin", "login": login])
           }
 
           public var __typename: String {
@@ -284,7 +284,7 @@ public final class RepositoryQuery: GraphQLQuery {
           }
 
           public struct Author: GraphQLSelectionSet {
-            public static let possibleTypes: [String] = ["EnterpriseUserAccount", "Organization", "User", "Bot", "Mannequin"]
+            public static let possibleTypes: [String] = ["Bot", "EnterpriseUserAccount", "Mannequin", "Organization", "User"]
 
             public static var selections: [GraphQLSelection] {
               return [
@@ -301,8 +301,16 @@ public final class RepositoryQuery: GraphQLQuery {
               self.resultMap = unsafeResultMap
             }
 
+            public static func makeBot(avatarUrl: String, login: String) -> Author {
+              return Author(unsafeResultMap: ["__typename": "Bot", "avatarUrl": avatarUrl, "login": login])
+            }
+
             public static func makeEnterpriseUserAccount(avatarUrl: String, login: String) -> Author {
               return Author(unsafeResultMap: ["__typename": "EnterpriseUserAccount", "avatarUrl": avatarUrl, "login": login])
+            }
+
+            public static func makeMannequin(avatarUrl: String, login: String) -> Author {
+              return Author(unsafeResultMap: ["__typename": "Mannequin", "avatarUrl": avatarUrl, "login": login])
             }
 
             public static func makeOrganization(avatarUrl: String, login: String) -> Author {
@@ -311,14 +319,6 @@ public final class RepositoryQuery: GraphQLQuery {
 
             public static func makeUser(avatarUrl: String, login: String) -> Author {
               return Author(unsafeResultMap: ["__typename": "User", "avatarUrl": avatarUrl, "login": login])
-            }
-
-            public static func makeBot(avatarUrl: String, login: String) -> Author {
-              return Author(unsafeResultMap: ["__typename": "Bot", "avatarUrl": avatarUrl, "login": login])
-            }
-
-            public static func makeMannequin(avatarUrl: String, login: String) -> Author {
-              return Author(unsafeResultMap: ["__typename": "Mannequin", "avatarUrl": avatarUrl, "login": login])
             }
 
             public var __typename: String {

--- a/Sources/StarWarsAPI/API.swift
+++ b/Sources/StarWarsAPI/API.swift
@@ -1048,7 +1048,7 @@ public final class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "1d3ad903dad146ff9d7aa09813fc01becd017489bfc1af8ffd178498730a5a26"
 
-  public var queryDocument: String { return operationDefinition.appending(FriendsNames.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + FriendsNames.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -1241,7 +1241,7 @@ public final class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "e02ef22e116ad1ca35f0298ed3badb60eeb986203f0088575a5f137768c322fc"
 
-  public var queryDocument: String { return operationDefinition.appending(CharacterName.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + CharacterName.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -1636,7 +1636,7 @@ public final class HeroAppearsInWithFragmentQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "1756158bd7736d58db45a48d74a724fa1b6fdac735376df8afac8318ba5431fb"
 
-  public var queryDocument: String { return operationDefinition.appending(CharacterAppearsIn.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + CharacterAppearsIn.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -2299,7 +2299,7 @@ public final class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "b31aec7d977249e185922e4cc90318fd2c7197631470904bf937b0626de54b4f"
 
-  public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + HeroDetails.fragmentDefinition) }
 
   public var includeDetails: Bool
 
@@ -3485,7 +3485,7 @@ public final class HeroDetailsWithFragmentQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "d20fa2f460058b8eec3d227f2f6088a708cf35dfa2b5ebf1414e34f9674ecfce"
 
-  public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + HeroDetails.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -3801,7 +3801,7 @@ public final class DroidDetailsWithFragmentQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "7277e97563e911ac8f5c91d401028d218aae41f38df014d7fa0b037bb2a2e739"
 
-  public var queryDocument: String { return operationDefinition.appending(DroidDetails.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + DroidDetails.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -4432,7 +4432,7 @@ public final class HeroNameWithFragmentQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "b952f0054915a32ec524ac0dde0244bcda246649debe149f9e32e303e21c8266"
 
-  public var queryDocument: String { return operationDefinition.appending(CharacterName.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + CharacterName.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -4562,7 +4562,7 @@ public final class HeroNameWithFragmentAndIdQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "a87a0694c09d1ed245e9a80f245d96a5f57b20a4aa936ee9ab09b2a43620db02"
 
-  public var queryDocument: String { return operationDefinition.appending(CharacterName.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + CharacterName.fragmentDefinition) }
 
   public var episode: Episode?
 
@@ -4702,7 +4702,7 @@ public final class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
 
   public let operationIdentifier: String? = "0664fed3eb4f9fbdb44e8691d9e8fd11f2b3c097ba11327592054f602bd3ba1a"
 
-  public var queryDocument: String { return operationDefinition.appending(CharacterNameAndAppearsIn.fragmentDefinition) }
+  public var queryDocument: String { return operationDefinition.appending("\n" + CharacterNameAndAppearsIn.fragmentDefinition) }
 
   public var episode: Episode?
 

--- a/Sources/StarWarsAPI/operationIDs.json
+++ b/Sources/StarWarsAPI/operationIDs.json
@@ -25,11 +25,11 @@
   },
   "1d3ad903dad146ff9d7aa09813fc01becd017489bfc1af8ffd178498730a5a26": {
     "name": "HeroAndFriendsNamesWithFragment",
-    "source": "query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ...FriendsNames\n  }\n}"
+    "source": "query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ...FriendsNames\n  }\n}\nfragment FriendsNames on Character {\n  __typename\n  friends {\n    __typename\n    name\n  }\n}"
   },
   "e02ef22e116ad1ca35f0298ed3badb60eeb986203f0088575a5f137768c322fc": {
     "name": "HeroAndFriendsNamesWithFragmentTwice",
-    "source": "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      ...CharacterName\n    }\n    ... on Droid {\n      friends {\n        __typename\n        ...CharacterName\n      }\n    }\n  }\n}"
+    "source": "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      ...CharacterName\n    }\n    ... on Droid {\n      friends {\n        __typename\n        ...CharacterName\n      }\n    }\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
   },
   "22d772c0fc813281705e8f0a55fc70e71eeff6e98f3f9ef96cf67fb896914522": {
     "name": "HeroAppearsIn",
@@ -37,7 +37,7 @@
   },
   "1756158bd7736d58db45a48d74a724fa1b6fdac735376df8afac8318ba5431fb": {
     "name": "HeroAppearsInWithFragment",
-    "source": "query HeroAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterAppearsIn\n  }\n}"
+    "source": "query HeroAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterAppearsIn\n  }\n}\nfragment CharacterAppearsIn on Character {\n  __typename\n  appearsIn\n}"
   },
   "3dd42259adf2d0598e89e0279bee2c128a7913f02b1da6aa43f3b5def6a8a1f8": {
     "name": "HeroNameConditionalExclusion",
@@ -61,7 +61,7 @@
   },
   "b31aec7d977249e185922e4cc90318fd2c7197631470904bf937b0626de54b4f": {
     "name": "HeroDetailsFragmentConditionalInclusion",
-    "source": "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ...HeroDetails @include(if: $includeDetails)\n  }\n}"
+    "source": "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ...HeroDetails @include(if: $includeDetails)\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    height\n  }\n  ... on Droid {\n    primaryFunction\n  }\n}"
   },
   "4d465fbc6e3731d011025048502f16278307d73300ea9329a709d7e2b6815e40": {
     "name": "HeroNameTypeSpecificConditionalInclusion",
@@ -81,11 +81,11 @@
   },
   "d20fa2f460058b8eec3d227f2f6088a708cf35dfa2b5ebf1414e34f9674ecfce": {
     "name": "HeroDetailsWithFragment",
-    "source": "query HeroDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...HeroDetails\n  }\n}"
+    "source": "query HeroDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...HeroDetails\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    height\n  }\n  ... on Droid {\n    primaryFunction\n  }\n}"
   },
   "7277e97563e911ac8f5c91d401028d218aae41f38df014d7fa0b037bb2a2e739": {
     "name": "DroidDetailsWithFragment",
-    "source": "query DroidDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...DroidDetails\n  }\n}"
+    "source": "query DroidDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...DroidDetails\n  }\n}\nfragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}"
   },
   "37cd5626048e7243716ffda9e56503939dd189772124a1c21b0e0b87e69aae01": {
     "name": "HeroFriendsOfFriendsNames",
@@ -101,15 +101,15 @@
   },
   "b952f0054915a32ec524ac0dde0244bcda246649debe149f9e32e303e21c8266": {
     "name": "HeroNameWithFragment",
-    "source": "query HeroNameWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterName\n  }\n}"
+    "source": "query HeroNameWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterName\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
   },
   "a87a0694c09d1ed245e9a80f245d96a5f57b20a4aa936ee9ab09b2a43620db02": {
     "name": "HeroNameWithFragmentAndID",
-    "source": "query HeroNameWithFragmentAndID($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    ...CharacterName\n  }\n}"
+    "source": "query HeroNameWithFragmentAndID($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    ...CharacterName\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
   },
   "0664fed3eb4f9fbdb44e8691d9e8fd11f2b3c097ba11327592054f602bd3ba1a": {
     "name": "HeroNameAndAppearsInWithFragment",
-    "source": "query HeroNameAndAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterNameAndAppearsIn\n  }\n}"
+    "source": "query HeroNameAndAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterNameAndAppearsIn\n  }\n}\nfragment CharacterNameAndAppearsIn on Character {\n  __typename\n  name\n  appearsIn\n}"
   },
   "561e22ac4da5209f254779b70e01557fb2fc57916b9914088429ec809e166cad": {
     "name": "HeroParentTypeDependentField",

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-ZIP_FILE_DOWNLOAD_URL="https://install.apollographql.com/legacy-cli/darwin/2.28.3"
+ZIP_FILE_DOWNLOAD_URL="https://install.apollographql.com/legacy-cli/darwin/2.30.1"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
 IS_RETRY="false"
@@ -58,7 +58,7 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="cb2f4b9f53eb8443661e7658e407a3837da3d781649f8bc66a1c6cf7d32acef1"
+  EXPECTED_SHASUM="c2b1215eb8e82ec9d777f4b1590ed0f60960a23badadd889e4d129eb08866f14"
   update_shasum
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then


### PR DESCRIPTION
In this PR: 
- Update JS CLI to 2.30.1 to grab some new fixes to code generation with fragments [Tooling-#2017] (https://github.com/apollographql/apollo-tooling/pull/2017)
- Removes an unnecessary workaround thanks to the codegen fixes 🎉  (thanks @darrenclark and @manicmaniac) 