### PR TITLE
Disable CI on any `1.0` named branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,18 +200,46 @@ workflows:
     jobs:
       - Swift_Build:
           name: Build with SPM
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - IntegrationTests_macOS_current:
           name: Apollo Integration Tests macOS << pipeline.parameters.macos_version >>
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - macOS_current:
           name: Apollo macOS << pipeline.parameters.macos_version >>
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - iOS_current:
           name: Apollo iOS << pipeline.parameters.ios_current_version >>
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - iOS_previous:
           name: Apollo iOS << pipeline.parameters.ios_previous_version >>
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - tvOS_current:
           name: Apollo tvOS << pipeline.parameters.tvos_version >>
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - CodegenLib_macOS_current:
           name: Swift Code Generation
+          filters:
+            # Don't run this on any branch with "1.0" in the name (temporary!)
+            branches:
+              ignore: /.*1.0.*/
       - CocoaPodsTrunk:
           name: Push Podspec to CocoaPods Trunk
           requires:


### PR DESCRIPTION
**This is a temporary change** to stop skewing CI metrics until the `release/1.0-alpha-incubating` is in a state where tests are expected to pass; right now they are not.