### PR TITLE
Allow to skip reconnection when updating headers and payload

### DIFF
--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -310,17 +310,22 @@ public class WebSocketTransport {
     }
   }
 
-  public func updateHeaderValues(_ values: [String: String?]) {
+  public func updateHeaderValues(_ values: [String: String?], reconnectIfConnected: Bool = true) {
     for (key, value) in values {
       self.websocket.request.setValue(value, forHTTPHeaderField: key)
     }
 
-    self.reconnectWebSocket()
+	if reconnectIfConnected && isConnected() {
+      self.reconnectWebSocket()
+	}
   }
 
-  public func updateConnectingPayload(_ payload: GraphQLMap) {
+  public func updateConnectingPayload(_ payload: GraphQLMap, reconnectIfConnected: Bool = true) {
     self.connectingPayload = payload
-    self.reconnectWebSocket()
+
+	if reconnectIfConnected && isConnected() {
+      self.reconnectWebSocket()
+	}
   }
 
   private func reconnectWebSocket() {


### PR DESCRIPTION
Fix for https://github.com/apollographql/apollo-ios/issues/1705

-[WebSocketTransport updateHeaderValues:]
-[WebSocketTransport updateConnectingPayload:]

"reconnects" not connected socket - it shouldn't - there is reason why it is not connected. At least it should check if it's connected and then reconnect, but even better it should do nothing and allow developer to decide what to do. 
If you updating both (headers and payload) you creating unnecessary reconnects, in some cases developer might not even want to connect on those changes