### PR TITLE
Update Stencil to 0.14.0

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -3076,7 +3076,7 @@
 			repositoryURL = "https://github.com/stencilproject/Stencil.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.13.1;
+				minimumVersion = 0.14.0;
 			};
 		};
 		9B7BDAAA23FDEA7B00ACD198 /* XCRemoteSwiftPackageReference "Starscream" */ = {

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
-          "version": "0.13.1"
+          "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
+          "version": "0.14.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
       .upToNextMinor(from: "3.1.1")),
     .package(
       url: "https://github.com/stencilproject/Stencil.git",
-      .upToNextMinor(from: "0.13.1")),
+      .upToNextMinor(from: "0.14.0")),
     ],
     targets: [
       .target(


### PR DESCRIPTION
OK, this time actually tested in full. This should fix a couple build warnings in Xcode 12. 