### PR TITLE
Add section on defining custom scalars for dynamic types (ie, JSON)

### DIFF
--- a/docs/source/fetching-queries.md
+++ b/docs/source/fetching-queries.md
@@ -125,6 +125,35 @@ If you want to use the custom scalars within your code, you must set `passthroug
 
 Once you've done that, you can either create your own type locally or use a `typealias` to declare an equivilent. This is very, very frequently used with `Date` types. Please see the [Custom Scalar Playground Page](https://github.com/apollographql/apollo-ios/blob/main/Playgrounds/ApolloMacPlayground.playground/Pages/CustomScalars.xcplaygroundpage/Contents.swift) available within the `apollo-iOS` repo for a full example using a custom date type.
 
+#### JSON Custom Scalars
+
+Some custom scalars are set up to potentially return multiple types at runtime. This is not ideal since you lose type safety, but if you're using an API you don't have control over, there's often not a great alternative to this.
+
+When this happens, because you don't know the type that's coming in, you can't set up a single `typealias` for that scalar. Instead, you need to define some other way of instantiating your custom scalar object. 
+
+This happens most often with JSON, which can return either an array or a dictionary. Here's an example of how you can use an enum to allow dynamic-but-limited types to parse (with `CustomJSON` as a placeholder type name`): 
+
+```swift
+enum CustomJSON {
+  case dictionary([String: Any])
+  case array([Any])
+}
+
+extension CustomJSON: JSONDecodable {
+  init(jsonValue value: JSONValue) throws {
+    if let dict = value as? [String: Any] {
+      self = .dictionary(dict)
+    } else if let array = value as? [Any] {
+      self = .array(array)
+    } else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: CustomJSON.self)
+    }
+  }
+}
+```
+
+Again, make sure to define this in a file that is outside of your generated code, or it will get overwritten. 
+
 ## Specifying a cache policy
 
 [This section has moved to the Caching documentation](/caching/). 

--- a/docs/source/fetching-queries.md
+++ b/docs/source/fetching-queries.md
@@ -125,7 +125,7 @@ If you want to use the custom scalars within your code, you must set `passthroug
 
 Once you've done that, you can either create your own type locally or use a `typealias` to declare an equivilent. This is very, very frequently used with `Date` types. Please see the [Custom Scalar Playground Page](https://github.com/apollographql/apollo-ios/blob/main/Playgrounds/ApolloMacPlayground.playground/Pages/CustomScalars.xcplaygroundpage/Contents.swift) available within the `apollo-iOS` repo for a full example using a custom date type.
 
-#### JSON Custom Scalars
+#### JSON and other Custom Scalars with multiple return types
 
 Some custom scalars are set up to potentially return multiple types at runtime. This is not ideal since you lose type safety, but if you're using an API you don't have control over, there's often not a great alternative to this.
 


### PR DESCRIPTION
We get this question A LOT, so it seemed like we should make this answer easier to surface. 