### PR TITLE
Document potential footgun with custom derived data

### DIFF
--- a/docs/shared/spm-run-script-panel.mdx
+++ b/docs/shared/spm-run-script-panel.mdx
@@ -6,6 +6,8 @@ import {
 
 <ExpansionPanel title="Swift Package Manager Run Script">
 
+> **NOTE**: If your Derived Data is in a custom location, stop, go back, and use the [Swift Scripting](./swift-scripting) method instead. This script relies on Derived Data being in the default location. Swift Scripting doesn't rely on Derived Data at all.
+
 If you're using Xcode 11 or higher, SPM will check out the appropriate build script along with the rest of the files when it checks out the repo. Add the following to your Run Script build phase: 
 
 ```sh

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -76,7 +76,7 @@ Code generation uses your `.graphql` files to generate API code that will help y
 
 The wrapper will call through to the included binaries and files that constitute the `apollo` command-line interface. This ensures that you can use our tooling without having to worry about NPM Version Hell™, and that the version of the framework you're using is compatible with the version of the codegen you're using.
 
-> 🚧 BETA ALERT 🚧 : Instead of writing the rest of this in Bash, try using our new [Swift Scripting Library](./swift-scripting), now in Beta! It supports downloading a schema and generating code.
+> 🎉 NEW SHINY ALERT 🎉 : Instead of writing the rest of this in Bash, try using our new [Swift Scripting Library](./swift-scripting), now in Beta! It supports downloading a schema and generating code. 
 
 The location of this wrapper script is slightly different based on how you've integrated Apollo into your project, but the first steps are the same everywhere: 
 


### PR DESCRIPTION
Thanks to #1509 for pointing this out - if you're using a custom location for Derived Data, the documented script that to go diving through Derived Data to find the bash script to run doesn't work at all. 

When I have more time (LOL in like 2043?) I'm planning to update the docs to recommend the Swift Scripting method as the main method, but for now I did at least take the Beta warning off since it's...no longer in Beta. 