### PR TITLE
Fixed typo of `InterceptorProvider`.

### DIFF
--- a/docs/source/tutorial/tutorial-mutations.md
+++ b/docs/source/tutorial/tutorial-mutations.md
@@ -12,7 +12,7 @@ The `ApolloClient` uses something called a `NetworkTransport` under the hood. By
 
 A `RequestChain` runs your request through an array of `ApolloInterceptor` objects which can mutate the request and/or check the cache before it hits the network, and then do additional work after a response is received from the network. 
 
-The `RequestChainNetworkTransport` uses an object that conforms to the `InterceptorProivder` protocol in order to create that array of interceptors for each operation it executes. There are a couple of providers that are set up by default, which return a fairly standard array of interceptors. 
+The `RequestChainNetworkTransport` uses an object that conforms to the `InterceptorProvider` protocol in order to create that array of interceptors for each operation it executes. There are a couple of providers that are set up by default, which return a fairly standard array of interceptors. 
 
 The nice thing is that you can also add your own interceptors to the chain anywhere you need to perform custom actions. In this case, you want to have an interceptor that will add 
 

--- a/docs/source/tutorial/tutorial-mutations.md
+++ b/docs/source/tutorial/tutorial-mutations.md
@@ -14,7 +14,7 @@ A `RequestChain` runs your request through an array of `ApolloInterceptor` objec
 
 The `RequestChainNetworkTransport` uses an object that conforms to the `InterceptorProvider` protocol in order to create that array of interceptors for each operation it executes. There are a couple of providers that are set up by default, which return a fairly standard array of interceptors. 
 
-The nice thing is that you can also add your own interceptors to the chain anywhere you need to perform custom actions. In this case, you want to have an interceptor that will add 
+The nice thing is that you can also add your own interceptors to the chain anywhere you need to perform custom actions. In this case, you want to have an interceptor that will add your token.
 
 First, create the new interceptor. Go to **File > New > File...** and create a new **Swift File**. Name it **TokenAddingInterceptor.swift**. Open that file, and add the 
 


### PR DESCRIPTION
Just a quick fix! Changed `InterceptorProivder` to `InterceptorProvider` in the auth tutorial documentation.