### PR TITLE
Add pluralization and singularization support for new codegen

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		9B455CE72492D0A3002255A9 /* Collection+Apollo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */; };
 		9B455CEB2492FB03002255A9 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CEA2492FB03002255A9 /* String+SHA.swift */; };
 		9B47515D2575AA4A0001FB87 /* InflectorKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9B47515C2575AA4A0001FB87 /* InflectorKit */; };
+		9B47518D2575AA850001FB87 /* Pluralizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B47516D2575AA690001FB87 /* Pluralizer.swift */; };
+		9B4751AD2575B5070001FB87 /* PluralizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4751AC2575B5070001FB87 /* PluralizerTests.swift */; };
 		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
 		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
 		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
@@ -554,6 +556,8 @@
 		9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalBoolean.swift; sourceTree = "<group>"; };
 		9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+Apollo.swift"; sourceTree = "<group>"; };
 		9B455CEA2492FB03002255A9 /* String+SHA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SHA.swift"; sourceTree = "<group>"; };
+		9B47516D2575AA690001FB87 /* Pluralizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pluralizer.swift; sourceTree = "<group>"; };
+		9B4751AC2575B5070001FB87 /* PluralizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluralizerTests.swift; sourceTree = "<group>"; };
 		9B4AA8AD239EFDC9003E1300 /* Apollo-Target-CodegenTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenTests.xcconfig"; sourceTree = "<group>"; };
 		9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClient.swift; sourceTree = "<group>"; };
 		9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBinAPI.swift; sourceTree = "<group>"; };
@@ -1070,6 +1074,14 @@
 			name = Extensions;
 			sourceTree = "<group>";
 		};
+		9B4751BD2575BAFB0001FB87 /* Naming */ = {
+			isa = PBXGroup;
+			children = (
+				9B47516D2575AA690001FB87 /* Pluralizer.swift */,
+			);
+			name = Naming;
+			sourceTree = "<group>";
+		};
 		9B6835472463486200337AE6 /* ApolloCore */ = {
 			isa = PBXGroup;
 			children = (
@@ -1122,6 +1134,7 @@
 		9B7B6F50233C26E400F32205 /* ApolloCodegenLib */ = {
 			isa = PBXGroup;
 			children = (
+				9B4751BD2575BAFB0001FB87 /* Naming */,
 				9BCB585D240758B2002F766E /* Extensions */,
 				9BD681332405F6BB000874CB /* Codegen */,
 				9BD681322405F69C000874CB /* CLI */,
@@ -1251,6 +1264,7 @@
 				9BAEEC0D234BB95B00808306 /* FileManagerExtensionsTests.swift */,
 				9B68F0542416B33300E97318 /* LineByLineComparison.swift */,
 				9BD681352405F725000874CB /* JSONTests.swift */,
+				9B4751AC2575B5070001FB87 /* PluralizerTests.swift */,
 				9B8C3FB4248DA3E000707B13 /* URLExtensionsTests.swift */,
 				9B3D711024884E1B00D8BAF4 /* UnionEnumGenerationTests.swift */,
 				9B0E4719240AFA060093BDA7 /* VariableToSwiftTypeTests.swift */,
@@ -2391,6 +2405,7 @@
 				9B0E4718240AF6D70093BDA7 /* ASTVariableType.swift in Sources */,
 				9B0E471C240B167C0093BDA7 /* String+Apollo.swift in Sources */,
 				9BAEEBF32346DDAD00808306 /* CodegenLogger.swift in Sources */,
+				9B47518D2575AA850001FB87 /* Pluralizer.swift in Sources */,
 				9B3D70FE2488388E00D8BAF4 /* UnionEnumGenerator.swift in Sources */,
 				9B518C8C235F8B5F004C426D /* ApolloFilePathHelper.swift in Sources */,
 				9B518C87235F819E004C426D /* CLIDownloader.swift in Sources */,
@@ -2505,6 +2520,7 @@
 				9B3D711524889EB000D8BAF4 /* ExpectedNoCasesSearchResultType.swift in Sources */,
 				9B68F0552416B33300E97318 /* LineByLineComparison.swift in Sources */,
 				9BAEEC15234C132600808306 /* CLIExtractorTests.swift in Sources */,
+				9B4751AD2575B5070001FB87 /* PluralizerTests.swift in Sources */,
 				9B5A1EFE24352AED00F066BB /* ExpectedColorInput.swift in Sources */,
 				9BD681382405F7F6000874CB /* JSONTestHelpers.swift in Sources */,
 				9BAEEC19234C297800808306 /* ApolloCodegenTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		9B455CE62492D0A3002255A9 /* OptionalBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE32492D0A3002255A9 /* OptionalBoolean.swift */; };
 		9B455CE72492D0A3002255A9 /* Collection+Apollo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CE42492D0A3002255A9 /* Collection+Apollo.swift */; };
 		9B455CEB2492FB03002255A9 /* String+SHA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B455CEA2492FB03002255A9 /* String+SHA.swift */; };
+		9B47515D2575AA4A0001FB87 /* InflectorKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9B47515C2575AA4A0001FB87 /* InflectorKit */; };
 		9B4F453F244A27B900C2CF7D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F453E244A27B900C2CF7D /* URLSessionClient.swift */; };
 		9B4F4541244A2A9200C2CF7D /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4540244A2A9200C2CF7D /* HTTPBinAPI.swift */; };
 		9B4F4543244A2AD300C2CF7D /* URLSessionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4F4542244A2AD300C2CF7D /* URLSessionClientTests.swift */; };
