### PR TITLE
Add 'CacheClearingPolicy' for more control over how the cache is cleared

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -80,9 +80,12 @@ extension ApolloClient: ApolloClientProtocol {
     }
   }
 
-  public func clearCache(callbackQueue: DispatchQueue = .main,
-                         completion: ((Result<Void, Error>) -> Void)? = nil) {
-    self.store.clearCache(completion: completion)
+  public func clearCache(
+    usingPolicy policy: CacheClearingPolicy,
+    callbackQueue: DispatchQueue = .main,
+    completion: ((Result<Void, Error>) -> Void)? = nil
+  ) {
+    self.store.clearCache(usingPolicy: policy, callbackQueue: callbackQueue, completion: completion)
   }
   
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,

--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -155,4 +155,15 @@ extension ApolloClient: ApolloClientProtocol {
   }
 }
 
+// MARK: - convenience overloads
 
+extension ApolloClient {
+  /// Clears all records from the cache store.
+  /// - Warning: The cache may be used by other clients. Calling this method will affect all clients using the same cache!
+  /// - Parameters:
+  ///   - callbackQueue: An optional queue to execute the completion handler on. The default is `.main`.
+  ///   - completion: An optional completion closure to execute when the cache has been cleared. The default is `nil`.
+  public func clearCache(callbackQueue: DispatchQueue = .main, completion: ((Result<Void, Error>) -> Void)? = nil) {
+    self.clearCache(usingPolicy: .allRecords, callbackQueue: callbackQueue, completion: completion)
+  }
+}

--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -81,16 +81,3 @@ public protocol ApolloClientProtocol: class {
                                                     queue: DispatchQueue,
                                                     resultHandler: @escaping GraphQLResultHandler<Subscription.Data>) -> Cancellable
 }
-
-// MARK: conveniences
-
-extension ApolloClientProtocol {
-  /// Clears all records from the cache store.
-  /// - Warning: The cache may be used by other clients. Calling this method will affect all clients using the same cache!
-  /// - Parameters:
-  ///   - callbackQueue: An optional queue to execute the completion handler on. The default is `.main`.
-  ///   - completion: An optional completion closure to execute when the cache has been cleared. The default is `nil`.
-  func clearCache(callbackQueue: DispatchQueue = .main, completion: ((Result<Void, Error>) -> Void)? = nil) {
-    self.clearCache(usingPolicy: .allRecords, callbackQueue: callbackQueue, completion: completion)
-  }
-}

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -4,17 +4,6 @@ import Foundation
 public typealias CacheKeyForObject = (_ object: JSONObject) -> JSONValue?
 public typealias DidChangeKeysFunc = (Set<CacheKey>, UUID?) -> Void
 
