### PR TITLE
Fix auth header in `UserManagementInterceptor` example

### DIFF
--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -395,7 +395,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     let provider = LegacyInterceptorProvider(client: mockClient, store: store)
     let network = RequestChainNetworkTransport(interceptorProvider: provider,
                                                endpointURL: self.endpoint,
-                                               additionalHeaders: ["Authentication": "Bearer 1234"],
+                                               additionalHeaders: ["Authorization": "Bearer 1234"],
                                                useGETForQueries: true)
     
     let expectation = self.expectation(description: "Query sent")
@@ -411,7 +411,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     
     XCTAssertEqual(request.url?.host, network.endpointURL.host)
     XCTAssertEqual(request.httpMethod, "GET")
-    XCTAssertEqual(request.allHTTPHeaderFields!["Authentication"], "Bearer 1234")
+    XCTAssertEqual(request.allHTTPHeaderFields!["Authorization"], "Bearer 1234")
     
     try self.validateUrlParams(with: request,
                                query: query,

--- a/docs/source/initialization.md
+++ b/docs/source/initialization.md
@@ -137,7 +137,7 @@ class UserManagementInterceptor: ApolloInterceptor {
         response: HTTPResponse<Operation>?,
         completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
         
-        request.addHeader(name: "Authentication", value: "Bearer: \(token.value)")
+        request.addHeader(name: "Authorization", value: "Bearer \(token.value)")
         chain.proceedAsync(request: request,
                            response: response,
                            completion: completion)


### PR DESCRIPTION
The correct name of the header is `Authorization`, not `Authentication`. For example, [the "Downloading Schema" section](https://www.apollographql.com/docs/ios/downloading-schema/) uses `Authorization` to download the schema. Additionally, there should be no colon between `Bearer` and the actual token.