### PR TITLE
Bail out of build scripts if a build is an index build

### DIFF
--- a/docs/shared/carthage-run-script-panel.mdx
+++ b/docs/shared/carthage-run-script-panel.mdx
@@ -13,6 +13,9 @@ The scripts and binaries which you need to generate code will be included in the
 Once everyone's on the same page about that, you should be able to use this build script:
 
 ```sh
+# Don't run this during index builds
+if [ $ACTION = "indexbuild" ]; then exit 0; fi
+
 SCRIPT_PATH="${SRCROOT}/Carthage/Checkouts/apollo-ios/scripts"
 cd "${SRCROOT}/${TARGET_NAME}"
 "${SCRIPT_PATH}"/run-bundled-codegen.sh codegen:generate --target=swift --includes=./**/*.graphql --localSchemaFile="schema.json" API.swift

--- a/docs/shared/pods-run-script-panel.mdx
+++ b/docs/shared/pods-run-script-panel.mdx
@@ -9,6 +9,9 @@ import {
 Our CocoaPods install includes the code-generation scripts and binaries of the `apollo` CLI client as files which will not be added to the framework, but which you can still call from a Run Script Build Phase. Add the following to the Run Script:
 
 ```sh
+# Don't run this during index builds
+if [ $ACTION = "indexbuild" ]; then exit 0; fi
+
 SCRIPT_PATH="${PODS_ROOT}/Apollo/scripts"
 cd "${SRCROOT}/${TARGET_NAME}"
 "${SCRIPT_PATH}"/run-bundled-codegen.sh codegen:generate --target=swift --includes=./**/*.graphql --localSchemaFile="schema.json" API.swift

--- a/docs/shared/spm-run-script-panel.mdx
+++ b/docs/shared/spm-run-script-panel.mdx
@@ -11,6 +11,9 @@ import {
 If you're using Xcode 11 or higher, SPM will check out the appropriate build script along with the rest of the files when it checks out the repo. Add the following to your Run Script build phase: 
 
 ```sh
+# Don't run this during index builds
+if [ $ACTION = "indexbuild" ]; then exit 0; fi
+
 # Go to the build root and search up the chain to find the Derived Data Path where the source packages are checked out.
 DERIVED_DATA_CANDIDATE="${BUILD_ROOT}"
 

--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -186,6 +186,9 @@ This is best achieved with a Run Script Build Phase.
 3. Update the build phase run script to `cd` into the folder where your executable's code lives, then run `swift run` (using `xcrun` so that you can ensure it runs with the correct SDK, no matter what type of project you're building): 
 
     ```
+    # Don't run this during index builds
+    if [ $ACTION = "indexbuild" ]; then exit 0; fi
+
     cd "${SRCROOT}"/ApolloCodegen
     xcrun -sdk macosx swift run ApolloCodegen generate
     ```


### PR DESCRIPTION
Should help significantly with #1921. Huge thanks to @filipe-lemos for [sharing this](https://github.com/apollographql/apollo-ios/issues/1921#issuecomment-940041368).