### PR TITLE
Fix for exponential WebSocket reconnections

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -90,7 +90,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
   ///
   /// - Parameter identifier: The identifier of the task to clear.
   open func clear(task identifier: Int) {
-    self.tasks.mutate { $0.removeValue(forKey: identifier) }
+    self.tasks.mutate { _ = $0.removeValue(forKey: identifier) }
   }
   
   /// Clears underlying dictionaries of any data related to all tasks.

--- a/Sources/ApolloCore/Atomic.swift
+++ b/Sources/ApolloCore/Atomic.swift
@@ -22,10 +22,11 @@ public class Atomic<T> {
   
   /// Mutates the underlying value within a lock.
   /// - Parameter block: The block to execute to mutate the value.
-  public func mutate(block: (inout T) -> Void) {
+  public func mutate<U>(block: (inout T) -> U) -> U {
     lock.lock()
-    block(&_value)
+    let result = block(&_value)
     lock.unlock()
+    return result
   }
 }
 

--- a/Sources/ApolloCore/Atomic.swift
+++ b/Sources/ApolloCore/Atomic.swift
@@ -22,6 +22,7 @@ public class Atomic<T> {
   
   /// Mutates the underlying value within a lock.
   /// - Parameter block: The block to execute to mutate the value.
+  /// - Returns: The value returned by the block.
   public func mutate<U>(block: (inout T) -> U) -> U {
     lock.lock()
     let result = block(&_value)

--- a/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
@@ -28,7 +28,7 @@ class WebSocketTransportTests: XCTestCase {
     let mockWebSocketDelegate = MockWebSocketDelegate()
 
     let mockWebSocket = self.webSocketTransport.websocket as? MockWebSocket
-    self.webSocketTransport.isSocketConnected.mutate { $0 = true }
+    self.webSocketTransport.socketConnectionState.mutate { $0 = .connected }
     mockWebSocket?.delegate = mockWebSocketDelegate
 
     let exp = expectation(description: "Waiting for reconnect")


### PR DESCRIPTION
This pull request fixes #1753.

When `WebSocketTransport` gets two errors in a row from Starscream (https://github.com/daltoniam/Starscream/issues/881), it no longer performs two reconnections.