### PR TITLE
Allow callbackQueue to be specified for GraphQLWatcher

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -88,7 +88,7 @@ extension ApolloClient: ApolloClientProtocol {
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,
                                                             cachePolicy: CachePolicy = .returnCacheDataElseFetch,
                                                             contextIdentifier: UUID? = nil,
-                                                            queue: DispatchQueue = DispatchQueue.main,
+                                                            queue: DispatchQueue = .main,
                                                             resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
     return self.networkTransport.send(operation: query,
                                       cachePolicy: cachePolicy,
@@ -100,9 +100,11 @@ extension ApolloClient: ApolloClientProtocol {
 
   public func watch<Query: GraphQLQuery>(query: Query,
                                          cachePolicy: CachePolicy = .returnCacheDataElseFetch,
+                                         callbackQueue: DispatchQueue = .main,
                                          resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self,
                                       query: query,
+                                      callbackQueue: callbackQueue,
                                       resultHandler: resultHandler)
     watcher.fetch(cachePolicy: cachePolicy)
     return watcher

--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -22,7 +22,7 @@ public protocol ApolloClientProtocol: class {
   /// - Parameters:
   ///   - query: The query to fetch.
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server and when data should be loaded from the local cache.
-  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - contextIdentifier: [optional] A unique identifier for this request, to help with deduping cache hits for watchers. Should default to `nil`.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: An object that can be used to cancel an in progress fetch.
@@ -37,7 +37,7 @@ public protocol ApolloClientProtocol: class {
   /// - Parameters:
   ///   - query: The query to fetch.
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
-  ///   - callbackQueue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - callbackQueue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   func watch<Query: GraphQLQuery>(query: Query,
@@ -50,7 +50,7 @@ public protocol ApolloClientProtocol: class {
   /// - Parameters:
   ///   - mutation: The mutation to perform.
   ///   - publishResultToStore: If `true`, this will publish the result returned from the operation to the cache store. Default is `true`.
-  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
   /// - Returns: An object that can be used to cancel an in progress mutation.
   func perform<Mutation: GraphQLMutation>(mutation: Mutation,
@@ -76,7 +76,7 @@ public protocol ApolloClientProtocol: class {
   /// - Parameters:
   ///   - subscription: The subscription to subscribe to.
   ///   - fetchHTTPMethod: The HTTP Method to be used.
-  ///   - queue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
+  ///   - queue: A dispatch queue on which the result handler will be called. Should default to the main queue.
   ///   - resultHandler: An optional closure that is called when mutation results are available or when an error occurs.
   /// - Returns: An object that can be used to cancel an in progress subscription.
   func subscribe<Subscription: GraphQLSubscription>(subscription: Subscription,

--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -37,10 +37,12 @@ public protocol ApolloClientProtocol: class {
   /// - Parameters:
   ///   - query: The query to fetch.
   ///   - cachePolicy: A cache policy that specifies when results should be fetched from the server or from the local cache.
+  ///   - callbackQueue: A dispatch queue on which the result handler will be called. Defaults to the main queue.
   ///   - resultHandler: [optional] A closure that is called when query results are available or when an error occurs.
   /// - Returns: A query watcher object that can be used to control the watching behavior.
   func watch<Query: GraphQLQuery>(query: Query,
                                   cachePolicy: CachePolicy,
+                                  callbackQueue: DispatchQueue,
                                   resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query>
 
   /// Performs a mutation by sending it to the server.


### PR DESCRIPTION
As mentioned in https://github.com/apollographql/apollo-ios/discussions/1718 there may be situations where it makes sense to call the result handler for the `GraphQLWatcher` in a background thread to lessen the load of the main thread.