### PR TITLE
Networking Beta Tweaks

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9B260C04245A090600562176 /* RequestChainNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B260C03245A090600562176 /* RequestChainNetworkTransport.swift */; };
 		9B260C08245A437400562176 /* InterceptorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B260C07245A437400562176 /* InterceptorProvider.swift */; };
 		9B260C0A245A532500562176 /* LegacyParsingInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B260C09245A532500562176 /* LegacyParsingInterceptor.swift */; };
+		9B2B66F42513FAFE00B53ABF /* CancellationHandlingInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2B66F32513FAFE00B53ABF /* CancellationHandlingInterceptor.swift */; };
 		9B2DFBBF24E1FA1A00ED3AE6 /* Apollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FC750441D2A532C00458D91 /* Apollo.framework */; };
 		9B2DFBC024E1FA1A00ED3AE6 /* Apollo.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9FC750441D2A532C00458D91 /* Apollo.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9B2DFBC724E1FA4800ED3AE6 /* UploadAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B2DFBC524E1FA3E00ED3AE6 /* UploadAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -491,6 +492,7 @@
 		9B260C03245A090600562176 /* RequestChainNetworkTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestChainNetworkTransport.swift; sourceTree = "<group>"; };
 		9B260C07245A437400562176 /* InterceptorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterceptorProvider.swift; sourceTree = "<group>"; };
 		9B260C09245A532500562176 /* LegacyParsingInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyParsingInterceptor.swift; sourceTree = "<group>"; };
+		9B2B66F32513FAFE00B53ABF /* CancellationHandlingInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellationHandlingInterceptor.swift; sourceTree = "<group>"; };
 		9B2DFBB624E1FA0D00ED3AE6 /* UploadAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UploadAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B2DFBC524E1FA3E00ED3AE6 /* UploadAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UploadAPI.h; sourceTree = "<group>"; };
 		9B2DFBC624E1FA3E00ED3AE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -627,10 +629,10 @@
 		9BAEEC14234C132600808306 /* CLIExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExtractorTests.swift; sourceTree = "<group>"; };
 		9BAEEC16234C275600808306 /* ApolloSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloSchemaTests.swift; sourceTree = "<group>"; };
 		9BAEEC18234C297800808306 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
+		9BB1DAC624A66B2500396235 /* ApolloMacPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = ApolloMacPlayground.playground; path = Playgrounds/ApolloMacPlayground.playground; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9BC139A224EDCA4400876D29 /* InterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterceptorTests.swift; sourceTree = "<group>"; };
 		9BC139A524EDCAD900876D29 /* BlindRetryingTestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlindRetryingTestInterceptor.swift; sourceTree = "<group>"; };
 		9BC139A724EDCE4F00876D29 /* RetryToCountThenSucceedInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryToCountThenSucceedInterceptor.swift; sourceTree = "<group>"; };
-		9BB1DAC624A66B2500396235 /* ApolloMacPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = ApolloMacPlayground.playground; path = Playgrounds/ApolloMacPlayground.playground; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9BC2D9CE233C3531007BD083 /* Apollo-Target-ApolloCodegen.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-ApolloCodegen.xcconfig"; sourceTree = "<group>"; };
 		9BC2D9D1233C6DC0007BD083 /* Basher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Basher.swift; sourceTree = "<group>"; };
 		9BC742AB24CFB2FF0029282C /* ApolloErrorInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloErrorInterceptor.swift; sourceTree = "<group>"; };
@@ -932,6 +934,7 @@
 				9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */,
 				9BC139A524EDCAD900876D29 /* BlindRetryingTestInterceptor.swift */,
 				9BC139A724EDCE4F00876D29 /* RetryToCountThenSucceedInterceptor.swift */,
+				9B2B66F32513FAFE00B53ABF /* CancellationHandlingInterceptor.swift */,
 			);
 			name = TestHelpers;
 			sourceTree = "<group>";
