### PR TITLE
Update JSON v2 to have expressible by _ literal

### DIFF
--- a/Sources/ApolloCodegenLib/JSON.swift
+++ b/Sources/ApolloCodegenLib/JSON.swift
@@ -31,60 +31,6 @@ public enum JSONValue: Codable, Equatable {
     }
   }
   
-  public init(_ array: [Any?]) throws {
-    var jsonArray = [JSONValue]()
-    for item in array {
-      if let unwrappedValue = item {
-        if let boolValue = unwrappedValue as? Bool {
-          jsonArray.append(.bool(boolValue))
-        } else if let intValue = unwrappedValue as? Int {
-          jsonArray.append(.int(intValue))
-        } else if let stringValue = unwrappedValue as? String {
-          jsonArray.append(.string(stringValue))
-        } else if let doubleValue = unwrappedValue as? Double {
-          jsonArray.append(.double(doubleValue))
-        } else if let arrayValue = unwrappedValue as? [Any?] {
-          jsonArray.append(try JSONValue(arrayValue))
-        } else if let dictionaryValue = unwrappedValue as? [String: Any?] {
-          jsonArray.append(try JSONValue(dictionaryValue))
-        } else {
-          throw JSONValueError.invalidType
-        }
-      } else {
-        jsonArray.append(.null)
-      }
-    }
-    
-    self = .array(jsonArray)
-  }
-  
-  public init(_ dictionary: [String: Any?]) throws {
-    var jsonDictionary = [String: JSONValue]()
-    for (key, value) in dictionary {
-      if let unwrappedValue = value {
-        if let boolValue = unwrappedValue as? Bool {
-          jsonDictionary[key] = .bool(boolValue)
-        } else if let intValue = unwrappedValue as? Int {
-          jsonDictionary[key] = .int(intValue)
-        } else if let stringValue = unwrappedValue as? String {
-          jsonDictionary[key] = .string(stringValue)
-        } else if let doubleValue = unwrappedValue as? Double {
-          jsonDictionary[key] = .double(doubleValue)
-        } else if let arrayValue = unwrappedValue as? [Any?] {
-          jsonDictionary[key] = try JSONValue(arrayValue)
-        } else if let dictionaryValue = unwrappedValue as? [String: Any?] {
-          jsonDictionary[key] = try JSONValue(dictionaryValue)
-        } else {
-          throw JSONValueError.invalidType
-        }
-      } else {
-        jsonDictionary[key] = .null
-      }
-    }
-    
-    self = .dictionary(jsonDictionary)
-  }
-  
   public static func ==(lhs: JSONValue, rhs: JSONValue) -> Bool {
     switch (lhs, rhs) {
     case (.bool(let lhsValue), .bool(let rhsValue)):
@@ -236,26 +182,14 @@ public enum JSONValue: Codable, Equatable {
 // MARK: - Expressible by _ literal conformances
 
 extension JSONValue: ExpressibleByArrayLiteral {
-  public typealias ArrayLiteralElement = Any?
-
-  public init(arrayLiteral elements: Any?...) {
-    do {
-      self = try JSONValue(elements)
-    } catch {
-      fatalError("Could not instantiate JSON from elements \(elements)")
-    }
+  public init(arrayLiteral elements: JSONValue...) {
+    self = .array(elements)
   }
 }
 
 extension JSONValue: ExpressibleByDictionaryLiteral {
-  
-  public init(dictionaryLiteral elements: (String, Any?)...) {
-    let dictionary = Dictionary(uniqueKeysWithValues: elements)
-    do {
-      self = try JSONValue(dictionary)
-    } catch {
-      fatalError("Could not instantiate JSON from elements \(elements)")
-    }
+  public init(dictionaryLiteral elements: (String, JSONValue)...) {
+    self = .dictionary([String: JSONValue](uniqueKeysWithValues: elements))
   }
 }
 

--- a/Sources/ApolloCodegenLib/JSON.swift
+++ b/Sources/ApolloCodegenLib/JSON.swift
@@ -31,6 +31,60 @@ public enum JSONValue: Codable, Equatable {
     }
   }
   
+  public init(_ array: [Any?]) throws {
+    var jsonArray = [JSONValue]()
+    for item in array {
+      if let unwrappedValue = item {
+        if let boolValue = unwrappedValue as? Bool {
+          jsonArray.append(.bool(boolValue))
+        } else if let intValue = unwrappedValue as? Int {
+          jsonArray.append(.int(intValue))
+        } else if let stringValue = unwrappedValue as? String {
+          jsonArray.append(.string(stringValue))
+        } else if let doubleValue = unwrappedValue as? Double {
+          jsonArray.append(.double(doubleValue))
+        } else if let arrayValue = unwrappedValue as? [Any?] {
+          jsonArray.append(try JSONValue(arrayValue))
+        } else if let dictionaryValue = unwrappedValue as? [String: Any?] {
+          jsonArray.append(try JSONValue(dictionaryValue))
+        } else {
+          throw JSONValueError.invalidType
+        }
+      } else {
+        jsonArray.append(.null)
+      }
+    }
+    
+    self = .array(jsonArray)
+  }
+  
+  public init(_ dictionary: [String: Any?]) throws {
+    var jsonDictionary = [String: JSONValue]()
+    for (key, value) in dictionary {
+      if let unwrappedValue = value {
+        if let boolValue = unwrappedValue as? Bool {
+          jsonDictionary[key] = .bool(boolValue)
+        } else if let intValue = unwrappedValue as? Int {
+          jsonDictionary[key] = .int(intValue)
+        } else if let stringValue = unwrappedValue as? String {
+          jsonDictionary[key] = .string(stringValue)
+        } else if let doubleValue = unwrappedValue as? Double {
+          jsonDictionary[key] = .double(doubleValue)
+        } else if let arrayValue = unwrappedValue as? [Any?] {
+          jsonDictionary[key] = try JSONValue(arrayValue)
+        } else if let dictionaryValue = unwrappedValue as? [String: Any?] {
+          jsonDictionary[key] = try JSONValue(dictionaryValue)
+        } else {
+          throw JSONValueError.invalidType
+        }
+      } else {
+        jsonDictionary[key] = .null
+      }
+    }
+    
+    self = .dictionary(jsonDictionary)
+  }
+  
   public static func ==(lhs: JSONValue, rhs: JSONValue) -> Bool {
     switch (lhs, rhs) {
     case (.bool(let lhsValue), .bool(let rhsValue)):
@@ -176,5 +230,69 @@ public enum JSONValue: Codable, Equatable {
     } else {
       throw JSONValueError.invalidType
     }
+  }
+}
+
+// MARK: - Expressible by _ literal conformances
+
+extension JSONValue: ExpressibleByArrayLiteral {
+  public typealias ArrayLiteralElement = Any?
+
+  public init(arrayLiteral elements: Any?...) {
+    do {
+      self = try JSONValue(elements)
+    } catch {
+      fatalError("Could not instantiate JSON from elements \(elements)")
+    }
+  }
+}
+
+extension JSONValue: ExpressibleByDictionaryLiteral {
+  
+  public init(dictionaryLiteral elements: (String, Any?)...) {
+    let dictionary = Dictionary(uniqueKeysWithValues: elements)
+    do {
+      self = try JSONValue(dictionary)
+    } catch {
+      fatalError("Could not instantiate JSON from elements \(elements)")
+    }
+  }
+}
+
+extension JSONValue: ExpressibleByIntegerLiteral {
+  public typealias IntegerLiteralType = Int
+  
+  public init(integerLiteral value: Int) {
+    self = .int(value)
+  }
+}
+
+extension JSONValue: ExpressibleByFloatLiteral {
+  public typealias FloatLiteralType = Double
+
+  public init(floatLiteral value: Double) {
+    self = .double(value)
+  }
+}
+
+extension JSONValue: ExpressibleByBooleanLiteral {
+  public typealias BooleanLiteralType = Bool
+  
+  public init(booleanLiteral value: Bool) {
+    self = .bool(value)
+  }
+}
+
+extension JSONValue: ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) {
+    self = .null
+  }
+}
+
+extension JSONValue: ExpressibleByStringLiteral {
+  public typealias StringLiteralType = String
+  
+  public init(stringLiteral value: String) {
+    self = .string(value)
   }
 }

--- a/Tests/ApolloCodegenTests/JSONTests.swift
+++ b/Tests/ApolloCodegenTests/JSONTests.swift
@@ -425,28 +425,4 @@ class JSONTests: XCTestCase {
       XCTFail("String literal conversion failed")
     }
   }
-  
-  func testAddingNonJSONElementWillThrowError() {
-    // NOTE: Don't try testing this with literals or it'll just blow up in your face
-    let array: [Any?] = [
-      1,
-      2.0,
-      "string",
-      true,
-      nil,
-      XCTestCase()
-    ]
-    
-    XCTAssertThrowsError(try JSONValue(array)) { error in
-      switch error {
-      case JSONValue.JSONValueError.invalidType:
-        // This is what we want
-        break
-      default:
-        XCTFail("Incorrect error type!")
-      }
-    }
-  }
 }
