### PR TITLE
Refactor GraphQLOperation definition models

### DIFF
--- a/Sources/Apollo/HTTPRequest.swift
+++ b/Sources/Apollo/HTTPRequest.swift
@@ -83,10 +83,10 @@ extension HTTPRequest: Equatable {
   
   public static func == (lhs: HTTPRequest<Operation>, rhs: HTTPRequest<Operation>) -> Bool {
     lhs.graphQLEndpoint == rhs.graphQLEndpoint
-      && lhs.contextIdentifier == rhs.contextIdentifier
-      && lhs.additionalHeaders == rhs.additionalHeaders
-      && lhs.cachePolicy == rhs.cachePolicy
-      && lhs.operation.queryDocument == rhs.operation.queryDocument
+    && lhs.contextIdentifier == rhs.contextIdentifier
+    && lhs.additionalHeaders == rhs.additionalHeaders
+    && lhs.cachePolicy == rhs.cachePolicy
+    && lhs.operation.definition?.queryDocument == rhs.operation.definition?.queryDocument
   }
 }
 

--- a/Sources/Apollo/JSONRequest.swift
+++ b/Sources/Apollo/JSONRequest.swift
@@ -63,6 +63,12 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     switch operation.operationType {
     case .query:
       if isPersistedQueryRetry {
+#warning("""
+TODO: if using persistedOperationsOnly, we should throw an error. Not sure if that should be
+here or somewhere else in the RequestChain? Probably earlier than this when we actually go to
+start a retry.
+Need to write unit tests for this new behavior.
+""")
         useGetMethod = self.useGETForPersistedQueryRetry
         sendQueryDocument = true
         autoPersistQueries = true

--- a/Sources/Apollo/JSONRequest.swift
+++ b/Sources/Apollo/JSONRequest.swift
@@ -54,10 +54,6 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
                cachePolicy: cachePolicy)
   }
   
-  open var sendOperationIdentifier: Bool {
-    self.operation.operationIdentifier != nil
-  }
-  
   open override func toURLRequest() throws -> URLRequest {
     var request = try super.toURLRequest()
         
@@ -91,9 +87,8 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     }
     
     let body = self.requestBodyCreator.requestBody(for: operation,
-                                               sendOperationIdentifiers: self.sendOperationIdentifier,
-                                               sendQueryDocument: sendQueryDocument,
-                                               autoPersistQuery: autoPersistQueries)
+                                                   sendQueryDocument: sendQueryDocument,
+                                                   autoPersistQuery: autoPersistQueries)
     
     let httpMethod: GraphQLHTTPMethod = useGetMethod ? .GET : .POST
     switch httpMethod {

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -9,13 +9,11 @@ public protocol RequestBodyCreator {
   ///
   /// - Parameters:
   ///   - operation: The operation to use
-  ///   - sendOperationIdentifiers: Whether or not to send operation identifiers. Should default to `false`.
   ///   - sendQueryDocument: Whether or not to send the full query document. Should default to `true`.
   ///   - autoPersistQuery: Whether to use auto-persisted query information. Should default to `false`.
   /// - Returns: The created `GraphQLMap`
   func requestBody<Operation: GraphQLOperation>(
     for operation: Operation,
-    sendOperationIdentifiers: Bool,
     sendQueryDocument: Bool,
     autoPersistQuery: Bool
   ) -> JSONEncodableDictionary
@@ -27,7 +25,6 @@ extension RequestBodyCreator {
   
   public func requestBody<Operation: GraphQLOperation>(
     for operation: Operation,
-    sendOperationIdentifiers: Bool,
     sendQueryDocument: Bool,
     autoPersistQuery: Bool
   ) -> JSONEncodableDictionary {
@@ -37,14 +34,6 @@ extension RequestBodyCreator {
 
     if let variables = operation.variables {
       body["variables"] = variables.jsonEncodableObject
-    }
-
-    if sendOperationIdentifiers {
-      guard let operationIdentifier = operation.operationIdentifier else {
-        preconditionFailure("To send operation identifiers, Apollo types must be generated with operationIdentifiers")
-      }
-
-      body["id"] = operationIdentifier
     }
 
     if sendQueryDocument {

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -5,13 +5,13 @@ import ApolloUtils
 #endif
 
 public protocol RequestBodyCreator {
-  /// Creates a `GraphQLMap` out of the passed-in operation
+  /// Creates a `JSONEncodableDictionary` out of the passed-in operation
   ///
   /// - Parameters:
   ///   - operation: The operation to use
   ///   - sendQueryDocument: Whether or not to send the full query document. Should default to `true`.
   ///   - autoPersistQuery: Whether to use auto-persisted query information. Should default to `false`.
-  /// - Returns: The created `GraphQLMap`
+  /// - Returns: The created `JSONEncodableDictionary`
   func requestBody<Operation: GraphQLOperation>(
     for operation: Operation,
     sendQueryDocument: Bool,
@@ -37,7 +37,10 @@ extension RequestBodyCreator {
     }
 
     if sendQueryDocument {
-      body["query"] = operation.queryDocument
+      guard let document = operation.definition?.queryDocument else {
+        preconditionFailure("To send query documents, Apollo types must be generated with `OperationDefinition`s.")
+      }
+      body["query"] = document
     }
 
     if autoPersistQuery {

--- a/Sources/Apollo/UploadRequest.swift
+++ b/Sources/Apollo/UploadRequest.swift
@@ -58,8 +58,6 @@ open class UploadRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
   /// - Throws: Any error arising from creating the form data
   /// - Returns: The created form data
   open func requestMultipartFormData() throws -> MultipartFormData {
-    let shouldSendOperationID = (self.operation.operationIdentifier != nil)
-
     let formData: MultipartFormData
 
     if let boundary = manualBoundary {
@@ -72,7 +70,6 @@ open class UploadRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     // for the files in the rest of the form data
     let fieldsForFiles = Set(files.map { $0.fieldName }).sorted()
     var fields = self.requestBodyCreator.requestBody(for: operation,
-                                                     sendOperationIdentifiers: shouldSendOperationID,
                                                      sendQueryDocument: true,
                                                      autoPersistQuery: false)
     var variables = fields["variables"] as? JSONEncodableDictionary ?? JSONEncodableDictionary()

--- a/Sources/ApolloAPI/FragmentProtocols.swift
+++ b/Sources/ApolloAPI/FragmentProtocols.swift
@@ -6,7 +6,9 @@
 /// any `Fragment` included in it's `Fragments` object via its `fragments` property.
 ///
 /// - SeeAlso: `HasFragments`, `ToFragments`
-public protocol Fragment: AnySelectionSet { }
+public protocol Fragment: AnySelectionSet {
+  var fragmentDefinition: String { get }
+}
 
 // MARK: - HasFragments
 

--- a/Sources/ApolloAPI/GraphQLNullable.swift
+++ b/Sources/ApolloAPI/GraphQLNullable.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Indicates the presence of a value, supporting both `nil` and `null` values.
+///
+/// In GraphQL, explicitly providing a `null` value for an input value to a field argument is
+/// semantically different from not providing a value at all (`nil`). This enum allows you to
+/// distinguish your input values between `null` and `nil`.
+///
+/// - See: [GraphQLSpec - Input Values - Null Value](http://spec.graphql.org/June2018/#sec-Null-Value)
 @dynamicMemberLookup
 public enum GraphQLNullable<Wrapped>: ExpressibleByNilLiteral {
 

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -80,15 +80,17 @@ public extension GraphQLOperation {
 
   var definition: OperationDefinition? {
     switch self.document {
-    case let .automaticallyPersisted(_, definition), let .notPersisted(definition):
+    case let .automaticallyPersisted(_, definition),
+      let .notPersisted(definition):
       return definition
     default: return nil
     }
   }
-
+  
   var operationIdentifier: String? {
     switch self.document {
-    case let .automaticallyPersisted(identifier, _), let .persistedOperationsOnly(identifier):
+    case let .automaticallyPersisted(identifier, _),
+      let .persistedOperationsOnly(identifier):
       return identifier
     default: return nil
     }

--- a/Sources/ApolloTestSupport/MockOperation.swift
+++ b/Sources/ApolloTestSupport/MockOperation.swift
@@ -5,12 +5,8 @@ open class MockOperation<SelectionSet: RootSelectionSet>: GraphQLOperation {
 
   public let operationType: GraphQLOperationType
 
-  public var operationDefinition: String = "None"
-  public var operationIdentifier: String?
   public var operationName: String = "MockOperationName"
-
-  public var stubbedQueryDocument: String?
-  public final var queryDocument: String { stubbedQueryDocument ?? operationDefinition }
+  public var document: DocumentType = .notPersisted(definition: .init("None"))
 
   open var variables: Variables?
 
@@ -96,5 +92,9 @@ open class AbstractMockSelectionSet: AnySelectionSet {
 }
 
 open class MockSelectionSet: AbstractMockSelectionSet, RootSelectionSet { }
+
+open class MockFragment: AbstractMockSelectionSet, RootSelectionSet, Fragment {
+  public var fragmentDefinition: String = ""
+}
 
 open class MockTypeCase: AbstractMockSelectionSet, TypeCase { }

--- a/Sources/ApolloTestSupport/MockOperation.swift
+++ b/Sources/ApolloTestSupport/MockOperation.swift
@@ -6,7 +6,7 @@ open class MockOperation<SelectionSet: RootSelectionSet>: GraphQLOperation {
   public let operationType: GraphQLOperationType
 
   public var operationName: String = "MockOperationName"
-  public var document: DocumentType = .notPersisted(definition: .init("None"))
+  public var document: DocumentType = .notPersisted(definition: .init("Mock Operation Definition"))
 
   open var variables: Variables?
 

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -84,8 +84,6 @@ public class WebSocketTransport {
     public fileprivate(set) var clientName: String
     /// The client version to use for this client. Defaults to `Self.defaultClientVersion`.
     public fileprivate(set) var clientVersion: String
-    /// Whether or not to send operation identifiers with operations. Defaults to false.
-    public let sendOperationIdentifiers: Bool
     /// Whether to auto reconnect when websocket looses connection. Defaults to true.
     public let reconnect: Atomic<Bool>
     /// How long to wait before attempting to reconnect. Defaults to half a second.
@@ -108,7 +106,6 @@ public class WebSocketTransport {
     public init(
       clientName: String = WebSocketTransport.defaultClientName,
       clientVersion: String = WebSocketTransport.defaultClientVersion,
-      sendOperationIdentifiers: Bool = false,
       reconnect: Bool = true,
       reconnectionInterval: TimeInterval = 0.5,
       allowSendingDuplicates: Bool = true,
@@ -119,7 +116,6 @@ public class WebSocketTransport {
     ) {
       self.clientName = clientName
       self.clientVersion = clientVersion
-      self.sendOperationIdentifiers = sendOperationIdentifiers
       self.reconnect = Atomic(reconnect)
       self.reconnectionInterval = reconnectionInterval
       self.allowSendingDuplicates = allowSendingDuplicates
@@ -299,7 +295,6 @@ public class WebSocketTransport {
   func sendHelper<Operation: GraphQLOperation>(operation: Operation, resultHandler: @escaping (_ result: Result<JSONObject, Error>) -> Void) -> String? {
     let body = config.requestBodyCreator
       .requestBody(for: operation,
-                   sendOperationIdentifiers: self.config.sendOperationIdentifiers,
                    sendQueryDocument: true,
                    autoPersistQuery: false)
     let identifier = config.operationMessageIdCreator.requestId()

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -94,7 +94,7 @@ public class WebSocketTransport {
     ///  If false, remember to call `resumeWebSocketConnection()` to connect.
     ///  Defaults to true.
     public let connectOnInit: Bool
-    /// [optional]The payload to send on connection. Defaults to an empty `GraphQLMap`.
+    /// [optional]The payload to send on connection. Defaults to an empty `JSONEncodableDictionary`.
     public fileprivate(set) var connectingPayload: JSONEncodableDictionary?
     /// The `RequestBodyCreator` to use when serializing requests. Defaults to an `ApolloRequestBodyCreator`.
     public let requestBodyCreator: RequestBodyCreator

--- a/Sources/UploadAPI/API.swift
+++ b/Sources/UploadAPI/API.swift
@@ -36,8 +36,10 @@ public final class File: Object {
 // MARK: - Mutations
 
 public final class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
-  /// The raw GraphQL definition of this operation.
-  public let operationDefinition: String =
+  public let operationName: String = "UploadMultipleFilesToTheSameParameter"
+  public let document: DocumentType = .automaticallyPersisted(
+    operationIdentifier: "88858c283bb72f18c0049dc85b140e72a4046f469fa16a8bf4bcf01c11d8a2b7",
+    definition: .init(
     """
     mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {
       multipleUpload(files: $files) {
@@ -48,11 +50,7 @@ public final class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutatio
         mimetype
       }
     }
-    """
-
-  public let operationName: String = "UploadMultipleFilesToTheSameParameter"
-
-  public let operationIdentifier: String? = "88858c283bb72f18c0049dc85b140e72a4046f469fa16a8bf4bcf01c11d8a2b7"
+    """))
 
   public var files: [String]
 
