### PR TITLE
Added missing import of Foundation.

### DIFF
--- a/Sources/ApolloTestSupport/MockNetworkTransport.swift
+++ b/Sources/ApolloTestSupport/MockNetworkTransport.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import Apollo
 
 public final class MockNetworkTransport: RequestChainNetworkTransport {


### PR DESCRIPTION
Build is failing when opening via the Package.swift without this.