@@ -824,6 +825,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B47515D2575AA4A0001FB87 /* InflectorKit in Frameworks */,
 				9B68F04D2413239100E97318 /* Stencil in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1827,6 +1829,7 @@
 			name = ApolloCodegenLib;
 			packageProductDependencies = (
 				9B68F04C2413239100E97318 /* Stencil */,
+				9B47515C2575AA4A0001FB87 /* InflectorKit */,
 			);
 			productName = ApolloCodegenLib;
 			productReference = 9B7B6F47233C26D100F32205 /* ApolloCodegenLib.framework */;
@@ -2183,6 +2186,7 @@
 				9B7BDAAA23FDEA7B00ACD198 /* XCRemoteSwiftPackageReference "Starscream" */,
 				9B7BDAF423FDEE2600ACD198 /* XCRemoteSwiftPackageReference "SQLite.swift" */,
 				9B68F04B2413239100E97318 /* XCRemoteSwiftPackageReference "Stencil" */,
+				9B47515B2575AA4A0001FB87 /* XCRemoteSwiftPackageReference "InflectorKit" */,
 			);
 			productRefGroup = 9FC750451D2A532C00458D91 /* Products */;
 			projectDirPath = "";
@@ -3371,6 +3375,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		9B47515B2575AA4A0001FB87 /* XCRemoteSwiftPackageReference "InflectorKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apollographql/InflectorKit.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		9B68F04B2413239100E97318 /* XCRemoteSwiftPackageReference "Stencil" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stencilproject/Stencil.git";
@@ -3398,6 +3410,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		9B47515C2575AA4A0001FB87 /* InflectorKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B47515B2575AA4A0001FB87 /* XCRemoteSwiftPackageReference "InflectorKit" */;
+			productName = InflectorKit;
+		};
 		9B68F04C2413239100E97318 /* Stencil */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9B68F04B2413239100E97318 /* XCRemoteSwiftPackageReference "Stencil" */;

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/apollographql/InflectorKit.git",
         "state": {
           "branch": "master",
-          "revision": "f898cb1506b58962f76871686a55768c11e956cc",
+          "revision": "b1d0099abe36facd198113633f502889842906af",
           "version": null
         }
       },

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "InflectorKit",
+        "repositoryURL": "https://github.com/apollographql/InflectorKit.git",
+        "state": {
+          "branch": "master",
+          "revision": "f898cb1506b58962f76871686a55768c11e956cc",
+          "version": null
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "InflectorKit",
+        "repositoryURL": "https://github.com/apollographql/InflectorKit",
+        "state": {
+          "branch": "master",
+          "revision": "f898cb1506b58962f76871686a55768c11e956cc",
+          "version": null
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
-          "version": "0.13.1"
+          "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
+          "version": "0.14.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,9 @@ let package = Package(
     .package(
       url: "https://github.com/stencilproject/Stencil.git",
       .upToNextMinor(from: "0.14.0")),
+    .package(
+      url: "https://github.com/apollographql/InflectorKit",
+      .branch("master")),
     ],
     targets: [
       .target(
@@ -50,6 +53,7 @@ let package = Package(
       name: "ApolloCodegenLib",
       dependencies: [
         "ApolloCore",
+        "InflectorKit",
         .product(name: "Stencil", package: "Stencil"),
       ]),
     .target(

--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -63,6 +63,7 @@ public struct ApolloCodegenOptions {
   }
   
   let codegenEngine: CodeGenerationEngine
+  let additionalInflectionRules: [InflectionRule]
   let includes: String
   let mergeInFieldsFromFragmentSpreads: Bool
   let namespace: String?
@@ -93,7 +94,9 @@ public struct ApolloCodegenOptions {
   ///  - suppressSwiftMultilineStringLiterals: Don't use multi-line string literals when generating code. Defaults to false.
   ///  - urlToSchemaFile: The URL to your schema file.
   ///  - downloadTimeout: The maximum time to wait before indicating that the download timed out, in seconds. Defaults to 30 seconds.
+  ///  - additionalInflectionRules: [EXPERIMENTAL SWIFT CODEGEN ONLY] - Any non-default rules for pluralization or singularization you wish to include. Defaults to an empty array.
   public init(codegenEngine: CodeGenerationEngine = .default,
+              additionalInflectionRules: [InflectionRule] = [],
               includes: String = "./**/*.graphql",
               mergeInFieldsFromFragmentSpreads: Bool = true,
               modifier: AccessModifier = .public,
@@ -107,6 +110,7 @@ public struct ApolloCodegenOptions {
               urlToSchemaFile: URL,
               downloadTimeout: Double = 30.0) {
     self.codegenEngine = codegenEngine
+    self.additionalInflectionRules = additionalInflectionRules
     self.includes = includes
     self.mergeInFieldsFromFragmentSpreads = mergeInFieldsFromFragmentSpreads
     self.modifier = modifier

--- a/Sources/ApolloCodegenLib/Pluralizer.swift
+++ b/Sources/ApolloCodegenLib/Pluralizer.swift
@@ -1,0 +1,64 @@
+//
+//  Pluralizer.swift
+//  Apollo
+//
+//  Created by Ellen Shapiro on 11/30/20.
+//  Copyright © 2020 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+import InflectorKit
+
+/// The types of inflection rules that can be used to customize pluralization. 
+public enum InflectionRule {
+
+  /// A pluralization rule that allows taking a singular word and pluralizing it.
+  /// - singularRegex: A regular expression representing the single version of the word
+  /// - replacementRegex: A regular expression representing how to replace the singular version.
+  case pluralization(singularRegex: String, replacementRegex: String)
+  
+  /// A singularization rule that allows taking a plural word and singularizing it.
+  /// - pluralRegex: A regular expression represeinting the plural version of the word
+  /// - replacementRegex: A regular expression representing how to replace the singular version
+  case singularization(pluralRegex: String, replacementRegex: String)
+  
+  /// A definition of an irregular pluralization rule not easily captured by regex - for example "person" and "people".
+  /// - singular: The singular version of the word
+  /// - plural: The plural version of the word.
+  case irregular(singular: String, plural: String)
+  
+  /// A definition of a word that should never be pluralized or de-pluralized because it's the same no matter what the count - for example, "fish".
+  /// - word: The word that should never be adjusted.
+  case uncountable(word: String)
+}
+
+struct Pluralizer {
+  
+  private let inflector: TTTStringInflector
+  
+  init(rules: [InflectionRule] = []) {
+    let inflector = TTTStringInflector.default()
+    for rule in rules {
+      switch rule {
+      case .pluralization(let pluralRegex, let replacementRegex):
+        inflector.addPluralRule(pluralRegex, withReplacement: replacementRegex)
+      case .singularization(let singularRegex, let replacementRegex):
+        inflector.addSingularRule(singularRegex, withReplacement: replacementRegex)
+      case .irregular(let singular, let plural):
+        inflector.addIrregular(withSingular: singular, plural: plural)
+      case .uncountable(let word):
+        inflector.addUncountable(word)
+      }
+    }
+    
+    self.inflector = inflector
+  }
+  
+  func singluarize(_ string: String) -> String {
+    self.inflector.singularize(string)
+  }
+  
+  func pluralize(_ string: String) -> String {
+    self.inflector.pluralize(string)
+  }
+}

--- a/Tests/ApolloCodegenTests/PluralizerTests.swift
+++ b/Tests/ApolloCodegenTests/PluralizerTests.swift
@@ -1,0 +1,86 @@
+//
+//  SingularizationTests.swift
+//  ApolloCodegenTests
+//
+//  Created by Ellen Shapiro on 11/30/20.
+//  Copyright © 2020 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ApolloCodegenLib
+
+class PluralizerTests: XCTestCase {
+  
+  func testSimpleSingularization() {
+    let pluralizer = Pluralizer()
+    let pluralized = "Cats"
+    let singular = pluralizer.singluarize(pluralized)
+    XCTAssertEqual(singular, "Cat")
+  }
+  
+  func testSimplePluralization() {
+    let pluralizer = Pluralizer()
+    let singular = "Cat"
+    let pluralized = pluralizer.pluralize(singular)
+    XCTAssertEqual(pluralized, "Cats")
+  }
+  
+  func testAddingASingularizationRuleWorks() {
+    let defaultPluralizer = Pluralizer()
+    let pluralized = "Atlases"
+    let beforeRule = defaultPluralizer.singluarize(pluralized)
+    
+    // This should be wrong becuase we haven't applied the rule yet.
+    XCTAssertEqual(beforeRule, "Atlase")
+    
+    let pluralizerWithRule = Pluralizer(rules: [
+      .singularization(pluralRegex: "(atlas)(es)?$", replacementRegex: "$1")
+    ])
+    
+    let afterRule = pluralizerWithRule.singluarize(pluralized)
+    
+    // Now that we've applied the rule, this should be correct
+    XCTAssertEqual(afterRule, "Atlas")
+  }
+  
+  func testAddingAPluralizationRuleWorks() {
+    let defaultPluralizer = Pluralizer()
+    let singular = "Atlas"
+    let beforeRule = defaultPluralizer.pluralize(singular)
+    
+    // This should be wrong becuase we haven't applied the rule yet.
+    XCTAssertEqual(beforeRule, "Atlas")
+    
+    let pluralizerWithRule = Pluralizer(rules: [
+      .pluralization(singularRegex: "(atla)s", replacementRegex: "$1ses")
+    ])
+    let singularized = pluralizerWithRule.pluralize(singular)
+    
+    // Now that we've applied the rule, this should be correct
+    XCTAssertEqual(singularized, "Atlases")
+  }
+ 
+  func testPluralizerDoesntMessWithExistingCapitalization() {
+    let pluralizer = Pluralizer()
+    let singular = "CAT"
+    let pluralized = pluralizer.pluralize(singular)
+    XCTAssertEqual(pluralized, "CATs")
+    
+    let singularWithLowercase = "CaT"
+    let pluralizedWithLowercase = pluralizer.pluralize(singularWithLowercase)
+    XCTAssertEqual(pluralizedWithLowercase, "CaTs")
+  }
+  
+  func testSingularlizerWorksRegardlessOfCapitalization() {
+    let pluralizer = Pluralizer()
+    let pluralizedAllCaps = "CTAS"
+    let singularizedAllCaps = pluralizer.singluarize(pluralizedAllCaps)
+    XCTAssertEqual(singularizedAllCaps, "CTA")
+
+    let pluralizedWithOneLowercase = "CTAs"
+    let singularizedWithOneLowercase = pluralizer.singluarize(pluralizedWithOneLowercase)
+    XCTAssertEqual(singularizedWithOneLowercase, "CTA")
+  }
+  
+}


### PR DESCRIPTION
This PR brings in [`InflectorKit`](https://github.com/mattt/InflectorKit) from [a fork](https://github.com/apollographql/InflectorKit) where I've added SPM support. Probably going to PR that back to the main repo as well. 

I've also created a wrapper around it to keep it abstract, and added an `inflectionRule` enum to allow easy passing of multiple inflection rules without having to worry about using `InflectorKit` in the consuming code. 