### PR TITLE
Replace `class` constraint with `AnyObject`

### DIFF
--- a/Sources/Apollo/ApolloClientProtocol.swift
+++ b/Sources/Apollo/ApolloClientProtocol.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The `ApolloClientProtocol` provides the core API for Apollo. This API provides methods to fetch and watch queries, and to perform mutations.
-public protocol ApolloClientProtocol: class {
+public protocol ApolloClientProtocol: AnyObject {
 
   ///  A store used as a local cache.
   var store: ApolloStore { get }

--- a/Sources/Apollo/ApolloInterceptor.swift
+++ b/Sources/Apollo/ApolloInterceptor.swift
@@ -1,5 +1,5 @@
 /// A protocol to set up a chainable unit of networking work.
-public protocol ApolloInterceptor: class {
+public protocol ApolloInterceptor: AnyObject {
   
   /// Called when this interceptor should do its work.
   ///

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -15,7 +15,7 @@ func rootCacheKey<Operation: GraphQLOperation>(for operation: Operation) -> Stri
   }
 }
 
-protocol ApolloStoreSubscriber: class {
+protocol ApolloStoreSubscriber: AnyObject {
   
   /// A callback that can be received by subscribers when keys are changed within the database
   ///

--- a/Sources/Apollo/Cancellable.swift
+++ b/Sources/Apollo/Cancellable.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An object that can be used to cancel an in progress action.
-public protocol Cancellable: class {
+public protocol Cancellable: AnyObject {
     /// Cancel an in progress action.
     func cancel()
 }

--- a/Sources/Apollo/GraphQLOperation.swift
+++ b/Sources/Apollo/GraphQLOperation.swift
@@ -4,7 +4,7 @@ public enum GraphQLOperationType {
   case subscription
 }
 
-public protocol GraphQLOperation: class {
+public protocol GraphQLOperation: AnyObject {
   var operationType: GraphQLOperationType { get }
 
   var operationDefinition: String { get }

--- a/Sources/Apollo/GraphQLResultAccumulator.swift
+++ b/Sources/Apollo/GraphQLResultAccumulator.swift
@@ -1,4 +1,4 @@
-protocol GraphQLResultAccumulator: class {
+protocol GraphQLResultAccumulator: AnyObject {
   associatedtype PartialResult
   associatedtype FieldEntry
   associatedtype ObjectResult

--- a/Sources/Apollo/NetworkTransport.swift
+++ b/Sources/Apollo/NetworkTransport.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A network transport is responsible for sending GraphQL operations to a server.
-public protocol NetworkTransport: class {
+public protocol NetworkTransport: AnyObject {
 
   /// Send a GraphQL operation to a server and return a response.
   ///

--- a/Sources/ApolloTestSupport/TestCacheProvider.swift
+++ b/Sources/ApolloTestSupport/TestCacheProvider.swift
@@ -4,7 +4,7 @@ import XCTest
 public typealias TearDownHandler = () throws -> ()
 public typealias TestDependency<Resource> = (Resource, TearDownHandler?)
 
-public protocol TestCacheProvider: class {
+public protocol TestCacheProvider: AnyObject {
   static func makeNormalizedCache(_ completionHandler: (Result<TestDependency<NormalizedCache>, Error>) -> ())
 }
 

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Transport Delegate
 
-public protocol WebSocketTransportDelegate: class {
+public protocol WebSocketTransportDelegate: AnyObject {
   func webSocketTransportDidConnect(_ webSocketTransport: WebSocketTransport)
   func webSocketTransportDidReconnect(_ webSocketTransport: WebSocketTransport)
   func webSocketTransport(_ webSocketTransport: WebSocketTransport, didDisconnectWithError error:Error?)


### PR DESCRIPTION
Pretty insignificant, but the recommended practice in Swift now is to use AnyObject instead of class, and recently there have been motions toward a new reference type (`actor`) that the `class` naming makes a little unclear, while AnyObject is more of a generic and all-encompassing term for reference types. Also, the class constraint typealias may be removed in future versions of Swift. 

ref: https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md#class-and-anyobject