### PR TITLE
Add initializer that takes database Connection

### DIFF
--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -31,6 +31,18 @@ public final class SQLiteNormalizedCache {
     try self.createTableIfNeeded()
   }
 
+  ///
+  /// Initializer that takes the Connection to use
+  /// - Parameters:
+  ///   - db: The database Connection to use
+  ///   - shouldVacuumOnClear: If the database should also be `VACCUM`ed on clear to remove all traces of info. Defaults to `false` since this involves a performance hit, but this should be used if you are storing any Personally Identifiable Information in the cache.
+  /// - Throws: Any errors attempting to access the database
+  public init(db: Connection, shouldVacuumOnClear: Bool = false) throws {
+    self.shouldVacuumOnClear = shouldVacuumOnClear
+    self.db = db
+    try self.createTableIfNeeded()
+  }
+
   private func recordCacheKey(forFieldCacheKey fieldCacheKey: CacheKey) -> CacheKey {
     let components = fieldCacheKey.components(separatedBy: ".")
     var updatedComponents = [String]()

--- a/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
+++ b/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import ApolloTestSupport
 import ApolloSQLiteTestSupport
 import StarWarsAPI
+import SQLite
 
 class CachePersistenceTests: XCTestCase {
 
@@ -57,6 +58,10 @@ class CachePersistenceTests: XCTestCase {
       
       self.waitForExpectations(timeout: 2, handler: nil)
     }
+  }
+
+  func testPassInConnectionDoesNotThrow() {
+    XCTAssertNoThrow(try SQLiteNormalizedCache(db: Connection()))
   }
 
   func testClearCache() {


### PR DESCRIPTION
### Updated SQLiteNormalizedCache
Because:
- It will allow consumers to further configure the Connection in their
application and pass it in
- See: https://github.com/apollographql/apollo-ios/pull/1162/files#r410367735

This commit:
- Adds a new initializer to SQLiteNormalizedCache