### PR TITLE
Fix deallocation issue on `additionalErrorHandler` completion when retry is called.

### DIFF
--- a/Sources/Apollo/RequestChain.swift
+++ b/Sources/Apollo/RequestChain.swift
@@ -162,8 +162,10 @@ public class RequestChain: Cancellable {
       return
     }
 
-    additionalHandler.handleErrorAsync(error: error, chain: self, request: request, response: response) { [weak self] result in
-      self?.callbackQueue.async {
+    // Capture callback queue so it doesn't get reaped when `self` is dealloced
+    let callbackQueue = self.callbackQueue
+    additionalHandler.handleErrorAsync(error: error, chain: self, request: request, response: response) { result in
+      callbackQueue.async {
         completion(result)
       }
     }


### PR DESCRIPTION
Looks like the fact that we're wrapping `additionalErrorHandler`'s callback with a `weak self` was causing a failure when a `retry` was done from within `additionalErrorHandler`, because `self`, and in turn the callback queue it was holding onto, got deallocated.

This fix pulls out the callback queue to prevent a retain cycle but hang on to the queue so the completion closure can be properly executed. 