### PR TITLE
Add dynamic library product to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,10 @@ let package = Package(
       name: "Apollo",
       targets: ["Apollo"]),
     .library(
+        name: "Apollo-Dynamic",
+        type: .dynamic,
+        targets: ["Apollo"]),
+    .library(
       name: "ApolloCodegenLib",
       targets: ["ApolloCodegenLib"]),
     .library(


### PR DESCRIPTION
We have two products that depend upon Apollo for iOS:
- Our core iOS app
- A first-party framework we use in other iOS apps

We recently migrated to use Swift Package Manager in both the core app and in the framework and are in the process of integrating the framework into the core app. This causes an error to occur:

> Swift package product 'Apollo' is linked as a static library by '&lt;core app&gt;' and '&lt;framework&gt;'. This will result in duplication of library code.

This is a known issue when integrating Swift packages in Xcode. The [Swift Package Manager documentation](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md) states that:

> A library's product can either be statically or dynamically linked. If possible, don't declare the type of library explicitly to let the Swift Package Manager choose between static or dynamic linking based on the preference of the package's consumer.

However, Xcode links Swift packages as static libraries unless they are specified as dynamic libraries in their respective `Package.swift` files. ([Reference 1](https://forums.swift.org/t/how-to-link-a-swift-package-as-dynamic/32062), [Reference 2](https://forums.swift.org/t/migrating-to-spm-from-mix-of-embedded-frameworks-and-static-libraries/34253), [Reference 3](https://developer.apple.com/forums/thread/128806).)

This PR proposes a way to work around this issue: It provides an additional `Apollo-Dynamic` product that is simply the `Apollo` library with the `.dynamic` type specifier. This is similar approach to `Paper`/`PaperStatic`/`PaperDynamic` sample code provided in the [Swift Package Manager documentation](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md#product).

This PR allows our core app and framework (and any others encountering this issue) to include the `Apollo-Dynamic` library and resolve the compiler/linker error. The `Apollo` product continues to act as a statically linked library.