### PR TITLE
Check that `URLSessionClient` hasn't been invalidated before sending

### DIFF
--- a/Sources/Apollo/NetworkFetchInterceptor.swift
+++ b/Sources/Apollo/NetworkFetchInterceptor.swift
@@ -29,7 +29,11 @@ public class NetworkFetchInterceptor: ApolloInterceptor, Cancellable {
       return
     }
     
-    self.currentTask = self.client.sendRequest(urlRequest) { result in
+    self.currentTask = self.client.sendRequest(urlRequest) { [weak self] result in
+      guard let self = self else {
+        return
+      }
+      
       defer {
         self.currentTask = nil
       }


### PR DESCRIPTION
Related to #1473 - this returns a clear error in terms of why something would not work without crashing the whole stack. 