### PR TITLE
Add customScalarFormat to convenience initializer on ApolloCodegenOptions

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -156,8 +156,8 @@ public struct ApolloCodegenOptions {
     self.init(codegenEngine: codegenEngine,
               operationIDsURL: operationIDsURL,
               outputFormat: .singleFile(atFileURL: outputFileURL),
-              urlToSchemaFile: schema,
               customScalarFormat: customScalarFormat,
+              urlToSchemaFile: schema,
               downloadTimeout: downloadTimeout)
   }
   

--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -135,9 +135,11 @@ public struct ApolloCodegenOptions {
   /// - Parameters:
   ///  - folder: The root of the target.
   ///  - codegenEngine: The code generation engine to use. Defaults to `CodeGenerationEngine.default`
+  ///  - customScalarFormat: How to handle properties using a custom scalar from the schema.
   ///  - downloadTimeout: The maximum time to wait before indicating that the download timed out, in seconds. Defaults to 30 seconds
   public init(targetRootURL folder: URL,
               codegenEngine: CodeGenerationEngine = .default,
+              customScalarFormat: CustomScalarFormat = .none,
               downloadTimeout: Double = 30.0) {
     let schema = folder.appendingPathComponent("schema.json")
     
@@ -155,6 +157,7 @@ public struct ApolloCodegenOptions {
               operationIDsURL: operationIDsURL,
               outputFormat: .singleFile(atFileURL: outputFileURL),
               urlToSchemaFile: schema,
+              customScalarFormat: customScalarFormat,
               downloadTimeout: downloadTimeout)
   }
   


### PR DESCRIPTION
Add customScalarFormat to convenience initializer on ApolloCodegenOptions. 
This allows users following the swift scripting guide (https://www.apollographql.com/docs/ios/swift-scripting/) to use a customScalarFormat.

Fixes issue brought up here: https://github.com/apollographql/apollo-ios/issues/1813