### PR TITLE
cancel task before reassigning and don't retain interceptor

### DIFF
--- a/Sources/Apollo/NetworkFetchInterceptor.swift
+++ b/Sources/Apollo/NetworkFetchInterceptor.swift
@@ -29,7 +29,13 @@ public class NetworkFetchInterceptor: ApolloInterceptor, Cancellable {
       return
     }
     
-    self.currentTask = self.client.sendRequest(urlRequest) { result in
+    self.currentTask?.cancel()
+    
+    self.currentTask = self.client.sendRequest(urlRequest) { [weak self] result in
+      guard let self = self else {
+        return
+	  }
+      
       defer {
         self.currentTask = nil
       }


### PR DESCRIPTION
What do you think about such change? 
From previous interactions I know you might not like canceling bit, but if we don't cancel `currentTask` before reassign `public func cancel()` becomes meaningless