### PR TITLE
parentType in SelectionSet of ApolloCodegenLib should not be array

### DIFF
--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -68,7 +68,7 @@ public class CompilationResult: JavaScriptObject {
   }
   
   public class SelectionSet: JavaScriptObject {
-    private(set) lazy var parentType: [GraphQLCompositeType] = self["parentType"]
+    private(set) lazy var parentType: GraphQLCompositeType = self["parentType"]
     
     private(set) lazy var selections: [Selection] = self["selections"]
   }


### PR DESCRIPTION
From the ir.ts: https://github.com/apollographql/apollo-ios/blob/main/Sources/ApolloCodegenLib/Frontend/JavaScript/src/compiler/ir.ts

This is not an array. Fixed this problem such that we can query
parentType properly now from SelectionSet.
