### PR TITLE
Add helper to deal with parsing and caching raw data in custom `NetworkTransport` instances

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		9BC2D9D3233C6EF0007BD083 /* Basher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC2D9D1233C6DC0007BD083 /* Basher.swift */; };
 		9BC742AC24CFB2FF0029282C /* ApolloErrorInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC742AB24CFB2FF0029282C /* ApolloErrorInterceptor.swift */; };
 		9BC742AE24CFB6450029282C /* LegacyCacheWriteInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC742AD24CFB6450029282C /* LegacyCacheWriteInterceptor.swift */; };
+		9BC90F5D252E609700AD0922 /* RawDataCacheHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC90F5C252E609700AD0922 /* RawDataCacheHelper.swift */; };
 		9BCF0CE023FC9CA50031D2A2 /* TestCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCF0CD923FC9CA50031D2A2 /* TestCacheProvider.swift */; };
 		9BCF0CE323FC9CA50031D2A2 /* XCTAssertHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCF0CDC23FC9CA50031D2A2 /* XCTAssertHelpers.swift */; };
 		9BCF0CE423FC9CA50031D2A2 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCF0CDD23FC9CA50031D2A2 /* MockURLSession.swift */; };
@@ -670,6 +671,7 @@
 		9BC2D9D1233C6DC0007BD083 /* Basher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Basher.swift; sourceTree = "<group>"; };
 		9BC742AB24CFB2FF0029282C /* ApolloErrorInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloErrorInterceptor.swift; sourceTree = "<group>"; };
 		9BC742AD24CFB6450029282C /* LegacyCacheWriteInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCacheWriteInterceptor.swift; sourceTree = "<group>"; };
+		9BC90F5C252E609700AD0922 /* RawDataCacheHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataCacheHelper.swift; sourceTree = "<group>"; };
 		9BCF0CD923FC9CA50031D2A2 /* TestCacheProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCacheProvider.swift; sourceTree = "<group>"; };
 		9BCF0CDA23FC9CA50031D2A2 /* ApolloTestSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApolloTestSupport.h; sourceTree = "<group>"; };
 		9BCF0CDC23FC9CA50031D2A2 /* XCTAssertHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssertHelpers.swift; sourceTree = "<group>"; };
@@ -1620,6 +1622,7 @@
 				9FCE2CED1E6BE2D800E34457 /* NormalizedCache.swift */,
 				9FC9A9CB1E2FD0760023C4D5 /* Record.swift */,
 				9FC9A9BC1E2C271C0023C4D5 /* RecordSet.swift */,
+				9BC90F5C252E609700AD0922 /* RawDataCacheHelper.swift */,
 			);
 			name = Store;
 			sourceTree = "<group>";
@@ -2575,6 +2578,7 @@
 				9F295E381E277B2A00A24949 /* GraphQLResultNormalizer.swift in Sources */,
 				9F86B68B1E6438D700B885FF /* GraphQLSelectionSetMapper.swift in Sources */,
 				9F55347B1DE1DB2100E54264 /* ApolloStore.swift in Sources */,
+				9BC90F5D252E609700AD0922 /* RawDataCacheHelper.swift in Sources */,
 				9BDE43D122C6655300FD7C7F /* Cancellable.swift in Sources */,
 				9BE071B12368D3F500FA5952 /* Dictionary+Helpers.swift in Sources */,
 				9F69FFA91D42855900E000B1 /* NetworkTransport.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		9BC742AC24CFB2FF0029282C /* ApolloErrorInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC742AB24CFB2FF0029282C /* ApolloErrorInterceptor.swift */; };
 		9BC742AE24CFB6450029282C /* LegacyCacheWriteInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC742AD24CFB6450029282C /* LegacyCacheWriteInterceptor.swift */; };
 		9BC90F5D252E609700AD0922 /* RawDataCacheHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC90F5C252E609700AD0922 /* RawDataCacheHelper.swift */; };
