### PR TITLE
Turn on thread sanitizer for tests

### DIFF
--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <EnvironmentVariables>

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <EnvironmentVariables>


### PR DESCRIPTION
Thanks to @martijnwalraven's hard work, we should now be able to have thread sanitizer running on all our tests instead of just the codegen tests. This PR updates our schemes to make that happen. 🤞