### PR TITLE
Use storage for locks

### DIFF
--- a/Sources/Apollo/Locking.swift
+++ b/Sources/Apollo/Locking.swift
@@ -1,25 +1,27 @@
 import Foundation
 
 final class Mutex {
-  private var _lock = pthread_mutex_t()
+  private var _lockPtr = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
 
   init() {
-    let result = pthread_mutex_init(&_lock, nil)
+    let result = pthread_mutex_init(_lockPtr, nil)
     assert(result == 0)
   }
 
   deinit {
-    let result = pthread_mutex_destroy(&_lock)
+    let result = pthread_mutex_destroy(_lockPtr)
+    _lockPtr.deinitialize(count: 1)
+    _lockPtr.deallocate()
     assert(result == 0)
   }
 
   func lock() {
-    let result = pthread_mutex_lock(&_lock)
+    let result = pthread_mutex_lock(_lockPtr)
     assert(result == 0)
   }
 
   func unlock() {
-    let result = pthread_mutex_unlock(&_lock)
+    let result = pthread_mutex_unlock(_lockPtr)
     assert(result == 0)
   }
 
@@ -31,28 +33,30 @@ final class Mutex {
 }
 
 final class ReadWriteLock {
-  private var _lock = pthread_rwlock_t()
+  private var _lockPtr = UnsafeMutablePointer<pthread_rwlock_t>.allocate(capacity: 1)
 
   init() {
-    let status = pthread_rwlock_init(&_lock, nil)
+    let status = pthread_rwlock_init(_lockPtr, nil)
     assert(status == 0)
   }
 
   deinit {
-    let status = pthread_rwlock_destroy(&_lock)
+    let status = pthread_rwlock_destroy(_lockPtr)
+    _lockPtr.deinitialize(count: 1)
+    _lockPtr.deallocate()
     assert(status == 0)
   }
 
   func lockForReading() {
-    pthread_rwlock_rdlock(&_lock)
+    pthread_rwlock_rdlock(_lockPtr)
   }
 
   func lockForWriting() {
-    pthread_rwlock_wrlock(&_lock)
+    pthread_rwlock_wrlock(_lockPtr)
   }
 
   func unlock() {
-    pthread_rwlock_unlock(&_lock)
+    pthread_rwlock_unlock(_lockPtr)
   }
 
   func withReadLock<T>(_ body: () throws -> T) rethrows -> T {


### PR DESCRIPTION
& operator in swift not equal to C's operator. Passing lock with inout
ref may cause race and potential crashes.

More details http://www.russbishop.net/the-law
Apple example https://fuchsia.googlesource.com/third_party/swift-corelibs-foundation/+/upstream/fuchsia_release/Foundation/NSLock.swift