+		9BC90F8A252E729700AD0922 /* RawCacheDataHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC90F6C252E727200AD0922 /* RawCacheDataHelperTests.swift */; };
 		9BCF0CE023FC9CA50031D2A2 /* TestCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCF0CD923FC9CA50031D2A2 /* TestCacheProvider.swift */; };
 		9BCF0CE323FC9CA50031D2A2 /* XCTAssertHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCF0CDC23FC9CA50031D2A2 /* XCTAssertHelpers.swift */; };
 		9BCF0CE423FC9CA50031D2A2 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCF0CDD23FC9CA50031D2A2 /* MockURLSession.swift */; };
@@ -672,6 +673,7 @@
 		9BC742AB24CFB2FF0029282C /* ApolloErrorInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloErrorInterceptor.swift; sourceTree = "<group>"; };
 		9BC742AD24CFB6450029282C /* LegacyCacheWriteInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCacheWriteInterceptor.swift; sourceTree = "<group>"; };
 		9BC90F5C252E609700AD0922 /* RawDataCacheHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataCacheHelper.swift; sourceTree = "<group>"; };
+		9BC90F6C252E727200AD0922 /* RawCacheDataHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawCacheDataHelperTests.swift; sourceTree = "<group>"; };
 		9BCF0CD923FC9CA50031D2A2 /* TestCacheProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCacheProvider.swift; sourceTree = "<group>"; };
 		9BCF0CDA23FC9CA50031D2A2 /* ApolloTestSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApolloTestSupport.h; sourceTree = "<group>"; };
 		9BCF0CDC23FC9CA50031D2A2 /* XCTAssertHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssertHelpers.swift; sourceTree = "<group>"; };
@@ -1489,6 +1491,8 @@
 			isa = PBXGroup;
 			children = (
 				9FA6ABC51EC0A9F7000017BE /* FetchQueryTests.swift */,
+				9FA6ABC61EC0A9F7000017BE /* LoadQueryFromStoreTests.swift */,
+				9BC90F6C252E727200AD0922 /* RawCacheDataHelperTests.swift */,
 				9FA6ABC81EC0A9F7000017BE /* StarWarsServerCachingRoundtripTests.swift */,
 				9FA6ABC91EC0A9F7000017BE /* StarWarsServerTests.swift */,
 				9FA6ABC61EC0A9F7000017BE /* LoadQueryFromStoreTests.swift */,
@@ -2549,6 +2553,7 @@
 				9FA6ABCD1EC0A9F7000017BE /* LoadQueryFromStoreTests.swift in Sources */,
 				9FA6ABCF1EC0A9F7000017BE /* StarWarsServerCachingRoundtripTests.swift in Sources */,
 				9FA6ABD21EC0A9F7000017BE /* WatchQueryTests.swift in Sources */,
+				9BC90F8A252E729700AD0922 /* RawCacheDataHelperTests.swift in Sources */,
 				9B60204F23FDFA9F00D0C8E0 /* SQLiteCacheTests.swift in Sources */,
 				9FA6ABD01EC0A9F7000017BE /* StarWarsServerTests.swift in Sources */,
 				9F8622F81EC2004200C38162 /* ReadWriteFromStoreTests.swift in Sources */,

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
@@ -82,6 +82,9 @@
                   Identifier = "SQLiteLoadQueryFromStoreTests">
                </Test>
                <Test
+                  Identifier = "SQLiteRawCacheDataHelperTests">
+               </Test>
+               <Test
                   Identifier = "SQLiteReadWriteFromStoreTests">
                </Test>
                <Test

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -73,6 +73,9 @@
                   Identifier = "LoadQueryFromStoreTests">
                </Test>
                <Test
+                  Identifier = "RawCacheDataHelperTests">
+               </Test>
+               <Test
                   Identifier = "ReadWriteFromStoreTests">
                </Test>
                <Test

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -71,19 +71,7 @@ public final class ApolloStore {
     }
   }
   
