### PR TITLE
Avoid having extra ? at the end of request url when queryItems are empty

### DIFF
--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -42,7 +42,10 @@ public struct GraphQLGETTransformer {
       return nil
     }
 
-    components.queryItems = queryItems
+    if queryItems.count > 0 {
+      components.queryItems = queryItems
+    }
+
     components.percentEncodedQuery =
       components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
 

--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -42,7 +42,7 @@ public struct GraphQLGETTransformer {
       return nil
     }
 
-    if queryItems.count > 0 {
+    if queryItems.apollo.isNotEmpty {
       components.queryItems = queryItems
     }
 

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -197,4 +197,12 @@ class GETTransformerTests: XCTestCase {
 
     XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?foo=bar&operationName=HeroName&query=query%20HeroName($episode:%20Episode)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22EMPIRE%22%7D")
   }
+
+	func testEncodingWithEmptyQueryParameter() throws {
+		let body: GraphQLMap = ["variables": nil]
+		let transformer = GraphQLGETTransformer(body: body, url: self.url)
+		let url = transformer.createGetURL()
+
+		XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql")
+	}
 }


### PR DESCRIPTION
Summary
----
Avoid having extra ? at the end of request url when queryItems are empty<!-- Summary of the changes -->

Details
----
 <!-- Details of the changes -->
Currently `GraphQLGETTransformer` is used to create query items for GET request endpoint. If property `body` of this struct is empty ( does not have value for a given key) such as:

> key : "variables"
> value : nil

which leads to queryItems is empty. By doing `components.queryItems = queryItems`, then the url ends up to have extra ? at the end like following: `https://this_is_sample/abcd?` instead of `https://this_is_sample/abcd`

Fix
----
Only assign `queryItems` to `URLComponent` when it is not empty