### PR TITLE
[Networking Stack] `additionalErrorInterceptor(for:)` doesn't work when subclassing `LegacyInterceptorProvider`

### DIFF
--- a/Sources/Apollo/InterceptorProvider.swift
+++ b/Sources/Apollo/InterceptorProvider.swift
@@ -65,6 +65,10 @@ open class LegacyInterceptorProvider: InterceptorProvider {
         LegacyCacheWriteInterceptor(store: self.store),
     ]
   }
+  
+  open func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+    return nil
+  }
 }
 
 // MARK: - Default implementation for swift codegen
@@ -109,4 +113,8 @@ open class CodableInterceptorProvider<FlexDecoder: FlexibleDecoder>: Interceptor
          // Swift codegen Phase 2: Add Cache Write interceptor
      ]
    }
+  
+  open func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+    return nil
+  }
 }

--- a/Sources/Apollo/InterceptorProvider.swift
+++ b/Sources/Apollo/InterceptorProvider.swift
@@ -66,7 +66,7 @@ open class LegacyInterceptorProvider: InterceptorProvider {
     ]
   }
   
-  open func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+  open func additionalErrorInterceptor<Operation: GraphQLOperation>(for operation: Operation) -> ApolloErrorInterceptor? {
     return nil
   }
 }
@@ -114,7 +114,7 @@ open class CodableInterceptorProvider<FlexDecoder: FlexibleDecoder>: Interceptor
      ]
    }
   
-  open func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+  open func additionalErrorInterceptor<Operation: GraphQLOperation>(for operation: Operation) -> ApolloErrorInterceptor? {
     return nil
   }
 }

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -229,7 +229,7 @@ class RequestChainTests: XCTestCase {
         ]
       }
       
-      func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+      override func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
         return self.errorInterceptor
       }
     }

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -202,4 +202,75 @@ class RequestChainTests: XCTestCase {
       XCTFail("Error interceptor did not receive an error!")
     }
   }
+  
+  func testErrorInterceptorGetsCalledInLegacyInterceptorProviderSubclass() {
+    class ErrorInterceptor: ApolloErrorInterceptor {
+      var error: Error? = nil
+      
+      func handleErrorAsync<Operation: GraphQLOperation>(
+        error: Error,
+        chain: RequestChain,
+        request: HTTPRequest<Operation>,
+        response: HTTPResponse<Operation>?,
+        completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+        
+        self.error = error
+        completion(.failure(error))
+      }
+    }
+    
+    class TestProvider: LegacyInterceptorProvider {
+      let errorInterceptor = ErrorInterceptor()
+      
+      override func interceptors<Operation: GraphQLOperation>(for operation: Operation) -> [ApolloInterceptor] {
+        return [
+          // An interceptor which will error without a response
+          AutomaticPersistedQueryInterceptor()
+        ]
+      }
+      
+      func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+        return self.errorInterceptor
+      }
+    }
+    
+    let provider = TestProvider()
+    let transport = RequestChainNetworkTransport(interceptorProvider: provider,
+                                                 endpointURL: TestURL.mockServer.url,
+                                                 autoPersistQueries: true)
+    
+    let expectation = self.expectation(description: "Hero name query complete")
+    _ = transport.send(operation: HeroNameQuery()) { result in
+      defer {
+        expectation.fulfill()
+      }
+      switch result {
+      case .success:
+        XCTFail("This should not have succeeded")
+      case .failure(let error):
+        switch error {
+        case AutomaticPersistedQueryInterceptor.APQError.noParsedResponse:
+          // This is what we want.
+          break
+        default:
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+    }
+    
+    self.wait(for: [expectation], timeout: 1)
+    
+    switch provider.errorInterceptor.error {
+    case .some(let error):
+      switch error {
+      case AutomaticPersistedQueryInterceptor.APQError.noParsedResponse:
+        // Again, this is what we expect.
+        break
+      default:
+        XCTFail("Unexpected error on the interceptor: \(error)")
+      }
+    case .none:
+      XCTFail("Error interceptor did not receive an error!")
+    }
+  }
 }

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -229,7 +229,7 @@ class RequestChainTests: XCTestCase {
         ]
       }
       
-      override func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
+      override func additionalErrorInterceptor<Operation: GraphQLOperation>(for operation: Operation) -> ApolloErrorInterceptor? {
         return self.errorInterceptor
       }
     }


### PR DESCRIPTION
## The problem

The problem is: the `additionalErrorInterceptor(for:)` function is never called, if the `InterceptorProvider` class in use is a subclass of any `InterceptorProvider` that *does not* declare the `additionalErrorInterceptor` function.

For example, consider this `CustomInterceptor` type:
```swift
class CustomInterceptor: LegacyInterceptorProvider {
  // Note that we don't use `override` here.
  func additionalErrorInterceptor<Operation>(for operation: Operation) -> ApolloErrorInterceptor? where Operation : GraphQLOperation {
    ErrorInterceptor()
  }
}
```

Its superclass, `LegacyInterceptorProvider`, does not provide an implementation of `additionalErrorInterceptor(for:)`, relying instead on the default implementation from the protocol, that returns `nil`.
Since its superclass does not implement this function, the implementation in `CustomInterceptor` is not overriding it, but declaring it anew. For some 🤯 reason, this means that the implementation that provides the `additionalErrorInterceptor` is never called. The default implementation in the extension of the `InterceptorProvider` protocol is called instead, returning `nil`.

## The solution

I suggest 2 small changes to solve this issue, and remove this trap.
- Remove the default implementation of `additionalErrorInterceptor(for:)` from `extension InterceptorProvider`. This will force base classes to implement it; the library expects the user to subclass one of the provided InterceptorProviders anyway, so I think it's acceptable.
- Implement `additionalErrorInterceptor(for:)` in both `LegacyInterceptorProvider` and `CodableInterceptorProvider`, so that subclasses will have something to override, but keeping the nice `nil` default.

These changes make for a pretty smooth solution, with only one small breaking change: `InterceptorProvider`s that did implement `additionalErrorInterceptor(for:)` before this change will have to add the `override` keyword, if they inherited from one of the provided `InterceptorProvider`s.

## Double checking

You can check out the first commit of this PR to see that the Unit test I added fails, reproducing the issue. Add the other commit, and everything is green again ✅ 