### PR TITLE
Update mutation tutorial code snippet to use correct cache policy

### DIFF
--- a/docs/source/tutorial/tutorial-mutations.md
+++ b/docs/source/tutorial/tutorial-mutations.md
@@ -361,7 +361,7 @@ private func loadLaunchDetails(forceReload: Bool = false) {
         
   let cachePolicy: CachePolicy
   if forceReload {
-    cachePolicy = .fetchIgnoringCacheCompletely
+    cachePolicy = .fetchIgnoringCacheData
   } else {
     cachePolicy = .returnCacheDataElseFetch
   } 


### PR DESCRIPTION
The code snippet doesn't match the cache policy specified in the tutorial instructions. This fixes that so that the cache is updated with the result that was forcefully fetched.