### PR TITLE
Remove default values from initializers

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -49,7 +49,7 @@ public class ApolloClient {
   /// - Parameters:
   ///   - networkTransport: A network transport used to send operations to a server.
   ///   - store: A store used as a local cache. Should default to an empty store backed by an in-memory cache.
-  public init(networkTransport: NetworkTransport, store: ApolloStore = ApolloStore(cache: InMemoryNormalizedCache())) {
+  public init(networkTransport: NetworkTransport, store: ApolloStore) {
     self.networkTransport = networkTransport
     self.store = store
   }

--- a/Sources/Apollo/InterceptorProvider.swift
+++ b/Sources/Apollo/InterceptorProvider.swift
@@ -42,7 +42,7 @@ open class LegacyInterceptorProvider: InterceptorProvider {
   ///   - store: The `ApolloStore` to use when reading from or writing to the cache. Defaults to the default initializer for ApolloStore.
   public init(client: URLSessionClient = URLSessionClient(),
               shouldInvalidateClientOnDeinit: Bool = true,
-              store: ApolloStore = ApolloStore()) {
+              store: ApolloStore) {
     self.client = client
     self.shouldInvalidateClientOnDeinit = shouldInvalidateClientOnDeinit
     self.store = store

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -231,7 +231,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testRequestBody() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint)
     
@@ -256,7 +257,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testRequestBodyWithVariable() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint)
     
@@ -281,7 +283,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testRequestBodyForAPQsWithVariable() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true)
@@ -307,7 +310,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testMutationRequestBodyForAPQs() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true)
@@ -333,7 +337,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testQueryStringForAPQsUseGetMethod() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,
@@ -358,7 +363,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testQueryStringForAPQsUseGetMethodWithVariable() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,
@@ -385,7 +391,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testUseGETForQueriesRequest() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                additionalHeaders: ["Authentication": "Bearer 1234"],
@@ -413,7 +420,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testNotUseGETForQueriesRequest() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint)
     
@@ -438,7 +446,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testNotUseGETForQueriesAPQsRequest() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true)
@@ -464,7 +473,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testUseGETForQueriesAPQsRequest() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,
@@ -491,7 +501,8 @@ class AutomaticPersistedQueriesTests: XCTestCase {
   
   func testNotUseGETForQueriesAPQsGETRequest() throws {
     let mockClient = MockURLSessionClient()
-    let provider = LegacyInterceptorProvider(client: mockClient)
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
                                                autoPersistQueries: true,

--- a/Tests/ApolloTests/InterceptorTests.swift
+++ b/Tests/ApolloTests/InterceptorTests.swift
@@ -27,8 +27,9 @@ class InterceptorTests: XCTestCase {
         ]
       }
     }
-    
-    let testProvider = TestProvider()
+
+    let store = ApolloStore()
+    let testProvider = TestProvider(store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: testProvider,
                                                endpointURL: TestURL.mockServer.url)
     
@@ -92,8 +93,9 @@ class InterceptorTests: XCTestCase {
         ]
       }
     }
-    
-    let testProvider = TestProvider()
+
+    let store = ApolloStore()
+    let testProvider = TestProvider(store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: testProvider,
                                                endpointURL: TestURL.mockServer.url)
     
@@ -138,8 +140,9 @@ class InterceptorTests: XCTestCase {
         ]
       }
     }
-    
-    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
+
+    let store = ApolloStore()
+    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
                                                endpointURL: TestURL.mockServer.url)
     
     let expectation = self.expectation(description: "Reqeust sent")
@@ -187,8 +190,9 @@ class InterceptorTests: XCTestCase {
         ]
       }
     }
-    
-    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
+
+    let store = ApolloStore()
+    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
                                                endpointURL: TestURL.mockServer.url)
     
     let expectation = self.expectation(description: "Reqeust sent")
@@ -243,8 +247,9 @@ class InterceptorTests: XCTestCase {
         ]
       }
     }
