### PR TITLE
Track and cancel RequestChain when RequestChainNetworkTransport is released

### DIFF
--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -24,7 +24,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
   /// The `RequestBodyCreator` object to use to build your `URLRequest`.
   public var requestBodyCreator: RequestBodyCreator
   
-  /// List of all active RequestChain
+  /// List of all active `RequestChain`.
   private var activeRequestChains = NSHashTable<RequestChain>.weakObjects()
   
   /// Designated initializer

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -101,6 +101,8 @@ open class RequestChainNetworkTransport: NetworkTransport {
     let interceptors = self.interceptorProvider.interceptors(for: operation)
     let chain = RequestChain(interceptors: interceptors, callbackQueue: callbackQueue)
     chain.additionalErrorHandler = self.interceptorProvider.additionalErrorInterceptor(for: operation)
+    activeRequestChains.add(chain)
+    
     let request = self.constructRequest(for: operation,
                                         cachePolicy: cachePolicy,
                                         contextIdentifier: contextIdentifier)


### PR DESCRIPTION
Possible workaround for https://github.com/apollographql/apollo-ios/issues/1473 - I'm personally not that happy with it