### PR TITLE
Remove unnecessary assertion failure 

### DIFF
--- a/Sources/Apollo/DispatchQueue+Optional.swift
+++ b/Sources/Apollo/DispatchQueue+Optional.swift
@@ -27,7 +27,7 @@ public extension ApolloExtension where Base == DispatchQueue {
         action(result)
       }
     } else if case .failure(let error) = result {
-      assertionFailure("Encountered failure result, but no completion handler was defined to handle it: \(error)")
+      debugPrint("Apollo: Encountered failure result, but no completion handler was defined to handle it: \(error)")
     }
   }
 }


### PR DESCRIPTION
Addresses #2004.

After consulting with @martijnwalraven it seems like leaving this in as a `debugPrint` will help with the original purpose of this line, which is to provide some information about an unhandled failure, without causing assertions in debug mode when `nil` has been _purposely_ passed in. 