### PR TITLE
Fix Xcode version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This combination of models with value semantics, one way data flow, and automati
 
 ## Contributing
 
-This project is being developed using Xcode 11 and Swift 5.0.
+This project is being developed using Xcode 12 and Swift 5.3.
 
 If you open `Apollo.xcworkspace`, you should be able to run the tests of the Apollo, ApolloSQLite, and ApolloWebSocket frameworks on your Mac or an iOS Simulator.
 


### PR DESCRIPTION
Since 0.33.0, support for Xcode 11 has been dropped.

https://github.com/apollographql/apollo-ios/issues/1391#issuecomment-693608876
> You will need to use Xcode 12 for versions 0.33.0 and higher.