### PR TITLE
Fix typos in error messages

### DIFF
--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -16,7 +16,7 @@ struct CLIDownloader {
     var errorDescription: String? {
       switch self {
       case .badResponse(let code, let response):
-        return "Recieved bad response from server (code \(code)): \(String(describing: response))"
+        return "Received bad response from server (code \(code)): \(String(describing: response))"
       case .emptyDataReceived:
         return "Empty data was receieved from the server."
       case .noDataReceived:

--- a/Tests/ApolloCodegenTests/LineByLineComparison.swift
+++ b/Tests/ApolloCodegenTests/LineByLineComparison.swift
@@ -72,7 +72,7 @@ struct LineByLineComparison {
     let expectedLines = expected.components(separatedBy: "\n")
 
     guard receivedLines.count == expectedLines.count else {
-      XCTFail("Expected \(expectedLines.count) lines, received \(receivedLines.count) lines.\nExpected: \n\(expected)\nRecieved: \n\(received)",
+      XCTFail("Expected \(expectedLines.count) lines, received \(receivedLines.count) lines.\nExpected: \n\(expected)\nReceived: \n\(received)",
               file: file,
               line: line)
       return


### PR DESCRIPTION
`Recieved` -> `Received`