### PR TITLE
Check task state in `URLSessionClient` before trying to add data

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -253,6 +253,11 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   open func urlSession(_ session: URLSession,
                        dataTask: URLSessionDataTask,
                        didReceive data: Data) {
+    guard dataTask.state != .canceling else {
+      // Task is in the process of cancelling, don't bother handling its data.
+      return
+    }
+    
     self.tasks.mutate {
       guard let taskData = $0[dataTask.taskIdentifier] else {
         assertionFailure("No data found for task \(dataTask.taskIdentifier), cannot append received data")


### PR DESCRIPTION
If the task state is `canceling` when `didReceive data` is hit, we should bail out before trying to mutate the data. 