### PR TITLE
Move default implementation of RequestBodyCreator

### DIFF
--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -29,6 +29,22 @@ extension RequestBodyCreator {
                                                        sendOperationIdentifiers: Bool = false,
                                                        sendQueryDocument: Bool = true,
                                                        autoPersistQuery: Bool = false) -> GraphQLMap {
+    self.requestBody(for: operation,
+                     sendOperationIdentifiers: sendOperationIdentifiers,
+                     sendQueryDocument: sendQueryDocument,
+                     autoPersistQuery: autoPersistQuery)
+  }
+}
+
+// Helper struct to create requests independently of HTTP operations.
+public struct ApolloRequestBodyCreator: RequestBodyCreator {
+  // Internal init methods cannot be used in public methods
+  public init() { }
+
+  public func requestBody<Operation>(for operation: Operation,
+                              sendOperationIdentifiers: Bool,
+                              sendQueryDocument: Bool,
+                              autoPersistQuery: Bool) -> GraphQLMap where Operation : GraphQLOperation {
     var body: GraphQLMap = [
       "variables": operation.variables,
       "operationName": operation.operationName,
@@ -58,10 +74,4 @@ extension RequestBodyCreator {
 
     return body
   }
-}
-
-// Helper struct to create requests independently of HTTP operations.
-public struct ApolloRequestBodyCreator: RequestBodyCreator {
-  // Internal init methods cannot be used in public methods
-  public init() { }
 }


### PR DESCRIPTION
To fix this [issues](https://github.com/apollographql/apollo-ios/issues/1444).

I propose to move default implementation of the `RequestBodyCreator` protocol in `ApolloRequestBodyCreator `