### PR TITLE
Tweaks to Websocket tests

### DIFF
--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -26,6 +26,17 @@ class StarWarsSubscriptionTests: XCTestCase {
     self.wait(for: [self.connectionStartedExpectation!], timeout: 5)
   }
   
+  private func waitForSubscriptionsToStart(for delay: TimeInterval = 0.1, on queue: DispatchQueue = .main) {
+    /// This method works around changes to the subscriptions package which mean that subscriptions do not start passing on data the absolute instant they are created.
+    let waitExpectation = self.expectation(description: "Waited!")
+    
+    queue.asyncAfter(deadline: .now() + delay) {
+      waitExpectation.fulfill()
+    }
+    
+    self.wait(for: [waitExpectation], timeout: delay + 1)
+  }
+  
   // MARK: Subscriptions
   
   func testSubscribeReviewJediEpisode() {
@@ -52,6 +63,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       }
     }
     
+    self.waitForSubscriptionsToStart()
+        
     client.perform(mutation: CreateReviewForEpisodeMutation(episode: .jedi, review: ReviewInput(stars: 6, commentary: "This is the greatest movie!")))
     
     waitForExpectations(timeout: 10, handler: nil)
@@ -80,6 +93,8 @@ class StarWarsSubscriptionTests: XCTestCase {
         XCTFail("Unexpected error: \(error)")
       }
     }
+    
+    self.waitForSubscriptionsToStart()
     
     client.perform(mutation: CreateReviewForEpisodeMutation(episode: .empire, review: ReviewInput(stars: 13, commentary: "This is an even greater movie!")))
     
@@ -110,6 +125,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       }
     }
     
+    self.waitForSubscriptionsToStart()
+    
     client.perform(mutation: CreateReviewForEpisodeMutation(episode: .empire, review: ReviewInput(stars: 10, commentary: "This is an even greater movie!")))
     
     waitForExpectations(timeout: 3, handler: nil)
@@ -123,6 +140,8 @@ class StarWarsSubscriptionTests: XCTestCase {
     let sub = client.subscribe(subscription: ReviewAddedSubscription(episode: .jedi)) { _ in
       XCTFail("Received subscription after cancel")
     }
+    
+    self.waitForSubscriptionsToStart()
     
     sub.cancel()
     
@@ -154,6 +173,8 @@ class StarWarsSubscriptionTests: XCTestCase {
         XCTFail("Unexpected error: \(error)")
       }
     }
+    
+    self.waitForSubscriptionsToStart()
 
     for i in 1...count {
       let review = ReviewInput(stars: i, commentary: "The greatest movie ever!")
@@ -230,6 +251,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       newHopeFulfilledCount += 1
     }
     
+    self.waitForSubscriptionsToStart()
+    
     let episodes : [Episode] = [.empire, .jedi, .newhope]
     
     var selectedEpisodes = [Episode]()
@@ -287,6 +310,8 @@ class StarWarsSubscriptionTests: XCTestCase {
       }
     }
     
+    self.waitForSubscriptionsToStart(on: concurrentQueue)
+    
     // dispatched with a barrier flag to make sure
     // this is performed after subscription calls
     concurrentQueue.sync(flags: .barrier) {
@@ -317,7 +342,9 @@ class StarWarsSubscriptionTests: XCTestCase {
     let sub2 = client.subscribe(subscription: secondSubscription) { _ in
       invertedExpectation.fulfill()
     }
-        
+    
+    self.waitForSubscriptionsToStart(on: concurrentQueue)
+    
     concurrentQueue.async {
       sub1.cancel()
       expectation.fulfill()
@@ -343,6 +370,8 @@ class StarWarsSubscriptionTests: XCTestCase {
     let sub = self.client.subscribe(subscription: empireReviewSubscription) { _ in
       invertedExpectation.fulfill()
     }
+    
+    self.waitForSubscriptionsToStart(on: concurrentQueue)
     
     concurrentQueue.async {
       sub.cancel()
@@ -386,5 +415,4 @@ extension StarWarsSubscriptionTests: WebSocketTransportDelegate {
   func webSocketTransportDidConnect(_ webSocketTransport: WebSocketTransport) {
     self.connectionStartedExpectation?.fulfill()
   }
-  
 }

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -11,12 +11,19 @@ class StarWarsSubscriptionTests: XCTestCase {
   var client: ApolloClient!
   var webSocketTransport: WebSocketTransport!
   
+  var connectionStartedExpectation: XCTestExpectation?
+  
   override func setUp() {
     super.setUp()
     
+    self.connectionStartedExpectation = self.expectation(description: "Web socket connected")
+    
     WebSocketTransport.provider = ApolloWebSocket.self
     webSocketTransport = WebSocketTransport(request: URLRequest(url: URL(string: SERVER)!))
+    webSocketTransport.delegate = self
     client = ApolloClient(networkTransport: webSocketTransport)
+
+    self.wait(for: [self.connectionStartedExpectation!], timeout: 5)
   }
   
   // MARK: Subscriptions
@@ -372,4 +379,12 @@ class StarWarsSubscriptionTests: XCTestCase {
     
     waitForExpectations(timeout: 10, handler: nil)
   }
+}
+
+extension StarWarsSubscriptionTests: WebSocketTransportDelegate {
+  
+  func webSocketTransportDidConnect(_ webSocketTransport: WebSocketTransport) {
+    self.connectionStartedExpectation?.fulfill()
+  }
+  
 }


### PR DESCRIPTION
We've been having a lot of back and forth in the [StarWars Server repo](https://github.com/apollographql/starwars-server) because upgrades made in that repo to patch security vulnerabiliteis were causing test failures in this repo's web socket tests. 
We've traced this back to [this change in `graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions/commit/c8a7f7cf4897c479d15631c9a9039dba93054a80), made over a year ago. Basically what these changes meant was that until `subscribe` was actually called, the listener for changes wasn't really ready. 

Working with subscriptions locally in current versions of `graphql-subscriptions`, you can get notified of when the subscription enters a ready state, but that information isn't propagated back to the iOS SDK. The iOS SDK only receives callbacks when a new piece of data comes down the pipe from the subscription. This meant that several of our concurrent tests or tests which relied on multiple subscriptions would fail, since not all subscriptions would be ready if we threw a ton of things at the server concurrently. 

The problem is that without a significant change to allow some kind of `subscription ready` information to be passed along to the iOS SDK, there's no way to know for sure when a specific subscription is ready, and test failures become indeterminate. The change also has been in place for long enough on the `graphql-subscriptions` side that reverting it willy-nilly could cause significant problems for other repos. 

The workaround for this is basically: Wait a tenth of a second after calling `subscribe` to make sure subscriptions actually are ready before we start throwing data down the pipe to be handled by the subscriptions. In a real world environment, this kind of delay is expected, but it does make me a little itchy to be doing this in tests. Ultimately, though, what we're testing is essentially the same: When subscriptions are created and then more data is sent, do the subscriptions receive the correct data (or not receive it, if those subscriptions have been cancelled)? So I'll put on my calamine lotion and deal with this one unless someone's got a better suggestion. 

Big thanks to @abernix and @hwillson for all their help troubleshooting this. 