### PR TITLE
Remove redundant nil check in InMemoryNormalizedCache's clear()

### DIFF
--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -33,11 +33,6 @@ public final class InMemoryNormalizedCache: NormalizedCache {
   public func clear(callbackQueue: DispatchQueue?,
                     completion: ((Result<Void, Error>) -> Void)?) {
     clearImmediately()
-
-    guard let completion = completion else {
-      return
-    }
-
     DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
                                                    action: completion,
                                                    result: .success(()))


### PR DESCRIPTION
`returnResultAsyncIfNeeded` already checks for `nil`. In all the other methods in this class, we rely on that check instead of doing it ourselves beforehand, so this is also more consistent.