### PR TITLE
Fixes an issue where existing query params on graphQLEndpoint are ignored

### DIFF
--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -23,7 +23,7 @@ public struct GraphQLGETTransformer {
       return nil
     }
 
-    var queryItems: [URLQueryItem] = []
+    var queryItems: [URLQueryItem] = components.queryItems ?? []
 
     do {
       _ = try self.body.sorted(by: {$0.key < $1.key}).compactMap({ arg in

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -136,4 +136,21 @@ class GETTransformerTests: XCTestCase {
     let queryString = url?.absoluteString == "http://localhost:8080/graphql?extensions=%7B%22persistedQuery%22:%7B%22sha256Hash%22:%22f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671%22,%22version%22:1%7D%7D&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:null%7D"
     XCTAssertTrue(queryString)
   }
+
+  func testEncodingQueryWithExistingParameters() throws {
+    let operation = HeroNameQuery(episode: .empire)
+    let body = requestBodyCreator.requestBody(for: operation,
+                                              sendOperationIdentifiers: false,
+                                              sendQueryDocument: true,
+                                              autoPersistQuery: false)
+
+    var components = URLComponents(string: url.absoluteString)!
+    components.queryItems = [URLQueryItem(name: "foo", value: "bar")]
+
+    let transformer = GraphQLGETTransformer(body: body, url: components.url!)
+
+    let url = transformer.createGetURL()
+
+    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?foo=bar&operationName=HeroName&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22EMPIRE%22%7D")
+  }
 }


### PR DESCRIPTION
## What

Currently there's no way to add additional query parameters to the GET graph requests as it appears the `GraphQLGETTransformer` is creating a new array of `queryItems` and ignoring any parameters that's already on the `graphQLEndpoint`