@@ -100,8 +98,10 @@ public final class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutatio
 }
 
 public final class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
-  /// The raw GraphQL definition of this operation.
-  public let operationDefinition: String =
+  public let operationName: String = "UploadMultipleFilesToDifferentParameters"
+  public let document: DocumentType = .automaticallyPersisted(
+    operationIdentifier: "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5",
+    definition: .init(
     """
     mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {
       multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) {
@@ -112,11 +112,7 @@ public final class UploadMultipleFilesToDifferentParametersMutation: GraphQLMuta
         mimetype
       }
     }
-    """
-
-  public let operationName: String = "UploadMultipleFilesToDifferentParameters"
-
-  public let operationIdentifier: String? = "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5"
+    """))
 
   public var singleFile: String
   public var multipleFiles: [String]
@@ -176,8 +172,10 @@ public final class UploadMultipleFilesToDifferentParametersMutation: GraphQLMuta
 }
 
 public final class UploadOneFileMutation: GraphQLMutation {
-  /// The raw GraphQL definition of this operation.
-  public let operationDefinition: String =
+  public let operationName: String = "UploadOneFile"
+  public let document: DocumentType = .automaticallyPersisted(
+    operationIdentifier: "c5d5919f77d9ba16a9689b6b0ad4b781cb05dc1dc4812623bf80f7c044c09533",
+    definition: .init(
     """
     mutation UploadOneFile($file: Upload!) {
       singleUpload(file: $file) {
@@ -188,11 +186,7 @@ public final class UploadOneFileMutation: GraphQLMutation {
         mimetype
       }
     }
-    """
-
-  public let operationName: String = "UploadOneFile"
-
-  public let operationIdentifier: String? = "c5d5919f77d9ba16a9689b6b0ad4b781cb05dc1dc4812623bf80f7c044c09533"
+    """))
 
   public var file: String
 

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -43,16 +43,18 @@ class AutomaticPersistedQueriesTests: XCTestCase {
       self.episode = episode
       super.init()
       self.variables = ["episode": episode]
-      self.operationIdentifier = "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671"
-      self.operationDefinition = "MockHeroNameQuery - Operation Definition"
+      self.document = .automaticallyPersisted(
+        operationIdentifier: "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671",
+        definition: .init("MockHeroNameQuery - Operation Definition"))
     }
   }
 
   fileprivate class APQMockMutation: MockMutation<MockSelectionSet> {
     override init() {
       super.init()
-      self.operationIdentifier = "4a1250de93ebcb5cad5870acf15001112bf27bb963e8709555b5ff67a1405374"
-      self.operationDefinition = "APQMockMutation - Operation Definition"
+      self.document = .automaticallyPersisted(
+        operationIdentifier: "4a1250de93ebcb5cad5870acf15001112bf27bb963e8709555b5ff67a1405374",
+        definition: .init("APQMockMutation - Operation Definition"))
     }
   }
 
