### PR TITLE
Community Updates - ROADMAP/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
-# Apollo iOS
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/146856/124335690-fc7ecd80-db4f-11eb-93fa-dcf4469bb07b.png" alt="Apollo GraphQL"/>
+</p>
 
-[![CircleCI](https://circleci.com/gh/apollographql/apollo-ios/tree/main.svg?style=shield)](https://circleci.com/gh/apollographql/apollo-ios/tree/main) [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollographql/apollo-ios/main/LICENSE) [![Swift 5 Supported](https://img.shields.io/badge/Swift-5.0-orange.svg)](https://github.com/apple/swift) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)   [![CocoaPods](https://img.shields.io/cocoapods/v/Apollo.svg)](https://cocoapods.org/pods/Apollo) 
+<p align="center">
+  <a href="https://circleci.com/gh/apollographql/apollo-ios/tree/main">
+    <img src="https://circleci.com/gh/apollographql/apollo-ios/tree/main.svg?style=shield" alt="CircleCI build status">
+  </a>
+  <a href="https://raw.githubusercontent.com/apollographql/apollo-ios/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000" alt="MIT license">
+  </a>
+  <a href="Platforms">
+    <img src="https://img.shields.io/badge/platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS-333333.svg" alt="Supported Platforms: iOS, macOS, tvOS, watchOS" />
+  </a>
+</p>
 
-Apollo iOS is a strongly-typed, caching GraphQL client for iOS, written in Swift.
+<p align="center">
+  <a href="https://github.com/apple/swift">
+    <img src="https://img.shields.io/badge/Swift-5.0-orange.svg" alt="Swift 5 supported">
+  </a>
+  <a href="https://swift.org/package-manager/">
+    <img src="https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square" alt="Swift Package Manager compatible">
+  </a>
+  <a href="https://github.com/Carthage/Carthage">
+    <img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" alt="Carthage compatible">
+  </a>
+  <a href="https://cocoapods.org/pods/Apollo">
+    <img src="https://img.shields.io/cocoapods/v/Apollo.svg" alt="CocoaPods compatible">
+  </a>
+</p>
+
+### Apollo iOS is a strongly-typed, caching GraphQL client, written in Swift.
 
 It allows you to execute queries and mutations against a GraphQL server, and returns results as query-specific Swift types. This means you don’t have to deal with parsing JSON, or passing around dictionaries and making clients cast values to the right type manually. You also don't have to write model types yourself, because these are generated from the GraphQL definitions your UI uses.
 
@@ -12,16 +39,21 @@ Apollo iOS does more than simply run your queries against a GraphQL server: It n
 
 This combination of models with value semantics, one way data flow, and automatic consistency management, leads to a very powerful and elegant programming model that allows you to eliminate common glue code and greatly simplifies app development.
 
-## Documentation
+## Getting started
 
-[Read the full docs at apollographql.com/docs/ios/](https://www.apollographql.com/docs/ios/)
+If you are new to GraphQL, start with the [tutorial](https://www.apollographql.com/docs/ios/tutorial/tutorial-introduction/) that will guide you through building an iOS app using Swift and Apollo iOS. There is also [comprehensive documentation](https://www.apollographql.com/docs/ios/) of the SDK, including an [API reference](https://www.apollographql.com/docs/ios/api-reference/).
 
-## Changelog
-[Read about the latest changes to the library](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md)
+## Releases and changelog
+
+[All releases](https://github.com/apollographql/apollo-ios/releases) are catalogued and we maintain a [changelog](https://github.com/apollographql/apollo-ios/blob/main/CHANGELOG.md) which details all changes to the library.
+
+## Roadmap
+
+The [roadmap](https://github.com/apollographql/apollo-ios/blob/main/ROADMAP.md) is a high-level document that describes the next major steps or milestones for this project. We are always open to feature requests, and contributions from the community.
 
 ## Contributing
 
-This project is being developed using Xcode 12 and Swift 5.3.
+This project is being developed using Xcode 12.5 and Swift 5.4.
 
 If you open `Apollo.xcodeproj`, you should be able to run the tests of the Apollo, ApolloSQLite, and ApolloWebSocket frameworks on your Mac or an iOS Simulator.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ These are subject to change and anything that dramatically changes APIs or break
 - **Cache Improvements**: Here we are looking at bringing across some features inspired by Apollo Client 3 and Apollo Android 
     - **Better pagination support**. Better support for caching and updating paginated lists of objects. 
     - **Reducing over-normalization**. Only separating out results into individual records when something that can identify them is present
-    - **Real cache eviction & dangling reference collection**. There's presently a way to manually remove objects for a given key or pattern, but Apollo Client 3 hass given us a roadmap for how to handle some of this stuff much more thoroughly and safely. 
+    - **Real cache eviction & dangling reference collection**. There's presently a way to manually remove objects for a given key or pattern, but Apollo Client 3 has given us a roadmap for how to handle some of this stuff much more thoroughly and safely. 
     - **Cache metadata**. Ability to add per-field metadata if needed, to allow for TTL and time-based invalidation, etc.
 
 - **Dependency Manager test suite**. We've seen a few issues around things that work well for at least one of the three major iOS dependency managers, but causes problems in others. We plan to make a repo that we can use to automatically test for common issues against new versions of the library on CocoaPods, Carthage, and Swift Package Manager *before* they're released.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,45 +1,40 @@
-# Roadmap
+# Apollo iOS Roadmap - _Last Updated July 2021_
 
-This document is meant to give the community some idea of where we're going with the iOS SDK in the short and longer term. 
+Releases adhere to the [Semantic Versioning Specification](https://semver.org/). Under this scheme, version numbers and the way they change convey meaning about the underlying code and what has been modified from one version to the next.
 
-This document was last updated on January 4th, 2020 
+## 0.x - _Current_
 
-^ If that's more than three months ago, please file an issue asking [@designatednerd](https://github.com/designatednerd) to update this document. 😃
+This version is being used in many Production codebases, and we're committed to resolving issues and bugs raised by the community. We are not considering any further substantial work to be done in this version.
 
+## 1.0 - _Estimated Release Q4 2021_
 
-## Short-Term
+These are the three guiding principles we're aiming for in a 1.0 release.
+- **Stability**: Achieve a stable foundation that can be trusted for years to come, maintaining backwards compatibility within major version releases.
+- **Completeness**: The three main parts to the SDK must be feature complete: code generation, network fetching/parsing, and caching.
+- **Clarity**: Everything must be clearly documented with as many working samples as possible.
 
-These are things we plan to be working on **within the next 3 months**.
+These are the major initiatives planned for 1.0.
+- **Swift Codegen Rewrite**: The code generation is being rewritten with a Swift-first approach instead of relying on scripting and Typescript. This will allow easier community contribution to code generation and provide the opportunity to improve various characteristics such as generated code size and performance.
+    - We are finishing the spec at the moment which will then be published as an RFC for review and feedback.
+    - Once we're ready to begin implementation those details and development phases will be shared here.
 
-- **Swift Codegen Rewrite, Continued**: As outlined in much greater detail in the [RFC issue](https://github.com/apollographql/apollo-ios/issues/939), we're rewriting our code generation. This has taken ~~somewhat~~ ~~a lot~~ colossally longer than expected, but the following phases are still in progress:
-    
-    - **Start generating code with Swift instead of Typescript**. This will allow much easier community contribution to code generation, and allow us to take on a bunch of improvements like `Hashable`, `Equatable`, and potentially `Identifiable` without having to fight with Typescript to do it.
-    - **Add immutable caching to new generated code**. Caching is currently heavily tied into our existing parsing mechanism. We're going to separate that out in two phases: The first will allow caching that *cannot* be changed by the consumer.
-    - **Add mutable caching to new generated code**. This is the final stage of updating caching: Allowing caching that *can* be changed by the consumer.
-    - **Remove Old Codegen**. Once all this is built, older codegen will be deprecated. 
+- **Networking Stack Improvements**: The goal is to simplify and stabilise the networking stack.
+    - The [updated network stack](https://github.com/apollographql/apollo-ios/issues/1340) solved a number of long standing issues with the old barebones NetworkTransport but still has limitations. Switching to a composable request chain would enable building a pipeline out of reusable and customizable parts, giving users full control over the steps that are invoked to satisfy requests. This pattern has proven really useful for the JavaScript client (Apollo Link), and has been used succesfully in a number of other projects (like [OkHttp](https://square.github.io/okhttp/)).
 
-    You can follow this effort through the [Swift Codegen GitHub project](https://github.com/apollographql/apollo-ios/projects/2).
-    
-- **Cache Improvements**: We've had a ton of requests for this and we've got some extra muscle now, so we're going to be working on many requests. First up, some features inspired by Apollo Client 3 for the web: 
+- **Improved Documentation and Tutorials**:
+    - Using [DocC](https://developer.apple.com/documentation/docc) would enable a richer, more integrated documentation experience.
+
+## 1.x/2.0 - _Future_
+
+These are subject to change and anything that dramatically changes APIs or breaks backwards compatibility with 1.x releases will be reserved for the next major version.
+
+- **Cache Improvements**: Here we are looking at bringing across some features inspired by Apollo Client 3 and Apollo Android 
     - **Better pagination support**. Better support for caching and updating paginated lists of objects. 
     - **Reducing over-normalization**. Only separating out results into individual records when something that can identify them is present
-    - **Codable Support**: Which will allow easier moving between any storage method and objects, along with working better with updated codegen.
-
-- **General bug-bashing**: There are always a few outstanding general issues and small feature requests I'd like to address, and we'll be dealing with any new issues as they come up.
-
-
-## Long-Term
-
-These are things we plan to be working on **beyond the next 3 months**. 
-
-We're very open to any help we can get on these if your goals would be advanced by making these things work better sooner.
-
-- **Moar Cache Stuff**: Some additional improvements to the cache to 
-    - **Real cache eviction & dangling reference collection**. There's presently a way to manually remove a value for a given key, but AC3's given us a roadmap for how to handle some of this stuff much more thoroughly and safely. 
-    - **Cache metadata**. Ability to add per-field metadata if needed, to allow for TTL and time-based invalidation, along with other possible goodies.
+    - **Real cache eviction & dangling reference collection**. There's presently a way to manually remove objects for a given key or pattern, but Apollo Client 3 hass given us a roadmap for how to handle some of this stuff much more thoroughly and safely. 
+    - **Cache metadata**. Ability to add per-field metadata if needed, to allow for TTL and time-based invalidation, etc.
 
 - **Dependency Manager test suite**. We've seen a few issues around things that work well for at least one of the three major iOS dependency managers, but causes problems in others. We plan to make a repo that we can use to automatically test for common issues against new versions of the library on CocoaPods, Carthage, and Swift Package Manager *before* they're released.
 
-- **Wrapper libraries**. A very highly voted suggestion in our fall 2019 developer survey was wrapper libraries for concurrency helpers like RxSwift, Combine, and PromiseKit. 
-
-    Note that we are **not** locked into any particular set of other dependencies to support yet, but we anticipate these will be wrappers in a separate repository that have Apollo as a dependency. As individual wrappers move into nearer-term work, we'll outline which specific ones we'll be supporting.
+- **Wrapper libraries**. A very highly voted suggestion in our fall 2019 developer survey was wrapper libraries for concurrency helpers like RxSwift, Combine, PromiseKit, and Async/Await. 
+    - Note that we are **not** locked into any particular set of other dependencies to support yet, but we anticipate these will be wrappers in a separate repository that have Apollo as a dependency. As individual wrappers move into nearer-term work, we'll outline which specific ones we'll be supporting.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,7 @@
 # Apollo iOS Roadmap - _Last Updated July 2021_
 
+_If this document has not been updated within the past three months, please [file an issue](https://github.com/apollographql/apollo-ios/issues/new/choose) asking the [maintainers](https://github.com/apollographql/apollo-ios#maintainers) to update it._
+
 Releases adhere to the [Semantic Versioning Specification](https://semver.org/). Under this scheme, version numbers and the way they change convey meaning about the underlying code and what has been modified from one version to the next.
 
 ## 0.x - _Current_

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ This version is being used in many Production codebases, and we're committed to 
 
 These are the three guiding principles we're aiming for in a 1.0 release.
 - **Stability**: Achieve a stable foundation that can be trusted for years to come, maintaining backwards compatibility within major version releases.
-- **Completeness**: The three main parts to the SDK must be feature complete: code generation, network fetching/parsing, and caching.
+- **Completeness**: There are three main parts to the SDK: code generation, network fetching/parsing, and caching. These must provide enough functionality to be a good foundation for incremental improvements in future releases without requiring breaking changes.
 - **Clarity**: Everything must be clearly documented with as many working samples as possible.
 
 These are the major initiatives planned for 1.0.
@@ -23,8 +23,7 @@ These are the major initiatives planned for 1.0.
 - **Networking Stack Improvements**: The goal is to simplify and stabilise the networking stack.
     - The [updated network stack](https://github.com/apollographql/apollo-ios/issues/1340) solved a number of long standing issues with the old barebones NetworkTransport but still has limitations and is complicated to use. Adopting patterns that have proven useful for the web client, such as Apollo Link, will provide more flexibility and give developers full control over the steps that are invoked to satisfy requests.
 
-- **Improved Documentation and Tutorials**:
-    - Using [DocC](https://developer.apple.com/documentation/docc) would enable a richer, more integrated documentation experience.
+- **Improved Documentation and Tutorials**: We want developers to be able to self-serve as much as possible and having comprehensive, guiding documentation is essential to that experience.
 
 ## 1.x/2.0 - _Future_
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ These are the major initiatives planned for 1.0.
     - Once we're ready to begin implementation those details and development phases will be shared here.
 
 - **Networking Stack Improvements**: The goal is to simplify and stabilise the networking stack.
-    - The [updated network stack](https://github.com/apollographql/apollo-ios/issues/1340) solved a number of long standing issues with the old barebones NetworkTransport but still has limitations. Switching to a composable request chain would enable building a pipeline out of reusable and customizable parts, giving users full control over the steps that are invoked to satisfy requests. This pattern has proven really useful for the JavaScript client (Apollo Link), and has been used succesfully in a number of other projects (like [OkHttp](https://square.github.io/okhttp/)).
+    - The [updated network stack](https://github.com/apollographql/apollo-ios/issues/1340) solved a number of long standing issues with the old barebones NetworkTransport but still has limitations and is complicated to use. Adopting patterns that have proven useful for the web client, such as Apollo Link, will provide more flexibility and give developers full control over the steps that are invoked to satisfy requests.
 
 - **Improved Documentation and Tutorials**:
     - Using [DocC](https://developer.apple.com/documentation/docc) would enable a richer, more integrated documentation experience.


### PR DESCRIPTION
These changes are focussed on public community facing documentation:
1. Update the roadmap document inline with the latest planning. You can view this as rendered Markdown with [this link](https://github.com/apollographql/apollo-ios/blob/community-updates/ROADMAP.md). Closes #1863 
2. I've also taken the liberty to 'improve' the readme; _subjective improvements_. You can view this as rendered Markdown with [this link](https://github.com/apollographql/apollo-ios/blob/community-updates/README.md).
    * Uses HTML tags to get centered content - much nicer visually.
    * I think it's important to have Apollo branding on the project and identify stewardship beyond just maintainers.
    * Provide clarity on supported platforms - specifically the omission of Linux.
    * Add a link directly to the tutorial which I'm hoping is an easier entry point for those new to GraphQL and this project.
    * Increase visibility to the roadmap beyond just a file in the repo.