-
-

--- a/Tests/ApolloCodegenTests/JSONTests.swift
+++ b/Tests/ApolloCodegenTests/JSONTests.swift
@@ -207,4 +207,246 @@ class JSONTests: XCTestCase {
       XCTFail("Incorrect type")
     }
   }
+  
+  // MARK: Literals
+  
+  func testArrayLiteralWithoutNesting() {
+    let jsonDict: JSONValue = [
+      1,
+      2.0,
+      "string",
+      true,
+      nil,
+    ]
+    
+    switch jsonDict {
+    case .array(let jsonValues):
+      XCTAssertEqual(jsonValues[0], .int(1))
+      XCTAssertEqual(jsonValues[1], .double(2.0))
+      XCTAssertEqual(jsonValues[2], .string("string"))
+      XCTAssertEqual(jsonValues[3], .bool(true))
+      XCTAssertEqual(jsonValues[4], .null)
+    default:
+      XCTFail("Array was not created!")
+    }
+  }
+  
+  func testDictionaryLiteralWithoutNesting() throws {
+    let jsonDict: JSONValue = [
+      "an_int": 1,
+      "a_double": 2.0,
+      "a_string": "string",
+      "a_bool": true,
+      "a_nil": nil,
+    ]
+    
+    switch jsonDict {
+    case .dictionary(let dict):
+      XCTAssertEqual(dict.count, 5)
+      XCTAssertEqual(dict["an_int"], .int(1))
+      XCTAssertEqual(dict["a_double"], .double(2.0))
+      XCTAssertEqual(dict["a_string"], .string("string"))
+      XCTAssertEqual(dict["a_bool"], .bool(true))
+      XCTAssertEqual(dict["a_nil"], .null)
+    default:
+      XCTFail("Dictionary was not created!")
+    }
+  }
+  
+  func testDictionaryLiteralWithNestedArray() throws {
+    let jsonDictionary: JSONValue = [
+      "a_boolean": true,
+      "a_string": "Yep",
+      "an_int": 42,
+      "something_null": nil,
+      "an_array": [
+        "single",
+        "type",
+        "array",
+        "here"
+      ],
+    ]
+  
+    switch jsonDictionary {
+    case .dictionary(let dict):
+      XCTAssertEqual(dict["a_boolean"], .bool(true))
+      XCTAssertEqual(dict["a_string"], .string("Yep"))
+      XCTAssertEqual(dict["an_int"], .int(42))
+      XCTAssertEqual(dict["something_null"], .null)
+      
+      let nestedArray = try XCTUnwrap(dict["an_array"])
+      switch nestedArray {
+      case .array(let array):
+        XCTAssertEqual(array[0], .string("single"))
+        XCTAssertEqual(array[1], .string("type"))
+        XCTAssertEqual(array[2], .string("array"))
+        XCTAssertEqual(array[3], .string("here"))
+      default:
+        XCTFail("Failed to create nested array within dictionary")
+      }
+    default:
+      XCTFail("Failed to create dictionary with nested array")
+    }
+  }
+  
+  func testArrayLiteralWithNestedDictionaries() throws {
+    let arrayOfDictsJSON: JSONValue = [
+        [
+          "name": "George Michael",
+          "colors": [
+            "Gray"
+          ],
+          "type": "Cat"
+        ],
+        [
+          "name": "Hank",
+          "colors": [
+            "Black",
+            "White"
+          ],
+          "type": "Cat"
+        ]
+      ]
+    
+    switch arrayOfDictsJSON {
+    case .array(let array):
+      XCTAssertEqual(array.count, 2)
+      let first = try XCTUnwrap(array.first)
+      switch first {
+      case .dictionary(let firstDict):
+        XCTAssertEqual(firstDict["name"], .string("George Michael"))
+        XCTAssertEqual(firstDict["colors"], .array([.string("Gray")]))
+        // Or we can check equality with an array literal
+        XCTAssertEqual(firstDict["colors"], ["Gray"])
+        XCTAssertEqual(firstDict["type"], .string("Cat"))
+      default:
+        XCTFail("Could not get first dictionary in array")
+      }
+      
+      let last = try XCTUnwrap(array.last)
+      switch last {
+      case .dictionary(let lastDict):
+        XCTAssertEqual(lastDict["name"], .string("Hank"))
+        XCTAssertEqual(lastDict["colors"], .array([.string("Black"), .string("White")]))
+        // Or we can check equality with an array literal
+        XCTAssertEqual(lastDict["colors"], ["Black", "White"])
+        XCTAssertEqual(lastDict["type"], .string("Cat"))
+      default:
+        XCTFail("Could not get last dictionary in array")
+      }
+    default:
+      XCTFail("Failed to create array with nested dictionaries")
+    }
+  }
+  
+  func testDictionaryLiteralWithNestedDictionary() throws {
+    let dictJSON: JSONValue = [
+      "a_boolean": true,
+      "a_string": "Yep",
+      "an_int": 42,
+      "something_null": nil,
+      "another_dictionary": [
+        "a_double": 53.2
+      ]
+    ]
+    
+    switch dictJSON {
+    case .dictionary(let dict):
+      XCTAssertEqual(dict.count, 5)
+      XCTAssertEqual(dict["a_boolean"], .bool(true))
+      XCTAssertEqual(dict["a_string"], .string("Yep"))
+      XCTAssertEqual(dict["an_int"], .int(42))
+      XCTAssertEqual(dict["something_null"], .null)
+      
+      let innerDictionary = try XCTUnwrap(dict["another_dictionary"])
+      switch innerDictionary {
+      case .dictionary(let innerDict):
+        XCTAssertEqual(innerDict.count, 1)
+        XCTAssertEqual(innerDict["a_double"], .double(53.2))
+      default:
+        XCTFail("Couldn't create nested dictionary with in a dictionary literal")
+      }
+    default:
+      XCTFail("Couldn't create dictionary literal with a nested dictionary")
+    }
+  }
+  
+  func testBooleanLiteralConversion() {
+    let json: JSONValue = true
+    
+    switch json {
+    case .bool(let value):
+      XCTAssertTrue(value)
+    default:
+      XCTFail("Boolean literal conversion failed")
+    }
+  }
+  
+  func testIntegerLiteralConversion() {
+    let json: JSONValue = 1
+    switch json {
+    case .int(let value):
+      XCTAssertEqual(value, 1)
+    default:
+      XCTFail("Integer literal conversion failed")
+    }
+  }
+  
+  func testNilLiteralConversion() {
+    let json: JSONValue = nil
+    
+    switch json {
+    case .null:
+      // This is what we want
+      break
+    default:
+      XCTFail("Nil literal conversion failed")
+    }
+  }
+  
+  func testDoubleLiteralConversion() {
+    let json: JSONValue = 23.7534123567
+    
+    switch json {
+    case .double(let value):
+      XCTAssertEqual(value, 23.7534123567, accuracy: 0.0000000000001)
+    default:
+      XCTFail("Double literal conversion failed")
+    }
+  }
+  
+  func testStringLiteralConversion() {
+    let json: JSONValue = "Hello, Dave."
+    
+    switch json {
+    case .string(let value):
+      XCTAssertEqual(value, "Hello, Dave.")
+    default:
+      XCTFail("String literal conversion failed")
+    }
+  }
+  
+  func testAddingNonJSONElementWillThrowError() {
+    // NOTE: Don't try testing this with literals or it'll just blow up in your face
+    let array: [Any?] = [
+      1,
+      2.0,
+      "string",
+      true,
+      nil,
+      XCTestCase()
+    ]
+    
+    XCTAssertThrowsError(try JSONValue(array)) { error in
+      switch error {
+      case JSONValue.JSONValueError.invalidType:
+        // This is what we want
+        break
+      default:
+        XCTFail("Incorrect error type!")
+      }
+    }
+  }
 }
+
+


### PR DESCRIPTION
From a discussion I was having last week in #1482, here's some literal conformances in my codable-compatible version of arbitrary JSON for use in future tests. 