-    
-    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
+
+    let store = ApolloStore()
+    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
                                                endpointURL: TestURL.mockServer.url)
     
     let expectation = self.expectation(description: "Reqeust sent")

--- a/Tests/ApolloTests/InterceptorTests.swift
+++ b/Tests/ApolloTests/InterceptorTests.swift
@@ -28,8 +28,7 @@ class InterceptorTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let testProvider = TestProvider(store: store)
+    let testProvider = TestProvider()
     let network = RequestChainNetworkTransport(interceptorProvider: testProvider,
                                                endpointURL: TestURL.mockServer.url)
     
@@ -94,8 +93,7 @@ class InterceptorTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let testProvider = TestProvider(store: store)
+    let testProvider = TestProvider()
     let network = RequestChainNetworkTransport(interceptorProvider: testProvider,
                                                endpointURL: TestURL.mockServer.url)
     
@@ -141,8 +139,7 @@ class InterceptorTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
+    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
                                                endpointURL: TestURL.mockServer.url)
     
     let expectation = self.expectation(description: "Reqeust sent")
@@ -191,8 +188,7 @@ class InterceptorTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
+    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
                                                endpointURL: TestURL.mockServer.url)
     
     let expectation = self.expectation(description: "Reqeust sent")
@@ -248,8 +244,7 @@ class InterceptorTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
+    let network = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
                                                endpointURL: TestURL.mockServer.url)
     
     let expectation = self.expectation(description: "Reqeust sent")

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -78,8 +78,9 @@ class RequestChainTests: XCTestCase {
         []
       }
     }
-    
-    let transport = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
+
+    let store = ApolloStore()
+    let transport = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
                                                  endpointURL: TestURL.mockServer.url)
     let expectation = self.expectation(description: "kickoff failed")
     _ = transport.send(operation: HeroNameQuery()) { result in
@@ -117,8 +118,9 @@ class RequestChainTests: XCTestCase {
         ]
       }
     }
-    
-    let provider = TestProvider()
+
+    let store = ApolloStore()
+    let provider = TestProvider(store: store)
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url)
     let expectation = self.expectation(description: "Send succeeded")
@@ -163,8 +165,9 @@ class RequestChainTests: XCTestCase {
         return self.errorInterceptor
       }
     }
-    
-    let provider = TestProvider()
+
+    let store = ApolloStore()
+    let provider = TestProvider(store: store)
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url,
                                                  autoPersistQueries: true)
@@ -234,8 +237,9 @@ class RequestChainTests: XCTestCase {
         return self.errorInterceptor
       }
     }
-    
-    let provider = TestProvider()
+
+    let store = ApolloStore()
+    let provider = TestProvider(store: store)
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url,
                                                  autoPersistQueries: true)

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -79,8 +79,7 @@ class RequestChainTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let transport = RequestChainNetworkTransport(interceptorProvider: TestProvider(store: store),
+    let transport = RequestChainNetworkTransport(interceptorProvider: TestProvider(),
                                                  endpointURL: TestURL.mockServer.url)
     let expectation = self.expectation(description: "kickoff failed")
     _ = transport.send(operation: HeroNameQuery()) { result in
@@ -119,8 +118,7 @@ class RequestChainTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let provider = TestProvider(store: store)
+    let provider = TestProvider()
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url)
     let expectation = self.expectation(description: "Send succeeded")
@@ -166,8 +164,7 @@ class RequestChainTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let provider = TestProvider(store: store)
+    let provider = TestProvider()
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url,
                                                  autoPersistQueries: true)
@@ -238,8 +235,7 @@ class RequestChainTests: XCTestCase {
       }
     }
 
-    let store = ApolloStore()
-    let provider = TestProvider(store: store)
+    let provider = TestProvider()
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url,
                                                  autoPersistQueries: true)

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -235,7 +235,7 @@ class RequestChainTests: XCTestCase {
       }
     }
 
