### PR TITLE
docs: Replace 'data graph' with 'graph'

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
@@ -6,7 +6,7 @@ public struct ApolloSchemaDownloadConfiguration {
   /// How to attempt to download your schema
   public enum DownloadMethod: Equatable {
 
-    /// The Apollo Schema Registry, which serves as a central hub for managing your data graph.
+    /// The Apollo Schema Registry, which serves as a central hub for managing your graph.
     case apolloRegistry(_ settings: ApolloRegistrySettings)
     /// GraphQL Introspection connecting to the specified URL.
     case introspection(endpointURL: URL)

--- a/docs/source/api/ApolloCodegenLib/enums/ApolloSchemaDownloadConfiguration.DownloadMethod.md
+++ b/docs/source/api/ApolloCodegenLib/enums/ApolloSchemaDownloadConfiguration.DownloadMethod.md
@@ -15,7 +15,7 @@ How to attempt to download your schema
 case apolloRegistry(_ settings: ApolloRegistrySettings)
 ```
 
-The Apollo Schema Registry, which serves as a central hub for managing your data graph.
+The Apollo Schema Registry, which serves as a central hub for managing your graph.
 
 ### `introspection(endpointURL:)`
 


### PR DESCRIPTION
This branch replaces instances of 'data graph' in our docs with 'graph' to be more in line with the language that we use in our marketing these days.

cc @jchesterman
