### PR TITLE
RequestChain error handling callback queue

### DIFF
--- a/Sources/Apollo/RequestChain.swift
+++ b/Sources/Apollo/RequestChain.swift
@@ -161,13 +161,12 @@ public class RequestChain: Cancellable {
       }
       return
     }
-    
-    
-    additionalHandler.handleErrorAsync(error: error,
-                                       chain: self,
-                                       request: request,
-                                       response: response,
-                                       completion: completion)
+
+    additionalHandler.handleErrorAsync(error: error, chain: self, request: request, response: response) { [weak self] result in
+      self?.callbackQueue.async {
+        completion(result)
+      }
+    }
   }
   
   /// Handles a resulting value by returning it on the appropriate queue.


### PR DESCRIPTION
Ensures the `additionalErrorHandler`'s completion is called on the correct `callbackQueue`.

This fixes a threading error where the RequestChain does not complete on the specified `callbackQueue` due to the queue not being used in the case that there's an `additionalErrorHandler` specified.