### PR TITLE
Add cache fallback CachePolicy

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -13,6 +13,8 @@ public enum CachePolicy {
   case returnCacheDataDontFetch
   /// Return data from the cache if available, and always fetch results from the server.
   case returnCacheDataAndFetch
+  /// Attempt to fetch from the server, using cache data if available on error
+  case fetchReturningCacheDataOnError
   
   /// The current default cache policy.
   public static var `default`: CachePolicy {

--- a/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/FetchQueryTests.swift
@@ -87,7 +87,7 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
     let query = HeroNameQuery()
     let resultObserver = self.makeResultObserver(for: query)
 
-    let serverRequestExpectation = self.server.expect(HeroNameQuery.self) { _ in .failure(TestError()) }
+    let serverRequestExpectation = self.server.expect(HeroNameQuery.self) { _ in throw TestError() }
 
     let fetchResultFromServerExpectation = resultObserver.expectation(description: "Received cache data") {
       try XCTAssertSuccessResult($0) { result in
@@ -109,7 +109,7 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
     let query = HeroNameQuery()
     let resultObserver = self.makeResultObserver(for: query)
 
-    let serverRequestExpectation = self.server.expect(HeroNameQuery.self) { _ in .failure(TestError.expectation) }
+    let serverRequestExpectation = self.server.expect(HeroNameQuery.self) { _ in throw TestError.expectation }
 
     let fetchResultFromServerExpectation = resultObserver.expectation(description: "Received cache data") { result in
       try XCTAssertFailureResult(result) {

--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -202,7 +202,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
     
     runActivity("Fetch same query from server with different argument") { _ in
-      let serverRequestExpectation = server.expect(HeroNameQuery.self) { request in
+      let serverRequestExpectation = server.expect(HeroNameQuery.self) { request -> JSONObject in
         XCTAssertEqual(request.operation.episode, .jedi)
         
         return [
@@ -269,7 +269,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
     
     runActivity("Fetch same query from server with different argument but returning same object with changed data") { _ in
-      let serverRequestExpectation = server.expect(HeroNameWithIdQuery.self) { request in
+      let serverRequestExpectation = server.expect(HeroNameWithIdQuery.self) { request -> JSONObject in
         XCTAssertEqual(request.operation.episode, .jedi)
         return [
           "data": [

--- a/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
+++ b/Tests/ApolloCacheDependentTests/WatchQueryTests.swift
@@ -202,7 +202,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
     
     runActivity("Fetch same query from server with different argument") { _ in
-      let serverRequestExpectation = server.expect(HeroNameQuery.self) { request -> JSONObject in
+      let serverRequestExpectation = server.expect(HeroNameQuery.self) { request in
         XCTAssertEqual(request.operation.episode, .jedi)
         
         return [
@@ -269,7 +269,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
     
     runActivity("Fetch same query from server with different argument but returning same object with changed data") { _ in
-      let serverRequestExpectation = server.expect(HeroNameWithIdQuery.self) { request -> JSONObject in
+      let serverRequestExpectation = server.expect(HeroNameWithIdQuery.self) { request in
         XCTAssertEqual(request.operation.episode, .jedi)
         return [
           "data": [


### PR DESCRIPTION
Motivation:

It is sometimes acceptable to fallback to whatever cache data might be available when a particular fetch request fails either due to network or server problems.

This adds a missing 'CachePolicy' that falls back to use the cache after first attempting a fetch request.

Modifications:

- Add: `fetchReturningCacheDataOnError` case to `CachePolicy`
- Add: `CacheError` type to `LegacyCacheReadInterceptor` that is returned if both the network and cache fails to provide a successful result
- Change: `LegacyCacheReadInterceptor` to handle new policy

Result:

Developers should now have the ability to rely on their cache in more scenarios, such as when the server or network is having issues.