### PR TITLE
Apply cache policy case .default  in fetch and watch

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -86,7 +86,7 @@ extension ApolloClient: ApolloClientProtocol {
   }
   
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,
-                                                            cachePolicy: CachePolicy = .returnCacheDataElseFetch,
+                                                            cachePolicy: CachePolicy = .default,
                                                             contextIdentifier: UUID? = nil,
                                                             queue: DispatchQueue = .main,
                                                             resultHandler: GraphQLResultHandler<Query.Data>? = nil) -> Cancellable {
@@ -99,7 +99,7 @@ extension ApolloClient: ApolloClientProtocol {
   }
 
   public func watch<Query: GraphQLQuery>(query: Query,
-                                         cachePolicy: CachePolicy = .returnCacheDataElseFetch,
+                                         cachePolicy: CachePolicy = .default,
                                          callbackQueue: DispatchQueue = .main,
                                          resultHandler: @escaping GraphQLResultHandler<Query.Data>) -> GraphQLQueryWatcher<Query> {
     let watcher = GraphQLQueryWatcher(client: self,


### PR DESCRIPTION
The CachePolicy enum has a default policy but it was only used in subscribe. This updates the other 2 locations