### PR TITLE
Fix retain cycle

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -15,7 +15,13 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
 
   private let contextIdentifier = UUID()
 
-  private var fetching: Atomic<Cancellable?> = Atomic(nil)
+  private class WeakCancellableContainer {
+    weak var cancellable: Cancellable?
+    fileprivate init(_ cancellable: Cancellable?) {
+      self.cancellable = cancellable
+    }
+  }
+  private var fetching: Atomic<WeakCancellableContainer> = Atomic(.init(nil))
 
   private var dependentKeys: Atomic<Set<CacheKey>?> = Atomic(nil)
 
@@ -46,8 +52,8 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   func fetch(cachePolicy: CachePolicy) {
     fetching.mutate {
       // Cancel anything already in flight before starting a new fetch
-      $0?.cancel()
-      $0 = client?.fetch(query: query, cachePolicy: cachePolicy, contextIdentifier: self.contextIdentifier, queue: callbackQueue) { [weak self] result in
+      $0.cancellable?.cancel()
+      $0.cancellable = client?.fetch(query: query, cachePolicy: cachePolicy, contextIdentifier: self.contextIdentifier, queue: callbackQueue) { [weak self] result in
         guard let self = self else { return }
 
         switch result {
@@ -66,7 +72,7 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
 
   /// Cancel any in progress fetching operations and unsubscribe from the store.
   public func cancel() {
-    fetching.value?.cancel()
+    fetching.value.cancellable?.cancel()
     client?.store.unsubscribe(self)
   }
 


### PR DESCRIPTION
[This change](https://github.com/apollographql/apollo-ios/commit/0a5c5279ec84f6cac8f323f04cc725c07baedcd7#diff-8996a82e55b7b8458390d71ded4f5cc7fb9605e169b94a73c0e6f15752cda52aL14-R14) turned a weak reference into a strong one and created a cycle that might keep all watch objects in memory.

This pull request adds a test that fails without my fix and succeeds otherwise. Test was pushed in a first, separate commit to make it easier to check out the branch at that commit and see the error.

This might be related to [this story](https://github.com/apollographql/apollo-ios/issues/516)