@@ -77,7 +79,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     let queryString = jsonBody["query"] as? String
     if queryDocument {
       XCTAssertEqual(queryString,
-                     operation.queryDocument,
+                     operation.definition?.queryDocument,
                      file: file,
                      line: line)
     }
@@ -146,7 +148,7 @@ class AutomaticPersistedQueriesTests: XCTestCase {
     let queryString = url.queryItemDictionary?["query"]
     if queryDocument {
       XCTAssertEqual(queryString,
-                     query.queryDocument,
+                     query.definition?.queryDocument,
                      file: file,
                      line: line)
     } else {

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -40,7 +40,6 @@ query MockQuery($param: String) {
     operation.variables = ["param": "TestParamValue"]
 
     let body = requestBodyCreator.requestBody(for: operation,
-                                              sendOperationIdentifiers: false,
                                               sendQueryDocument: true,
                                               autoPersistQuery: false)
     
@@ -67,7 +66,6 @@ query MockQuery($param: MockEnum) {
     operation.variables = ["param": MockEnum.LARGE]
 
     let body = requestBodyCreator.requestBody(for: operation,
-                                              sendOperationIdentifiers: false,
                                               sendQueryDocument: true,
                                               autoPersistQuery: false)
 
@@ -94,7 +92,6 @@ query MockQuery($a: String, $b: Boolean!) {
     operation.variables = ["a": "TestParamValue", "b": true]
 
     let body = requestBodyCreator.requestBody(for: operation,
-                                              sendOperationIdentifiers: false,
                                               sendQueryDocument: true,
                                               autoPersistQuery: false)
     
@@ -218,7 +215,6 @@ query MockQuery($param: String) {
     operation.variables = ["param": GraphQLNullable<String>.null]
 
     let body = requestBodyCreator.requestBody(for: operation,
-                                              sendOperationIdentifiers: false,
                                               sendQueryDocument: true,
                                               autoPersistQuery: false)
 

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -29,14 +29,16 @@ class GETTransformerTests: XCTestCase {
   func test__createGetURL__queryWithSingleParameterAndVariable_encodesURL() {
     let operation = MockOperation.mock()
     operation.operationName = "TestOpName"
-    operation.stubbedQueryDocument = """
-query MockQuery($param: String) {
-  testField(param: $param) {
-    __typename
-    name
-  }
-}
-"""
+    operation.document = .notPersisted(definition: .init(
+    """
+    query MockQuery($param: String) {
+      testField(param: $param) {
+        __typename
+        name
+      }
+    }
+    """))
+
     operation.variables = ["param": "TestParamValue"]
 
     let body = requestBodyCreator.requestBody(for: operation,
@@ -55,14 +57,15 @@ query MockQuery($param: String) {
   func test__createGetURL__query_withEnumParameterAndVariable_encodesURL() {
     let operation = MockOperation.mock()
     operation.operationName = "TestOpName"
-    operation.stubbedQueryDocument = """
-query MockQuery($param: MockEnum) {
-  testField(param: $param) {
-    __typename
-    name
-  }
-}
-"""
+    operation.document = .notPersisted(definition: .init(
+    """
+    query MockQuery($param: MockEnum) {
+      testField(param: $param) {
+        __typename
+        name
+      }
+    }
+    """))
     operation.variables = ["param": MockEnum.LARGE]
 
     let body = requestBodyCreator.requestBody(for: operation,
@@ -81,14 +84,16 @@ query MockQuery($param: MockEnum) {
   func test__createGetURL__queryWithMoreThanOneParameter_withIncludeDirective_encodesURL() throws {
     let operation = MockOperation.mock()
     operation.operationName = "TestOpName"
-    operation.stubbedQueryDocument = """
-query MockQuery($a: String, $b: Boolean!) {
-  testField(param: $a) {
-    __typename
-    nestedField @include(if: $b)
-  }
-}
-"""
+    operation.document = .notPersisted(definition: .init(
+    """
+    query MockQuery($a: String, $b: Boolean!) {
+      testField(param: $a) {
+        __typename
+        nestedField @include(if: $b)
+      }
+    }
+    """))
+
     operation.variables = ["a": "TestParamValue", "b": true]
 
     let body = requestBodyCreator.requestBody(for: operation,
@@ -107,8 +112,9 @@ query MockQuery($a: String, $b: Boolean!) {
   func test__createGetURL__queryWith2DParameter_encodesURL_withBodyComponentsInAlphabeticalOrder() throws {
     let operation = MockOperation.mock()
     operation.operationName = "TestOpName"
-    operation.stubbedQueryDocument = "query MockQuery {}"
-    operation.operationIdentifier = "4d465fbc6e3731d01102504850"
+    operation.document = .automaticallyPersisted(
+      operationIdentifier: "4d465fbc6e3731d01102504850",
+      definition: .init("query MockQuery {}"))
     
     let persistedQuery: JSONEncodableDictionary = [
       "version": 1,
@@ -120,7 +126,7 @@ query MockQuery($a: String, $b: Boolean!) {
     ]
     
     let body: JSONEncodableDictionary = [
-      "query": operation.queryDocument,
+      "query": operation.definition?.queryDocument,
       "extensions": extensions
     ]
     
@@ -141,7 +147,7 @@ query MockQuery($a: String, $b: Boolean!) {
     ]
 
     let body: JSONEncodableDictionary = [
-      "query": operation.queryDocument,
+      "query": operation.definition?.queryDocument,
       "extensions": extensions
     ]
 
@@ -162,7 +168,7 @@ query MockQuery($a: String, $b: Boolean!) {
     ]
 
     let body: JSONEncodableDictionary = [
-      "query": operation.queryDocument,
+      "query": operation.definition?.queryDocument,
       "extensions": extensions
     ]
 
@@ -177,7 +183,7 @@ query MockQuery($a: String, $b: Boolean!) {
   func test__createGetURL__queryWithPersistedQueryID_withoutQueryParameter_encodesURL() throws {
     let operation = MockOperation.mock()
     operation.operationName = "TestOpName"
-    operation.operationIdentifier = "4d465fbc6e3731d01102504850"
+    operation.document = .persistedOperationsOnly(operationIdentifier: "4d465fbc6e3731d01102504850")
     
     let persistedQuery: JSONEncodableDictionary = [
       "version": 1,
@@ -204,14 +210,15 @@ query MockQuery($a: String, $b: Boolean!) {
   func test__createGetURL__queryWithNullValueForVariable_encodesVariableWithNull() {
     let operation = MockOperation.mock()
     operation.operationName = "TestOpName"
-    operation.stubbedQueryDocument = """
-query MockQuery($param: String) {
-  testField(param: $param) {
-    __typename
-    name
-  }
-}
-"""
+    operation.document = .notPersisted(definition: .init(
+    """
+    query MockQuery($param: String) {
+      testField(param: $param) {
+        __typename
+        name
+      }
+    }
+    """))
     operation.variables = ["param": GraphQLNullable<String>.null]
 
     let body = requestBodyCreator.requestBody(for: operation,
@@ -235,7 +242,7 @@ query MockQuery($param: String) {
     ]
 
     let body: JSONEncodableDictionary = [
-      "query": operation.queryDocument,
+      "query": operation.definition?.queryDocument,
       "extensions": extensions
     ]
 

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -761,7 +761,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       override class var __typename: String { "MockChildObject" }
     }
 
-    class MockFragment: MockSelectionSet, Fragment {
+    class GivenFragment: MockFragment {
       override class var __parentType: ParentType { .Object(MockChildObject.self) }
       override class var selections: [Selection] {[
         .field("child", Child.self)
@@ -777,12 +777,12 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     class GivenSelectionSet: MockSelectionSet, HasFragments {
       override class var __parentType: ParentType { .Object(MockChildObject.self) }
       override class var selections: [Selection] {[
-        .fragment(MockFragment.self)
+        .fragment(GivenFragment.self)
       ]}
 
       struct Fragments: ResponseObject {
         let data: ResponseDict
-        var childFragment: MockFragment { _toFragment() }
+        var childFragment: GivenFragment { _toFragment() }
       }
     }
 
@@ -903,7 +903,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   func test__booleanCondition_include_fragment__givenVariableIsTrue_getsValuesForFragmentFields() throws {
     // given
-    class MockFragment: MockSelectionSet, Fragment {
+    class GivenFragment: MockFragment {
       override class var selections: [Selection] {[
         .field("name", String.self),
       ]}
@@ -912,7 +912,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     class GivenSelectionSet: MockSelectionSet {
       override class var selections: [Selection] {[
         .field("id", String.self),
-        .include(if: "variable", .fragment(MockFragment.self))
+        .include(if: "variable", .fragment(GivenFragment.self))
       ]}
     }
     let object: JSONObject = ["name": "Luke Skywalker", "id": "1234"]
@@ -928,7 +928,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   func test__booleanCondition_include_fragment__givenVariableIsFalse_doesNotGetValuesForFragmentFields() throws {
     // given
-    class MockFragment: MockSelectionSet, Fragment {
+    class GivenFragment: MockFragment {
       override class var selections: [Selection] {[
         .field("name", String.self),
       ]}
@@ -937,7 +937,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     class GivenSelectionSet: MockSelectionSet {
       override class var selections: [Selection] {[
         .field("id", String.self),
-        .include(if: "variable", .fragment(MockFragment.self))
+        .include(if: "variable", .fragment(GivenFragment.self))
       ]}
     }
     let object: JSONObject = ["name": "Luke Skywalker", "id": "1234"]
@@ -1109,7 +1109,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_typeCaseOnNamedFragment__givenVariableIsTrue_typeCaseMatchesParentType_getsValuesForTypeCaseFields() throws {
     // given
     class Person: Object {}
-    class MockFragment: MockSelectionSet, Fragment {
+    class GivenFragment: MockFragment {
       override class var selections: [Selection] {[
         .field("name", String.self),
       ]}
@@ -1124,7 +1124,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { .Object(Person.self)}
         override class var selections: [Selection] {[
-          .fragment(MockFragment.self),
+          .fragment(GivenFragment.self),
         ]}
       }
     }
@@ -1221,7 +1221,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   func test__booleanCondition_skip_singleField__givenVariableIsTrue_givenFieldIdSelectedByAnotherSelection_getsValueForField() throws {
     // given
-    class MockFragment: MockSelectionSet, Fragment {
+    class GivenFragment: MockFragment {
       override class var selections: [Selection] {[
         .field("name", String.self),
       ]}
@@ -1230,7 +1230,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     class GivenSelectionSet: MockSelectionSet {
       override class var selections: [Selection] {[
         .skip(if: "variable", .field("name", String.self)),
-        .fragment(MockFragment.self)
+        .fragment(GivenFragment.self)
       ]}
     }
     let object: JSONObject = ["name": "Luke Skywalker"]

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -18,8 +18,7 @@ class RequestBodyCreatorTests: XCTestCase {
     with creator: RequestBodyCreator,
     for operation: Operation
   ) -> JSONEncodableDictionary {
-    creator.requestBody(for: operation,
-                        sendOperationIdentifiers: false,
+    creator.requestBody(for: operation,                        
                         sendQueryDocument: true,
                         autoPersistQuery: false)
   }

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -30,7 +30,7 @@ class RequestBodyCreatorTests: XCTestCase {
     let operation = MockOperation.mock()
     operation.operationName = "Test Operation Name"
     operation.variables = ["TestVar": 123]
-    operation.stubbedQueryDocument = "Test Query Document"
+    operation.document = .notPersisted(definition: .init("Test Query Document"))
 
     let creator = ApolloRequestBodyCreator()
 

--- a/Tests/ApolloTests/TestCustomRequestBodyCreator.swift
+++ b/Tests/ApolloTests/TestCustomRequestBodyCreator.swift
@@ -15,7 +15,6 @@ struct TestCustomRequestBodyCreator: RequestBodyCreator {
 
   func requestBody<Operation: GraphQLOperation>(
     for operation: Operation,
-    sendOperationIdentifiers: Bool,
     sendQueryDocument: Bool, autoPersistQuery: Bool
   ) -> JSONEncodableDictionary {
     stubbedRequestBody

--- a/Tests/ApolloTests/UploadRequestTests.swift
+++ b/Tests/ApolloTests/UploadRequestTests.swift
@@ -56,7 +56,7 @@ class UploadRequestTests: XCTestCase {
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"id":"c5d5919f77d9ba16a9689b6b0ad4b781cb05dc1dc4812623bf80f7c044c09533","operationName":"UploadOneFile","query":"mutation UploadOneFile($file: Upload!) {\\n  singleUpload(file: $file) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"file":null}}
+{"operationName":"UploadOneFile","query":"mutation UploadOneFile($file: Upload!) {\\n  singleUpload(file: $file) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"file":null}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
@@ -104,7 +104,7 @@ Alpha file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"id":"88858c283bb72f18c0049dc85b140e72a4046f469fa16a8bf4bcf01c11d8a2b7","operationName":"UploadMultipleFilesToTheSameParameter","query":"mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {\\n  multipleUpload(files: $files) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"files":[null,null]}}
+{"operationName":"UploadMultipleFilesToTheSameParameter","query":"mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {\\n  multipleUpload(files: $files) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"files":[null,null]}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
@@ -166,7 +166,7 @@ Bravo file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"id":"1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5","operationName":"UploadMultipleFilesToDifferentParameters","query":"mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {\\n  multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"multipleFiles":["b.txt","c.txt"],\"secondField\":null,"singleFile":"a.txt","uploads\":null}}
+{"operationName":"UploadMultipleFilesToDifferentParameters","query":"mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {\\n  multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"multipleFiles":["b.txt","c.txt"],\"secondField\":null,"singleFile":"a.txt","uploads\":null}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 


### PR DESCRIPTION
I want use to allows for code gen to generate only the required data when using APQs.

Some users have expressed the desire to use only "allowlisted" operations and they don't want the code generation in that case to expose the entire query definition in the compiled binary. The query document was required before, now you can set it up to use different methods.