### PR TITLE
Remove root redirect and build deploy previews at /

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,2 +1,1 @@
-/ /docs/ios/
 /docs/ios/tutorial /docs/ios/tutorial/tutorial-introduction

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,5 @@
   command = "gatsby build --prefix-paths && mkdir -p docs/ios && mv public/* docs/ios && mv docs public/ && mv public/docs/ios/_redirects public"
 [build.environment]
   NPM_VERSION = "6"
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch removes the root-level redirect in the docs and forces deploy previews to be deployed at the root to account for this change.