### PR TITLE
Fix issue where CodableParsingInterceptor always fails

### DIFF
--- a/Sources/Apollo/CodableParsingInterceptor.swift
+++ b/Sources/Apollo/CodableParsingInterceptor.swift
@@ -39,7 +39,13 @@ public class CodableParsingInterceptor<FlexDecoder: FlexibleDecoder>: ApolloInte
     }
     
     do {
-      let parsedData = try GraphQLResult<Operation.Data>(from: createdResponse.rawData, decoder: self.decoder)
+      typealias ResultType = GraphQLResult<Operation.Data>
+
+      guard let ParseableResultType = ResultType.self as? _ParseableBase.Type else {
+        throw ParseableError.unsupportedInitializer
+      }
+
+      let parsedData = try ParseableResultType._decode(from: createdResponse.rawData, decoder: decoder) as! ResultType
       createdResponse.parsedResponse = parsedData
       chain.proceedAsync(request: request,
                          response: response,

--- a/Sources/Apollo/GraphQLResult.swift
+++ b/Sources/Apollo/GraphQLResult.swift
@@ -1,11 +1,7 @@
 import Foundation
 
 /// Represents the result of a GraphQL operation.
-public struct GraphQLResult<Data>: Parseable {
-  
-  public init<T: FlexibleDecoder>(from data: Foundation.Data, decoder: T) throws {
-    throw ParseableError.unsupportedInitializer
-  }
+public struct GraphQLResult<Data> {
   
   /// The typed result data, or `nil` if an error was encountered that prevented a valid response.
   public let data: Data?
@@ -37,8 +33,9 @@ public struct GraphQLResult<Data>: Parseable {
   }
 }
 
-extension GraphQLResult where Data: Decodable {
-  
+extension GraphQLResult: _ParseableBase where Data: Decodable {}
+
+extension GraphQLResult: Parseable where Data: Decodable {
   public init<T: FlexibleDecoder>(from data: Foundation.Data, decoder: T) throws {
     // SWIFT CODEGEN: fix this to handle codable better
     let data = try decoder.decode(Data.self, from: data)

--- a/Sources/Apollo/Parseable.swift
+++ b/Sources/Apollo/Parseable.swift
@@ -6,8 +6,15 @@ public enum ParseableError: Error {
   case notYetImplemented
 }
 
-/// A protocol to represent anything that can be decoded by a `FlexibleDecoder`
-public protocol Parseable {
+/// Base protocol with no `Self` requirements, to support dynamically checking
+/// whether a type is `Parseable`. Do not conform to this protocol directly.
+public protocol _ParseableBase {
+  /// Returns an instance of `Self`, type-erased as `Any`.
+  static func _decode<T: FlexibleDecoder>(from data: Data, decoder: T) throws -> Any
+}
+
+/// A protocol to represent anything that can be decoded by a `FlexibleDecoder`.
+public protocol Parseable: _ParseableBase {
   
   /// Required initializer
   ///
@@ -15,6 +22,15 @@ public protocol Parseable {
   ///   - data: The data to decode
   ///   - decoder: The decoder to use to decode it
   init<T: FlexibleDecoder>(from data: Data, decoder: T) throws
+}
+
+extension Parseable {
+
+  /// Default implementation of _decode(from:decoder:) that decodes an instance
+  /// of `Self` and erases its type as `Any`.
+  public static func _decode<T: FlexibleDecoder>(from data: Data, decoder: T) throws -> Any {
+    try Self(from: data, decoder: decoder)
+  }
 }
 
 // MARK: - Default implementation for Decodable


### PR DESCRIPTION
In practice, `GraphQLResult.init(from:decoder:)` would always fail when called by `CodableParsingInterceptor`. Its default implementation, when `Data` is not known to conform to `Decodable`, would unconditionally throw `ParseableError.unsupportedInitializer`. Because `CodableParsingInterceptor.interceptAsync` is a generic context where the operation's `Data` may not be `Decodable`, it would always select the default initialiser, even if a `Decodable` implementation is available.

Dynamically casting to `Parseable` isn't possible because of its `Self` requirement, which it inherits from `Decodable`. To work around this, we introduce a "private" (underscored) base protocol that has no `Self` requirement, and type-erases decoded values to `Any`. A default implementation of this method then allows `CodableParsingInterceptor` to dynamically call into `Parseable.init(from:decoder:)` via `_ParsableBase._decode(from:decoder:)`, then force-cast back to `Operation.Data`.