-  func publishWithCompletion(recordSet: RecordSet,
-                             identifier: UUID? = nil,
-                             completion: @escaping (Result<Void, Error>) -> Void) {
-    self.publish(records: recordSet)
-      .andThen {
-        completion(.success(()))
-      }
-      .catch { error in
-        completion(.failure(error))
-      }
-  }
-
-  private func publish(records: RecordSet, identifier: UUID? = nil) -> Promise<Void> {
+  func publish(records: RecordSet, identifier: UUID? = nil) -> Promise<Void> {
     return Promise<Void> { fulfill, reject in
       queue.async(flags: .barrier) {
         self.cacheLock.withWriteLock {

--- a/Sources/Apollo/RawDataCacheHelper.swift
+++ b/Sources/Apollo/RawDataCacheHelper.swift
@@ -1,0 +1,233 @@
+import Foundation
+import ApolloCore
+
+/// A protocol to allow fetching of raw data from the network, without
+/// doing any error handling at the network level.
+public protocol RawNetworkFetcher {
+  
+  /// A method that will be called when data should be fetched from the network.
+  ///
+  /// This should generally be called from a custom `NetworkTransport` implementation.
+  ///
+  /// - Parameter onSuccess: The completion closure to call when data has been successfully fetched from the network.
+  func fetchData(onSuccess: (Data) -> Void)
+}
+
+/// A class to provide a bridge to allow users with custom `NetworkTransports`
+/// who can't switch to `RequestChainNetworkTransport` or a subclass of it to
+/// continue to be able to use that transport to hit the cache in the previously
+/// expected order.
+///
+/// A new `RawDataCacheHelper` should be used for each request, so that requests
+/// can be cancelled if needed.
+public class RawDataCacheHelper {
+  
+  private var isCancelled = Atomic<Bool>(false)
+  private var isNotCancelled: Bool {
+    !self.isCancelled.value
+  }
+  
+  /// Designated initializer.
+  public init() {}
+  
+  ///
+  /// - Parameters:
+  ///   - operation: The operation
+  ///   - cachePolicy: The `CachePolicy` to use when fetching.
+  ///   - contextIdentifier: [optional] A unique identifier for this request, to help with deduping cache hits for watchers.
+  ///   - store: The store to use to read and write from
+  ///   - networkFetcher: An object
+  ///   - completion: The completion closure to execute when parsed data or an error has been received. NOTE: May be called more than once, especially when using the `.returnCacheDataAndFetch` cache policy
+  public func sendViaCache<Operation: GraphQLOperation>(
+    operation: Operation,
+    cachePolicy: CachePolicy,
+    contextIdentifier: UUID? = nil,
+    store: ApolloStore,
+    networkFetcher: RawNetworkFetcher,
+    completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+    
+    switch cachePolicy {
+    case .fetchIgnoringCacheCompletely:
+      networkFetcher.fetchData { data in
+        self.parseDataFast(data: data,
+                           operation: operation,
+                           completion: completion)
+      }
+    case .returnCacheDataElseFetch:
+      self.fetchFromStore(store: store,
+                          operation: operation) { storeResult in
+        switch storeResult {
+        case .success(let graphQLResult):
+          completion(.success(graphQLResult))
+        case .failure:
+          networkFetcher.fetchData { data in
+            self.parseThenWriteToStore(data: data,
+                                       store: store,
+                                       operation: operation,
+                                       contextIdentifier: contextIdentifier,
+                                       completion: completion)
+          }
+        }
+      }
+    case .fetchIgnoringCacheData:
+      networkFetcher.fetchData { [weak self] data in
+        self?.parseThenWriteToStore(data: data,
+                                    store: store,
+                                    operation: operation,
+                                    contextIdentifier: contextIdentifier,
+                                    completion: completion)
+      }
+    case .returnCacheDataDontFetch:
+      self.fetchFromStore(store: store,
+                          operation: operation,
+                          completion: completion)
+    case .returnCacheDataAndFetch:
+      self.fetchFromStore(
+        store: store,
+        operation: operation) { storeResult in
+        switch storeResult {
+        case .failure:
+          // Don't return the error here, just proceed
+          break
+        case .success(let result):
+          // Return result, THEN proceed.
+          completion(.success(result))
+        }
+        
+        networkFetcher.fetchData { [weak self] data in
+          self?.parseThenWriteToStore(data: data,
+                                      store: store,
+                                      operation: operation,
+                                      contextIdentifier: contextIdentifier,
+                                      completion: completion)
+        }
+      }
+    }
+  }
+  
+  private func parseThenWriteToStore<Operation: GraphQLOperation>(
+    data: Data,
+    store: ApolloStore,
+    operation: Operation,
+    contextIdentifier: UUID?,
+    completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+    
+    self.parseData(
+      data: data,
+      operation: operation,
+      cacheKeyForObject: store.cacheKeyForObject,
+      completion: { [weak self] result in
+        switch result {
+        case .failure(let error):
+          completion(.failure(error))
+        case .success(let (result, recordSet)):
+          self?.writeToStore(store: store,
+                             operation: operation,
+                             contextIdentifier: contextIdentifier,
+                             recordSet: recordSet,
+                             result: result,
+                             completion: completion)
+        }
+      })
+  }
+  
+  // MARK: - Cache Fetch
+  
+  private func fetchFromStore<Operation: GraphQLOperation>(
+    store: ApolloStore,
+    operation: Operation,
+    completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+    
+    guard self.isNotCancelled else {
+      return
+    }
+    
+    store.load(query: operation, resultHandler: completion)
+  }
+  
+  // MARK: - Parsing
+  
+  private func deserialize<Operation: GraphQLOperation>(
+    data: Data,
+    operation: Operation) throws -> GraphQLResponse<Operation.Data> {
+   
+    let deserialized = try JSONSerializationFormat.deserialize(data: data)
+    guard let body = deserialized as? JSONObject else {
+      throw LegacyParsingInterceptor.LegacyParsingError.couldNotParseToLegacyJSON(data: data)
+    }
+  
+    return GraphQLResponse(operation: operation, body: body)
+  }
+  
+  private func parseDataFast<Operation: GraphQLOperation>(
+    data: Data,
+    operation: Operation,
+    completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+    
+    guard self.isNotCancelled else {
+      return
+    }
+    
+    do {
+      let graphQLResponse = try self.deserialize(data: data, operation: operation)
+      let result = try graphQLResponse.parseResultFast()
+      completion(.success(result))
+    } catch {
+      completion(.failure(error))
+    }
+  }
+  
+  private func parseData<Operation: GraphQLOperation>(
+    data: Data,
+    operation: Operation,
+    cacheKeyForObject: CacheKeyForObject?,
+    completion: @escaping (Result<(GraphQLResult<Operation.Data>, RecordSet?), Error>) -> Void) {
+    
+    guard self.isNotCancelled else {
+      return
+    }
+    
+    do {
+      let graphQLResponse = try self.deserialize(data: data, operation: operation)
+      graphQLResponse.parseResultWithCompletion(cacheKeyForObject: cacheKeyForObject,
+                                                completion: completion)
+    } catch {
+      completion(.failure(error))
+    }
+  }
+  
+  // MARK: - Cache Write
+  
+  private func writeToStore<Operation: GraphQLOperation>(
+    store: ApolloStore,
+    operation: Operation,
+    contextIdentifier: UUID?,
+    recordSet: RecordSet?,
+    result: GraphQLResult<Operation.Data>,
+    completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+      
+    guard self.isNotCancelled else {
+      return
+    }
+    
+    guard let records = recordSet else {
+      return
+    }
+      
+    store.publishWithCompletion(recordSet: records, identifier: contextIdentifier) { publishResult in
+      switch publishResult {
+      case .failure(let error):
+        completion(.failure(error))
+      case .success:
+        completion(.success(result))
+      }
+    }
+  }
+}
+
+extension RawDataCacheHelper: Cancellable {
+  
+  public func cancel() {
+    self.isCancelled.value = true
+  }
+}

--- a/Sources/Apollo/RawDataCacheHelper.swift
+++ b/Sources/Apollo/RawDataCacheHelper.swift
@@ -215,14 +215,13 @@ public class RawDataCacheHelper {
       return
     }
       
-    store.publishWithCompletion(recordSet: records, identifier: contextIdentifier) { publishResult in
-      switch publishResult {
-      case .failure(let error):
-        completion(.failure(error))
-      case .success:
-        completion(.success(result))
+    store.publish(records: records, identifier: contextIdentifier)
+      .catch { error in
+        // Something has gone terribly wrong and we should at least know about it during development
+        assertionFailure(String(describing: error))
       }
-    }
+    
+    completion(.success(result))
   }
 }
 

--- a/Sources/Apollo/RawDataCacheHelper.swift
+++ b/Sources/Apollo/RawDataCacheHelper.swift
@@ -28,6 +28,8 @@ public class RawDataCacheHelper {
     !self.isCancelled.value
   }
   
+  let id = UUID()
+  
   /// Designated initializer.
   public init() {}
   
@@ -242,6 +244,12 @@ public class RawDataCacheHelper {
       }
     
     completion(.success(result))
+  }
+}
+
+extension RawDataCacheHelper: Equatable {
+  public static func == (lhs: RawDataCacheHelper, rhs: RawDataCacheHelper) -> Bool {
+    lhs.id == rhs.id
   }
 }
 

--- a/Sources/Apollo/RawDataCacheHelper.swift
+++ b/Sources/Apollo/RawDataCacheHelper.swift
@@ -8,9 +8,10 @@ public protocol RawNetworkFetcher {
   /// A method that will be called when data should be fetched from the network.
   ///
   /// This should generally be called from a custom `NetworkTransport` implementation.
-  ///
-  /// - Parameter onSuccess: The completion closure to call when data has been successfully fetched from the network.
-  func fetchData(onSuccess: (Data) -> Void)
+  /// - Parameters:
+  ///   - operation: The operation being executed
+  ///   - onSuccess: The completion closure to call when data has been successfully fetched from the network.
+  func fetchData<Operation: GraphQLOperation>(operation: Operation, onSuccess: @escaping (Data) -> Void)
 }
 
 /// A class to provide a bridge to allow users with custom `NetworkTransports`
@@ -48,7 +49,7 @@ public class RawDataCacheHelper {
     
     switch cachePolicy {
     case .fetchIgnoringCacheCompletely:
-      networkFetcher.fetchData { data in
+      networkFetcher.fetchData(operation: operation) { data in
         self.parseDataFast(data: data,
                            operation: operation,
                            completion: completion)
@@ -60,7 +61,7 @@ public class RawDataCacheHelper {
         case .success(let graphQLResult):
           completion(.success(graphQLResult))
         case .failure:
-          networkFetcher.fetchData { data in
+          networkFetcher.fetchData(operation: operation) { data in
             self.parseThenWriteToStore(data: data,
                                        store: store,
                                        operation: operation,
@@ -70,7 +71,7 @@ public class RawDataCacheHelper {
         }
       }
     case .fetchIgnoringCacheData:
-      networkFetcher.fetchData { [weak self] data in
+      networkFetcher.fetchData(operation: operation) { [weak self] data in
         self?.parseThenWriteToStore(data: data,
                                     store: store,
                                     operation: operation,
@@ -94,7 +95,7 @@ public class RawDataCacheHelper {
           completion(.success(result))
         }
         
-        networkFetcher.fetchData { [weak self] data in
+        networkFetcher.fetchData(operation: operation) { [weak self] data in
           self?.parseThenWriteToStore(data: data,
                                       store: store,
                                       operation: operation,

--- a/Tests/ApolloCacheDependentTests/RawCacheDataHelperTests.swift
+++ b/Tests/ApolloCacheDependentTests/RawCacheDataHelperTests.swift
@@ -18,7 +18,7 @@ class RawCacheDataHelperTests: XCTestCase, CacheTesting {
   }
   
   private class TestFetcher: RawNetworkFetcher {
-    func fetchData<Operation: GraphQLOperation>(operation: Operation, onSuccess: @escaping (Data) -> Void) {
+    func fetchData<Operation: GraphQLOperation>(operation: Operation, completion: @escaping (Result<Data, Error>) -> Void) {
       let json = """
 {
   "data": {
@@ -31,7 +31,7 @@ class RawCacheDataHelperTests: XCTestCase, CacheTesting {
 }
 """
       
-      onSuccess(json.data(using: .utf8)!)
+      completion(.success(json.data(using: .utf8)!))
     }
   }
   

--- a/Tests/ApolloCacheDependentTests/RawCacheDataHelperTests.swift
+++ b/Tests/ApolloCacheDependentTests/RawCacheDataHelperTests.swift
@@ -1,0 +1,413 @@
+//
+//  RawCacheDataHelperTests.swift
+//  Apollo
+//
+//  Created by Ellen Shapiro on 10/7/20.
+//  Copyright © 2020 Apollo GraphQL. All rights reserved.
+//
+
+import XCTest
+import Apollo
+import ApolloTestSupport
+import StarWarsAPI
+
+class RawCacheDataHelperTests: XCTestCase, CacheTesting {
+  
+  var cacheType: TestCacheProvider.Type {
+    InMemoryTestCacheProvider.self
+  }
+  
+  private class TestFetcher: RawNetworkFetcher {
+    func fetchData(onSuccess: (Data) -> Void) {
+      let json = """
+{
+  "data": {
+    "hero": {
+      "__typename": "Human",
+      "name": "Luke Skywalker"
+    }
+  },
+  "errors": null
+}
+"""
+      
+      onSuccess(json.data(using: .utf8)!)
+    }
+  }
+  
+  func testFetchIgnoringCacheCompletelyIgnoresExistingCacheAndReturnsDataAndDoesNotWriteToCache() {
+    
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+      ]
+    ]
+    
+    withCache(initialRecords: initialRecords) { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .fetchIgnoringCacheCompletely,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // This should have the result from the network:
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        // The existing item in the cache should not have been touched:
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Droid")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testFetchIgnoringCacheDataIgnoresExistingCacheAndReturnsDataAndWritesToCache() {
+    
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+      ]
+    ]
+    
+    withCache(initialRecords: initialRecords) { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .fetchIgnoringCacheData,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // This should have the result from the network:
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      // The existing item in the cache should have been updated
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testReturnCacheDataDontFetchWithRecordReturnsTheRecordAndDoesNotUpdateTheCache() {
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+      ]
+    ]
+    
+    withCache(initialRecords: initialRecords) { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .returnCacheDataDontFetch,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // This should have the result from the network:
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Droid")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      // The existing item in the cache should have been updated
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Droid")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testReturnCacheDataDontFetchWithoutRecordReturnsAnErrorAndDoesNotUpdateTheCache() {
+    withCache { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .returnCacheDataDontFetch,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // This should be an error since there's nothing in the initial cache and we're not going out to fetch:
+        switch cacheHelperResult {
+        case .failure(let error):
+          switch error {
+          case JSONDecodingError.missingValue:
+            // This is what we expect.
+            break
+          default:
+            XCTFail("Unexpected error type: \(error)")
+          }
+        case .success:
+          XCTFail("This fetch should not have succeeded with an empty cache!")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        // There should still be nothing in the cache
+        switch cacheResult {
+        case .failure(let error):
+          switch error {
+          case JSONDecodingError.missingValue:
+            // This is what we expect.
+            break
+          default:
+            XCTFail("Unexpected error type: \(error)")
+          }
+        case .success:
+          XCTFail("This fetch should not have succeeded with an empty cache!")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testReturnCacheDataElseFetchWithRecordReturnsTheRecordAndDoesNotUpdateTheCache() {
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+      ]
+    ]
+    
+    withCache(initialRecords: initialRecords) { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .returnCacheDataElseFetch,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // This should have the result from the network:
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Droid")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        // The existing item in the cache should not have been touched:
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Droid")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testReturnCacheDataElseFetchWithoutRecordReturnsRecordFromNetworkAndUpdatesTheCache() {
+    withCache { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .returnCacheDataElseFetch,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // We should get the result from the network here
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        // Result from network should now be in cache
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testReturnCacheDataAndFetchWithRecordReturnsCacheRecordThenNetworkRecordAndUpdatesCache() {
+    let initialRecords: RecordSet = [
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+      ]
+    ]
+    
+    withCache(initialRecords: initialRecords) { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      fetchExpectation.expectedFulfillmentCount = 2
+      var callbackCount = 0
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .returnCacheDataAndFetch,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        callbackCount += 1
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          switch callbackCount {
+          case 1:
+            // This should have the result from the cache:
+            XCTAssertEqual(graphQLResult.data?.hero?.name, "R2-D2")
+            XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Droid")
+          case 2:
+            // This should have the result from the network:
+            XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+            XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+          default:
+            XCTFail("Too many callbacks!")
+          }
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        // This should now have the result from the network:
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+  
+  func testReturnCacheDataAndFetchWithoutRecordReturnsOnceWithFetchedRecordAndUpdatesCache() {
+    withCache { cache in
+      let store = ApolloStore(cache: cache)
+      
+      let fetchExpectation = self.expectation(description: "Fetch complete")
+      RawDataCacheHelper().sendViaCache(operation: HeroNameQuery(),
+                                        cachePolicy: .returnCacheDataElseFetch,
+                                        store: store,
+                                        networkFetcher: TestFetcher()) { cacheHelperResult in
+        // We should get the result from the network here, and only once
+        switch cacheHelperResult {
+        case .failure(let error):
+          XCTFail("Unexpected error with cache helper: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        fetchExpectation.fulfill()
+      }
+      self.wait(for: [fetchExpectation], timeout: 2)
+      
+      let loadExpectation = self.expectation(description: "Load complete")
+      store.load(query: HeroNameQuery()) { cacheResult in
+        // Result from network should now be in cache
+        switch cacheResult {
+        case .failure(let error):
+          XCTFail("Unexpected error fetching from cache: \(error)")
+        case .success(let graphQLResult):
+          XCTAssertEqual(graphQLResult.data?.hero?.name, "Luke Skywalker")
+          XCTAssertEqual(graphQLResult.data?.hero?.__typename, "Human")
+        }
+        
+        loadExpectation.fulfill()
+      }
+      self.wait(for: [loadExpectation], timeout: 2)
+    }
+  }
+}

--- a/Tests/ApolloCacheDependentTests/RawCacheDataHelperTests.swift
+++ b/Tests/ApolloCacheDependentTests/RawCacheDataHelperTests.swift
@@ -18,7 +18,7 @@ class RawCacheDataHelperTests: XCTestCase, CacheTesting {
   }
   
   private class TestFetcher: RawNetworkFetcher {
-    func fetchData(onSuccess: (Data) -> Void) {
+    func fetchData<Operation: GraphQLOperation>(operation: Operation, onSuccess: @escaping (Data) -> Void) {
       let json = """
 {
   "data": {

--- a/Tests/ApolloCacheDependentTests/SQLiteCacheTests.swift
+++ b/Tests/ApolloCacheDependentTests/SQLiteCacheTests.swift
@@ -50,3 +50,10 @@ class SQLiteWatchQueryTests: WatchQueryTests {
   }
 }
 
+class SQLiteRawCacheDataHelperTests: RawCacheDataHelperTests {
+  
+  override var cacheType: TestCacheProvider.Type {
+    SQLiteTestCacheProvider.self
+  }
+}
+


### PR DESCRIPTION
So as part of the network refactor, I moved the logic for caching out of `ApolloClient` and into interceptors, with the logic that making this much more granular would allow people to order things in whatever order they'd like and/or do whatever pre-cache or post-cache manipulation they wanted. 

Turns out I missed one critical use case: Custom `NetworkTransport` implementations that can't be converted into interceptors. In this case, we'd removed all the cache fetch and store logic with nothing to replace it, so essentially every call became `fetchIgnoringCacheCompletely`. 🤦‍♀️

To fix that, I've added a `RawCacheDataHelper`, which allows you to pass in the requisite items as well as an object satisfying the `RawNetworkFetcher` protocol. The helper will use the passed-in `CachePolicy` to determine the order and necessity of hitting the store read -> fetch from network -> store write circuit, and if hitting the network is necessary, it will call `fetchData` with the operation to be fetched so that your network layer can do what's necessary to actually go out and fetch that data. Some examples of how this would work are in the `RawCacheDataHelper` tests. 

I also made a couple things in the `ApolloStore` switch to using completion closures in their internal APIs rather than the `Promise` implementation that's really been more of a source of confusion than anything. I'd eventually like to rip that out and this seemed like a good place to keep that logic from propagating.