### PR TITLE
SQLite dependency inversion

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		9B9BBAF524DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9BBAF424DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift */; };
 		9B9BBB1C24DB760B0021C30F /* UploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9BBB1A24DB75E60021C30F /* UploadTests.swift */; };
 		9B9F16A726013DAB00FB2F31 /* SQLiteDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9F16A626013DAB00FB2F31 /* SQLiteDatabase.swift */; };
+		9B9F16B82601532500FB2F31 /* SQLiteDotSwiftDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9F16B72601532500FB2F31 /* SQLiteDotSwiftDatabase.swift */; };
 		9BA1244A22D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1244922D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift */; };
 		9BA3130E2302BEA5007B7FC5 /* DispatchQueue+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */; };
 		9BAD16B923FE362600007BEF /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
@@ -699,6 +700,7 @@
 		9B9BBB1624DB74720021C30F /* Apollo-Target-UploadAPI.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Apollo-Target-UploadAPI.xcconfig"; sourceTree = "<group>"; };
 		9B9BBB1A24DB75E60021C30F /* UploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTests.swift; sourceTree = "<group>"; };
 		9B9F16A626013DAB00FB2F31 /* SQLiteDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabase.swift; sourceTree = "<group>"; };
+		9B9F16B72601532500FB2F31 /* SQLiteDotSwiftDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabase.swift; sourceTree = "<group>"; };
 		9BA1244922D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONSerialization+Sorting.swift"; sourceTree = "<group>"; };
 		9BA22FD823FF306300C537FC /* Configuration */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Configuration; sourceTree = "<group>"; };
 		9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Optional.swift"; sourceTree = "<group>"; };
@@ -1333,6 +1335,7 @@
 				9B7BDACD23FDEBE300ACD198 /* SQLiteSerialization.swift */,
 				9B7BDACE23FDEBE300ACD198 /* Info.plist */,
 				9B9F16A626013DAB00FB2F31 /* SQLiteDatabase.swift */,
+				9B9F16B72601532500FB2F31 /* SQLiteDotSwiftDatabase.swift */,
 			);
 			name = ApolloSQLite;
 			path = Sources/ApolloSQLite;
@@ -2594,6 +2597,7 @@
 			files = (
 				9B7BDAD023FDEBE300ACD198 /* SQLiteSerialization.swift in Sources */,
 				9B7BDAD223FDEBE300ACD198 /* SQLiteNormalizedCache.swift in Sources */,
+				9B9F16B82601532500FB2F31 /* SQLiteDotSwiftDatabase.swift in Sources */,
 				9B9F16A726013DAB00FB2F31 /* SQLiteDatabase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		9B9BBAF324DB39D70021C30F /* UploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9BBAF224DB39D70021C30F /* UploadRequest.swift */; };
 		9B9BBAF524DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9BBAF424DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift */; };
 		9B9BBB1C24DB760B0021C30F /* UploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9BBB1A24DB75E60021C30F /* UploadTests.swift */; };
+		9B9F16A726013DAB00FB2F31 /* SQLiteDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9F16A626013DAB00FB2F31 /* SQLiteDatabase.swift */; };
 		9BA1244A22D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1244922D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift */; };
 		9BA3130E2302BEA5007B7FC5 /* DispatchQueue+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */; };
 		9BAD16B923FE362600007BEF /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
@@ -697,6 +698,7 @@
 		9B9BBAF424DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticPersistedQueryInterceptor.swift; sourceTree = "<group>"; };
 		9B9BBB1624DB74720021C30F /* Apollo-Target-UploadAPI.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Apollo-Target-UploadAPI.xcconfig"; sourceTree = "<group>"; };
 		9B9BBB1A24DB75E60021C30F /* UploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTests.swift; sourceTree = "<group>"; };
+		9B9F16A626013DAB00FB2F31 /* SQLiteDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabase.swift; sourceTree = "<group>"; };
 		9BA1244922D8A8EA00BF1D24 /* JSONSerialization+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONSerialization+Sorting.swift"; sourceTree = "<group>"; };
 		9BA22FD823FF306300C537FC /* Configuration */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Configuration; sourceTree = "<group>"; };
 		9BA3130D2302BEA5007B7FC5 /* DispatchQueue+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Optional.swift"; sourceTree = "<group>"; };
@@ -1330,6 +1332,7 @@
 				9B7BDACF23FDEBE300ACD198 /* SQLiteNormalizedCache.swift */,
 				9B7BDACD23FDEBE300ACD198 /* SQLiteSerialization.swift */,
 				9B7BDACE23FDEBE300ACD198 /* Info.plist */,
