### PR TITLE
Expose `cacheKey` function as `public`

### DIFF
--- a/Sources/Apollo/GraphQLSelectionSet.swift
+++ b/Sources/Apollo/GraphQLSelectionSet.swift
@@ -61,7 +61,7 @@ public struct GraphQLField: GraphQLSelection {
     self.type = type
   }
 
-  func cacheKey(with variables: [String: JSONEncodable]?) throws -> String {
+  public func cacheKey(with variables: [String: JSONEncodable]?) throws -> String {
     if
       let argumentValues = try arguments?.evaluate(with: variables),
       argumentValues.apollo.isNotEmpty {

--- a/Tests/ApolloTests/CacheKeyForFieldTests.swift
+++ b/Tests/ApolloTests/CacheKeyForFieldTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Apollo
+import Apollo
 import ApolloTestSupport
 import StarWarsAPI
 


### PR DESCRIPTION
This changes the access modifier of the `GraphQLField.cacheKey` function from `internal` to `public`. 

The [caveat](https://github.com/apollographql/apollo-ios/issues/1972#issuecomment-941540807) to this change is:
> For the 1.0 release, I'd like to consider if there is a better way to expose cache keys that is safer and more stable, but since we are rewriting a large piece of the execution layer there, exposing this in the 0.x version for now seems fine.

Closes #1972 