@@ -2526,6 +2529,7 @@
 				9FE1C6E71E634C8D00C02284 /* PromiseTests.swift in Sources */,
 				9B64F6762354D219002D1BB5 /* URL+QueryDict.swift in Sources */,
 				9FADC8541E6B86D900C677E6 /* DataLoaderTests.swift in Sources */,
+				9B2B66F42513FAFE00B53ABF /* CancellationHandlingInterceptor.swift in Sources */,
 				9B21FD772422C8CC00998B5C /* TestFileHelper.swift in Sources */,
 				9BC139A624EDCAD900876D29 /* BlindRetryingTestInterceptor.swift in Sources */,
 				9B96500A24BE62B7003C29C0 /* RequestChainTests.swift in Sources */,

--- a/Playgrounds/ApolloMacPlayground.playground/Pages/SQLiteCache.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/ApolloMacPlayground.playground/Pages/SQLiteCache.xcplaygroundpage/Contents.swift
@@ -6,10 +6,6 @@ import PlaygroundSupport
 
 //: # Setting up a client with a SQLite cache
 
-//: First, you'll need to set up a network transport, since you will also need that to set up the client:
-let serverURL = URL(string: "http://localhost:8080/graphql")!
-let networkTransport = HTTPNetworkTransport(url: serverURL)
-
 //: You'll need to make sure you import the ApolloSQLite library IF you are not using CocoaPods (CocoaPods will automatically flatten everything down to a single Apollo import):
 import ApolloSQLite
 
@@ -26,12 +22,16 @@ let sqliteCache = try SQLiteNormalizedCache(fileURL: sqliteFileURL)
 //: And then instantiate an instance of `ApolloStore` with the cache you've just created:
 let store = ApolloStore(cache: sqliteCache)
 
+//: Next, you'll need to set up a network transport, since you will also need that to set up the client:
+let serverURL = URL(string: "http://localhost:8080/graphql")!
+let networkTransport = RequestChainNetworkTransport(interceptorProvider: LegacyInterceptorProvider(store: store), endpointURL: serverURL)
+
 //: Finally, pass that into your `ApolloClient` initializer, and you're now set up to use the SQLite cache for persistent storage:
 let apolloClient = ApolloClient(networkTransport: networkTransport, store: store)
 
-
-//: Now, let's test
+//: Now, let's test it out against the Star Wars API!
 import StarWarsAPI
