### PR TITLE
Update SQLite.swift to version 13.0

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.subspec 'SQLite' do |ss|
     ss.source_files = 'Sources/ApolloSQLite/*.swift'
     ss.dependency 'Apollo/Core'
-    ss.dependency 'SQLite.swift', '~>0.12.2'
+    ss.dependency 'SQLite.swift', '~>0.13.0'
   end
 
   # Websocket and subscription support based on Starscream

--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.subspec 'SQLite' do |ss|
     ss.source_files = 'Sources/ApolloSQLite/*.swift'
     ss.dependency 'Apollo/Core'
-    ss.dependency 'SQLite.swift', '~>0.13.0'
+    ss.dependency 'SQLite.swift', '~>0.13.1'
   end
 
   # Websocket and subscription support based on Starscream

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -3429,7 +3429,7 @@
 			repositoryURL = "https://github.com/stephencelis/SQLite.swift.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.13.0;
+				minimumVersion = 0.13.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -3429,7 +3429,7 @@
 			repositoryURL = "https://github.com/stephencelis/SQLite.swift.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.12.2;
+				minimumVersion = 0.13.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
-          "version": "0.12.2"
+          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
+          "version": "0.13.0"
         }
       }
     ]

--- a/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Apollo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
-          "version": "0.13.0"
+          "revision": "60a65015f6402b7c34b9a924f755ca0a73afeeaa",
+          "version": "0.13.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
-          "version": "0.12.2"
-        }
-      },
-      {
-        "package": "Starscream",
-        "repositoryURL": "https://github.com/apollographql/Starscream",
-        "state": {
-          "branch": null,
-          "revision": "8cf77babe5901693396436f4f418a6db0f328b78",
-          "version": "3.1.2"
+          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
+          "version": "0.13.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
-          "version": "0.13.0"
+          "revision": "60a65015f6402b7c34b9a924f755ca0a73afeeaa",
+          "version": "0.13.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/stephencelis/SQLite.swift.git",
-      .upToNextMinor(from: "0.13.0"))
+      .upToNextMinor(from: "0.13.1"))
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/stephencelis/SQLite.swift.git",
-      .upToNextMinor(from: "0.12.2"))    
+      .upToNextMinor(from: "0.13.0"))
   ],
   targets: [
     .target(

--- a/SwiftScripts/Package.resolved
+++ b/SwiftScripts/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
-          "version": "0.13.0"
+          "revision": "60a65015f6402b7c34b9a924f755ca0a73afeeaa",
+          "version": "0.13.1"
         }
       },
       {

--- a/SwiftScripts/Package.resolved
+++ b/SwiftScripts/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
-          "version": "0.12.2"
+          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
+          "version": "0.13.0"
         }
       },
       {


### PR DESCRIPTION
## Overview

This PR: 
- Updates the version of SQLite being used in Apollo-iOS to version 13.0 

### What do we get by upgrading to version 13.0?

The release notes for version 13.0 aren't super descriptive (`Support for Xcode 12 and iOS 14 + fixes`) but version 13.0 includes new table functionality for SQLite.swift, such as `upsert` and `insertMany`.

I know that y'all are planning on [switching out SQLite.swift](https://github.com/apollographql/apollo-ios/issues/1658) for GRDB or FMDB, but this a small quality of life improvement for those of us who are also using `SQLite.swift` in our application which depend upon Apollo. 


### What should we test?

Everything... should be the same? The diff between versions is [fairly small](https://github.com/stephencelis/SQLite.swift/compare/0.12.2...0.13.0) and concerns around `next()` and `failableNext()` [don't seem to impact Apollo](https://github.com/stephencelis/SQLite.swift/blob/master/Sources/SQLite/Typed/Query.swift#L984-L990) since we're using [`map`](https://github.com/apollographql/apollo-ios/blob/0.47.1/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift#L39) and not `next()` or `failableNext()` directly. 

