### PR TITLE
flip cleanup order to avoid hitting assert in race condition

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -61,9 +61,9 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// NOTE: This must be called from the `deinit` of anything holding onto this client in order to break a retain cycle with the delegate.
   public func invalidate() {
-    self.clearAllTasks()
     self.session?.invalidateAndCancel()
     self.session = nil
+    self.clearAllTasks()
   }
   
   /// Clears underlying dictionaries of any data related to a particular task identifier.


### PR DESCRIPTION
I think this fixes https://github.com/apollographql/apollo-ios/issues/1376