### PR TITLE
Add workaround for Optional JSONEncoding errors

### DIFF
--- a/Sources/Apollo/JSONStandardTypeConversions.swift
+++ b/Sources/Apollo/JSONStandardTypeConversions.swift
@@ -105,6 +105,22 @@ extension Optional: JSONEncodable {
       return NSNull()
     case .some(let wrapped as JSONEncodable):
       return wrapped.jsonValue
+      
+    // WORKAROUND: For reasons I don't totally understand, when the underlying type is `Any`,
+    // even though all of these conform to `JSONEncodable`, the `as JSONEncodable` above
+    //  fails, and we need to handle them individually.
+    case .some(let wrapped as String):
+      return wrapped.jsonValue
+    case .some(let wrapped as Int):
+      return wrapped.jsonValue
+    case .some(let wrapped as Double):
+      return wrapped.jsonValue
+    case .some(let wrapped as Bool):
+      return wrapped.jsonValue
+    case .some(let wrapped as [String: Any?]):
+      return wrapped.jsonValue
+    case .some(let wrapped as [Any?]):
+      return wrapped.jsonValue
     default:
       fatalError("Optional is only JSONEncodable if Wrapped is")
     }

--- a/Sources/Apollo/JSONStandardTypeConversions.swift
+++ b/Sources/Apollo/JSONStandardTypeConversions.swift
@@ -145,6 +145,16 @@ extension Dictionary: JSONEncodable {
   }
 }
 
+extension Dictionary: JSONDecodable {
+    public init(jsonValue value: JSONValue) throws {
+        guard let dictionary = value as? Dictionary else {
+            throw JSONDecodingError.couldNotConvert(value: value, to: Dictionary.self)
+        }
+        
+        self = dictionary
+    }
+}
+
 extension Array: JSONEncodable {
   public var jsonValue: JSONValue {
     return map() { element -> (JSONValue) in

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -38,4 +38,48 @@ class JSONTests: XCTestCase {
     XCTAssertFalse(value ~= JSONDecodingError.nullValue)
     XCTAssertFalse(value ~= JSONDecodingError.missingValue)
   }
+  
+  func testJSONDictionaryEncodingAndDecoding() throws {
+    let jsonString = """
+{
+  "a_dict": {
+    "a_bool": true,
+    "another_dict" : {
+      "a_double": 23.1,
+      "an_int": 8,
+      "a_string": "LOL wat"
+    },
+    "an_array": [
+      "one",
+      "two",
+      "three"
+    ],
+    "a_null": null
+  }
+}
+"""
+    let data = try XCTUnwrap(jsonString.data(using: .utf8))
+    let json = try JSONSerializationFormat.deserialize(data: data)
+    XCTAssertNotNil(json)
+    
+    let dict = try Dictionary<String, Any?>(jsonValue: json)
+    XCTAssertNotNil(dict)
+    
+    let moarData = try JSONSerializationFormat.serialize(value: dict)
+    XCTAssertNotNil(moarData)
+    
+    print(String(bytes: moarData, encoding: .utf8)!)
+  }
+  
+
+}
+
+extension Dictionary: JSONDecodable {
+    public init(jsonValue value: JSONValue) throws {
+        guard let dictionary = value as? Dictionary else {
+            throw JSONDecodingError.couldNotConvert(value: value, to: Dictionary.self)
+        }
+        
+        self = dictionary
+    }
 }

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -74,13 +74,3 @@ class JSONTests: XCTestCase {
 """)
   }
 }
-
-extension Dictionary: JSONDecodable {
-    public init(jsonValue value: JSONValue) throws {
-        guard let dictionary = value as? Dictionary else {
-            throw JSONDecodingError.couldNotConvert(value: value, to: Dictionary.self)
-        }
-        
-        self = dictionary
-    }
-}

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -65,13 +65,14 @@ class JSONTests: XCTestCase {
     let dict = try Dictionary<String, Any?>(jsonValue: json)
     XCTAssertNotNil(dict)
     
-    let moarData = try JSONSerializationFormat.serialize(value: dict)
-    XCTAssertNotNil(moarData)
+    let reserialized = try JSONSerializationFormat.serialize(value: dict)
+    XCTAssertNotNil(reserialized)
     
-    print(String(bytes: moarData, encoding: .utf8)!)
+    let stringFromReserialized = try XCTUnwrap(String(bytes: reserialized, encoding: .utf8))
+    XCTAssertEqual(stringFromReserialized, """
+{"a_dict":{"a_bool":1,"a_null":null,"an_array":["one","two","three"],"another_dict":{"a_double":23.100000000000001,"a_string":"LOL wat","an_int":8}}}
+""")
   }
-  
-
 }
 
 extension Dictionary: JSONDecodable {


### PR DESCRIPTION
This is basically a band-aid on #1305 and similar bugs, which could occur when using a custom JSON scalar and trying to persist it to the cache. If the type of the typealiased JSON was `[String: Any?]`, which is expected, the `as JSONEncodable` would fail to recognize several types that have that conformance in an extension, and those types need to be unwrapped manually. 

This is a band-aid rather than a permanent fix because once I can get the Swift codegen stuff going again, I'm going to rip all this `JSONEncodable` stuff out in favor of a `Codable` solution (you can see a preview of the more flexible part of this in [the JSON type I'm using in the Codegen lib](https://github.com/apollographql/apollo-ios/blob/main/Sources/ApolloCodegenLib/JSON.swift)).  

But that's gonna be a hot minute, so band-aid it is!