+				9B9F16A626013DAB00FB2F31 /* SQLiteDatabase.swift */,
 			);
 			name = ApolloSQLite;
 			path = Sources/ApolloSQLite;
@@ -2591,6 +2594,7 @@
 			files = (
 				9B7BDAD023FDEBE300ACD198 /* SQLiteSerialization.swift in Sources */,
 				9B7BDAD223FDEBE300ACD198 /* SQLiteNormalizedCache.swift in Sources */,
+				9B9F16A726013DAB00FB2F31 /* SQLiteDatabase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import Apollo
+#endif
 
 public struct DatabaseRow {
   let cacheKey: CacheKey

--- a/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -1,11 +1,3 @@
-//
-//  SQLiteDatabase.swift
-//  ApolloSQLite
-//
-//  Created by Ellen Shapiro on 3/16/21.
-//  Copyright © 2021 Apollo GraphQL. All rights reserved.
-//
-
 import Foundation
 #if !COCOAPODS
 import Apollo

--- a/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -1,0 +1,50 @@
+//
+//  SQLiteDatabase.swift
+//  ApolloSQLite
+//
+//  Created by Ellen Shapiro on 3/16/21.
+//  Copyright © 2021 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+import Apollo
+
+public struct DatabaseRow {
+  let cacheKey: CacheKey
+  let storedInfo: String
+}
+
+public protocol SQLiteDatabase {
+  
+  init(fileURL: URL) throws
+  
+  func createRecordsTableIfNeeded() throws
+  
+  func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow]
+
+  func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws
+  
+  func deleteRecord(for cacheKey: CacheKey) throws
+  
+  func clearDatabase(shouldVacuumOnClear: Bool) throws
+  
+}
+
+public extension SQLiteDatabase {
+  
+  static var tableName: String {
+    "records"
+  }
+  
+  static var idColumnName: String {
+    "_id"
+  }
+
+  static var keyColumnName: String {
+    "key"
+  }
+
+  static var recordColumName: String {
+    "record"
+  }
+}

--- a/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -1,0 +1,70 @@
+//
+//  SQLiteDotSwiftDatabase.swift
+//  ApolloSQLite
+//
+//  Created by Ellen Shapiro on 3/16/21.
+//  Copyright © 2021 Apollo GraphQL. All rights reserved.
+//
+
+import Foundation
+#if !COCOAPODS
+import Apollo
+#endif
+import SQLite
+
+public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
+  private var db: Connection!
+  
+  private let records: Table
+  private let keyColumn: Expression<CacheKey>
+  private let recordColumn: Expression<String>
+  
+  public init(fileURL: URL) throws {
+    self.records = Table(Self.tableName)
+    self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
+    self.recordColumn = Expression<String>(Self.recordColumName)
+    self.db = try Connection(.uri(fileURL.absoluteString), readonly: false)
+  }
+  
+  public init(connection: Connection) {
+    self.records = Table(Self.tableName)
+    self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
+    self.recordColumn = Expression<String>(Self.recordColumName)
+    self.db = connection
+  }
+  
+  public func createRecordsTableIfNeeded() throws {
+    try self.db.run(self.records.create(ifNotExists: true) { table in
+      table.column(Expression<Int64>(Self.idColumnName), primaryKey: .autoincrement)
+      table.column(keyColumn, unique: true)
+      table.column(Expression<String>(Self.recordColumName))
+    })
+    try self.db.run(self.records.createIndex(keyColumn, unique: true, ifNotExists: true))
+  }
+  
+  public func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow] {
+    let query = self.records.filter(keys.contains(keyColumn))
+    return try self.db.prepare(query).map { row in
+      let record = row[self.recordColumn]
+      let key = row[self.keyColumn]
+      
+      return DatabaseRow(cacheKey: key, storedInfo: record)
+    }
+  }
+  
+  public func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws {
+    try self.db.run(self.records.insert(or: .replace, self.keyColumn <- cacheKey, self.recordColumn <- recordString))
+  }
+  
+  public func deleteRecord(for cacheKey: CacheKey) throws {
+    let query = self.records.filter(keyColumn == cacheKey)
+    try self.db.run(query.delete())
+  }
+  
+  public func clearDatabase(shouldVacuumOnClear: Bool) throws {
+    try self.db.run(records.delete())
+    if shouldVacuumOnClear {
+      try self.db.prepare("VACUUM;").run()
+    }
+  }
+}

--- a/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -1,11 +1,3 @@
-//
-//  SQLiteDotSwiftDatabase.swift
-//  ApolloSQLite
-//
-//  Created by Ellen Shapiro on 3/16/21.
-//  Copyright © 2021 Apollo GraphQL. All rights reserved.
-//
-
 import Foundation
 #if !COCOAPODS
 import Apollo

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -9,15 +9,69 @@ public enum SQLiteNormalizedCacheError: Error {
   case invalidRecordShape(object: Any)
 }
 
+public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
+  private var db: Connection!
+  
+  private let records: Table
+  private let keyColumn: Expression<CacheKey>
+  private let recordColumn: Expression<String>
+  
+  public init(fileURL: URL) throws {
+    self.records = Table(Self.tableName)
+    self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
+    self.recordColumn = Expression<String>(Self.recordColumName)
+    self.db = try Connection(.uri(fileURL.absoluteString), readonly: false)
+  }
+  
+  public init(connection: Connection) {
+    self.records = Table(Self.tableName)
+    self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
+    self.recordColumn = Expression<String>(Self.recordColumName)
+    self.db = connection
+  }
+  
+  public func createRecordsTableIfNeeded() throws {    
+    try self.db.run(self.records.create(ifNotExists: true) { table in
+      table.column(Expression<Int64>(Self.idColumnName), primaryKey: .autoincrement)
+      table.column(keyColumn, unique: true)
+      table.column(Expression<String>(Self.recordColumName))
+    })
+    try self.db.run(self.records.createIndex(keyColumn, unique: true, ifNotExists: true))
+  }
+  
+  public func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow] {
+    let query = self.records.filter(keys.contains(keyColumn))
+    return try self.db.prepare(query).map { row in
+      let record = row[self.recordColumn]
+      let key = row[self.keyColumn]
+      
+      return DatabaseRow(cacheKey: key, storedInfo: record)
+    }
+  }
+  
+  public func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws {
+    try self.db.run(self.records.insert(or: .replace, self.keyColumn <- cacheKey, self.recordColumn <- recordString))
+  }
+  
+  public func deleteRecord(for cacheKey: CacheKey) throws {
+    let query = self.records.filter(keyColumn == cacheKey)
+    try self.db.run(query.delete())
+  }
+  
+  public func clearDatabase(shouldVacuumOnClear: Bool) throws {
+    try self.db.run(records.delete())
+    if shouldVacuumOnClear {
+      try self.db.prepare("VACUUM;").run()
+    }
+  }
+}
+
 /// A `NormalizedCache` implementation which uses a SQLite database to store data.
 public final class SQLiteNormalizedCache {
 
-  private let db: Connection
-  private let records = Table("records")
-  private let id = Expression<Int64>("_id")
-  private let key = Expression<CacheKey>("key")
-  private let record = Expression<String>("record")
   private let shouldVacuumOnClear: Bool
+  
+  let database: SQLiteDatabase
 
   /// Designated initializer
   ///
@@ -25,24 +79,21 @@ public final class SQLiteNormalizedCache {
   ///   - fileURL: The file URL to use for your database.
   ///   - shouldVacuumOnClear: If the database should also be `VACCUM`ed on clear to remove all traces of info. Defaults to `false` since this involves a performance hit, but this should be used if you are storing any Personally Identifiable Information in the cache.
   /// - Throws: Any errors attempting to open or create the database.
-  public init(fileURL: URL, shouldVacuumOnClear: Bool = false) throws {
+  public init(fileURL: URL,
+              databaseType: SQLiteDatabase.Type = SQLiteDotSwiftDatabase.self,
+              shouldVacuumOnClear: Bool = false) throws {
+    self.database = try databaseType.init(fileURL: fileURL)
     self.shouldVacuumOnClear = shouldVacuumOnClear
-    self.db = try Connection(.uri(fileURL.absoluteString), readonly: false)
-    try self.createTableIfNeeded()
+    try self.database.createRecordsTableIfNeeded()
   }
 
-  ///
-  /// Initializer that takes the Connection to use
-  /// - Parameters:
-  ///   - db: The database Connection to use
-  ///   - shouldVacuumOnClear: If the database should also be `VACCUM`ed on clear to remove all traces of info. Defaults to `false` since this involves a performance hit, but this should be used if you are storing any Personally Identifiable Information in the cache.
-  /// - Throws: Any errors attempting to access the database
-  public init(db: Connection, shouldVacuumOnClear: Bool = false) throws {
+  public init(database: SQLiteDatabase,
+              shouldVacuumOnClear: Bool = false) throws {
+    self.database = database
     self.shouldVacuumOnClear = shouldVacuumOnClear
-    self.db = db
-    try self.createTableIfNeeded()
+    try self.database.createRecordsTableIfNeeded()
   }
-
+  
   private func recordCacheKey(forFieldCacheKey fieldCacheKey: CacheKey) -> CacheKey {
     let components = fieldCacheKey.components(separatedBy: ".")
     var updatedComponents = [String]()
@@ -64,17 +115,8 @@ public final class SQLiteNormalizedCache {
     return updatedComponents.joined(separator: ".")
   }
 
-  private func createTableIfNeeded() throws {
-    try self.db.run(self.records.create(ifNotExists: true) { table in
-      table.column(id, primaryKey: .autoincrement)
-      table.column(key, unique: true)
-      table.column(record)
-    })
-    try self.db.run(self.records.createIndex(key, unique: true, ifNotExists: true))
-  }
-
   private func mergeRecords(records: RecordSet) throws -> Set<CacheKey> {
-    var recordSet = RecordSet(records: try self.selectRecords(forKeys: records.keys))
+    var recordSet = RecordSet(records: try self.selectRecords(for: records.keys))
     let changedFieldKeys = recordSet.merge(records: records)
     let changedRecordKeys = changedFieldKeys.map { self.recordCacheKey(forFieldCacheKey: $0) }
     for recordKey in Set(changedRecordKeys) {
@@ -84,38 +126,25 @@ public final class SQLiteNormalizedCache {
           assertionFailure("Serialization should yield UTF-8 data")
           continue
         }
-        try self.db.run(self.records.insert(or: .replace, self.key <- recordKey, self.record <- recordString))
+        
+        try self.database.addOrUpdateRecordString(recordString, for: recordKey)
       }
     }
     return Set(changedFieldKeys)
   }
-
-  private func selectRecords(forKeys keys: Set<CacheKey>) throws -> [Record] {
-    let query = self.records.filter(keys.contains(key))
-    return try self.db.prepare(query).map { try parse(row: $0) }
-  }
-
-  private func clearRecords() throws {
-    try self.db.run(records.delete())
-    if self.shouldVacuumOnClear {
-      try self.db.prepare("VACUUM;").run()
-    }
-  }
   
-  private func removeSQLiteRecord(for cacheKey: CacheKey) throws {
-    let query = self.records.filter(key == cacheKey)
-    try self.db.run(query.delete())
+  fileprivate func selectRecords(for keys: Set<CacheKey>) throws -> [Record] {
+    try self.database.selectRawRows(forKeys: keys)
+      .map { try self.parse(row: $0) }
   }
 
-  private func parse(row: Row) throws -> Record {
-    let record = row[self.record]
-
-    guard let recordData = record.data(using: .utf8) else {
-      throw SQLiteNormalizedCacheError.invalidRecordEncoding(record: record)
+  private func parse(row: DatabaseRow) throws -> Record {
+    guard let recordData = row.storedInfo.data(using: .utf8) else {
+      throw SQLiteNormalizedCacheError.invalidRecordEncoding(record: row.storedInfo)
     }
 
     let fields = try SQLiteSerialization.deserialize(data: recordData)
-    return Record(key: row[key], fields)
+    return Record(key: row.cacheKey, fields)
   }
 }
 
@@ -124,8 +153,10 @@ public final class SQLiteNormalizedCache {
 extension SQLiteNormalizedCache: NormalizedCache {
   public func loadRecords(forKeys keys: Set<CacheKey>) throws -> [CacheKey: Record] {
     return [CacheKey: Record](uniqueKeysWithValues:
-                                try selectRecords(forKeys: keys)
-                                .map { record in (record.key, record) })
+                                try selectRecords(for: keys)
+                                .map { record in
+                                  (record.key, record)
+                                })
   }
   
   public func merge(records: RecordSet) throws -> Set<CacheKey> {
@@ -133,10 +164,10 @@ extension SQLiteNormalizedCache: NormalizedCache {
   }
   
   public func removeRecord(for key: CacheKey) throws {
-    try removeSQLiteRecord(for: key)
+    try self.database.deleteRecord(for: key)
   }
   
   public func clear() throws {
-    try clearRecords()
+    try self.database.clearDatabase(shouldVacuumOnClear: self.shouldVacuumOnClear)
   }
 }

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SQLite
 #if !COCOAPODS
 import Apollo
 #endif
@@ -7,63 +6,6 @@ import Apollo
 public enum SQLiteNormalizedCacheError: Error {
   case invalidRecordEncoding(record: String)
   case invalidRecordShape(object: Any)
-}
-
-public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
-  private var db: Connection!
-  
-  private let records: Table
-  private let keyColumn: Expression<CacheKey>
-  private let recordColumn: Expression<String>
-  
-  public init(fileURL: URL) throws {
-    self.records = Table(Self.tableName)
-    self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
-    self.recordColumn = Expression<String>(Self.recordColumName)
-    self.db = try Connection(.uri(fileURL.absoluteString), readonly: false)
-  }
-  
-  public init(connection: Connection) {
-    self.records = Table(Self.tableName)
-    self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
-    self.recordColumn = Expression<String>(Self.recordColumName)
-    self.db = connection
-  }
-  
-  public func createRecordsTableIfNeeded() throws {    
-    try self.db.run(self.records.create(ifNotExists: true) { table in
-      table.column(Expression<Int64>(Self.idColumnName), primaryKey: .autoincrement)
-      table.column(keyColumn, unique: true)
-      table.column(Expression<String>(Self.recordColumName))
-    })
-    try self.db.run(self.records.createIndex(keyColumn, unique: true, ifNotExists: true))
-  }
-  
-  public func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow] {
-    let query = self.records.filter(keys.contains(keyColumn))
-    return try self.db.prepare(query).map { row in
-      let record = row[self.recordColumn]
-      let key = row[self.keyColumn]
-      
-      return DatabaseRow(cacheKey: key, storedInfo: record)
-    }
-  }
-  
-  public func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws {
-    try self.db.run(self.records.insert(or: .replace, self.keyColumn <- cacheKey, self.recordColumn <- recordString))
-  }
-  
-  public func deleteRecord(for cacheKey: CacheKey) throws {
-    let query = self.records.filter(keyColumn == cacheKey)
-    try self.db.run(query.delete())
-  }
-  
-  public func clearDatabase(shouldVacuumOnClear: Bool) throws {
-    try self.db.run(records.delete())
-    if shouldVacuumOnClear {
-      try self.db.prepare("VACUUM;").run()
-    }
-  }
 }
 
 /// A `NormalizedCache` implementation which uses a SQLite database to store data.

--- a/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
+++ b/Tests/ApolloSQLiteTests/CachePersistenceTests.swift
@@ -68,7 +68,13 @@ class CachePersistenceTests: XCTestCase {
   }
 
   func testPassInConnectionDoesNotThrow() {
-    XCTAssertNoThrow(try SQLiteNormalizedCache(db: Connection()))
+    do {
+      let database = try SQLiteDotSwiftDatabase(connection: Connection())
+      _ = try SQLiteNormalizedCache(database: database)
+
+    } catch {
+      XCTFail("Passing in connection failed with error: \(error)")
+    }
   }
 
   func testClearCache() throws {


### PR DESCRIPTION
In this PR, in preparation for ripping out `SQLite.swift` (see #1658), I've pulled stuff out into a protocol to try to figure out _exactly_ which APIs we're using in `SQLite.swift` so we can make a better determination of how to replace it. 

Doing this as a separate PR since a) it gives me more options when trying to replace it and b) helps me know what I done broke when I do try to replace it 😛 