### PR TITLE
Allow different types of fetches on a watcher

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -43,7 +43,7 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
     fetch(cachePolicy: .fetchIgnoringCacheData)
   }
 
-  public func fetch(cachePolicy: CachePolicy) {
+  func fetch(cachePolicy: CachePolicy) {
     fetching.mutate {
       // Cancel anything already in flight before starting a new fetch
       $0?.cancel()

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -43,7 +43,7 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
     fetch(cachePolicy: .fetchIgnoringCacheData)
   }
 
-  func fetch(cachePolicy: CachePolicy) {
+  public func fetch(cachePolicy: CachePolicy) {
     fetching.mutate {
       // Cancel anything already in flight before starting a new fetch
       $0?.cancel()

--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -39,8 +39,8 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
 
   /// Refetch a query from the server.
-  public func refetch() {
-    fetch(cachePolicy: .fetchIgnoringCacheData)
+  public func refetch(cachePolicy: CachePolicy = .fetchIgnoringCacheData) {
+    fetch(cachePolicy: cachePolicy)
   }
 
   func fetch(cachePolicy: CachePolicy) {


### PR DESCRIPTION
Publicly exposing `GraphQLQueryWatcher`'s fetch() function would allow us to make other kinds of fetches besides the `fetchIgnoringCacheData` exposed by `refetch()`. Our use case is that our custom version of `InMemoryNormalizedCache` has cache expiration, and we want to be able to hit the network only if the cache has become invalid. Alternately, we could manually check the cache, but this seems cleaner.