### PR TITLE
Add and test validation of multiple vs. single file urls

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -9,11 +9,17 @@ public class ApolloCodegen {
   /// Errors which can happen with code generation
   public enum CodegenError: Error, LocalizedError {
     case folderDoesNotExist(_ url: URL)
+    case multipleFilesButNotDirectoryURL(_ url: URL)
+    case singleFileButNotSwiftFileURL(_ url: URL)
     
     public var errorDescription: String? {
       switch self {
       case .folderDoesNotExist(let url):
         return "Can't run codegen trying to run the command from \(url) because there is no folder there! This should be the folder which, at some depth, contains all your `.graphql` files."
+      case .multipleFilesButNotDirectoryURL(let url):
+        return "Codegen is requesting multiple file generation, but the URL passed in (\(url)) is not a directory URL. Please check your URL and try again."
+      case .singleFileButNotSwiftFileURL(let url):
+        return "Codegen is requesting single file generation, but the URL passed in (\(url)) is a not a Swift file URL. Please check your URL and try again."
       }
     }
   }
@@ -35,8 +41,17 @@ public class ApolloCodegen {
     
     switch options.outputFormat {
     case .multipleFiles(let folderURL):
+      /// We have to try to create the folder first because the stuff
+      /// underlying `isDirectoryURL` only works on actual directories
       try FileManager.default.apollo.createFolderIfNeeded(at: folderURL)
+      guard folderURL.apollo.isDirectoryURL else {
+        throw CodegenError.multipleFilesButNotDirectoryURL(folderURL)
+      }
     case .singleFile(let fileURL):
+      guard fileURL.apollo.isSwiftFileURL else {
+        throw CodegenError.singleFileButNotSwiftFileURL(fileURL)
+      }
+      
       try FileManager.default.apollo.createContainingFolderIfNeeded(for: fileURL)
     }
 

--- a/Sources/ApolloCodegenLib/FileFinder.swift
+++ b/Sources/ApolloCodegenLib/FileFinder.swift
@@ -1,28 +1,42 @@
 import Foundation
 
 public struct FileFinder {
-    
+  
   #if compiler(>=5.3)
   /// Version that works if you're using the 5.3 compiler or above
   /// - Parameter filePath: The full file path of the file to find. Defaults to the `#filePath` of the caller.
   /// - Returns: The file URL for the parent folder.
-    public static func findParentFolder(from filePath: StaticString = #filePath) -> URL {
-      self.findParentFolder(from: filePath.apollo.toString)
-    }
+  public static func findParentFolder(from filePath: StaticString = #filePath) -> URL {
+    self.findParentFolder(from: filePath.apollo.toString)
+  }
+  
+  /// The URL of a file at a given path
+  /// - Parameter filePath: The full file path of the file to find
+  /// - Returns: The file's URL
+  public static func fileURL(from filePath: StaticString = #filePath) -> URL {
+    URL(fileURLWithPath: filePath.apollo.toString)
+  }
   #else
-    /// Version that works if you're using the 5.2 compiler or below
-    /// - Parameter file: The full file path of the file to find. Defaults to the `#file` of the caller.
-    /// - Returns: The file URL for the parent folder.
-    public static func findParentFolder(from filePath: StaticString = #file) -> URL {
-      self.findParentFolder(from: filePath.apollo.toString)
-    }
+  /// Version that works if you're using the 5.2 compiler or below
+  /// - Parameter file: The full file path of the file to find. Defaults to the `#file` of the caller.
+  /// - Returns: The file URL for the parent folder.
+  public static func findParentFolder(from filePath: StaticString = #file) -> URL {
+    self.findParentFolder(from: filePath.apollo.toString)
+  }
+  
+  /// The URL of a file at a given path
+  /// - Parameter filePath: The full file path of the file to find
+  /// - Returns: The file's URL
+  public static func fileURL(from filePath: StaticString = #file) -> URL {
+    URL(fileURLWithPath: filePath.apollo.toString)
+  }
   #endif
-    
+  
   /// Finds the parent folder from a given file path.
   /// - Parameter filePath: The full file path, as a string
   /// - Returns: The file URL for the parent folder.
-    public static func findParentFolder(from filePath: String) -> URL {
-        let url = URL(fileURLWithPath: filePath)
-        return url.deletingLastPathComponent()
-    }
+  public static func findParentFolder(from filePath: String) -> URL {
+    let url = URL(fileURLWithPath: filePath)
+    return url.deletingLastPathComponent()
+  }
 }

--- a/Sources/ApolloCodegenLib/URL+Apollo.swift
+++ b/Sources/ApolloCodegenLib/URL+Apollo.swift
@@ -18,6 +18,25 @@ public enum ApolloURLError: Error, LocalizedError {
 
 extension ApolloExtension where Base == URL {
   
+  /// Determines if the URL passed in is a directory URL.
+  ///
+  /// NOTE: Only works if something at the URL already exists.
+  ///
+  /// - Returns: True if the URL is a directory URL, false if it isn't.
+  var isDirectoryURL: Bool {
+    guard
+      let resourceValues = try? base.resourceValues(forKeys: [.isDirectoryKey]),
+      let isDirectory = resourceValues.isDirectory else {
+        return false
+    }
+    
+    return isDirectory
+  }
+  
+  var isSwiftFileURL: Bool {
+    base.pathExtension == "swift"
+  }
+  
   /// - Returns: the URL to the parent folder of the current URL.
   public func parentFolderURL() -> URL {
     base.deletingLastPathComponent()

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -110,6 +110,54 @@ class ApolloCodegenTests: XCTestCase {
     ])
   }
   
+  func testTryingToUseAFileURLToOutputMultipleFilesFails() {
+    let scriptFolderURL = CodegenTestHelper.cliFolderURL()
+    let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()
+    let starWarsSchemaFileURL = CodegenTestHelper.starWarsSchemaFileURL()
+    let outputFolder = CodegenTestHelper.outputFolderURL()
+    let outputFile = outputFolder.appendingPathComponent("API.swift")
+    
+    let options = ApolloCodegenOptions(outputFormat: .multipleFiles(inFolderAtURL: outputFile),
+                                       urlToSchemaFile: starWarsSchemaFileURL,
+                                       downloadTimeout: CodegenTestHelper.timeout)
+    do {
+      _ = try ApolloCodegen.run(from: starWarsFolderURL,
+                                with: scriptFolderURL,
+                                options: options)
+    } catch {
+      switch error {
+      case ApolloCodegen.CodegenError.multipleFilesButNotDirectoryURL(let url):
+        XCTAssertEqual(url, outputFile)
+      default:
+        XCTFail("Unexpected error running codegen: \(error.localizedDescription)")
+
+      }
+    }
+  }
+  
+  func testTryingToUseAFolderURLToOutputASingleFileFails() {
+    let scriptFolderURL = CodegenTestHelper.cliFolderURL()
+    let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()
+    let starWarsSchemaFileURL = CodegenTestHelper.starWarsSchemaFileURL()
+    let outputFolder = CodegenTestHelper.outputFolderURL()
+    
+    let options = ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: outputFolder),
+                                       urlToSchemaFile: starWarsSchemaFileURL,
+                                       downloadTimeout: CodegenTestHelper.timeout)
+    do {
+      _ = try ApolloCodegen.run(from: starWarsFolderURL,
+                                with: scriptFolderURL,
+                                options: options)
+    } catch {
+      switch error {
+      case ApolloCodegen.CodegenError.singleFileButNotSwiftFileURL(let url):
+        XCTAssertEqual(url, outputFolder)
+      default:
+        XCTFail("Unexpected error running codegen: \(error.localizedDescription)")
+      }
+    }
+  }
+  
   func testCodegenWithSingleFileOutputsSingleFile() throws {
     let scriptFolderURL = CodegenTestHelper.cliFolderURL()
     let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()

--- a/Tests/ApolloCodegenTests/URLExtensionsTests.swift
+++ b/Tests/ApolloCodegenTests/URLExtensionsTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-import ApolloCodegenLib
+@testable import ApolloCodegenLib
 import ApolloCore
 
 class URLExtensionsTests: XCTestCase {
@@ -68,4 +68,39 @@ class URLExtensionsTests: XCTestCase {
     
     XCTAssertEqual(child, expectedFile)
   }
+  
+  func testIsDirectoryForExistingDirectory() {
+    let parentDirectory = FileFinder.findParentFolder()
+    XCTAssertTrue(FileManager.default.apollo.folderExists(at: parentDirectory))
+    XCTAssertTrue(parentDirectory.apollo.isDirectoryURL)
+  }
+  
+  func testIsDirectoryForExistingFile() {
+    let currentFileURL = FileFinder.fileURL()
+    XCTAssertTrue(FileManager.default.apollo.fileExists(at: currentFileURL))
+    XCTAssertFalse(currentFileURL.apollo.isDirectoryURL)
+  }
+  
+  func testIsSwiftFileForExistingFile() {
+    let currentFileURL = FileFinder.fileURL()
+    XCTAssertTrue(FileManager.default.apollo.fileExists(at: currentFileURL))
+    XCTAssertTrue(currentFileURL.apollo.isSwiftFileURL)
+  }
+  
+  func testIsSwiftFileForNonExistentFileWithSingleExtension() {
+    let currentDirectory = FileFinder.findParentFolder()
+    let doesntExist = currentDirectory.appendingPathComponent("test.swift")
+    
+    XCTAssertFalse(FileManager.default.apollo.fileExists(at: doesntExist))
+    XCTAssertTrue(doesntExist.apollo.isSwiftFileURL)
+  }
+  
+  func testIsSwiftFileForNonExistentFileWithMultipleExtensions() {
+    let currentDirectory = FileFinder.findParentFolder()
+    let doesntExist = currentDirectory.appendingPathComponent("test.graphql.swift")
+    
+    XCTAssertFalse(FileManager.default.apollo.fileExists(at: doesntExist))
+    XCTAssertTrue(doesntExist.apollo.isSwiftFileURL)
+  }
+  
 }


### PR DESCRIPTION
Addresses concerns raised by #1557. 

One thing that's a bit annoying is that the underlying foundation API can only determine if something is a directory URL or not for a url where something already exists, if the directory hasn't already been created, we can't check it. For a file, we're essentially just checking that the last file extension is `.swift`, since there's not really a great way to check it otherwise. 