### PR TITLE
#720: Changed fragment spreads to still collect the fields for new types

### DIFF
--- a/Sources/Apollo/Decoding.swift
+++ b/Sources/Apollo/Decoding.swift
@@ -59,12 +59,10 @@ private func collectFields(from selections: [GraphQLSelection],
     case let fragmentSpread as GraphQLFragmentSpread:
       let fragment = fragmentSpread.fragment
 
-      if let runtimeType = runtimeType, fragment.possibleTypes.contains(runtimeType) {
-        try collectFields(from: fragment.selections,
-                          forRuntimeType: runtimeType,
-                          into: &groupedFields,
-                          variables: variables)
-      }
+      try collectFields(from: fragment.selections,
+                        forRuntimeType: runtimeType,
+                        into: &groupedFields,
+                        variables: variables)
     case let typeCase as GraphQLTypeCase:
       let selections: [GraphQLSelection]
       if let runtimeType = runtimeType {


### PR DESCRIPTION
Fixes #720 

When collecting fields for a `GraphQLFragmentSpread`, removed the check that the `runtimeType` is one of the `possibleTypes` the fragment contains. My comment on the original issue goes into more details. https://github.com/apollographql/apollo-ios/issues/720#issuecomment-801537410

This allows Fragments on an interface type to support new types returned from the server with out requiring an app update.

## Example
Based the starwars API. Let's say the app has the following query and the codegen used the flag `mergeInFieldsFromFragmentSpreads: false`.
```graphql
query HanSolo {
  character(id: 1002) {
    name
    friends {
      ...Friend
    }
  }
}

fragment Friend on Character {
  name
}
```

Some time later after releasing the app, the backend realizes it's missing Chewbacca. So they add a new type `Wookie` that conforms to `Character` and add the missing friend relationships.

Now when the already released app fetches the `HanSoloQuery`, it will try to parse the response from the backend. The `__typename` coming back on the response for one of the friends is `Wookie`, but the code generated type for the `Friend` fragment doesn't have that listed as one of the possible types so it skips collecting the `name` field. Then when the app tries to read the `name` field from the `Friend` type, it crashes because the getter for that field assumes it will be there.
```swift
return resultMap["name"]! as! String
```

## Additional Notes
I also found that this method isn't called by any of the tests. A future improvement could be to add tests that use the generated code using different flags. It seems like the default value `mergeInFieldsFromFragmentSpreads: true` is only used in the tests currently, and there could be other flags with similar gaps in their testing.