### PR TITLE
Cast Double as String if the jsonValue is of type Double.

### DIFF
--- a/Sources/Apollo/JSONStandardTypeConversions.swift
+++ b/Sources/Apollo/JSONStandardTypeConversions.swift
@@ -7,6 +7,8 @@ extension String: JSONDecodable, JSONEncodable {
         self = string
     case let int as Int:
         self = String(int)
+    case let double as Double:
+        self = String(double)
     default:
         throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
     }

--- a/Tests/ApolloTests/ParseQueryResponseTests.swift
+++ b/Tests/ApolloTests/ParseQueryResponseTests.swift
@@ -37,7 +37,7 @@ class ParseQueryResponseTests: XCTestCase {
     }
   }
 
-  func testHeroNameQueryWithDifferentType() throws {
+  func testHeroNameQueryWithScalarIntType() throws {
     let query = HeroNameQuery()
     
     let response = GraphQLResponse(operation: query, body: [
@@ -51,7 +51,7 @@ class ParseQueryResponseTests: XCTestCase {
     XCTAssertEqual(result.data?.hero?.name, "10")
   }
 
-  func testHeroNameQueryWithWrongType() throws {
+  func testHeroNameQueryWithScalarDoubleType() throws {
     let query = HeroNameQuery()
 
     let response = GraphQLResponse(operation: query, body: [
@@ -60,15 +60,9 @@ class ParseQueryResponseTests: XCTestCase {
       ]
     ])
 
-    XCTAssertThrowsError(try response.parseResult().await()) { error in
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
-        XCTAssertEqual(error.path, ["hero", "name"])
-        XCTAssertEqual(value as? Double, 10.0)
-        XCTAssertTrue(expectedType == String.self)
-      } else {
-        XCTFail("Unexpected error: \(error)")
-      }
-    }
+    let (result, _) = try response.parseResult().await()
+    
+    XCTAssertEqual(result.data?.hero?.name, "10.0")
   }
   
   func testHeroAppearsInQuery() throws {

--- a/Tests/ApolloTests/ReadFieldValueTests.swift
+++ b/Tests/ApolloTests/ReadFieldValueTests.swift
@@ -59,7 +59,7 @@ class ReadFieldValueTests: XCTestCase {
     }
   }
   
-  func testGetScalarWithDifferentType() throws {
+  func testGetScalarWithIntType() throws {
     let object: JSONObject = ["name": 10]
     let field = GraphQLField("name", type: .nonNull(.scalar(String.self)))
 
@@ -69,19 +69,14 @@ class ReadFieldValueTests: XCTestCase {
     XCTAssertEqual(value, "10")
   }
 
-  func testGetScalarWithWrongType() throws {
+  func testGetScalarWithDoubleType() throws {
     let object: JSONObject = ["name": 10.0]
     let field = GraphQLField("name", type: .nonNull(.scalar(String.self)))
 
-    XCTAssertThrowsError(try readFieldValue(field, from: object)) { (error) in
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
-        XCTAssertEqual(error.path, ["name"])
-        XCTAssertEqual(value as? Double, 10.0)
-        XCTAssertTrue(expectedType == String.self)
-      } else {
-        XCTFail("Unexpected error: \(error)")
-      }
-    }
+    let value = try XCTUnwrap(try readFieldValue(field, from: object) as? String,
+                              "Wrong type, name should be a String!")
+
+    XCTAssertEqual(value, "10.0")
   }
   
   func testGetOptionalScalar() throws {
@@ -115,7 +110,7 @@ class ReadFieldValueTests: XCTestCase {
     XCTAssertNil(value)
   }
   
-  func testGetOptionalScalarWithDifferentType() throws {
+  func testGetOptionalScalarIntType() throws {
     let object: JSONObject = ["name": 10]
     let field = GraphQLField("name", type: .scalar(String.self))
 
@@ -125,19 +120,14 @@ class ReadFieldValueTests: XCTestCase {
     XCTAssertEqual(value, "10")
   }
 
-  func testGetOptionalScalarWithWrongType() throws {
+  func testGetOptionalScalarDoubleType() throws {
     let object: JSONObject = ["name": 10.0]
     let field = GraphQLField("name", type: .scalar(String.self))
 
-    XCTAssertThrowsError(try readFieldValue(field, from: object)) { (error) in
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
-        XCTAssertEqual(error.path, ["name"])
-        XCTAssertEqual(value as? Double, 10.0)
-        XCTAssertTrue(expectedType == String.self)
-      } else {
-        XCTFail("Unexpected error: \(error)")
-      }
-    }
+    let value = try XCTUnwrap(try readFieldValue(field, from: object) as? String,
+                              "Wrong type, name should be a String!")
+
+    XCTAssertEqual(value, "10.0")
   }
   
   func testGetScalarList() throws {
@@ -186,7 +176,7 @@ class ReadFieldValueTests: XCTestCase {
     }
   }
   
-  func testGetScalarListWithDifferentType() throws {
+  func testGetScalarListWithIntType() throws {
     let object: JSONObject = ["appearsIn": [4, 5, 6]]
     let field = GraphQLField("appearsIn", type: .nonNull(.list(.nonNull(.scalar(Episode.self)))))
 
@@ -195,19 +185,13 @@ class ReadFieldValueTests: XCTestCase {
     XCTAssertEqual(value, [.__unknown("4"), .__unknown("5"), .__unknown("6")])
   }
 
-  func testGetScalarListWithWrongType() throws {
+  func testGetScalarListWithDoubleType() throws {
     let object: JSONObject = ["appearsIn": [4.0, 5.0, 6.0]]
     let field = GraphQLField("appearsIn", type: .nonNull(.list(.nonNull(.scalar(Episode.self)))))
 
-    XCTAssertThrowsError(try readFieldValue(field, from: object)) { (error) in
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
-        XCTAssertEqual(error.path, ["appearsIn"])
-        XCTAssertEqual(value as? Double, 4.0)
-        XCTAssertTrue(expectedType == String.self)
-      } else {
-        XCTFail("Unexpected error: \(error)")
-      }
-    }
+    let value = try readFieldValue(field, from: object) as! [Episode]
+
+    XCTAssertEqual(value, [.__unknown("4.0"), .__unknown("5.0"), .__unknown("6.0")])
   }
   
   func testGetOptionalScalarList() throws {
@@ -251,7 +235,7 @@ class ReadFieldValueTests: XCTestCase {
     XCTAssertNil(value)
   }
   
-  func testGetOptionalScalarListWithDifferentType() throws {
+  func testGetOptionalScalarListWithIntType() throws {
     let object: JSONObject = ["appearsIn": [4, 5, 6]]
     let field = GraphQLField("appearsIn", type: .list(.nonNull(.scalar(Episode.self))))
     
@@ -260,19 +244,13 @@ class ReadFieldValueTests: XCTestCase {
     XCTAssertEqual(value, [.__unknown("4"), .__unknown("5"), .__unknown("6")])
   }
 
-  func testGetOptionalScalarListWithWrongType() throws {
+  func testGetOptionalScalarListWithDoubleType() throws {
     let object: JSONObject = ["appearsIn": [4.0, 5.0, 6.0]]
     let field = GraphQLField("appearsIn", type: .list(.nonNull(.scalar(Episode.self))))
 
-    XCTAssertThrowsError(try readFieldValue(field, from: object)) { (error) in
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
-        XCTAssertEqual(error.path, ["appearsIn"])
-        XCTAssertEqual(value as? Double, 4.0)
-        XCTAssertTrue(expectedType == String.self)
-      } else {
-        XCTFail("Unexpected error: \(error)")
-      }
-    }
+    let value = try readFieldValue(field, from: object) as! [Episode]
+
+    XCTAssertEqual(value, [.__unknown("4.0"), .__unknown("5.0"), .__unknown("6.0")])
   }
   
   func testGetScalarListWithOptionalElements() throws {


### PR DESCRIPTION
Similar problem with [this](https://github.com/apollographql/apollo-ios/pull/402)

This PR is trying solve problem with casting scalar as Double to String. Here is an error:
`Apollo.GraphQLResultError(path: filterMoneyTransactions.nodes.0.amount, underlying: Apollo.JSONDecodingError.couldNotConvert(value: 0.24, to: Swift.String))`

Scheme for this part looks like this:
```
type MoneyTransaction {
   ref: EntityRef (scalar)
   amount: MoneyAmount (scalar)
}
```