### PR TITLE
Add `deleteRecord(for key:)` to `ReadWriteTransaction`

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -2154,7 +2154,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1210;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1230;
 				ORGANIZATIONNAME = "Apollo GraphQL";
 				TargetAttributes = {
 					9B2DFBB524E1FA0D00ED3AE6 = {

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo Playground.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo Playground.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/Apollo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloCodegenLib.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloCodegenLib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloCore.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloPerformanceTests.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloPerformanceTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloSQLite.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
+++ b/Apollo.xcodeproj/xcshareddata/xcschemes/ApolloWebSocket.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -242,7 +242,13 @@ public final class ApolloStore {
       try write(object: object, withKey: key, variables: variables)
     }
     
-    public func removeRecord(for key: CacheKey) throws {
+    /// Removes the object for the specified cache key. Does not cascade
+    /// or allow removal of only certain fields. Does nothing if an object
+    /// does not exist for the given key.
+    ///
+    /// - Parameters:
+    ///   - key: The cache key to remove the object for
+    public func removeObject(for key: CacheKey) throws {
       try self.cache.removeRecord(for: key)
     }
 

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -241,6 +241,10 @@ public final class ApolloStore {
       try body(&object)
       try write(object: object, withKey: key, variables: variables)
     }
+    
+    public func removeRecord(for key: CacheKey) throws {
+      try self.cache.removeRecord(for: key)
+    }
 
     public func write<Query: GraphQLQuery>(data: Query.Data, forQuery query: Query) throws {
       try write(object: data,

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -13,6 +13,10 @@ public final class InMemoryNormalizedCache: NormalizedCache {
     }
   }
 
+  public func removeRecord(for key: CacheKey) throws {
+    records.removeRecord(for: key)
+  }
+  
   public func merge(records newRecords: RecordSet) throws -> Set<CacheKey> {
     return records.merge(records: newRecords)
   }

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -15,6 +15,20 @@ public protocol NormalizedCache {
   ///   - records: The set of records to merge.
   /// - Returns: A set of keys corresponding to *fields* that have changed (i.e. QUERY_ROOT.Foo.myField). These are the same type of keys as are returned by RecordSet.merge(records:).
   func merge(records: RecordSet) throws -> Set<CacheKey>
+
+  /// Removes a record for the specified key. This method will only
+  /// remove whole records, not individual fields.
+  ///
+  /// If you attempt to pass a cache key for a  single field, this
+  /// method will do nothing since it won't be able to locate a
+  /// record to remove based on that key.
+  ///
+  /// This method does not support cascading delete - it will only
+  /// remove the record for the specified key, and not any references to it or from it.
+  /// 
+  /// - Parameters:
+  ///   - key: The cache key to remove the record for
+  func removeRecord(for key: CacheKey) throws
   
   /// Clears all records.
   func clear() throws

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -9,6 +9,10 @@ public struct RecordSet {
   public mutating func insert(_ record: Record) {
     storage[record.key] = record
   }
+  
+  public mutating func removeRecord(for key: CacheKey) {
+    storage.removeValue(forKey: key)
+  }
 
   public mutating func clear() {
     storage.removeAll()

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -101,6 +101,12 @@ public final class SQLiteNormalizedCache {
       try self.db.prepare("VACUUM;").run()
     }
   }
+  
+  private func removeSQLiteRecord(for cacheKey: CacheKey) throws {
+    let recordKey = self.recordCacheKey(forFieldCacheKey: cacheKey)
+    let query = self.records.filter(key == recordKey)
+    try self.db.run(query.delete())
+  }
 
   private func parse(row: Row) throws -> Record {
     let record = row[self.record]
@@ -125,6 +131,10 @@ extension SQLiteNormalizedCache: NormalizedCache {
   
   public func merge(records: RecordSet) throws -> Set<CacheKey> {
     return try mergeRecords(records: records)
+  }
+  
+  public func removeRecord(for key: CacheKey) throws {
+    try removeSQLiteRecord(for: key)
   }
   
   public func clear() throws {

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -103,8 +103,7 @@ public final class SQLiteNormalizedCache {
   }
   
   private func removeSQLiteRecord(for cacheKey: CacheKey) throws {
-    let recordKey = self.recordCacheKey(forFieldCacheKey: cacheKey)
-    let query = self.records.filter(key == recordKey)
+    let query = self.records.filter(key == cacheKey)
     try self.db.run(query.delete())
   }
 

--- a/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
@@ -77,7 +77,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let removeCompletedExpectation = expectation(description: "Remove completed")
 
     store.withinReadWriteTransaction({ transaction in
-      try transaction.removeRecord(for: "hero")
+      try transaction.removeObject(for: "hero")
     }, completion: { result in
       defer { removeCompletedExpectation.fulfill() }
       XCTAssertSuccessResult(result)
@@ -138,7 +138,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let removeCompletedExpectation = expectation(description: "Remove completed")
 
     store.withinReadWriteTransaction({ transaction in
-      try transaction.removeRecord(for: "hero.name")
+      try transaction.removeObject(for: "hero.name")
     }, completion: { result in
       defer { removeCompletedExpectation.fulfill() }
       XCTAssertSuccessResult(result)
@@ -325,7 +325,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       let friendsNames = data.hero?.friends?.compactMap { $0?.name }
       XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
       
-      try transaction.removeRecord(for: "1003")
+      try transaction.removeObject(for: "1003")
     }, completion: { result in
       defer { readWriteCompletedExpectation.fulfill() }
       XCTAssertSuccessResult(result)

--- a/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloCacheDependentTests/ReadWriteFromStoreTests.swift
@@ -51,6 +51,113 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [readCompletedExpectation], timeout: defaultWaitTimeout)
   }
   
+  func testReadHeroNameQueryAfterRemovingRecord() throws {
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+    
+    let query = HeroNameQuery()
+    
+    let readCompletedExpectation = expectation(description: "Read completed")
+    
+    store.withinReadWriteTransaction({ transaction in
+      let data = try transaction.read(query: query)
+      
+      XCTAssertEqual(data.hero?.__typename, "Droid")
+      XCTAssertEqual(data.hero?.name, "R2-D2")
+      
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+    
+    self.wait(for: [readCompletedExpectation], timeout: defaultWaitTimeout)
+    
+    let removeCompletedExpectation = expectation(description: "Remove completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      try transaction.removeRecord(for: "hero")
+    }, completion: { result in
+      defer { removeCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+        
+    self.wait(for: [removeCompletedExpectation], timeout: defaultWaitTimeout)
+    
+    let refetchExpectation = expectation(description: "Refetch completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      _ = try transaction.read(query: query)
+    }, completion: { result in
+      defer { refetchExpectation.fulfill() }
+      XCTAssertFailureResult(result) { refetchError in
+        guard let error = refetchError as? GraphQLResultError else {
+          XCTFail("Unexpected error trying to load a removed record: \(refetchError)")
+          return
+        }
+        
+        XCTAssertEqual(error.path, ["hero"])
+
+        switch error.underlying {
+        case JSONDecodingError.missingValue:
+          // This is correct.
+          break
+        default:
+          XCTFail("Unexpected error trying to load a removed record: \(refetchError)")
+        }
+      }
+    })
+    
+    self.wait(for: [refetchExpectation], timeout: defaultWaitTimeout)
+  }
+  
+  func testHeroNameQueryStillLoadsAfterAttemptingToDeleteFieldKey() throws {
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": Reference(key: "hero")],
+      "hero": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+    
+    let query = HeroNameQuery()
+    
+    let readCompletedExpectation = expectation(description: "Read completed")
+    
+    store.withinReadWriteTransaction({ transaction in
+      let data = try transaction.read(query: query)
+      
+      XCTAssertEqual(data.hero?.__typename, "Droid")
+      XCTAssertEqual(data.hero?.name, "R2-D2")
+      
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+    
+    self.wait(for: [readCompletedExpectation], timeout: defaultWaitTimeout)
+    
+    let removeCompletedExpectation = expectation(description: "Remove completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      try transaction.removeRecord(for: "hero.name")
+    }, completion: { result in
+      defer { removeCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+        
+    self.wait(for: [removeCompletedExpectation], timeout: defaultWaitTimeout)
+    
+    let refetchExpectation = expectation(description: "Refetch completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      _ = try transaction.read(query: query)
+    }, completion: { result in
+      defer { refetchExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+    
+    self.wait(for: [refetchExpectation], timeout: defaultWaitTimeout)
+  }
+  
   func testReadHeroNameQueryWithVariable() throws {
     mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero(episode:JEDI)": Reference(key: "hero(episode:JEDI)")],
@@ -185,6 +292,70 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }, completion: { result in
       defer { readCompletedExpectation.fulfill() }
       XCTAssertSuccessResult(result)
+    })
+    
+    self.wait(for: [readCompletedExpectation], timeout: defaultWaitTimeout)
+  }
+  
+  func testReadHeroAndFriendsNamesQueryFailsAfterRemovingFriendRecord() throws {
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": Reference(key: "2001")],
+      "2001": [
+        "name": "R2-D2",
+        "__typename": "Droid",
+        "friends": [
+          Reference(key: "1000"),
+          Reference(key: "1002"),
+          Reference(key: "1003")
+        ]
+      ],
+      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
+      "1002": ["__typename": "Human", "name": "Han Solo"],
+      "1003": ["__typename": "Human", "name": "Leia Organa"],
+    ])
+    
+    let query = HeroAndFriendsNamesQuery()
+    
+    let readWriteCompletedExpectation = expectation(description: "ReadWrite completed")
+    
+    store.withinReadWriteTransaction({ transaction in
+      let data = try transaction.read(query: query)
+      
+      XCTAssertEqual(data.hero?.name, "R2-D2")
+      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
+      XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+      
+      try transaction.removeRecord(for: "1003")
+    }, completion: { result in
+      defer { readWriteCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+    
+    self.wait(for: [readWriteCompletedExpectation], timeout: defaultWaitTimeout)
+    
+    let readCompletedExpectation = expectation(description: "Read completed")
+    
+    store.withinReadTransaction({ transaction in
+      _ = try transaction.read(query: query)
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertFailureResult(result) { readError in
+        guard let error = readError as? GraphQLResultError else {
+          XCTFail("Unexpected error for reading removed record: \(readError)")
+          return
+        }
+        
+        /// The error should occur when trying to load all the hero's friend references, since one has been deleted
+        XCTAssertEqual(error.path, ["hero", "friends"])
+        
+        switch error.underlying {
+        case JSONDecodingError.missingValue:
+          // This is what we want
+          return
+        default:
+          XCTFail("Unexpected error for reading removed record: \(error.underlying)")
+        }
+      }
     })
     
     self.wait(for: [readCompletedExpectation], timeout: defaultWaitTimeout)

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -33,6 +33,10 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
     }
   }
   
+  func removeRecord(for key: CacheKey) throws {
+    records.removeRecord(for: key)
+  }
+  
   func merge(records: RecordSet) throws -> Set<CacheKey> {
     return self.records.merge(records: records)
   }

--- a/docs/source/caching.mdx
+++ b/docs/source/caching.mdx
@@ -183,32 +183,25 @@ store.withinReadWriteTransaction({ transaction in
 Delete functionality is limited at this time. There are presently two deletion methods available on `ApolloStore`, which are supported by both the in memory and the `SQLite` caches:
 
 1. `clear` - Removes everything from the cache immediately. This is basically the "Nuke it from orbit, it's the only way to be sure" option. 
-2. `removeObject(for:)` Removes a single object for the given `CacheKey`. 
+2. `removeObject(for:)` on `ReadWriteTransaction`. Removes a single object for the given `CacheKey`. 
 
 `removeObject(for:)` will only remove things at the level of an object - that is, it cannot remove individual properties from an object, and it cannot remove outside references **to** an object. 
 
+You will need to have an understanding of how you are generating cache keys to be able to use this method effectively. If you're taking advantage of our `cacheKeyForObject` function, that will help significantly: You'll have a clear understanding of how cache keys are generated, so you can easily figure out how to construct a cache key to delete. 
+
+For instance, let's say your `cacheKeyForObject` function looks like this: 
+
 ```swift
-// Assuming we start with records of the following format:
-// "QUERY_ROOT": ["hero": Reference(key: "hero")],
-// "hero": ["__typename": "Droid", "name": "R2-D2"]
-store.withinReadWriteTransaction({ transaction in
-  let query = HeroNameQuery()
-  let data = try transaction.read(query: query)
-      
-  print(data.hero?.__typename) // Optional("Droid")
-  print(data.hero?.name) // Optional("R2-D2")
-  
-  try transaction.removeRecord(for: "hero")
-  
-  // This will now throw an error since the `hero` record
-  // referred to in `"QUERY_ROOT"` has been removed.
-  let reread = try transaction.read(query: query)
-})
+apollo.cacheKeyForObject = { $0["id"] }
 ```
 
-In this case, `QUERY_ROOT` will still have the reference to a `hero` record, but the second read will fail since the value for that record is missing. 
+This would indicate that for every object which has an `id` property, it will be cached with that `id` as the key. This would be ideal for an API which uses globally unique identifiers, as our Star Wars API does. 
 
-As of right now, there is not a way to delete a single field's value. For instance, calling `try transaction.removeRecord(for: "hero.name")` will result in no action, as there would not be a record with the cache key `"hero.name"`, since `name` is a field on the `hero` record.
+This means that if you have previously fetched an object with the ID `"2001"`, you can call `transaction.removeObject(for: "2001")` on a `ReadWriteTransaction` to remove any object cached with that key, along with all of its associated scalar properties and the references to other objects it stores. 
 
-Please note that due to how we normalize everything, many other records may have references to the same record, and this deletion mechanism does not account for that. If you are planning to remove something, be sure that you either a) Know for sure you no longer need it, or b) Are fine with triggering an additional fetch if the missing value causes a read to fail. 
+`removeObject` does _not_ cascade its removals - if you remove an object which has reference to another object, the reference will be removed, but that other object will not be removed and will remain in the cache. Likewise, if you delete an object, references _to_ that object will not be deleted, they will simply fail when you attempt to load the object again. 
+
+This means that if you are planning to remove something, be sure that you either a) Know for sure you no longer need it, or b) Are fine with triggering an additional fetch if the missing value causes a read to fail. 
+
+> Note: As of right now, there is not a way to delete a single property's value. For instance, calling `try transaction.removeRecord(for: "2001.name")` will result in no action, as there would not be a record with the cache key `"2001.name"`, since `name` is a scalar field on the `"2001"` record.
 

--- a/docs/source/caching.mdx
+++ b/docs/source/caching.mdx
@@ -199,9 +199,9 @@ This would indicate that for every object which has an `id` property, it will be
 
 This means that if you have previously fetched an object with the ID `"2001"`, you can call `transaction.removeObject(for: "2001")` on a `ReadWriteTransaction` to remove any object cached with that key, along with all of its associated scalar properties and the references to other objects it stores. 
 
-`removeObject` does _not_ cascade its removals - if you remove an object which has reference to another object, the reference will be removed, but that other object will not be removed and will remain in the cache. Likewise, if you delete an object, references _to_ that object will not be deleted, they will simply fail when you attempt to load the object again. 
+`removeObject` does _not_ cascade its removals - if you remove an object which has reference to another object, the reference will be removed, but that other object will not be removed and will remain in the cache. Likewise, if you delete an object, references _to_ that object will not be deleted, they will simply fail, causing a cache miss, when you attempt to load the object again. 
 
-This means that if you are planning to remove something, be sure that you either a) Know for sure you no longer need it, or b) Are fine with triggering an additional fetch if the missing value causes a read to fail. 
+This means that if you are planning to remove something, be sure that you either a) Know for sure you no longer need it, or b) Are fine with your cache policy potentially triggering an additional fetch if the missing value causes a read to fail. 
 
 > Note: As of right now, there is not a way to delete a single property's value. For instance, calling `try transaction.removeRecord(for: "2001.name")` will result in no action, as there would not be a record with the cache key `"2001.name"`, since `name` is a scalar field on the `"2001"` record.
 

--- a/docs/source/caching.mdx
+++ b/docs/source/caching.mdx
@@ -177,3 +177,38 @@ store.withinReadWriteTransaction({ transaction in
   }
 })
 ```
+
+### delete
+
+Delete functionality is limited at this time. There are presently two options available on `NormalizedCache` which are supported by the included implementations of it: 
+
+1. `clear` - Removes everything from the cache immediately. This is basically the "Nuke it from orbit, it's the only way to be sure" option. 
+2. `removeRecord(for:)` Removes a single record for the given `CacheKey`. 
+
+`removeRecord(for:)` will only remove things at the level of a record - that is, it cannot remove individual fields from a record, and it cannot remove outside references **to** a record. 
+
+```swift
+// Assuming we start with records of the following format:
+// "QUERY_ROOT": ["hero": Reference(key: "hero")],
+// "hero": ["__typename": "Droid", "name": "R2-D2"]
+store.withinReadWriteTransaction({ transaction in
+  let query = HeroNameQuery()
+  let data = try transaction.read(query: query)
+      
+  print(data.hero?.__typename) // Optional("Droid")
+  print(data.hero?.name) // Optional("R2-D2")
+  
+  try transaction.removeRecord(for: "hero")
+  
+  // This will now throw an error since the `hero` record
+  // referred to in `"QUERY_ROOT"` has been removed.
+  let reread = try transaction.read(query: query)
+})
+```
+
+In this case, `QUERY_ROOT` will still have the reference to a `hero` record, but the second read will fail since the value for that record is missing. 
+
+As of right now, there is not a way to delete a single field's value. For instance, calling `try transaction.removeRecord(for: "hero.name")` will result in no action, as there would not be a record with the cache key `"hero.name"`, since `name` is a field on the `hero` record.
+
+Please note that due to how we normalize everything, many other records may have references to the same record, and this deletion mechanism does not account for that. If you are planning to remove something, be sure that you either a) Know for sure you no longer need it, or b) Are fine with triggering an additional fetch if the missing value causes a read to fail. 
+

--- a/docs/source/caching.mdx
+++ b/docs/source/caching.mdx
@@ -180,12 +180,12 @@ store.withinReadWriteTransaction({ transaction in
 
 ### delete
 
-Delete functionality is limited at this time. There are presently two options available on `NormalizedCache` which are supported by the included implementations of it: 
+Delete functionality is limited at this time. There are presently two deletion methods available on `ApolloStore`, which are supported by both the in memory and the `SQLite` caches:
 
 1. `clear` - Removes everything from the cache immediately. This is basically the "Nuke it from orbit, it's the only way to be sure" option. 
-2. `removeRecord(for:)` Removes a single record for the given `CacheKey`. 
+2. `removeObject(for:)` Removes a single object for the given `CacheKey`. 
 
-`removeRecord(for:)` will only remove things at the level of a record - that is, it cannot remove individual fields from a record, and it cannot remove outside references **to** a record. 
+`removeObject(for:)` will only remove things at the level of an object - that is, it cannot remove individual properties from an object, and it cannot remove outside references **to** an object. 
 
 ```swift
 // Assuming we start with records of the following format:


### PR DESCRIPTION
This comes with a ton of caveats, but I tried to document them in both code and in the docs. 

Note that we're going to be looking at a much more robust system for cache eviction and possibly garbage collection in the future, but this is a stopgap until that's ready to go live.