### PR TITLE
Replace undefined types and variables in doc

### DIFF
--- a/docs/source/fetching-queries.md
+++ b/docs/source/fetching-queries.md
@@ -125,9 +125,9 @@ Because the above query won't fetch `appearsIn`, this property is not part of th
 
 By default, Apollo constructs queries and sends them to your graphql endpoint using `POST` with the JSON generated. 
 
-If you want Apollo to use `GET` instead, pass `true` to the optional `useGETForQueries` parameter when setting up your `HTTPNetworkTransport`. This will set up all queries conforming to `GraphQLQuery` sent through the HTTP transport to use `GET`. 
+If you want Apollo to use `GET` instead, pass `true` to the optional `useGETForQueries` parameter when setting up your `RequestChainNetworkTransport`. This will set up all queries conforming to `GraphQLQuery` sent through the HTTP transport to use `GET`.
 
->**NOTE:** This is a toggle which affects all queries sent through that client, so if you need to have certain queries go as `POST` and certain ones go as `GET`, you will likely have to swap out the `HTTPNetworkTransport`.
+>**NOTE:** This is a toggle which affects all queries sent through that client, so if you need to have certain queries go as `POST` and certain ones go as `GET`, you will likely have to swap out the `RequestChainNetworkTransport`.
 
 ## JSON serialization
 
@@ -160,9 +160,9 @@ To use APQs with the iOS SDK:
 - When generating your code, pass a local path for output for the `--operationIdsPath` (or pass a file URL to the `operationIDsURL` on `ApolloCodegenOptions` if using Swift Scripting).  
 
     This will generate a document with all your operations, but more importantly it will cause operation identifiers to be generated with your code. 
-- When creating your `ApolloClient`, make sure to manually instantiate your `HTTPNetworkTransport` and set `enableAutoPersistedQueries` and `sendOperationIdentifiers` to `true`.
+- When creating your `ApolloClient`, make sure to manually instantiate your `RequestChainNetworkTransport` and set `autoPersistQueries`.
 
