### PR TITLE
[NetworkFetchInterceptor] Don't early exit during request completion if the task was cancelled

### DIFF
--- a/Sources/Apollo/NetworkFetchInterceptor.swift
+++ b/Sources/Apollo/NetworkFetchInterceptor.swift
@@ -41,10 +41,6 @@ public class NetworkFetchInterceptor: ApolloInterceptor, Cancellable {
         self.currentTask.mutate { $0 = nil }
       }
       
-      guard chain.isNotCancelled else {
-        return
-      }
-      
       switch result {
       case .failure(let error):
         chain.handleErrorAsync(error,


### PR DESCRIPTION
I'm wondering why this `guard` stmt exists? When a task is cancelled, the `result` object will contain an error `Domain=NSURLErrorDomain Code=-999 "cancelled"`. Shouldn't we let the completion handlers run? This was causing a request to appear as if it was hanging because the completion was never called.