### PR TITLE
Update docs regarding not installing `Apollo-Dynamic` by default

### DIFF
--- a/docs/shared/spm-installation-panel.mdx
+++ b/docs/shared/spm-installation-panel.mdx
@@ -36,6 +36,8 @@ Select which packages you want to use. If you're just getting started, try selec
 
 ![select the packages you want to use](../source/screenshot/spm_select_package.png)
 
+_Note: Do **not** select the `Apollo-Dynamic` target, this is only for use for projects linking to our library dynamically. Most projects will not need to do this._
+
 </ExpansionPanelListItem>
 <ExpansionPanelListItem number="check">
   You're done!

--- a/docs/source/tutorial/tutorial-create-project.md
+++ b/docs/source/tutorial/tutorial-create-project.md
@@ -44,6 +44,8 @@ Next, you'll add a dependency on the `apollo-ios` repo and Apollo libraries usin
 
     <img src="images/select_libs.png" class="screenshot" alt="Select the first and third targets"/>
 
+    _Note: Do **not** select the `Apollo-Dynamic` target, this is only for use for projects linking to our library dynamically. Most projects, including this one, will not need to do this._
+    
 6. Click **Finish**. SPM fetches your dependencies. When it completes, you can see them in the project navigator:
 
     <img src="images/installed_dependencies.png" class="screenshot" alt="Screenshot of installed dependencies"/>


### PR DESCRIPTION
Since the `Apollo-Dynamic` target was added we have not updated the docs to tell people not to install it if you don't have to (and you usually don't have to). This fixes that. 