-    This will cause the `HTTPNetworkTransport` to actively look for the "Oh no, I don't have this hash!" error from the server.
+    This will cause the `RequestChainNetworkTransport` to actively look for the "Oh no, I don't have this hash!" error from the server.
 
 By default, retries of queries will use `POST`.  If for some reason (for example, your queries are hitting a CDN that has considerably better performance with `GET`), you need to use a `GET` for the 2nd try of a query, make sure to set the `useGETForPersistedQueryRetry` option to `true`. Most users will want to leave this option as `false`. 
 

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -14,7 +14,7 @@ class Network {
 }
 ```
 
-Under the hood, this will create a client using `HTTPNetworkTransport` with a default configuration. You can then use this client from anywhere in your code with `Network.shared.apollo`. 
+Under the hood, this will create a client using `RequestChainNetworkTransport` with a default configuration. You can then use this client from anywhere in your code with `Network.shared.apollo`.
 
 ## Advanced Client Creation
 
@@ -93,7 +93,7 @@ Since `URLSession` only supports use in the background using the delegate-based 
 
 One thing to be aware of: Because setting up a delegate is only possible in the initializer for `URLSession`, you can only pass in a `URLSessionConfiguration`, **not** an existing `URLSession`, to this class's initializer. 
 
-By default, instances of `URLSessionClient` use `URLSessionConfiguration.default` to set up their URL session, and instances of `HTTPNetworkTransport` use the default initializer for `URLSessionClient`.
+By default, instances of `URLSessionClient` use `URLSessionConfiguration.default` to set up their URL session, and instances of `LegacyInterceptorProvider` and `CodableInterceptorProvider` use the default initializer for `URLSessionClient`.
 
 The `URLSessionClient` class and most of its methods are `open` so you can subclass it if you need to override any of the delegate methods for the `URLSession` delegates we're using or you need to handle additional delegate scenarios.  
 

--- a/docs/source/mutations.md
+++ b/docs/source/mutations.md
@@ -105,7 +105,7 @@ At the moment, we only support uploads for a single operation, not for batch ope
 
 To upload a file, you will need: 
 
-- A `NetworkTransport` which also supports the `UploadingNetworkTransport` protocol on your `ApolloClient` instance. If you're using `HTTPNetworkTransport` (which is set up by default), this protocol is already supported. 
+- A `NetworkTransport` which also supports the `UploadingNetworkTransport` protocol on your `ApolloClient` instance. If you're using `RequestChainNetworkTransport` (which is set up by default), this protocol is already supported.
 - The correct `MIME` type for the data you're uploading. The default value is `application/octet-stream`. 
 - Either the data or the file URL of the data you want to upload. 
 - A mutation which takes an `Upload` as a parameter. Note that this must be supported by your server. 
@@ -169,4 +169,4 @@ A few other notes:
     it will not. Generally you should be able to deconstruct upload objects to allow you to send the appropriate fields.
 
 - If you are uploading an array of files, you need to use the same field name for each file. These will be updated at send time.
-- If you are uploading an array of files, the array of `String`s passed into the query must be the same number as the array of files. 
+- If you are uploading an array of files, the array of `String`s passed into the query must be the same number as the array of files.

--- a/docs/source/subscriptions.md
+++ b/docs/source/subscriptions.md
@@ -41,15 +41,15 @@ class Apollo {
   }()
   
   /// An HTTP transport to use for queries and mutations
-  private lazy var httpTransport: HTTPNetworkTransport = {
+  private lazy var normalTransport: RequestChainNetworkTransport = {
     let url = URL(string: "http://localhost:8080/graphql")!
-    return HTTPNetworkTransport(url: url)
+    return RequestChainNetworkTransport(interceptorProvider: LegacyInterceptorProvider(), endpointURL: url)
   }()
 
-  /// A split network transport to allow the use of both of the above 
+  /// A split network transport to allow the use of both of the above
   /// transports through a single `NetworkTransport` instance.
   private lazy var splitNetworkTransport = SplitNetworkTransport(
-    httpNetworkTransport: self.httpTransport, 
+    uploadingNetworkTransport: self.normalTransport,
     webSocketNetworkTransport: self.webSocketTransport
   )
 
@@ -163,15 +163,15 @@ class Apollo {
   }()
   
   /// An HTTP transport to use for queries and mutations.
-  private lazy var httpTransport: HTTPNetworkTransport = {
+  private lazy var normalTransport: RequestChainNetworkTransport = {
     let url = URL(string: "http://localhost:8080/graphql")!
-    return HTTPNetworkTransport(url: url)
+    return RequestChainNetworkTransport(interceptorProvider: LegacyInterceptorProvider(), endpointURL: url)
   }()
 
-  /// A split network transport to allow the use of both of the above 
+  /// A split network transport to allow the use of both of the above
   /// transports through a single `NetworkTransport` instance.
   private lazy var splitNetworkTransport = SplitNetworkTransport(
-    httpNetworkTransport: self.httpTransport, 
+    uploadingNetworkTransport: self.normalTransport,
     webSocketNetworkTransport: self.webSocketTransport
   )
 


### PR DESCRIPTION
Hi, noticed some of the documents contain deprecated types/variables after the networking stack change, and so replaced:

* `HTTPNetworkTransport` => either `RequestChainNetworkTransport` / `LegacyInterceptorProvider` / `CodableInterceptorProvider`
* `enableAutoPersistedQueries` => `autoPersistQueries`

Similarly, replaced sample codes in [doc for subscriptions](https://www.apollographql.com/docs/ios/subscriptions/). Mostly they're simply from [playground](https://github.com/apollographql/apollo-ios/blob/1ef93aca33f5223255278e7a030b76de46374351/Playgrounds/ApolloMacPlayground.playground/Pages/Subscriptions.xcplaygroundpage/Contents.swift) though. Let me know if they're not needed!