### PR TITLE
Codegen test updates

### DIFF
--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -57,6 +57,23 @@ class ApolloCodegenTests: XCTestCase {
       "'\(output.path)'",
     ])
   }
+
+  func testConvenienceInitializer_givenAllParameters_shouldBuildCorrectArguments() throws {
+    let targetURL = URL(string: "file://could/be/anything/not/important")!
+    let options = ApolloCodegenOptions(targetRootURL: targetURL, codegenEngine: .swift, downloadTimeout: 42.0)
+
+    XCTAssertEqual(options.downloadTimeout, 42.0)
+    XCTAssertEqual(options.arguments, [
+      "codegen:generate",
+      "--target=json-modern",
+      "--addTypename",
+      "--includes=\'./**/*.graphql\'",
+      "--localSchemaFile=\'/be/anything/not/important/schema.json\'",
+      "--operationIdsPath=\'/be/anything/not/important/operationIDs.json\'",
+      "--mergeInFieldsFromFragmentSpreads",
+      "\'/be/anything/not/important/API.json\'"
+    ])
+  }
   
   func testCreatingOptionsWithAllParameters() throws {
     let sourceRoot = CodegenTestHelper.sourceRootURL()

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -1,10 +1,3 @@
-//
-//  ApolloCodegenTests.swift
-//  ApolloCodegenTests
-//
-//  Copyright © 2021 Apollo GraphQL. All rights reserved.
-//
-
 import XCTest
 import ApolloCodegenTestSupport
 @testable import ApolloCodegenLib

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2,8 +2,7 @@
 //  ApolloCodegenTests.swift
 //  ApolloCodegenTests
 //
-//  Created by Ellen Shapiro on 10/7/19.
-//  Copyright © 2019 Apollo GraphQL. All rights reserved.
+//  Copyright © 2021 Apollo GraphQL. All rights reserved.
 //
 
 import XCTest
@@ -22,14 +21,13 @@ class ApolloCodegenTests: XCTestCase {
     super.tearDown()
   }
   
-  func testCreatingOptionsWithDefaultParameters() throws {
+  func testDesignatedInitializer_givenRequiredParameters_shouldBuildDefaultArguments() throws {
     let sourceRoot = CodegenTestHelper.sourceRootURL()
     let output = sourceRoot.appendingPathComponent("API.swift")
     let schema = sourceRoot.appendingPathComponent("schema.json")
     
     let options = ApolloCodegenOptions(outputFormat: .singleFile(atFileURL: output),
                                        urlToSchemaFile: schema)
-
     
     XCTAssertEqual(options.includes, "./**/*.graphql")
     XCTAssertTrue(options.mergeInFieldsFromFragmentSpreads)
@@ -75,7 +73,7 @@ class ApolloCodegenTests: XCTestCase {
     ])
   }
   
-  func testCreatingOptionsWithAllParameters() throws {
+  func testDesignatedInitializer_givenAllParameters_shouldBuildCorrectArguments() throws {
     let sourceRoot = CodegenTestHelper.sourceRootURL()
     let output = sourceRoot.appendingPathComponent("API")
     let schema = sourceRoot.appendingPathComponent("schema.json")
@@ -128,7 +126,7 @@ class ApolloCodegenTests: XCTestCase {
     ])
   }
   
-  func testTryingToUseAFileURLToOutputMultipleFilesFails() {
+  func testMultipleFilesOutputFormat_givenAFileURL_shouldFail() {
     let scriptFolderURL = CodegenTestHelper.cliFolderURL()
     let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()
     let starWarsSchemaFileURL = CodegenTestHelper.starWarsSchemaFileURL()
@@ -153,7 +151,7 @@ class ApolloCodegenTests: XCTestCase {
     }
   }
   
-  func testTryingToUseAFolderURLToOutputASingleFileFails() {
+  func testSingleFileOutputFormat_givenAFolderURL_shouldFail() {
     let scriptFolderURL = CodegenTestHelper.cliFolderURL()
     let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()
     let starWarsSchemaFileURL = CodegenTestHelper.starWarsSchemaFileURL()
@@ -176,7 +174,7 @@ class ApolloCodegenTests: XCTestCase {
     }
   }
   
-  func testCodegenWithSingleFileOutputsSingleFile() throws {
+  func testSingleFileOutputFormat_givenAFileURL_shouldSucceed() throws {
     let scriptFolderURL = CodegenTestHelper.cliFolderURL()
     let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()
     let starWarsSchemaFileURL = CodegenTestHelper.starWarsSchemaFileURL()
@@ -202,7 +200,7 @@ class ApolloCodegenTests: XCTestCase {
     XCTAssertEqual(contents.count, 1)
   }
   
-  func testCodegenWithMultipleFilesOutputsMultipleFiles() throws {
+  func testMultipleFilesOutputFormat_givenAFolderURL_shouldSucceed() throws {
     let scriptFolderURL = CodegenTestHelper.cliFolderURL()
     let starWarsFolderURL = CodegenTestHelper.starWarsFolderURL()
     let starWarsSchemaFileURL = CodegenTestHelper.starWarsSchemaFileURL()


### PR DESCRIPTION
1. Add test for `.swift` code generation engine argument
2. Update test function names to match #1849 