### PR TITLE
Fixed a data race that occasionally causes a crash

### DIFF
--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -228,7 +228,7 @@ public class WebSocketTransport {
       self.acked = false
 
       if let str = OperationMessage(payload: self.connectingPayload, type: .connectionInit).rawMessage {
-        write(str, force:true)
+        self.write(str, force:true)
       }
     }
   }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -224,12 +224,13 @@ public class WebSocketTransport {
   }
 
   public func initServer() {
-    self.acked = false
+    processingQueue.async {
+      self.acked = false
 
-    if let str = OperationMessage(payload: self.connectingPayload, type: .connectionInit).rawMessage {
-      write(str, force:true)
+      if let str = OperationMessage(payload: self.connectingPayload, type: .connectionInit).rawMessage {
+        write(str, force:true)
+      }
     }
-
   }
 
   public func closeConnection() {

--- a/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
@@ -48,6 +48,23 @@ class WebSocketTransportTests: XCTestCase {
 
     waitForExpectations(timeout: 3, handler: nil)
   }
+
+  func testCloseConnectionAndInit() {
+    WebSocketTransport.provider = MockWebSocket.self
+
+    self.webSocketTransport = WebSocketTransport(request: URLRequest(url: TestURL.mockServer.url),
+                                                 connectingPayload: ["Authorization": "OldToken"])
+    self.webSocketTransport.closeConnection()
+    self.webSocketTransport.updateConnectingPayload(["Authorization": "UpdatedToken"])
+    self.webSocketTransport.initServer()
+
+    let exp = expectation(description: "Wait")
+    let result = XCTWaiter.wait(for: [exp], timeout: 1.0)
+    if result == XCTWaiter.Result.timedOut {
+    } else {
+      XCTFail("Delay interrupted")
+    }
+  }
 }
 
 private final class MockWebSocketDelegate: WebSocketDelegate {


### PR DESCRIPTION
if webSocketTransport.closeConnection() and webSocketTransport.initServer() are called in succession. Fix was verified with Xcode Thread sanitizer