### PR TITLE
Don't allow multiple cancels on RequestChain

### DIFF
--- a/Sources/Apollo/RequestChain.swift
+++ b/Sources/Apollo/RequestChain.swift
@@ -111,6 +111,11 @@ public class RequestChain: Cancellable {
   
   /// Cancels the entire chain of interceptors.
   public func cancel() {
+    guard self.isNotCancelled else {
+      // Do not proceed, this chain has been cancelled.
+      return
+    }
+    
     self.isCancelled.mutate { $0 = true }
     
     // If an interceptor adheres to `Cancellable`, it should have its in-flight work cancelled as well.


### PR DESCRIPTION
I'm seeing some crashes in canceling interceptors. It's probably not `RequestChain` problem, but I see no reason why you should be able to cancel it multiple times.

![Screenshot 2021-02-22 at 10 59 07](https://user-images.githubusercontent.com/1027187/108699363-09821500-74fd-11eb-8102-421c9e7449e2.png)
