### PR TITLE
Address retain cycle with URLSessionClient

### DIFF
--- a/Sources/Apollo/HTTPNetworkTransport.swift
+++ b/Sources/Apollo/HTTPNetworkTransport.swift
@@ -141,6 +141,10 @@ public class HTTPNetworkTransport {
     self.useGETForPersistedQueryRetry = useGETForPersistedQueryRetry
     self.requestCreator = requestCreator
   }
+  
+  deinit {
+    self.client.invalidate()
+  }
 
   private func send<Operation: GraphQLOperation>(operation: Operation,
                                                  isPersistedQueryRetry: Bool,

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -57,8 +57,13 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
                               delegateQueue: callbackQueue)
   }
   
-  deinit {
+  /// Cleans up and invalidates everything related to this session client.
+  ///
+  /// NOTE: This must be called from the `deinit` of anything holding onto this client in order to break a retain cycle with the delegate.
+  public func invalidate() {
     self.clearAllTasks()
+    self.session.invalidateAndCancel()
+    self.session = nil
   }
   
   /// Clears underlying dictionaries of any data related to a particular task identifier.

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -62,7 +62,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   /// NOTE: This must be called from the `deinit` of anything holding onto this client in order to break a retain cycle with the delegate.
   public func invalidate() {
     self.clearAllTasks()
-    self.session.invalidateAndCancel()
+    self.session?.invalidateAndCancel()
     self.session = nil
   }
   


### PR DESCRIPTION
Addresses #1362 (at least partially) and #1292 (I believe in full). 

The `URLSessionClient` object holding on to the `URLSession` and being its delegate creates a retain cycle. However, hanging on to the `URLSession` weakly doesn't work either, because it's just immediately deallocated: 

<img width="991" alt="Screen Shot 2020-08-20 at 1 00 22 PM" src="https://user-images.githubusercontent.com/1976498/90808321-70700880-e2e5-11ea-9f22-59714aaa37f3.png">

The somewhat inelegant solution is that you have to manually invalidate the `URLSessionClient` and stop holding on to the `URLSession`. Fortunately for most people, we can have `HTTPNetworkClient` do this without them having to think about it. This does mean if you're using `URLSession` outside `HTTPNetworkClient` you need to remember to do this, but for now I think that should be an edge case. 