### PR TITLE
Update ApolloCodegenOptions to be compatible with default ApolloSchemaDownloadConfiguration output

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenOptions.swift
@@ -130,7 +130,7 @@ public struct ApolloCodegenOptions {
   public init(targetRootURL folder: URL,
               codegenEngine: CodeGenerationEngine = .default,
               downloadTimeout: Double = 30.0) {
-    let schema = folder.appendingPathComponent("schema.json")
+    let schema = folder.appendingPathComponent("schema.graphqls")
     
     let outputFileURL: URL
     switch codegenEngine {

--- a/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
@@ -27,5 +27,13 @@ class ApolloSchemaInternalTests: XCTestCase {
     let postType = try schema.getType(named: "Post")
     XCTAssertEqual(postType?.name, "Post")
   }
+
+  func testConfiguration_usingOnlyOutputFolders_shouldGenerateCompatibleFilenames() {
+    let downloadConfiguration = ApolloSchemaDownloadConfiguration(using: .introspection(endpointURL: TestURL.mockPort8080.url),
+                                                                  outputFolderURL: CodegenTestHelper.outputFolderURL())
+    let codegenOptions = ApolloCodegenOptions(targetRootURL: CodegenTestHelper.outputFolderURL())
+
+    XCTAssertEqual(downloadConfiguration.outputURL, codegenOptions.urlToSchemaFile)
+  }
 }
 


### PR DESCRIPTION
There was a mismatch in the SDL output filename and expected input schema filename - thanks for raising this @acoomans!