### PR TITLE
Document improvement for README about replace .xcworkspace to .xcodeproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This combination of models with value semantics, one way data flow, and automati
 
 This project is being developed using Xcode 12 and Swift 5.3.
 
-If you open `Apollo.xcworkspace`, you should be able to run the tests of the Apollo, ApolloSQLite, and ApolloWebSocket frameworks on your Mac or an iOS Simulator.
+If you open `Apollo.xcodeproj`, you should be able to run the tests of the Apollo, ApolloSQLite, and ApolloWebSocket frameworks on your Mac or an iOS Simulator.
 
-> **NOTE**: Due to a change in behavior in Xcode 11's git integration, if you check this repo out using Xcode, please close the window Xcode automatically opens using the Swift Package manager structure, and open the `Apollo.xcworkspace` file instead.
+> **NOTE**: Due to a change in behavior in Xcode 11's git integration, if you check this repo out using Xcode, please close the window Xcode automatically opens using the Swift Package manager structure, and open the `Apollo.xcodeproj` file instead.
 
 Some of the tests run against [a simple GraphQL server serving the Star Wars example schema](https://github.com/apollographql/starwars-server) (see installation instructions there).
 


### PR DESCRIPTION
## What
Replace file extension from `.xcworkspace` to `.xcodeproj` for README.

## Why
Looking into the [past](https://github.com/apollographql/apollo-ios/pull/1029), xcodeproj seems to be the correct.

## Motivation
I was reading the docs hoping to contribute to amazing product of apollo-ios and I found a question for project file extension.