### PR TITLE
CachePolicy.default as a stored property

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -15,9 +15,7 @@ public enum CachePolicy {
   case returnCacheDataAndFetch
   
   /// The current default cache policy.
-  public static var `default`: CachePolicy {
-    .returnCacheDataElseFetch
-  }
+  public static var `default`: CachePolicy = .returnCacheDataElseFetch
 }
 
 /// A handler for operation results.


### PR DESCRIPTION
Changed CachePolicy.default to be a stored static property, so that users can customize the default policy.