-    let provider = TestProvider()
+    let provider = TestProvider(store: ApolloStore())
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: TestURL.mockServer.url,
                                                  autoPersistQueries: true)

--- a/Tests/ApolloTests/RequestChainTests.swift
+++ b/Tests/ApolloTests/RequestChainTests.swift
@@ -15,11 +15,12 @@ class RequestChainTests: XCTestCase {
   
   lazy var legacyClient: ApolloClient = {
     let url = TestURL.starWarsServer.url
-    let provider = LegacyInterceptorProvider()
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(store: store)
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: url)
     
-    return ApolloClient(networkTransport: transport)
+    return ApolloClient(networkTransport: transport, store: store)
   }()
   
   func testLoading() {

--- a/Tests/ApolloTests/UploadTests.swift
+++ b/Tests/ApolloTests/UploadTests.swift
@@ -9,11 +9,12 @@ class UploadTests: XCTestCase {
   let uploadClientURL = TestURL.uploadServer.url
   
   lazy var client: ApolloClient = {
-    let provider = LegacyInterceptorProvider()
+    let store = ApolloStore()
+    let provider = LegacyInterceptorProvider(store: store)
     let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                  endpointURL: self.uploadClientURL)
     
-    return ApolloClient(networkTransport: transport)
+    return ApolloClient(networkTransport: transport, store: store)
   }()
   
   override static func tearDown() {

--- a/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
+++ b/Tests/ApolloWebsocketTests/MockWebSocketTests.swift
@@ -22,7 +22,7 @@ class MockWebSocketTests: XCTestCase {
   
     WebSocketTransport.provider = MockWebSocket.self
     networkTransport = WebSocketTransport(request: URLRequest(url: TestURL.mockServer.url))
-    client = ApolloClient(networkTransport: networkTransport!)
+    client = ApolloClient(networkTransport: networkTransport!, store: ApolloStore())
   }
     
   override func tearDown() {

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -23,7 +23,7 @@ class StarWarsSubscriptionTests: XCTestCase {
     WebSocketTransport.provider = ApolloWebSocket.self
     webSocketTransport = WebSocketTransport(request: URLRequest(url: TestURL.starWarsWebSocket.url))
     webSocketTransport.delegate = self
-    client = ApolloClient(networkTransport: webSocketTransport)
+    client = ApolloClient(networkTransport: webSocketTransport, store: ApolloStore())
 
     self.wait(for: [self.connectionStartedExpectation!], timeout: 5)
   }

--- a/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloWebsocketTests/StarWarsSubscriptionTests.swift
@@ -416,10 +416,11 @@ class StarWarsSubscriptionTests: XCTestCase {
     let reviewMutation = CreateAwesomeReviewMutation()
     
     // Send the mutations via a separate transport so they can still be sent when the websocket is disconnected
-    let interceptorProvider = LegacyInterceptorProvider()
+    let store = ApolloStore()
+    let interceptorProvider = LegacyInterceptorProvider(store: store)
     let alternateTransport = RequestChainNetworkTransport(interceptorProvider: interceptorProvider,
                                                           endpointURL: TestURL.starWarsServer.url)
-    let alternateClient = ApolloClient(networkTransport: alternateTransport)
+    let alternateClient = ApolloClient(networkTransport: alternateTransport, store: store)
     
     func sendReview() {
       let reviewSentExpectation = self.expectation(description: "review sent")

--- a/docs/source/tutorial/tutorial-mutations.md
+++ b/docs/source/tutorial/tutorial-mutations.md
@@ -86,7 +86,7 @@ class Network {
         let url = URL(string: "https://apollo-fullstack-tutorial.herokuapp.com/")!
         let transport = RequestChainNetworkTransport(interceptorProvider: provider,
                                                      endpointURL: url)
-        return ApolloClient(networkTransport: transport)
+        return ApolloClient(networkTransport: transport, store: store)
     }()
 }
 ```


### PR DESCRIPTION
Improves clarity and prevents mistakes showcased in #1460 by removing default values for initializers