### PR TITLE
Fix request body creator non-default implementations getting hammered by compiler

### DIFF
--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -25,10 +25,10 @@ extension RequestBodyCreator {
   ///   - sendQueryDocument: Whether or not to send the full query document. Defaults to true.
   ///   - autoPersistQuery: Whether to use auto-persisted query information. Defaults to false.
   /// - Returns: The created `GraphQLMap`
-  public func requestBody<Operation: GraphQLOperation>(for operation: Operation,
-                                                       sendOperationIdentifiers: Bool = false,
-                                                       sendQueryDocument: Bool = true,
-                                                       autoPersistQuery: Bool = false) -> GraphQLMap {
+  public func defaultRequestBody<Operation: GraphQLOperation>(for operation: Operation,
+                                                              sendOperationIdentifiers: Bool,
+                                                              sendQueryDocument: Bool,
+                                                              autoPersistQuery: Bool) -> GraphQLMap {
     var body: GraphQLMap = [
       "variables": operation.variables,
       "operationName": operation.operationName,
@@ -64,4 +64,16 @@ extension RequestBodyCreator {
 public struct ApolloRequestBodyCreator: RequestBodyCreator {
   // Internal init methods cannot be used in public methods
   public init() { }
+  
+  public func requestBody<Operation: GraphQLOperation>(
+    for operation: Operation,
+    sendOperationIdentifiers: Bool = false,
+    sendQueryDocument: Bool = true,
+    autoPersistQuery: Bool = false) -> GraphQLMap {
+    
+    return self.defaultRequestBody(for: operation,
+                                   sendOperationIdentifiers: sendOperationIdentifiers,
+                                   sendQueryDocument: sendQueryDocument,
+                                   autoPersistQuery: autoPersistQuery)
+  }
 }

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -8,7 +8,9 @@ public protocol RequestBodyCreator {
   ///
   /// - Parameters:
   ///   - operation: The operation to use
-  ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
+  ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Should default to `false`.
+  ///   - sendQueryDocument: Whether or not to send the full query document. Should default to `true`.
+  ///   - autoPersistQuery: Whether to use auto-persisted query information. Should default to `false`.
   /// - Returns: The created `GraphQLMap`
   func requestBody<Operation: GraphQLOperation>(for operation: Operation,
                                                 sendOperationIdentifiers: Bool,

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -16,19 +16,14 @@ public protocol RequestBodyCreator {
                                                 autoPersistQuery: Bool) -> GraphQLMap
 }
 
+// MARK: - Default Implementation
+
 extension RequestBodyCreator {
-  /// Creates a `GraphQLMap` out of the passed-in operation
-  ///
-  /// - Parameters:
-  ///   - operation: The operation to use
-  ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Defaults to false.
-  ///   - sendQueryDocument: Whether or not to send the full query document. Defaults to true.
-  ///   - autoPersistQuery: Whether to use auto-persisted query information. Defaults to false.
-  /// - Returns: The created `GraphQLMap`
-  public func defaultRequestBody<Operation: GraphQLOperation>(for operation: Operation,
-                                                              sendOperationIdentifiers: Bool,
-                                                              sendQueryDocument: Bool,
-                                                              autoPersistQuery: Bool) -> GraphQLMap {
+  
+  public func requestBody<Operation: GraphQLOperation>(for operation: Operation,
+                                                       sendOperationIdentifiers: Bool,
+                                                       sendQueryDocument: Bool,
+                                                       autoPersistQuery: Bool) -> GraphQLMap {
     var body: GraphQLMap = [
       "variables": operation.variables,
       "operationName": operation.operationName,
@@ -64,16 +59,4 @@ extension RequestBodyCreator {
 public struct ApolloRequestBodyCreator: RequestBodyCreator {
   // Internal init methods cannot be used in public methods
   public init() { }
-  
-  public func requestBody<Operation: GraphQLOperation>(
-    for operation: Operation,
-    sendOperationIdentifiers: Bool = false,
-    sendQueryDocument: Bool = true,
-    autoPersistQuery: Bool = false) -> GraphQLMap {
-    
-    return self.defaultRequestBody(for: operation,
-                                   sendOperationIdentifiers: sendOperationIdentifiers,
-                                   sendQueryDocument: sendQueryDocument,
-                                   autoPersistQuery: autoPersistQuery)
-  }
 }

--- a/Sources/Apollo/UploadRequest.swift
+++ b/Sources/Apollo/UploadRequest.swift
@@ -69,7 +69,10 @@ open class UploadRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     // Make sure all fields for files are set to null, or the server won't look
     // for the files in the rest of the form data
     let fieldsForFiles = Set(files.map { $0.fieldName }).sorted()
-    var fields = self.requestBodyCreator.requestBody(for: operation, sendOperationIdentifiers: shouldSendOperationID)
+    var fields = self.requestBodyCreator.requestBody(for: operation,
+                                                     sendOperationIdentifiers: shouldSendOperationID,
+                                                     sendQueryDocument: true,
+                                                     autoPersistQuery: false)
     var variables = fields["variables"] as? GraphQLMap ?? GraphQLMap()
     for fieldName in fieldsForFiles {
       if

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -270,7 +270,10 @@ public class WebSocketTransport {
   }
 
   func sendHelper<Operation: GraphQLOperation>(operation: Operation, resultHandler: @escaping (_ result: Result<JSONObject, Error>) -> Void) -> String? {
-    let body = requestBodyCreator.requestBody(for: operation, sendOperationIdentifiers: self.sendOperationIdentifiers)
+    let body = requestBodyCreator.requestBody(for: operation,
+                                              sendOperationIdentifiers: self.sendOperationIdentifiers,
+                                              sendQueryDocument: true,
+                                              autoPersistQuery: false)
     let sequenceNumber = "\(sequenceNumberCounter.increment())"
 
     guard let message = OperationMessage(payload: body, id: sequenceNumber).rawMessage else {

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -17,7 +17,10 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithSingleParameter() {
     let operation = HeroNameQuery(episode: .empire)
-    let body = requestBodyCreator.requestBody(for: operation, sendOperationIdentifiers: false)
+    let body = requestBodyCreator.requestBody(for: operation,
+                                              sendOperationIdentifiers: false,
+                                              sendQueryDocument: true,
+                                              autoPersistQuery: false)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -28,7 +31,10 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithMoreThanOneParameterIncludingNonHashableValue() throws {
     let operation = HeroNameTypeSpecificConditionalInclusionQuery(episode: .jedi, includeName: true)
-    let body = requestBodyCreator.requestBody(for: operation, sendOperationIdentifiers: false)
+    let body = requestBodyCreator.requestBody(for: operation,
+                                              sendOperationIdentifiers: false,
+                                              sendQueryDocument: true,
+                                              autoPersistQuery: false)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     
@@ -195,7 +201,10 @@ class GETTransformerTests: XCTestCase {
   
   func testEncodingQueryWithNullDefaultParameter() {
     let operation = HeroNameQuery()
-    let body = requestBodyCreator.requestBody(for: operation, sendOperationIdentifiers: false)
+    let body = requestBodyCreator.requestBody(for: operation,
+                                              sendOperationIdentifiers: false,
+                                              sendQueryDocument: true,
+                                              autoPersistQuery: false)
     
     let transformer = GraphQLGETTransformer(body: body, url: self.url)
     

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -15,18 +15,25 @@ class RequestBodyCreatorTests: XCTestCase {
   private let customRequestBodyCreator = TestCustomRequestBodyCreator()
   private let apolloRequestBodyCreator = ApolloRequestBodyCreator()
   
+  func create<Operation: GraphQLOperation>(with creator: RequestBodyCreator, for query: Operation) -> GraphQLMap {
+    creator.requestBody(for: query,
+                        sendOperationIdentifiers: false,
+                        sendQueryDocument: true,
+                        autoPersistQuery: false)
+  }
+  
   // MARK: - Tests
   
   func testRequestBodyWithApolloRequestBodyCreator() {
     let query = HeroNameQuery()
-    let req = apolloRequestBodyCreator.requestBody(for: query, sendOperationIdentifiers: false)
+    let req = self.create(with: apolloRequestBodyCreator, for: query)
 
     XCTAssertEqual(query.queryDocument, req["query"] as? String)
   }
 
   func testRequestBodyWithCustomRequestBodyCreator() {
     let query = HeroNameQuery()
-    let req = customRequestBodyCreator.requestBody(for: query, sendOperationIdentifiers: false)
+    let req = self.create(with: customRequestBodyCreator, for: query)
 
     XCTAssertEqual(query.queryDocument, req["test_query"] as? String)
   }

--- a/Tests/ApolloTests/TestCustomRequestBodyCreator.swift
+++ b/Tests/ApolloTests/TestCustomRequestBodyCreator.swift
@@ -9,7 +9,11 @@
 import Apollo
 
 struct TestCustomRequestBodyCreator: RequestBodyCreator {
-  public func requestBody<Operation: GraphQLOperation>(for operation: Operation, sendOperationIdentifiers: Bool) -> GraphQLMap {
+  func requestBody<Operation: GraphQLOperation>(
+    for operation: Operation,
+    sendOperationIdentifiers: Bool,
+    sendQueryDocument: Bool, autoPersistQuery: Bool) -> GraphQLMap {
+    
     var body: GraphQLMap = [
       "test_variables": operation.variables,
       "test_operationName": operation.operationName,


### PR DESCRIPTION
Addresses #1444. Note that this will be a **breaking change**.

So I seriously had to [rewatch this bit of _my own talk_ about this](https://youtu.be/a0m0acpM8II?t=812) to figure out why this hadn't twigged on me earlier: I was expecting this to be like the `sayHi` method in that example, where because it's declared in the protocol, the compiler uses the lowest level of implementation rather than going to to the default implementation. Instead, it's behaving like the `askHowAreYou` method, which is not defined in the implementation, and which is defaulting to the protocol's default implementation.

The test we had previously validated that things worked when called _directly_, but not when called _indirectly_: When I made the changes to the test in this PR, it immediately started failing, so that definitely meant that we were closer to the `askHowAreYou` situation.

As far as I can tell, this is some weird combination of circumstances in terms of what we were doing with default values on the default argument vs. the implementation in the test. I suspect that because it *looked* like we were making the same call, we thought we were. But due to the default implementation's default values, we were actually calling two totally different methods on the two tests, and that only revealed itself when called indirectly. 

SO. Because I know there are existing implementations that rely on just passing things straight through to what was the default implementation, I've updated that to just be called `defaultRequestBody` so it can be called from other implementations of `RequestBodyCreator`(you can see an example in how I set up the updated `ApolloRequestCreator`). This also allows you to grab the default and modify it instead of having to redo the whole thing yourself.