### PR TITLE
Manual cancellation of in-flight operations

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -74,10 +74,10 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
     
     let currentTaskIDs = self.tasks.value.keys
     if #available(OSX 10.11, *) {
-      session.getAllTasks { tasks in
+      session.getAllTasks { [weak self] tasks in
         for task in tasks {
           if currentTaskIDs.contains(task.taskIdentifier) {
-            task.cancel()
+            self?.cancel(task: task)
           }
         }
         

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -101,6 +101,11 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// Mostly useful for cleanup and/or after invalidation of the `URLSession`.
   open func clearAllTasks() {
+    guard self.tasks.value.apollo.isNotEmpty else {
+      // Nothing to clear
+      return
+    }
+    
     self.tasks.mutate { $0.removeAll() }
   }
   


### PR DESCRIPTION
This should address #1376 - when a session was being invalidated, its in-flight tasks weren't being cancelled before being removed from the list of active tasks on `URLSessionClient`. Why not, since we were calling `invalidateAndCancel`, which is supposed to cancel active tasks? Turns out there's one verrrry important piece of information that only lives on the web docs: 

<img width="779" alt="Screen Shot 2020-09-08 at 1 58 23 PM" src="https://user-images.githubusercontent.com/1976498/92518254-a6662580-f1dd-11ea-85a8-6633b53fe7e3.png">

Now, we're going through and actually cancelling all the tasks that are from the `URLSessionClient` before clearing out the array of active tasks. That should prevent tasks from calling back at a point where the assertion failure being hit in #1376 gets hit. 