### PR TITLE
Make response parsing helpers public

### DIFF
--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -57,7 +57,7 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet> {
     }
   }
 
-  func parseErrorsOnlyFast() -> [GraphQLError]? {
+  public func parseErrorsOnlyFast() -> [GraphQLError]? {
     guard let errorsEntry = self.body["errors"] as? [JSONObject] else {
       return nil
     }
@@ -65,7 +65,7 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet> {
     return errorsEntry.map(GraphQLError.init)
   }
 
-  func parseResultFast() throws -> GraphQLResult<Data>  {
+  public func parseResultFast() throws -> GraphQLResult<Data>  {
     let errors = self.parseErrorsOnlyFast()
 
     if let dataEntry = body["data"] as? JSONObject {


### PR DESCRIPTION
When extending the functionality of Apollo to perform custom logging or other behavior on requests, these functions would be useful to have access to. In particular, making `parseResultFast()` public enables `decode` to remain internal while still giving users the ability to parse GraphQL responses. Making `parseErrorsOnlyFast()` is less significant, however it still would be helpful to centralize the hardcoding of the "errors" key to this one function rather than hardcoding it in both the Apollo codebase and Apollo users' codebases.