-func rootCacheKey<Operation: GraphQLOperation>(for operation: Operation) -> String {
-  switch operation.operationType {
-  case .query:
-    return "QUERY_ROOT"
-  case .mutation:
-    return "MUTATION_ROOT"
-  case .subscription:
-    return "SUBSCRIPTION_ROOT"
-  }
-}
-
 protocol ApolloStoreSubscriber: class {
   
   /// A callback that can be received by subscribers when keys are changed within the database
@@ -175,7 +164,7 @@ public final class ApolloStore {
       let dependencyTracker = GraphQLDependencyTracker()
 
       return try transaction.execute(selections: Operation.Data.selections,
-                                     onObjectWithKey: rootCacheKey(for: query),
+                                     onObjectWithKey: query.operationType.cacheKey,
                                      variables: query.variables,
                                      accumulator: zip(mapper, dependencyTracker))
     }.map { (data: Operation.Data, dependentKeys: Set<CacheKey>) in
@@ -215,7 +204,7 @@ public final class ApolloStore {
 
     public func read<Query: GraphQLQuery>(query: Query) throws -> Query.Data {
       return try readObject(ofType: Query.Data.self,
-                            withKey: rootCacheKey(for: query),
+                            withKey: query.operationType.cacheKey,
                             variables: query.variables)
     }
 
@@ -304,7 +293,7 @@ public final class ApolloStore {
 
     public func write<Query: GraphQLQuery>(data: Query.Data, forQuery query: Query) throws {
       try write(object: data,
-                withKey: rootCacheKey(for: query),
+                withKey: query.operationType.cacheKey,
                 variables: query.variables)
     }
 

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -180,7 +180,7 @@ public final class ApolloStore {
       let dependencyTracker = GraphQLDependencyTracker()
 
       return try transaction.execute(selections: Operation.Data.selections,
-                                     onObjectWithKey: query.operationType.cacheKey,
+                                     onObjectWithKey: query.operationType.rootCacheKey,
                                      variables: query.variables,
                                      accumulator: zip(mapper, dependencyTracker))
     }.map { (data: Operation.Data, dependentKeys: Set<CacheKey>) in
@@ -220,7 +220,7 @@ public final class ApolloStore {
 
     public func read<Query: GraphQLQuery>(query: Query) throws -> Query.Data {
       return try readObject(ofType: Query.Data.self,
-                            withKey: query.operationType.cacheKey,
+                            withKey: query.operationType.rootCacheKey,
                             variables: query.variables)
     }
 
@@ -309,7 +309,7 @@ public final class ApolloStore {
 
     public func write<Query: GraphQLQuery>(data: Query.Data, forQuery query: Query) throws {
       try write(object: data,
-                withKey: query.operationType.cacheKey,
+                withKey: query.operationType.rootCacheKey,
                 variables: query.variables)
     }
 

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -1,10 +1,19 @@
+/// Enumeration of the possible GraphQL operations that can be executed against an API endpoint.
 public enum GraphQLOperationType {
   case query
   case mutation
   case subscription
+
+  var cacheKey: String {
+    switch self {
+    case .query: return "QUERY_ROOT"
+    case .mutation: return "MUTATION_ROOT"
+    case .subscription: return "SUBSCRIPTION_ROOT"
+    }
+  }
 }
 
-public protocol GraphQLOperation: class {
+public protocol GraphQLOperation: AnyObject {
   var operationType: GraphQLOperationType { get }
 
   var operationDefinition: String { get }
@@ -32,6 +41,8 @@ public extension GraphQLOperation {
   }
 }
 
+// - MARK: Conformances
+
 public protocol GraphQLQuery: GraphQLOperation {}
 public extension GraphQLQuery {
   var operationType: GraphQLOperationType { return .query }
@@ -45,9 +56,4 @@ public extension GraphQLMutation {
 public protocol GraphQLSubscription: GraphQLOperation {}
 public extension GraphQLSubscription {
   var operationType: GraphQLOperationType { return .subscription }
-}
-
-public protocol GraphQLFragment: GraphQLSelectionSet {
-  static var fragmentDefinition: String { get }
-  static var possibleTypes: [String] { get }
 }

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -4,7 +4,7 @@ public enum GraphQLOperationType {
   case mutation
   case subscription
 
-  var cacheKey: String {
+  var rootCacheKey: String {
     switch self {
     case .query: return "QUERY_ROOT"
     case .mutation: return "MUTATION_ROOT"

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -15,12 +15,12 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet>: Parseable {
 
   public init<Operation: GraphQLOperation>(operation: Operation, body: JSONObject) where Operation.Data == Data {
     self.body = body
-    rootKey = rootCacheKey(for: operation)
+    rootKey = operation.operationType.cacheKey
     variables = operation.variables
   }
   
   func setupOperation<Operation: GraphQLOperation> (_ operation: Operation) {
-    self.rootKey = rootCacheKey(for: operation)
+    self.rootKey = operation.operationType.cacheKey
     self.variables = operation.variables
   }
   

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -15,12 +15,12 @@ public final class GraphQLResponse<Data: GraphQLSelectionSet>: Parseable {
 
   public init<Operation: GraphQLOperation>(operation: Operation, body: JSONObject) where Operation.Data == Data {
     self.body = body
-    rootKey = operation.operationType.cacheKey
+    rootKey = operation.operationType.rootCacheKey
     variables = operation.variables
   }
   
   func setupOperation<Operation: GraphQLOperation> (_ operation: Operation) {
-    self.rootKey = operation.operationType.cacheKey
+    self.rootKey = operation.operationType.rootCacheKey
     self.variables = operation.variables
   }
   

--- a/Sources/Apollo/GraphQLSelectionSet.swift
+++ b/Sources/Apollo/GraphQLSelectionSet.swift
@@ -119,6 +119,11 @@ public struct GraphQLTypeCondition: GraphQLSelection {
   }
 }
 
+public protocol GraphQLFragment: GraphQLSelectionSet {
+  static var fragmentDefinition: String { get }
+  static var possibleTypes: [String] { get }
+}
+
 public struct GraphQLFragmentSpread: GraphQLSelection {
   let fragment: GraphQLFragment.Type
 

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -4,7 +4,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
   private let recordsLock = NSRecursiveLock()
 
-  public init(records: RecordSet = .init()) {
+  public init(records: RecordSet = RecordSet()) {
     self.records = records
   }
 

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -1,5 +1,46 @@
 import Foundation
 
+/// An object that drives behavior of clear operations on a given cache.
+public struct CacheClearingPolicy: Equatable {
+  /// Clears all records in the cache.
+  public static let allRecords = CacheClearingPolicy(.allRecords)
+  /// Clears all records whose key matches the provided glob pattern.
+  /// - Parameter pattern: The glob pattern to use for key matching. For example `*pollo` will match both `Apollo` and `pollo`.
+  public static func allMatchingKeyPattern(_ pattern: String) -> CacheClearingPolicy { .init(.allMatchingKeyPattern(pattern)) }
+  /// Clears the the first (oldest) records in the cache up to the given limit.
+  /// - Parameter k: The number of records to remove from the cache.
+  public static func first(_ k: Int) -> CacheClearingPolicy { .init(.first(k)) }
+  /// Clears the the last (most recent) records in the cache up to the given limit.
+  /// - Parameter k: The number of records to remove from the cache.
+  public static func last(_ k: Int) -> CacheClearingPolicy { .init(.last(k)) }
+
+  // actual policy storage
+
+  /// This is public due to language requirements for cross-target access.
+  /// Do not use this value, nor its type as they are an implementation detail.
+  public let _value: _Policy
+  private init(_ policy: _Policy) { self._value = policy }
+
+  /// This is public due to language requirements for cross-target access.
+  /// Do not use this type, nor any of its values, as they are an implementation detail.
+  public enum _Policy: Equatable {
+    case allRecords
+    case allMatchingKeyPattern(String)
+    case first(Int)
+    case last(Int)
+
+    public static func ==(lhs: _Policy, rhs: _Policy) -> Bool {
+      switch (lhs, rhs) {
+      case (.allRecords, .allRecords): return true
+      case let (.allMatchingKeyPattern(left), .allMatchingKeyPattern(right)): return left == right
+      case let (.first(left), .first(right)): return left == right
+      case let (.last(left), .last(right)): return left == right
+      default: return false
+      }
+    }
+  }
+}
+
 public protocol NormalizedCache {
 
   /// Loads records corresponding to the given keys.
@@ -22,14 +63,31 @@ public protocol NormalizedCache {
              callbackQueue: DispatchQueue?,
              completion: @escaping (Result<Set<CacheKey>, Error>) -> Void)
 
-  // Clears all records
-  ///
+  /// Clears records from the cache according to the policy provided.
   /// - Parameters:
-  ///   - callbackQueue: [optional] An alternate queue to fire the completion closure on. If nil, will fire on the current queue.
-  ///   - completion: [optional] A completion closure to fire when the clear function has completed.
-  func clear(callbackQueue: DispatchQueue?,
+  ///   - policy: The policy to use in determining which records to clear.
+  ///   - callbackQueue: An optional queue to execute the completion closure on.
+  ///   - completion: An optional completion closure to execute when the cache clearing has completed.
+  func clear(_ clearingPolicy: CacheClearingPolicy,
+             callbackQueue: DispatchQueue?,
              completion: ((Result<Void, Error>) -> Void)?)
 
-  // Clears all records synchronously
-  func clearImmediately() throws
+  /// Clears records from the cache synchronously according to the policy provided.
+  /// - Parameter policy: The policy to use in determining which records to clear.
+  func clearImmediately(_ clearingPolicy: CacheClearingPolicy) throws
+}
+
+extension NormalizedCache {
+  /// Clears all records in the cache.
+  /// - Parameters:
+  ///   - callbackQueue: An optional queue to execute the completion closure on.
+  ///   - completion: An optional completion closure to execute when the cache clearing has completed.
+  public func clear(callbackQueue: DispatchQueue? = nil, completion: ((Result<Void, Error>) -> Void)? = nil) {
+    self.clear(.allRecords, callbackQueue: callbackQueue, completion: completion)
+  }
+
+  /// Clears all records in the cache synchronously.
+  public func clearImmediately() throws {
+    try self.clearImmediately(.allRecords)
+  }
 }

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -8,10 +8,6 @@ public enum CacheClearingPolicy: Equatable {
   ///
   /// For example `*pollo` will match both `Apollo` and `pollo`.
   case allMatchingKeyPattern(String)
-  /// Clears the the first (oldest) records in the cache up to the given limit.
-  case first(Int)
-  /// Clears the the last (most recent) records in the cache up to the given limit.
-  case last(Int)
 }
 
 public protocol NormalizedCache {

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -1,44 +1,17 @@
 import Foundation
 
-/// An object that drives behavior of clear operations on a given cache.
-public struct CacheClearingPolicy: Equatable {
+/// An enumeration of behaviors for clear operations on a given cache.
+public enum CacheClearingPolicy: Equatable {
   /// Clears all records in the cache.
-  public static let allRecords = CacheClearingPolicy(.allRecords)
+  case allRecords
   /// Clears all records whose key matches the provided glob pattern.
-  /// - Parameter pattern: The glob pattern to use for key matching. For example `*pollo` will match both `Apollo` and `pollo`.
-  public static func allMatchingKeyPattern(_ pattern: String) -> CacheClearingPolicy { .init(.allMatchingKeyPattern(pattern)) }
+  ///
+  /// For example `*pollo` will match both `Apollo` and `pollo`.
+  case allMatchingKeyPattern(String)
   /// Clears the the first (oldest) records in the cache up to the given limit.
-  /// - Parameter k: The number of records to remove from the cache.
-  public static func first(_ k: Int) -> CacheClearingPolicy { .init(.first(k)) }
+  case first(Int)
   /// Clears the the last (most recent) records in the cache up to the given limit.
-  /// - Parameter k: The number of records to remove from the cache.
-  public static func last(_ k: Int) -> CacheClearingPolicy { .init(.last(k)) }
-
-  // actual policy storage
-
-  /// This is public due to language requirements for cross-target access.
-  /// Do not use this value, nor its type as they are an implementation detail.
-  public let _value: _Policy
-  private init(_ policy: _Policy) { self._value = policy }
-
-  /// This is public due to language requirements for cross-target access.
-  /// Do not use this type, nor any of its values, as they are an implementation detail.
-  public enum _Policy: Equatable {
-    case allRecords
-    case allMatchingKeyPattern(String)
-    case first(Int)
-    case last(Int)
-
-    public static func ==(lhs: _Policy, rhs: _Policy) -> Bool {
-      switch (lhs, rhs) {
-      case (.allRecords, .allRecords): return true
-      case let (.allMatchingKeyPattern(left), .allMatchingKeyPattern(right)): return left == right
-      case let (.first(left), .first(right)): return left == right
-      case let (.last(left), .last(right)): return left == right
-      default: return false
-      }
-    }
-  }
+  case last(Int)
 }
 
 public protocol NormalizedCache {

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -19,7 +19,7 @@ public struct RecordSet {
       self.storage = Dictionary(self.storage.dropLast(count))
 
     case let .allMatchingKeyPattern(pattern):
-      self.storage = self.storage.filter { !$0.key.contains(pattern) }
+      self.storage = self.storage.filter { !$0.key.contains(pattern.replacingOccurrences(of: "*", with: "")) }
 
     case .allRecords: fallthrough
     default:

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -12,12 +12,6 @@ public struct RecordSet {
 
   public mutating func clear(_ clearingPolicy: CacheClearingPolicy = .allRecords) {
     switch clearingPolicy {
-    case let .first(count):
-      self.storage = Dictionary(self.storage.dropFirst(count))
-
-    case let .last(count):
-      self.storage = Dictionary(self.storage.dropLast(count))
-
     case let .allMatchingKeyPattern(pattern):
       self.storage = self.storage.filter { !$0.key.contains(pattern.replacingOccurrences(of: "*", with: "")) }
 

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -12,14 +12,18 @@ public struct RecordSet {
 
   public mutating func clear(_ clearingPolicy: CacheClearingPolicy = .allRecords) {
     switch clearingPolicy._value {
-    case let .first(count): self.storage = .init(self.storage.dropFirst(count))
+    case let .first(count):
+      self.storage = Dictionary(self.storage.dropFirst(count))
 
-    case let .last(count): self.storage = .init(self.storage.dropLast(count))
+    case let .last(count):
+      self.storage = Dictionary(self.storage.dropLast(count))
 
-    case let .allMatchingKeyPattern(pattern): self.storage = self.storage.filter { !$0.key.contains(pattern) }
+    case let .allMatchingKeyPattern(pattern):
+      self.storage = self.storage.filter { !$0.key.contains(pattern) }
 
     case .allRecords: fallthrough
-    default: self.storage.removeAll()
+    default:
+      self.storage.removeAll()
     }
   }
 

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -11,7 +11,7 @@ public struct RecordSet {
   }
 
   public mutating func clear(_ clearingPolicy: CacheClearingPolicy = .allRecords) {
-    switch clearingPolicy._value {
+    switch clearingPolicy {
     case let .first(count):
       self.storage = Dictionary(self.storage.dropFirst(count))
 
@@ -21,8 +21,7 @@ public struct RecordSet {
     case let .allMatchingKeyPattern(pattern):
       self.storage = self.storage.filter { !$0.key.contains(pattern.replacingOccurrences(of: "*", with: "")) }
 
-    case .allRecords: fallthrough
-    default:
+    case .allRecords:
       self.storage.removeAll()
     }
   }

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -10,8 +10,17 @@ public struct RecordSet {
     storage[record.key] = record
   }
 
-  public mutating func clear() {
-    storage.removeAll()
+  public mutating func clear(_ clearingPolicy: CacheClearingPolicy = .allRecords) {
+    switch clearingPolicy._value {
+    case let .first(count): self.storage = .init(self.storage.dropFirst(count))
+
+    case let .last(count): self.storage = .init(self.storage.dropLast(count))
+
+    case let .allMatchingKeyPattern(pattern): self.storage = self.storage.filter { !$0.key.contains(pattern) }
+
+    case .allRecords: fallthrough
+    default: self.storage.removeAll()
+    }
   }
 
   public mutating func insert<S: Sequence>(contentsOf records: S) where S.Iterator.Element == Record {

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -96,7 +96,7 @@ public final class SQLiteNormalizedCache {
     return try self.db.prepare(query).map { try parse(row: $0) }
   }
 
-  private func clearRecords(accordingTo policy: CacheClearingPolicy) throws {
+  private func clearRecords(with policy: CacheClearingPolicy) throws {
     switch policy._value {
     case let .first(count):
       let firstKRecords = records.select(self.id).order(self.id.asc).limit(count)
@@ -184,7 +184,7 @@ extension SQLiteNormalizedCache: NormalizedCache {
   ) {
     let result: Swift.Result<Void, Error>
     do {
-      try self.clearRecords(accordingTo: clearingPolicy)
+      try self.clearRecords(with: clearingPolicy)
       result = .success(())
     } catch {
       result = .failure(error)
@@ -196,6 +196,6 @@ extension SQLiteNormalizedCache: NormalizedCache {
   }
 
   public func clearImmediately(_ clearingPolicy: CacheClearingPolicy) throws {
-    try self.clearRecords(accordingTo: clearingPolicy)
+    try self.clearRecords(with: clearingPolicy)
   }
 }

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -19,28 +19,29 @@ public final class SQLiteNormalizedCache {
   private let record = Expression<String>("record")
   private let shouldVacuumOnClear: Bool
 
-  /// Designated initializer
-  ///
+  /// Creates a store that uses the provided SQLite file connection.
   /// - Parameters:
-  ///   - fileURL: The file URL to use for your database.
-  ///   - shouldVacuumOnClear: If the database should also be `VACCUM`ed on clear to remove all traces of info. Defaults to `false` since this involves a performance hit, but this should be used if you are storing any Personally Identifiable Information in the cache.
-  /// - Throws: Any errors attempting to open or create the database.
-  public init(fileURL: URL, shouldVacuumOnClear: Bool = false) throws {
-    self.shouldVacuumOnClear = shouldVacuumOnClear
-    self.db = try Connection(.uri(fileURL.absoluteString), readonly: false)
-    try self.createTableIfNeeded()
-  }
-
-  ///
-  /// Initializer that takes the Connection to use
-  /// - Parameters:
-  ///   - db: The database Connection to use
-  ///   - shouldVacuumOnClear: If the database should also be `VACCUM`ed on clear to remove all traces of info. Defaults to `false` since this involves a performance hit, but this should be used if you are storing any Personally Identifiable Information in the cache.
-  /// - Throws: Any errors attempting to access the database
-  public init(db: Connection, shouldVacuumOnClear: Bool = false) throws {
+  ///   - db: The database connection to use.
+  ///   - shouldVacuumOnClear: If the database file should compact "VACUUM" its storage when clearing records. This can be a potentially long operation.
+  ///   Default is `false`. This SHOULD be set to `true` if you are storing any Personally Identifiable Information in the cache.
+  /// - Throws: Any errors attempting to access the database.
+  public init(db: Connection, compactFileOnClear shouldVacuumOnClear: Bool = false) throws {
     self.shouldVacuumOnClear = shouldVacuumOnClear
     self.db = db
     try self.createTableIfNeeded()
+  }
+
+  /// Creates a store that will establish its own connection to the SQLite file at the provided url.
+  /// - Parameters:
+  ///   - fileURL: The file URL to use for your database.
+  ///   - shouldVacuumOnClear: If the database file should compact "VACUUM" its storage when clearing records. This can be a potentially long operation.
+  ///   Default is `false`. This SHOULD be set to `true` if you are storing any Personally Identifiable Information in the cache.
+  /// - Throws: Any errors attempting to open or create the database.
+  convenience public init(fileURL: URL, compactFileOnClear shouldVacuumOnClear: Bool = false) throws {
+    try self.init(
+      db: try Connection(.uri(fileURL.absoluteString), readonly: false),
+      compactFileOnClear: shouldVacuumOnClear
+    )
   }
 
   private func recordCacheKey(forFieldCacheKey fieldCacheKey: CacheKey) -> CacheKey {

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -98,14 +98,6 @@ public final class SQLiteNormalizedCache {
 
   private func clearRecords(with policy: CacheClearingPolicy) throws {
     switch policy {
-    case let .first(count):
-      let firstKRecords = records.select(self.id).order(self.id.asc).limit(count)
-      try self.db.run(firstKRecords.delete())
-
-    case let .last(count):
-      let lastKRecords = records.select(self.id).order(self.id.desc).limit(count)
-      try self.db.run(lastKRecords.delete())
-
     case let .allMatchingKeyPattern(pattern):
       let matchingRecords = records.where(
         self.key.like(pattern.replacingOccurrences(of: "*", with: "%"))

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -97,7 +97,7 @@ public final class SQLiteNormalizedCache {
   }
 
   private func clearRecords(with policy: CacheClearingPolicy) throws {
-    switch policy._value {
+    switch policy {
     case let .first(count):
       let firstKRecords = records.select(self.id).order(self.id.asc).limit(count)
       try self.db.run(firstKRecords.delete())
@@ -112,8 +112,7 @@ public final class SQLiteNormalizedCache {
       )
       try self.db.run(matchingRecords.delete())
 
-    case .allRecords: fallthrough
-    default:
+    case .allRecords:
       try self.db.run(records.delete())
     }
 

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -36,7 +36,11 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     }
   }
   
-  func clear(callbackQueue: DispatchQueue?, completion: ((Result<Void, Error>) -> Void)?) {
+  func clear(
+    _ clearingPolicy: CacheClearingPolicy,
+    callbackQueue: DispatchQueue?,
+    completion: ((Result<Void, Error>) -> Void)?
+  ) {
     DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(1)) {
       self.records.clear()
       DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
@@ -45,7 +49,7 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     }
   }
   
-  func clearImmediately() {
+  func clearImmediately(_ clearingPolicy: CacheClearingPolicy) {
     records.clear()
   }
 }


### PR DESCRIPTION
Motivation:

It is common to want finer control over which records are removed from the cache without just deleting all records.

This modifies the framework to support different policies that a developer can specify when calling `clear` and `clearImmediately`.

Modifications:

- Rename: `shouldVacuumOnClear` argument label in `SQLiteNormalizedCache` initializers to `compactFileOnClear` to make it clearer for those unfamiliar with SQLite's terminology
- Add: `CacheClearingPolicy` with policies for removing the first/last K records, key pattern matching, and the current behavior of removing all records
- Add: `ApolloStore.clearCache` overload that accepts a `CacheClearingPolicy`
- Change: `RecordSet.clear` to accept a `CacheClearingPolicy`
- Change: `NormalizedCache.clear` and `NormalizedCache.clearImmediately` to accept a `CacheClearingPolicy`
  - The current methods are available as overloads
- Change: `ApolloClientProtocol.clearCache` to accept a `CacheClearingPolicy`
  - The current method is available as an overload

Result:

Developers can now have more control over which records to clear from their cache:

```swift
// current behavior
client.clearCache(usingPolicy: .allRecords)

// delete the first 10 records
client.clearCache(usingPolicy: .first(10))

// delete all hero records
client.clearCache(usingPolicy: .allMatchingKeyPattern("*hero*"))
```