### PR TITLE
Update references to Spectrum -> Github Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template-bug.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-bug.md
@@ -14,6 +14,7 @@ Please fill in the versions you're currently using:
 - `apollo-ios` SDK version:
 - Xcode version: 
 - Swift version: 
+- Package manager:
 
 ## Steps to reproduce
 

--- a/.github/ISSUE_TEMPLATE/issue-template-question.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Use this template to ask questions.
+about: Please don't use issues to ask questions, use Discussions instead.
 labels: question
 ---
 
@@ -9,16 +9,12 @@ labels: question
 
 Before you ask, check a few things to see if there might already be an answer: 
 
-- `CHANGELOG.md` has all the most recent changes
-- We have [extensive documentation available](https://www.apollographql.com/docs/ios), but we're always looking for ways to improve it!
+- [`CHANGELOG.md`](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) has all the most recent changes
+- We have [extensive documentation available](https://www.apollographql.com/docs/ios) (though we're always looking for ways to improve it!)
 
-If you still can't find the answer, please delete the text in this section and replace it with your question. 
 
-## Versions
+If neither of those have an answer for you, we've added a [Discussions instance](https://github.com/apollographql/apollo-ios/discussions) where our users can ask and answer questions - head on over there rather than opening an issue here please!
 
-Please fill in the versions you're currently using: 
+## Seriously
 
-- `apollo-ios` SDK version:
-- Xcode version: 
-- Swift version: 
-- Package manager:
+Please use [Github Discussions](https://github.com/apollographql/apollo-ios/discussions) for questions 😇

--- a/.github/ISSUE_TEMPLATE/issue-template-question.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-question.md
@@ -21,3 +21,4 @@ Please fill in the versions you're currently using:
 - `apollo-ios` SDK version:
 - Xcode version: 
 - Swift version: 
+- Package manager:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Excited about Apollo iOS and want to make it better? We’re excited too!
 
 Apollo is a community of developers just like you, striving to create the best tools and libraries around GraphQL. We welcome anyone who wants to contribute or provide constructive feedback, no matter your age or level of experience. If you want to help but don't know where to start, let us know, and we'll find something for you.
 
-Oh, and if you haven't already, stop by our [Spectrum Chat](https://spectrum.chat/apollo/apollo-ios)!
+Oh, and if you haven't already, stop by our [Github Discussions!](https://github.com/apollographql/apollo-ios/discussions)!
 
 Here are some ways to contribute to the project, from easiest to most difficult:
 
@@ -35,7 +35,7 @@ Improving the documentation, examples, and other open source content can be the 
 
 ### Responding to issues
 
-In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" on our Spectrum Chat!
+In addition to reporting issues, a great way to contribute to Apollo is to respond to other peoples' issues and try to identify the problem or help them work around it. If you’re interested in taking a more active role in this process, please go ahead and respond to issues. And don't forget to say "Hi" on our Github Discussions board!
 
 ### Small bug fixes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apollo iOS
 
-[![CircleCI](https://circleci.com/gh/apollographql/apollo-ios/tree/main.svg?style=shield)](https://circleci.com/gh/apollographql/apollo-ios/tree/main) [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollographql/apollo-ios/main/LICENSE) [![Swift 5 Supported](https://img.shields.io/badge/Swift-5.0-orange.svg)](https://github.com/apple/swift) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)   [![CocoaPods](https://img.shields.io/cocoapods/v/Apollo.svg)](https://cocoapods.org/pods/Apollo) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/apollo)
+[![CircleCI](https://circleci.com/gh/apollographql/apollo-ios/tree/main.svg?style=shield)](https://circleci.com/gh/apollographql/apollo-ios/tree/main) [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollographql/apollo-ios/main/LICENSE) [![Swift 5 Supported](https://img.shields.io/badge/Swift-5.0-orange.svg)](https://github.com/apple/swift) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)   [![CocoaPods](https://img.shields.io/cocoapods/v/Apollo.svg)](https://cocoapods.org/pods/Apollo) 
 
 Apollo iOS is a strongly-typed, caching GraphQL client for iOS, written in Swift.
 

--- a/docs/source/tutorial/tutorial-introduction.md
+++ b/docs/source/tutorial/tutorial-introduction.md
@@ -10,7 +10,7 @@ Welcome! This tutorial demonstrates adding the Apollo iOS SDK to an app to commu
 
 The tutorial assumes that you're using a Mac with Xcode installed. It also assumes some prior experience with iOS development.
 
-> If you encounter any issues during the tutorial, feel free to ask questions by either [opening an issue on our GitHub repo](https://github.com/apollographql/apollo-ios/issues) or [stopping by our Spectrum Chat for help](https://spectrum.chat/apollo/apollo-ios).
+> If you encounter any issues during the tutorial, feel free to ask questions by either [opening an issue on our GitHub repo](https://github.com/apollographql/apollo-ios/issues) or [stopping by our Github Discussions for help](https://github.com/apollographql/apollo-ios/discussions).
 
 ## What are you building?
 


### PR DESCRIPTION
[We're trying out Github Discussions](https://github.com/apollographql/apollo-ios/discussions/1492), so I've updated our documentation and issue templates to point folks there for questions rather than to Spectrum or GH issues. 

Also added a package manager field to the bug template since I keep having to ask that 🙃