### PR TITLE
Use a failable iterator when selecting records

### DIFF
--- a/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -36,7 +36,7 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
   
   public func selectRawRows(forKeys keys: Set<CacheKey>) throws -> [DatabaseRow] {
     let query = self.records.filter(keys.contains(keyColumn))
-    return try self.db.prepare(query).map { row in
+    return try self.db.prepareRowIterator(query).map { row in
       let record = row[self.recordColumn]
       let key = row[self.keyColumn]
       


### PR DESCRIPTION
The `prepare` function being used in `selectRawRows(forKeys:)` is [changing behaviour](https://github.com/apollographql/apollo-ios/issues/1658#issuecomment-901674890) such that errors during selection would be hidden. I think we can keep the expected error-on-iteration by switching to a row iterator that supports failure. This PR changes the internals of `selectRawRows(forKeys:)` to use `prepareRowIterator`, returning a `RowIterator` which conforms to `FailableIterator` therefore any error thrown would still be propagated out to the caller.