### PR TITLE
Upgrade Starscream library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
       .upToNextMinor(from: "0.12.2")),
     .package(
       url: "https://github.com/daltoniam/Starscream",
-      .upToNextMinor(from: "3.1.1")),
+      .upToNextMinor(from: "4.0.4")),
     .package(
       url: "https://github.com/stencilproject/Stencil.git",
       .upToNextMinor(from: "0.13.1")),

--- a/SwiftScripts/Package.resolved
+++ b/SwiftScripts/Package.resolved
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream",
         "state": {
           "branch": null,
-          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
-          "version": "3.1.1"
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
         }
       },
       {
@@ -125,15 +125,6 @@
           "branch": null,
           "revision": "f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb",
           "version": "0.1.1"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
         }
       },
       {


### PR DESCRIPTION
Upgraded the Starscream library to use the newer 4.x version of Starscream, which also gets rid of a transient dependency. 