### PR TITLE
Improve loadRecords performance in SQLiteNormalizedCache 

### DIFF
--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -141,7 +141,7 @@ extension SQLiteNormalizedCache: NormalizedCache {
     do {
       let records = try self.selectRecords(forKeys: keys)
       let recordsIndexMap = records.indices.reversed().reduce(into: [:]) { resultMap, index in
-        resultMap[records[index].key, default: index] = index
+        resultMap[records[index].key] = index
       }
 
       let recordsOrNil: [Record?] = keys.map { key in

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -140,7 +140,7 @@ extension SQLiteNormalizedCache: NormalizedCache {
     let result: Swift.Result<[Record?], Error>
     do {
       let records = try self.selectRecords(forKeys: keys)
-      let recordsIndexMap = records.indices.reversed().reduce(into: [:]) { resultMap, index in
+      let recordsIndexMap = records.indices.reduce(into: [:]) { resultMap, index in
         resultMap[records[index].key] = index
       }
 

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -140,8 +140,8 @@ extension SQLiteNormalizedCache: NormalizedCache {
     let result: Swift.Result<[Record?], Error>
     do {
       let records = try self.selectRecords(forKeys: keys)
-      let recordsIndexMap = records.indices.reversed().reduce(into: [:]) { recordsIndexMap, index in
-        recordsIndexMap[records[index].key, default: index] = index
+      let recordsIndexMap = records.indices.reversed().reduce(into: [:]) { resultMap, index in
+        resultMap[records[index].key, default: index] = index
       }
 
       let recordsOrNil: [Record?] = keys.map { key in

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -140,11 +140,12 @@ extension SQLiteNormalizedCache: NormalizedCache {
     let result: Swift.Result<[Record?], Error>
     do {
       let records = try self.selectRecords(forKeys: keys)
+      let recordsIndexMap = records.indices.reversed().reduce(into: [:]) { recordsIndexMap, index in
+        recordsIndexMap[records[index].key, default: index] = index
+      }
+
       let recordsOrNil: [Record?] = keys.map { key in
-        if let recordIndex = records.firstIndex(where: { $0.key == key }) {
-          return records[recordIndex]
-        }
-        return nil
+        recordsIndexMap[key].flatMap { records[$0] }
       }
 
       result = .success(recordsOrNil)


### PR DESCRIPTION
Motivation:

We noticed the performance of `loadRecords` on SQLiteNormalizedCache degrades especially when the query field contains arguments making the CacheKey string larger in memory size. Per our readings, loading a nominal 200 records from the SQLite store takes around 4.2x seconds, and the fix in this PR decreases time consumed by `loadRecords` to 0.8 seconds an improvement of 4x the current time.

Here is the screenshot of TimeProfile indicating the time spent in the == infix operator.

<img width="1034" alt="Screen Shot 2020-11-13 at 12 40 50 PM" src="https://user-images.githubusercontent.com/903536/99161907-1f856b80-26ac-11eb-8113-775e6699ca7d.png">


**What is the root cause of the performance issue?**

To answer that let us take a look at existing code in the `loadRecords` method

```
let recordsOrNil: [Record?] = keys.map { key in  // Loop N times
         if let recordIndex = records.firstIndex(where: { $0.key == key }) {	   // Loop N Times    
              recordsIndexMap[key].flatMap { records[$0] }
              return records[recordIndex]		
         }		
      return nil		
}
```
Here are a few problems from the above code:

1. The first two lines from the above code have a complexity of O(N^2) excluding the key comparison using `==`. 
2. looking at the stack trace from the Time Profile in the attached screenshot, reveals that string comparison is not using the hash and instead compares each string for equality. This would increase the complexity exponentially by another magnitude.

The performance is evident in queries that involve query fields with arguments as shown in the below example
```
query {
     searchEmployees(organizationId: String!): [Employee]
}
```

For the query `searchEmployees(organizationId: "<16 char UUID>")`, a sample CacheKey for a record would be `QUERY_ROOT.searchEmployees(orignzationId: "<16 char UUID>").<EmployeeField>` and this makes `CacheKey` comparison even more time-consuming as the length of the `CacheKey` increases, which is what happened in our case.

**Solution:**

```
 let recordsIndexMap = records.indices.reversed().reduce(into: [:]) { resultMap, index in
        resultMap[records[index].key, default: index] = index
  }

 let recordsOrNil: [Record?] = keys.map { key in
        recordsIndexMap[key].flatMap { records[$0] }
 }
```

Reduce the complexity of the code snippet to O(N) following the below steps:

* Convert the list of records `[Record]`  returned by `selectRecords` method into a hashmap `recordsIndexMap` with key being `CacheKey` and value is the index of the record in `[Record]`. This provides an O(1) time complexity to lookup `recordsIndexMap` for a given `CacheKey` to find the matching `Record` from the list of records `[Record]` l
* Construct `recordsOrNil` while doing a lookup with `recordsIndexMap` (basically a hashmap of CacheKeys) making the entire code snippet's complexity O(N)
thus bringing down the overall performance by the 2 fold magnitude 
