### PR TITLE
Pattern matching cache delete

### DIFF
--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -252,6 +252,16 @@ public final class ApolloStore {
       try self.cache.removeRecord(for: key)
     }
 
+    /// Removes all objects with a key that fully or partially matches the
+    /// supplied pattern. Does not cascade or allow removal of only certain
+    /// fields. Does nothing if an object does not exist for the given key.
+    ///
+    /// - Parameters:
+    ///   - pattern: The pattern that will be used to find matching cache keys
+    public func removeObjects(matching pattern: CacheKey) throws {
+      try self.cache.removeRecords(matching: pattern)
+    }
+
     public func write<Query: GraphQLQuery>(data: Query.Data, forQuery query: Query) throws {
       try write(object: data,
                 withKey: rootCacheKey(for: query),

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -252,12 +252,19 @@ public final class ApolloStore {
       try self.cache.removeRecord(for: key)
     }
 
-    /// Removes all objects with a key that fully or partially matches the
-    /// supplied pattern. Does not cascade or allow removal of only certain
-    /// fields. Does nothing if an object does not exist for the given key.
+    /// Removes records with keys that match the specified pattern. This method will only
+    /// remove whole records, it does not perform cascading deletes. This means only the
+    /// records with matched keys will be removed, and not any references to them. Key
+    /// matching is case-insensitive.
+    ///
+    /// If you attempt to pass a cache key for a single field, this method will do nothing
+    /// since it won't be able to locate a record to remove based on that key.
+    ///
+    /// This method can be very slow depending on the number of records in the cache.
+    /// It is recommended that this method be called in a background queue.
     ///
     /// - Parameters:
-    ///   - pattern: The pattern that will be used to find matching cache keys
+    ///   - pattern: The pattern that will be applied to find matching keys.
     public func removeObjects(matching pattern: CacheKey) throws {
       try self.cache.removeRecords(matching: pattern)
     }

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -257,8 +257,8 @@ public final class ApolloStore {
     /// records with matched keys will be removed, and not any references to them. Key
     /// matching is case-insensitive.
     ///
-    /// If you attempt to pass a cache key for a single field, this method will do nothing
-    /// since it won't be able to locate a record to remove based on that key.
+    /// If you attempt to pass a cache path for a single field, this method will do nothing
+    /// since it won't be able to locate a record to remove based on that path.
     ///
     /// - Note: This method can be very slow depending on the number of records in the cache.
     /// It is recommended that this method be called in a background queue.

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -260,7 +260,7 @@ public final class ApolloStore {
     /// If you attempt to pass a cache key for a single field, this method will do nothing
     /// since it won't be able to locate a record to remove based on that key.
     ///
-    /// This method can be very slow depending on the number of records in the cache.
+    /// - Note: This method can be very slow depending on the number of records in the cache.
     /// It is recommended that this method be called in a background queue.
     ///
     /// - Parameters:

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -22,7 +22,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
   }
 
   public func removeRecords(matching pattern: CacheKey) throws {
-    return records.removeRecords(matching: pattern)
+    records.removeRecords(matching: pattern)
   }
 
   public func clear() {

--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -21,6 +21,10 @@ public final class InMemoryNormalizedCache: NormalizedCache {
     return records.merge(records: newRecords)
   }
 
+  public func removeRecords(matching pattern: CacheKey) throws {
+    return records.removeRecords(matching: pattern)
+  }
+
   public func clear() {
     records.clear()
   }

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -35,8 +35,8 @@ public protocol NormalizedCache {
   /// records with matched keys will be removed, and not any references to them. Key
   /// matching is case-insensitive.
   ///
-  /// If you attempt to pass a cache key for a single field, this method will do nothing
-  /// since it won't be able to locate a record to remove based on that key.
+  /// If you attempt to pass a cache path for a single field, this method will do nothing
+  /// since it won't be able to locate a record to remove based on that path.
   ///
   /// - Note: This method can be very slow depending on the number of records in the cache.
   /// It is recommended that this method be called in a background queue.

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -30,14 +30,16 @@ public protocol NormalizedCache {
   ///   - key: The cache key to remove the record for
   func removeRecord(for key: CacheKey) throws
 
-  /// Removes records matching the specified pattern. This method will only remove
-  /// whole records, not individual fields.
+  /// Removes records with keys that match the specified pattern. This method will only
+  /// remove whole records, it does not perform cascading deletes. This means only the
+  /// records with matched keys will be removed, and not any references to them. Key
+  /// matching is case-insensitive.
   ///
-  /// If you attempt to pass a cache key for a  single field, this method will do nothing
+  /// If you attempt to pass a cache key for a single field, this method will do nothing
   /// since it won't be able to locate a record to remove based on that key.
   ///
-  /// This method does not support cascading delete - it will only remove the record
-  /// for the specified key, and not any references to it or from it.
+  /// This method can be very slow depending on the number of records in the cache.
+  /// It is recommended that this method be called in a background queue.
   ///
   /// - Parameters:
   ///   - pattern: The pattern that will be applied to find matching keys.

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -38,7 +38,7 @@ public protocol NormalizedCache {
   /// If you attempt to pass a cache key for a single field, this method will do nothing
   /// since it won't be able to locate a record to remove based on that key.
   ///
-  /// This method can be very slow depending on the number of records in the cache.
+  /// - Note: This method can be very slow depending on the number of records in the cache.
   /// It is recommended that this method be called in a background queue.
   ///
   /// - Parameters:

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -29,7 +29,20 @@ public protocol NormalizedCache {
   /// - Parameters:
   ///   - key: The cache key to remove the record for
   func removeRecord(for key: CacheKey) throws
-  
+
+  /// Removes records matching the specified pattern. This method will only remove
+  /// whole records, not individual fields.
+  ///
+  /// If you attempt to pass a cache key for a  single field, this method will do nothing
+  /// since it won't be able to locate a record to remove based on that key.
+  ///
+  /// This method does not support cascading delete - it will only remove the record
+  /// for the specified key, and not any references to it or from it.
+  ///
+  /// - Parameters:
+  ///   - pattern: The pattern that will be applied to find matching keys.
+  func removeRecords(matching pattern: CacheKey) throws
+
   /// Clears all records.
   func clear() throws
 }

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -14,6 +14,14 @@ public struct RecordSet {
     storage.removeValue(forKey: key)
   }
 
+  public mutating func removeRecords(matching pattern: CacheKey) {
+    for (key, _) in storage {
+      if key.contains(pattern) {
+        storage.removeValue(forKey: key)
+      }
+    }
+  }
+
   public mutating func clear() {
     storage.removeAll()
   }

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -16,7 +16,7 @@ public struct RecordSet {
 
   public mutating func removeRecords(matching pattern: CacheKey) {
     for (key, _) in storage {
-      if key.contains(pattern) {
+      if key.range(of: pattern, options: .caseInsensitive) != nil {
         storage.removeValue(forKey: key)
       }
     }

--- a/Sources/ApolloSQLite/SQLiteDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDatabase.swift
@@ -19,6 +19,8 @@ public protocol SQLiteDatabase {
   func addOrUpdateRecordString(_ recordString: String, for cacheKey: CacheKey) throws
   
   func deleteRecord(for cacheKey: CacheKey) throws
+
+  func deleteRecords(matching pattern: CacheKey) throws
   
   func clearDatabase(shouldVacuumOnClear: Bool) throws
   

--- a/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -52,6 +52,13 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
     let query = self.records.filter(keyColumn == cacheKey)
     try self.db.run(query.delete())
   }
+
+  public func deleteRecords(matching pattern: CacheKey) throws {
+    let wildcardPattern = "%\(pattern)%"
+    let query = self.records.filter(keyColumn.like(wildcardPattern))
+
+    try self.db.run(query.delete())
+  }
   
   public func clearDatabase(shouldVacuumOnClear: Bool) throws {
     try self.db.run(records.delete())

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -108,6 +108,10 @@ extension SQLiteNormalizedCache: NormalizedCache {
   public func removeRecord(for key: CacheKey) throws {
     try self.database.deleteRecord(for: key)
   }
+
+  public func removeRecords(matching pattern: CacheKey) throws {
+    try self.database.deleteRecords(matching: pattern)
+  }
   
   public func clear() throws {
     try self.database.clearDatabase(shouldVacuumOnClear: self.shouldVacuumOnClear)

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -36,6 +36,10 @@ private final class MockBatchedNormalizedCache: NormalizedCache {
   func removeRecord(for key: CacheKey) throws {
     records.removeRecord(for: key)
   }
+
+  func removeRecords(matching pattern: CacheKey) throws {
+    records.removeRecords(matching: pattern)
+  }
   
   func merge(records: RecordSet) throws -> Set<CacheKey> {
     return self.records.merge(records: records)


### PR DESCRIPTION
This adds `removeRecords(matching pattern: CacheKey)` to the normalized cache.

It is intended to be used through `ReadWriteTransaction` following the [established pattern for deletion](https://www.apollographql.com/docs/ios/caching/#delete), _see `removeObject(for:)`_.

Closes https://github.com/apollographql/apollo-ios/issues/1822.

#### Caveats
* This not a cascading delete, i.e.: if other records hold a reference to deleted records fetching them from the cache will fail.