### PR TITLE
Expose cache policy directive to refetch callers

### DIFF
--- a/Sources/Apollo/GraphQLQueryWatcher.swift
+++ b/Sources/Apollo/GraphQLQueryWatcher.swift
@@ -45,8 +45,8 @@ public final class GraphQLQueryWatcher<Query: GraphQLQuery>: Cancellable, Apollo
   }
 
   /// Refetch a query from the server.
-  public func refetch() {
-    fetch(cachePolicy: .fetchIgnoringCacheData)
+  public func refetch(cachePolicy: CachePolicy = .fetchIgnoringCacheData) {
+    fetch(cachePolicy: cachePolicy)
   }
 
   func fetch(cachePolicy: CachePolicy) {


### PR DESCRIPTION
### What
This picks up from #1802 to expose the cache policy directive for `refetch` calls while keeping the internal `fetch` method private.

Closes #1802 

### Why
See https://github.com/apollographql/apollo-ios/pull/1802#issue-649544503.

### Tests
_None additional_ - the current `WatchQueryTests` test cases validate cache/request behaviour so defaulting to anything other than `fetchIgnoringCacheData` or `fetchIgnoringCacheCompletely` would fail the tests.