### PR TITLE
Update documentation for pattern matching cache delete

### DIFF
--- a/docs/source/caching.mdx
+++ b/docs/source/caching.mdx
@@ -180,14 +180,15 @@ store.withinReadWriteTransaction({ transaction in
 
 ### delete
 
-Delete functionality is limited at this time. There are presently two deletion methods available on `ApolloStore`, which are supported by both the in memory and the `SQLite` caches:
+Delete functionality is limited at this time. There are presently three deletion methods available on `ApolloStore`, which are supported by both the in memory and the `SQLite` caches:
 
 1. `clear` - Removes everything from the cache immediately. This is basically the "Nuke it from orbit, it's the only way to be sure" option. 
 2. `removeObject(for:)` on `ReadWriteTransaction`. Removes a single object for the given `CacheKey`. 
+3. `removeObjects(matching:)` on `ReadWriteTransaction`. Removes all objects with a `CacheKey` that matches the given pattern. Pattern matching is **not** case sensitive. For an in memory cache it is the equivalent of checking whether the cache key _contains_ the pattern and `SQLite` caches will perform a `LIKE` query to remove the objects.
 
-`removeObject(for:)` will only remove things at the level of an object - that is, it cannot remove individual properties from an object, and it cannot remove outside references **to** an object. 
+`removeObject(for:)` and `removeObjects(matching:)` will only remove things at the level of an object - that is, they cannot remove individual properties from an object, and cannot remove outside references **to** an object. 
 
-You will need to have an understanding of how you are generating cache keys to be able to use this method effectively. If you're taking advantage of our `cacheKeyForObject` function, that will help significantly: You'll have a clear understanding of how cache keys are generated, so you can easily figure out how to construct a cache key to delete. 
+You will need to have an understanding of how you are generating cache keys to be able to use these methods effectively. If you're taking advantage of our `cacheKeyForObject` function, that will help significantly: You'll have a clear understanding of how cache keys are generated, so you can easily figure out how to construct a cache key or pattern to delete.
 
 For instance, let's say your `cacheKeyForObject` function looks like this: 
 
@@ -197,11 +198,13 @@ apollo.cacheKeyForObject = { $0["id"] }
 
 This would indicate that for every object which has an `id` property, it will be cached with that `id` as the key. This would be ideal for an API which uses globally unique identifiers, as our Star Wars API does. 
 
-This means that if you have previously fetched an object with the ID `"2001"`, you can call `transaction.removeObject(for: "2001")` on a `ReadWriteTransaction` to remove any object cached with that key, along with all of its associated scalar properties and the references to other objects it stores. 
+This means that if you have previously fetched an object with the ID `"2001"`, you can:
 
-`removeObject` does _not_ cascade its removals - if you remove an object which has reference to another object, the reference will be removed, but that other object will not be removed and will remain in the cache. Likewise, if you delete an object, references _to_ that object will not be deleted, they will simply fail, causing a cache miss, when you attempt to load the object again. 
+1. Call `transaction.removeObject(for: "2001")` on a `ReadWriteTransaction` to remove any object cached with that key, along with all of its associated scalar properties and the references to other objects it stores. 
+2. Call `transaction.removeObjects(matching: "200")` on a `ReadWriteTransaction` and all objects with `200` somewhere in their cache key would be removed, such as `2001`, `2002`, and `3200`.
+
+`removeObject(for:)` and `removeObjects(matching:)` do _not_ cascade removals - if you remove an object which has reference to another object, the reference will be removed, but that other object will not be removed and will remain in the cache. Likewise, if you delete an object, references _to_ that object will not be deleted, they will simply fail, causing a cache miss, when you attempt to load the object again. 
 
 This means that if you are planning to remove something, be sure that you either a) Know for sure you no longer need it, or b) Are fine with your cache policy potentially triggering an additional fetch if the missing value causes a read to fail. 
 
 > Note: As of right now, there is not a way to delete a single property's value. For instance, calling `try transaction.removeRecord(for: "2001.name")` will result in no action, as there would not be a record with the cache key `"2001.name"`, since `name` is a scalar field on the `"2001"` record.
-

--- a/docs/source/caching.mdx
+++ b/docs/source/caching.mdx
@@ -184,7 +184,7 @@ Delete functionality is limited at this time. There are presently three deletion
 
 1. `clear` - Removes everything from the cache immediately. This is basically the "Nuke it from orbit, it's the only way to be sure" option. 
 2. `removeObject(for:)` on `ReadWriteTransaction`. Removes a single object for the given `CacheKey`. 
-3. `removeObjects(matching:)` on `ReadWriteTransaction`. Removes all objects with a `CacheKey` that matches the given pattern. Pattern matching is **not** case sensitive. For an in memory cache it is the equivalent of checking whether the cache key _contains_ the pattern and `SQLite` caches will perform a `LIKE` query to remove the objects.
+3. `removeObjects(matching:)` on `ReadWriteTransaction`. Removes all objects with a `CacheKey` that matches the given pattern. Pattern matching is **not** case sensitive. For an in memory cache it is the equivalent of checking whether the cache key _contains_ the pattern and `SQLite` caches will perform a `LIKE` query to remove the objects. This method can be very slow depending on the number of records in the cache, it is recommended that this method be called in a background queue.
 
 `removeObject(for:)` and `removeObjects(matching:)` will only remove things at the level of an object - that is, they cannot remove individual properties from an object, and cannot remove outside references **to** an object. 
 


### PR DESCRIPTION
This updates the [documentation for cache delete](https://www.apollographql.com/docs/ios/caching/#delete) - _it should have been part of #1848_.

#### How to test the changes
1. Navigate to `apollo-ios/docs` in a terminal window
2. Execute `npm install`
3. Execute `npm start`
4. Open a browser to the link provided in the console

- [ ] Validate that the documentation for 'Direct cache access' -> 'delete' shows the updates and makes sense.