### PR TITLE
Fix swift warning when using cocoapods

### DIFF
--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if COCOAPODS
-import Apollo
-#else
+#if !COCOAPODS
 import ApolloCore
 #endif
 


### PR DESCRIPTION
`File 'GraphQLGETTransformer.swift' is part of module 'Apollo'; ignoring import`