### PR TITLE
Include missing Swift files for ApolloWebSocket in podspec

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
 
   # Websocket and subscription support based on Starscream
   s.subspec 'WebSocket' do |ss|
-    ss.source_files = 'Sources/ApolloWebSocket/*.swift'
+    ss.source_files = 'Sources/ApolloWebSocket/**/*.swift'
     ss.dependency 'Apollo/Core'
   end
 


### PR DESCRIPTION
Files in https://github.com/apollographql/apollo-ios/tree/main/Sources/ApolloWebSocket/DefaultImplementation were not part of the framework when used with Cocoapods.

