### PR TITLE
Add extensions property to GraphQLResult.

### DIFF
--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -175,6 +175,7 @@ public final class ApolloStore {
                                      accumulator: zip(mapper, dependencyTracker))
     }.map { (data: Query.Data, dependentKeys: Set<CacheKey>) in
       GraphQLResult(data: data,
+                    extensions: nil,
                     errors: nil,
                     source:.cache,
                     dependentKeys: dependentKeys)

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -30,6 +30,7 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet> {
       let mapper = GraphQLSelectionSetMapper<Data>()
       let normalizer = GraphQLResultNormalizer()
       let dependencyTracker = GraphQLDependencyTracker()
+      let extensions = body["extensions"] as? JSONObject
 
       return firstly {
         try executor.execute(selections: Data.selections,
@@ -40,15 +41,17 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet> {
         }.map { (data, records, dependentKeys) in
           (
             GraphQLResult(data: data,
-                         errors: errors,
-                         source: .server,
-                         dependentKeys: dependentKeys),
+                          extensions: extensions,
+                          errors: errors,
+                          source: .server,
+                          dependentKeys: dependentKeys),
             records
           )
       }
     } else {
       return Promise(fulfilled: (
         GraphQLResult(data: nil,
+                      extensions: nil,
                       errors: errors,
                       source: .server,
                       dependentKeys: nil),
@@ -72,13 +75,16 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet> {
       let data = try decode(selectionSet: Data.self,
                             from: dataEntry,
                             variables: variables)
+      let extensions = body["extensions"] as? JSONObject
 
       return GraphQLResult(data: data,
+                           extensions: extensions,
                            errors: errors,
                            source: .server,
                            dependentKeys: nil)
     } else {
       return GraphQLResult(data: nil,
+                           extensions: nil,
                            errors: errors,
                            source: .server,
                            dependentKeys: nil)

--- a/Sources/Apollo/GraphQLResult.swift
+++ b/Sources/Apollo/GraphQLResult.swift
@@ -4,6 +4,8 @@ public struct GraphQLResult<Data> {
   public let data: Data?
   /// A list of errors, or `nil` if the operation completed without encountering any errors.
   public let errors: [GraphQLError]?
+  /// A dictionary which services can use however they see fit to provide additional information to clients.
+  public let extensions: [String: Any]?
 
   /// Represents source of data
   public enum Source {
@@ -16,10 +18,12 @@ public struct GraphQLResult<Data> {
   let dependentKeys: Set<CacheKey>?
 
   public init(data: Data?,
+              extensions: [String: Any]?,
               errors: [GraphQLError]?,
               source: Source,
               dependentKeys: Set<CacheKey>?) {
     self.data = data
+    self.extensions = extensions
     self.errors = errors
     self.source = source
     self.dependentKeys = dependentKeys

--- a/Tests/ApolloTests/ParseQueryResponseTests.swift
+++ b/Tests/ApolloTests/ParseQueryResponseTests.swift
@@ -314,6 +314,60 @@ class ParseQueryResponseTests: XCTestCase {
     }
   }
   
+  func testExtensionsEntryNotNullWhenProvidedInResponseAccompanyingDataEntry() throws {
+    let query = HumanQuery(id: "9999")
+
+    let response = GraphQLResponse(operation: query, body: [
+      "data": ["human": NSNull()],
+      "extensions": [:]
+    ])
+
+    let (result, _) = try response.parseResult().await()
+
+    XCTAssertNotNil(result.extensions)
+  }
+
+  func testExtensionsValuesWhenPopulatedInResponse() throws {
+    let query = HumanQuery(id: "9999")
+
+    let response = GraphQLResponse(operation: query, body: [
+      "data": ["human": NSNull()],
+      "extensions": ["parentKey": ["childKey": "someValue"]]
+    ])
+
+    let (result, _) = try response.parseResult().await()
+    let extensionsDictionary = result.extensions
+    let childDictionary = extensionsDictionary?["parentKey"] as? JSONObject
+
+    XCTAssertNotNil(extensionsDictionary)
+    XCTAssertNotNil(childDictionary)
+    XCTAssertEqual(childDictionary, ["childKey": "someValue"])
+  }
+
+  func testExtensionsEntryNullWhenNotProvidedInResponse() throws {
+    let query = HumanQuery(id: "9999")
+
+    let response = GraphQLResponse(operation: query, body: [
+      "data": ["human": NSNull()]
+    ])
+
+    let (result, _) = try response.parseResult().await()
+
+    XCTAssertNil(result.extensions)
+  }
+
+  func testExtensionsEntryNullWhenDataEntryNotProvidedInResponse() throws {
+    let query = HumanQuery(id: "9999")
+
+    let response = GraphQLResponse(operation: query, body: [
+      "extensions": [:]
+    ])
+
+    let (result, _) = try response.parseResult().await()
+
+    XCTAssertNil(result.extensions)
+  }
+
   // MARK: Mutations
   
   func testCreateReviewForEpisode() throws {

--- a/Tests/ApolloTests/ParseQueryResponseTests.swift
+++ b/Tests/ApolloTests/ParseQueryResponseTests.swift
@@ -356,7 +356,7 @@ class ParseQueryResponseTests: XCTestCase {
     XCTAssertNil(result.extensions)
   }
 
-  func testExtensionsEntryNullWhenDataEntryNotProvidedInResponse() throws {
+  func testExtensionsEntryNotNullWhenDataEntryNotProvidedInResponse() throws {
     let query = HumanQuery(id: "9999")
 
     let response = GraphQLResponse(operation: query, body: [
@@ -365,7 +365,7 @@ class ParseQueryResponseTests: XCTestCase {
 
     let (result, _) = try response.parseResult().await()
 
-    XCTAssertNil(result.extensions)
+    XCTAssertNotNil(result.extensions)
   }
 
   // MARK: Mutations


### PR DESCRIPTION
- Added extensions property to GraphQLResult.
- Updated references.
- Implemented tests in ParseQueryResponseTests.

Addresses issue: [1348](https://github.com/apollographql/apollo-ios/issues/1348)