### PR TITLE
Use the provided callback queue instead of the store's default.

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -82,7 +82,7 @@ extension ApolloClient: ApolloClientProtocol {
 
   public func clearCache(callbackQueue: DispatchQueue = .main,
                          completion: ((Result<Void, Error>) -> Void)? = nil) {
-    self.store.clearCache(completion: completion)
+    self.store.clearCache(callbackQueue: callbackQueue, completion: completion)
   }
   
   @discardableResult public func fetch<Query: GraphQLQuery>(query: Query,


### PR DESCRIPTION
This resolves #1900 by passing the provided callback queue in `ApolloClient.clearCache(callbackQueue:completion:)` into the `ApolloStore.clearCache(callbackQueue:completion:)` call.

@calvincestari has kindly provided the relevant tests for this in #1901, so I won't duplicate them here.