+
 let query = HeroDetailsQuery(episode: .newhope)
 apolloClient.fetch(query: query) { result in
     // This is the outer Result, which has either a `GraphQLResult` or an `Error`

--- a/Playgrounds/ApolloMacPlayground.playground/Pages/Subscriptions.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/ApolloMacPlayground.playground/Pages/Subscriptions.xcplaygroundpage/Contents.swift
@@ -17,15 +17,15 @@ Your web backend must declare support for subscriptions in the Schema just like 
  
 To use subscriptions, you need to have a `NetworkTransport` implementation which supports them. Fortunately, with the `ApolloWebSocket` package, there are two!
  
-The first is the `WebSocketTransport`, which works with the web socket, and the second is the `SplitNetworkTransport`, which uses a web socket for subscriptions but a normal `HTTPNetworkTransport` for everything else.
+The first is the `WebSocketTransport`, which works with the web socket, and the second is the `SplitNetworkTransport`, which uses a web socket for subscriptions but a normal `RequestChainNetworkTransport` for everything else.
 
 In this instance, we'll use a `SplitNetworkTransport` since we want to demonstrate subscribing to changes, but we need to also be able to send changes for that subscription to come through.
 */
 
-//:First, setup the `HTTPNetworkTransport`:
+//:First, setup the `RequestChainNetworkTransport` that will handle your HTTP requests:
 
 let url = URL(string: "http://localhost:8080/graphql")!
-let normalTransport = HTTPNetworkTransport(url: url)
+let normalTransport = RequestChainNetworkTransport(interceptorProvider: LegacyInterceptorProvider(), endpointURL: url)
 
 //: Next, set up the `WebSocketTransport` to talk to the websocket endpoint. Note that this may take a different URL, sometimes with a `ws` prefix, than your normal http endpoint:
 
@@ -34,7 +34,7 @@ let webSocketTransport = WebSocketTransport(request: URLRequest(url: webSocketUR
 
 //: Then, set up the split transport with the two transports you've just created:
 
-let splitTransport = SplitNetworkTransport(httpNetworkTransport: normalTransport, webSocketNetworkTransport: webSocketTransport)
+let splitTransport = SplitNetworkTransport(uploadingNetworkTransport: normalTransport, webSocketNetworkTransport: webSocketTransport)
 
 //: Finally, instantiate your client with the split transport:
 

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -44,8 +44,8 @@ public final class ApolloStore {
 
   /// Designated initializer
   ///
-  /// - Parameter cache: An instance of `normalizedCache` to use to cache results.
-  public init(cache: NormalizedCache) {
+  /// - Parameter cache: An instance of `normalizedCache` to use to cache results. Defaults to an `InMemoryNormalizedCache`.
+  public init(cache: NormalizedCache = InMemoryNormalizedCache()) {
     self.cache = cache
     queue = DispatchQueue(label: "com.apollographql.ApolloStore", attributes: .concurrent)
   }

--- a/Sources/Apollo/InterceptorProvider.swift
+++ b/Sources/Apollo/InterceptorProvider.swift
@@ -9,6 +9,20 @@ public protocol InterceptorProvider {
   ///
   /// - Parameter operation: The operation to provide interceptors for
   func interceptors<Operation: GraphQLOperation>(for operation: Operation) -> [ApolloInterceptor]
+  
+  /// Provides an additional error interceptor for any additional handling of errors
+  /// before returning to the UI, such as logging.
+  /// - Parameter operation: The oper
+  func additionalErrorInterceptor<Operation: GraphQLOperation>(for operation: Operation) -> ApolloErrorInterceptor?
+}
+
+/// MARK: - Default Implementation
+
+public extension InterceptorProvider {
+  
+  func additionalErrorInterceptor<Operation: GraphQLOperation>(for operation: Operation) -> ApolloErrorInterceptor? {
+    return nil
+  }
 }
 
 // MARK: - Default implementation for typescript codegen

--- a/Sources/Apollo/InterceptorProvider.swift
+++ b/Sources/Apollo/InterceptorProvider.swift
@@ -39,10 +39,10 @@ open class LegacyInterceptorProvider: InterceptorProvider {
   /// - Parameters:
   ///   - client: The `URLSessionClient` to use. Defaults to the default setup.
   ///   - shouldInvalidateClientOnDeinit: If the passed-in client should be invalidated when this interceptor provider is deinitialized. If you are recreating the `URLSessionClient` every time you create a new provider, you should do this to prevent memory leaks. Defaults to true, since by default we provide a `URLSessionClient` to new instances.
-  ///   - store: The `ApolloStore` to use when reading from or writing to the cache.
+  ///   - store: The `ApolloStore` to use when reading from or writing to the cache. Defaults to the default initializer for ApolloStore.
   public init(client: URLSessionClient = URLSessionClient(),
               shouldInvalidateClientOnDeinit: Bool = true,
-              store: ApolloStore) {
+              store: ApolloStore = ApolloStore()) {
     self.client = client
     self.shouldInvalidateClientOnDeinit = shouldInvalidateClientOnDeinit
     self.store = store

--- a/Sources/Apollo/JSONRequest.swift
+++ b/Sources/Apollo/JSONRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A request which sends JSON related to a GraphQL operation.
-public class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
+open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
   
   public let requestCreator: RequestCreator
   
@@ -52,11 +52,11 @@ public class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
                cachePolicy: cachePolicy)
   }
   
-  public var sendOperationIdentifier: Bool {
+  open var sendOperationIdentifier: Bool {
     self.operation.operationIdentifier != nil
   }
   
-  public override func toURLRequest() throws -> URLRequest {
+  open override func toURLRequest() throws -> URLRequest {
     var request = try super.toURLRequest()
         
     let useGetMethod: Bool

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -73,6 +73,7 @@ public class RequestChainNetworkTransport: NetworkTransport {
     
     let interceptors = self.interceptorProvider.interceptors(for: operation)
     let chain = RequestChain(interceptors: interceptors, callbackQueue: callbackQueue)
+    chain.additionalErrorHandler = self.interceptorProvider.additionalErrorInterceptor(for: operation)
     let request = self.constructJSONRequest(for: operation,
                                             cachePolicy: cachePolicy,
                                             contextIdentifier: contextIdentifier)

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -231,8 +231,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testRequestBody() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint)
     
@@ -257,8 +256,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testRequestBodyWithVariable() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint)
     
@@ -283,8 +281,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testRequestBodyForAPQsWithVariable() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true)
@@ -310,8 +307,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testMutationRequestBodyForAPQs() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true)
@@ -337,8 +333,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testQueryStringForAPQsUseGetMethod() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,
@@ -363,8 +358,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testQueryStringForAPQsUseGetMethodWithVariable() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,
@@ -391,8 +385,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testUseGETForQueriesRequest() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                useGETForQueries: true)
@@ -418,8 +411,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testNotUseGETForQueriesRequest() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint)
     
@@ -444,8 +436,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testNotUseGETForQueriesAPQsRequest() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true)
@@ -471,8 +462,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testUseGETForQueriesAPQsRequest() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,
@@ -499,8 +489,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testNotUseGETForQueriesAPQsGETRequest() throws {
     let mockClient = MockURLSessionClient()
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
+    let provider = LegacyInterceptorProvider(client: mockClient)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,

--- a/Tests/ApolloTests/CancellationHandlingInterceptor.swift
+++ b/Tests/ApolloTests/CancellationHandlingInterceptor.swift
@@ -1,30 +1,34 @@
 //
-//  BlindRetryingTestInterceptor.swift
+//  CancellationHandlingInterceptor.swift
 //  ApolloTests
 //
-//  Created by Ellen Shapiro on 8/19/20.
+//  Created by Ellen Shapiro on 9/17/20.
 //  Copyright © 2020 Apollo GraphQL. All rights reserved.
 //
 
 import Foundation
 import Apollo
 
-// An interceptor which blindly retries every time it receives a request. 
-class BlindRetryingTestInterceptor: ApolloInterceptor {
-  var hitCount = 0
+class CancellationHandlingInterceptor: ApolloInterceptor, Cancellable {
   private(set) var hasBeenCancelled = false
-
+  
   func interceptAsync<Operation: GraphQLOperation>(
     chain: RequestChain,
     request: HTTPRequest<Operation>,
     response: HTTPResponse<Operation>?,
     completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
-    self.hitCount += 1
-    chain.retry(request: request,
-                completion: completion)
+    
+    guard !self.hasBeenCancelled else {
+      return
+    }
+    
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+      chain.proceedAsync(request: request,
+                         response: response,
+                         completion: completion)
+    }
   }
   
-  // Purposely not adhering to `Cancellable` here to make sure non `Cancellable` interceptors don't have this called.
   func cancel() {
     self.hasBeenCancelled = true
   }

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -15,9 +15,7 @@ class RequestChainTests: XCTestCase {
   
   lazy var legacyClient: ApolloClient = {
     let url = TestURL.starWarsServer.url
-    
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(store: store)
+    let provider = LegacyInterceptorProvider()
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: url)
     

--- a/Tests/ApolloTests/UploadTests.swift
+++ b/Tests/ApolloTests/UploadTests.swift
@@ -8,8 +8,7 @@ class UploadTests: XCTestCase {
   let uploadClientURL = TestURL.uploadServer.url
   
   lazy var client: ApolloClient = {
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let provider = LegacyInterceptorProvider(store: store)
+    let provider = LegacyInterceptorProvider()
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: self.uploadClientURL)
     

--- a/Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift
+++ b/Tests/ApolloWebsocketTests/SplitNetworkTransportTests.swift
@@ -20,9 +20,8 @@ class SplitNetworkTransportTests: XCTestCase {
   private let webSocketVersion = "TestWebSocketTransportVersion"
   
   private lazy var mockTransport: MockNetworkTransport = {
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
     let transport = MockNetworkTransport(body: JSONObject(),
-                                         store: store)
+                                         store: ApolloStore())
     
     transport.clientName = self.mockTransportName
     transport.clientVersion = self.mockTransportVersion

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -416,8 +416,7 @@ class StarWarsSubscriptionTests: XCTestCase {
     let reviewMutation = CreateAwesomeReviewMutation()
     
     // Send the mutations via a separate transport so they can still be sent when the websocket is disconnected
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
-    let interceptorProvider = LegacyInterceptorProvider(store: store)
+    let interceptorProvider = LegacyInterceptorProvider()
     let alternateTransport = RequestChainNetworkTransport(interceptorProvider: interceptorProvider,
                                                           endpointURL: TestURL.starWarsServer.url)
     let alternateClient = ApolloClient(networkTransport: alternateTransport)

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -59,18 +59,18 @@ The chain also includes a `retry` mechanism, which will go all the way back to t
 
 **IMPORTANT**: Do not call `retry` blindly. If your server is returning 500s or if the user has no internet, this will create an infinite loop of requests that are retrying (especially if you're not using something like the `MaxRetryInterceptor` to limit how many retries are made). This **will** kill your user's battery, and might also run up the bill on their data plan. Make sure to only request a retry when there's something your code can actually do about the problem!
 
-In the `RequestChainNetworkTransport`, each request creates an individual request chain, and uses an `ApolloInterceptorProvider` 
+In the `RequestChainNetworkTransport`, each request creates an individual request chain, and uses an `InterceptorProvider` 
 
-### Setting up `ApolloInterceptor` chains with `ApolloInterceptorProvider`
+### Setting up `ApolloInterceptor` chains with `InterceptorProvider`
 
-Every operation sent through a `RequestChainNetworkTransport` will be passed into an `ApolloInterceptorProvider` before going to the network. This protocol creates an array of interceptors for use by a single request chain based on the provided operation. 
+Every operation sent through a `RequestChainNetworkTransport` will be passed into an `InterceptorProvider` before going to the network. This protocol creates an array of interceptors for use by a single request chain based on the provided operation. 
 
 There are two default implementations for this protocol provided:
 
 - `LegacyInterceptorProvider` works with our existing parsing and caching system and tries to replicate the experience of using the old `HTTPNetworkTransport` as closely as possible. It takes a `URLSessionClient` and an `ApolloStore` to pass into the interceptors it uses.
 - `CodableInterceptorProvider` is a **work in progress**, which is going to be for use with our [Swift Codegen Rewrite](https://github.com/apollographql/apollo-ios/projects/2), (which, I swear, will eventually be finished). It is not suitable for use at this time. It takes a `URLSessionClient`, a `FlexibleDecoder` (something can decode anything that conforms to `Decodable`). It does not support caching yet.
 
-If you wish to make your own `ApolloInterceptorProvider` instead of using the provided one, you can take advantage of several interceptors that are included in the library: 
+If you wish to make your own `InterceptorProvider` instead of using the provided one, you can take advantage of several interceptors that are included in the library: 
 
 #### Pre-network
 - `MaxRetryInterceptor` checks to make sure a query has not been tried more than a maximum number of times. 


### PR DESCRIPTION
In this PR: 

- Updated `ApolloStore` to take a default cache of the `InMemoryNormalizedCache()`. 
- Updated `LegacyInterceptorProvider` to take a default store of the `ApolloStore` with that default cache. 
- Added a method to `InterceptorProvider` to provide an error interceptor, along with a default implementation that returns `nil`. 
- Added a bunch of tests to patch up holes in our test coverage
- Updated `JSONRequest` to be `open` so it can be subclassed. 
- Fixed some naming issues in documentation. 