### PR TITLE
Remove setter from `Atomic` to prevent API misuse, fix TSAN error in network interceptor

### DIFF
--- a/Sources/Apollo/RequestChain.swift
+++ b/Sources/Apollo/RequestChain.swift
@@ -111,7 +111,7 @@ public class RequestChain: Cancellable {
   
   /// Cancels the entire chain of interceptors.
   public func cancel() {
-    self.isCancelled.value = true
+    self.isCancelled.mutate { $0 = true }
     
     // If an interceptor adheres to `Cancellable`, it should have its in-flight work cancelled as well.
     for interceptor in self.interceptors {

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -70,7 +70,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// NOTE: This must be called from the `deinit` of anything holding onto this client in order to break a retain cycle with the delegate.
   public func invalidate() {
-    self.hasBeenInvalidated.value = true
+    self.hasBeenInvalidated.mutate { $0 = true }
     func cleanup() {
       self.session = nil
       self.clearAllTasks()

--- a/Sources/ApolloCore/Atomic.swift
+++ b/Sources/ApolloCore/Atomic.swift
@@ -14,21 +14,13 @@ public class Atomic<T> {
 
   /// The current value.
   public var value: T {
-    get {
-      lock.lock()
-      defer { lock.unlock() }
-
-      return _value
-    }
-    set {
-      lock.lock()
-      defer { lock.unlock() }
-
-      _value = newValue
-    }
+    lock.lock()
+    defer { lock.unlock() }
+    
+    return _value
   }
   
-  /// Mutates the underlying value within a lock. Mostly useful for mutating the contents of `Atomic` wrappers around collections.
+  /// Mutates the underlying value within a lock.
   /// - Parameter block: The block to execute to mutate the value.
   public func mutate(block: (inout T) -> Void) {
     lock.lock()

--- a/Sources/ApolloCore/Atomic.swift
+++ b/Sources/ApolloCore/Atomic.swift
@@ -12,7 +12,7 @@ public class Atomic<T> {
     _value = value
   }
 
-  /// The current value.
+  /// The current value. Read-only. To update the underlying value, use `mutate`.
   public var value: T {
     lock.lock()
     defer { lock.unlock() }

--- a/Sources/ApolloTestSupport/MockURLSession.swift
+++ b/Sources/ApolloTestSupport/MockURLSession.swift
@@ -26,7 +26,7 @@ public final class MockURLSessionClient: URLSessionClient {
   public override func sendRequest(_ request: URLRequest,
                                    rawTaskCompletionHandler: URLSessionClient.RawCompletion? = nil,
                                    completion: @escaping URLSessionClient.Completion) -> URLSessionTask {
-    self.lastRequest.value = request
+    self.lastRequest.mutate { $0 = request }
         
     // Capture data, response, and error instead of self to ensure we complete with the current state
     // even if it is changed before the block runs.

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -239,7 +239,7 @@ public class WebSocketTransport {
   }
 
   public func closeConnection() {
-    self.reconnect.value = false
+    self.reconnect.mutate { $0 = false }
 
     let str = OperationMessage(type: .connectionTerminate).rawMessage
     processingQueue.async {
@@ -325,12 +325,12 @@ public class WebSocketTransport {
 
   private func reconnectWebSocket() {
     let oldReconnectValue = reconnect.value
-    self.reconnect.value = false
+    self.reconnect.mutate { $0 = false }
 
     self.websocket.disconnect()
     self.websocket.connect()
 
-    reconnect.value = oldReconnectValue
+    self.reconnect.mutate { $0 = oldReconnectValue }
   }
   
   /// Disconnects the websocket while setting the auto-reconnect value to false,
@@ -338,7 +338,7 @@ public class WebSocketTransport {
   /// NOTE: You will receive an error on the subscription (should be a `Starscream.WSError` with code 1000) when the socket disconnects.
   /// ALSO NOTE: To reconnect after calling this, you will need to call `resumeWebSocketConnection`.
   public func pauseWebSocketConnection() {
-    self.reconnect.value = false
+    self.reconnect.mutate { $0 = false }
     self.websocket.disconnect()
   }
   
@@ -346,7 +346,7 @@ public class WebSocketTransport {
   ///
   /// - Parameter autoReconnect: `true` if you want the websocket to automatically reconnect if the connection drops. Defaults to true.
   public func resumeWebSocketConnection(autoReconnect: Bool = true) {
-    self.reconnect.value = autoReconnect
+    self.reconnect.mutate { $0 = autoReconnect }
     self.websocket.connect()
   }
 }
@@ -394,7 +394,7 @@ extension WebSocketTransport: NetworkTransport {
 extension WebSocketTransport: WebSocketDelegate {
 
   public func websocketDidConnect(socket: WebSocketClient) {
-    self.error.value = nil
+    self.error.mutate { $0 = nil }
     initServer()
     if reconnected {
       self.delegate?.webSocketTransportDidReconnect(self)
@@ -419,10 +419,12 @@ extension WebSocketTransport: WebSocketDelegate {
   public func websocketDidDisconnect(socket: WebSocketClient, error: Error?) {
     // report any error to all subscribers
     if let error = error {
-      self.error.value = WebSocketError(payload: nil, error: error, kind: .networkError)
+      self.error.mutate { $0 = WebSocketError(payload: nil,
+                                              error: error,
+                                              kind: .networkError) }
       self.notifyErrorAllHandlers(error)
     } else {
-      self.error.value = nil
+      self.error.mutate { $0 = nil }
     }
 
     self.delegate?.webSocketTransport(self, didDisconnectWithError: self.error.value)


### PR DESCRIPTION
@martijnwalraven pointed out in #1531 that it's a little too easy to accidentally misuse the `Atomic` API as it stands now, particularly in terms of dealing with things like toggling a boolean or making changes to an array. This PR removes the setter wrapper for `value`, so that if you need to make changes, you can only change things by using `mutate`, which executes the changes in a block for safety. 

I also fixed a thread sanitizer error in the Network interceptor around the `cancellable` that it holds onto. Once this and #1531 are merged, that should allow us to turn on thread sanitizer in tests permanently. 🤞