### PR TITLE
Fix uploads not getting `additionalHeaders`

### DIFF
--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -110,10 +110,12 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
   /// - Parameters:
   ///   - operation: The operation to create a request for
   ///   - files: The files you wish to upload
+  ///   - manualBoundary: [optional] A manually set boundary for your upload request. Defaults to nil. 
   /// - Returns: The created request.
   open func constructUploadRequest<Operation: GraphQLOperation>(
     for operation: Operation,
-    with files: [GraphQLFile]) -> HTTPRequest<Operation> {
+    with files: [GraphQLFile],
+    manualBoundary: String? = nil) -> HTTPRequest<Operation> {
     
     UploadRequest(graphQLEndpoint: self.endpointURL,
                   operation: operation,
@@ -121,6 +123,7 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
                   clientVersion: self.clientVersion,
                   additionalHeaders: self.additionalHeaders,
                   files: files,
+                  manualBoundary: manualBoundary,
                   requestBodyCreator: self.requestBodyCreator)
   }
   

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -69,7 +69,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
                 contextIdentifier: contextIdentifier,
                 clientName: self.clientName,
                 clientVersion: self.clientVersion,
-                additionalHeaders: additionalHeaders,
+                additionalHeaders: self.additionalHeaders,
                 cachePolicy: cachePolicy,
                 autoPersistQueries: self.autoPersistQueries,
                 useGETForQueries: self.useGETForQueries,
@@ -119,6 +119,7 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
                   operation: operation,
                   clientName: self.clientName,
                   clientVersion: self.clientVersion,
+                  additionalHeaders: self.additionalHeaders,
                   files: files,
                   requestBodyCreator: self.requestBodyCreator)
   }

--- a/Tests/ApolloTests/UploadTests.swift
+++ b/Tests/ApolloTests/UploadTests.swift
@@ -301,7 +301,9 @@ class UploadTests: XCTestCase {
     
     let transport = try XCTUnwrap(self.client.networkTransport as? RequestChainNetworkTransport)
     
-    let httpRequest = transport.constructUploadRequest(for: operation, with: [alphaFile], manualBoundary: "TEST.BOUNDARY")
+    let httpRequest = transport.constructUploadRequest(for: operation,
+                                                       with: [alphaFile],
+                                                       manualBoundary: "TEST.BOUNDARY")
     let uploadRequest = try XCTUnwrap(httpRequest as? UploadRequest)
     
     let urlRequest = try uploadRequest.toURLRequest()
@@ -348,7 +350,9 @@ Alpha file content.
     let operation = UploadMultipleFilesToTheSameParameterMutation(files: files.map { $0.originalName })
     let transport = try XCTUnwrap(self.client.networkTransport as? RequestChainNetworkTransport)
     
-    let httpRequest = transport.constructUploadRequest(for: operation, with: [alphaFile, betaFile], manualBoundary: "TEST.BOUNDARY")
+    let httpRequest = transport.constructUploadRequest(for: operation,
+                                                       with: [alphaFile, betaFile],
+                                                       manualBoundary: "TEST.BOUNDARY")
     let uploadRequest = try XCTUnwrap(httpRequest as? UploadRequest)
     
     let urlRequest = try uploadRequest.toURLRequest()


### PR DESCRIPTION
In this PR: 
- Fix for issue raised in #1634 where an auth token set in `additionalHeaders` was not getting passed to an upload request
- Updated testing to send request creation through the `RequestChainNetworkTransport`'s creator method to be able to test that the additional headers were actually getting set. 