### PR TITLE
Attempted fix for integration test failing on CI

### DIFF
--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -55,7 +55,7 @@ public class WebSocketTransport {
 
   private var subscribers = [String: (Result<JSONObject, Error>) -> Void]()
   private var subscriptions : [String: String] = [:]
-  private let processingQueue = DispatchQueue(label: "com.apollographql.WebSocketTransport")
+  let processingQueue = DispatchQueue(label: "com.apollographql.WebSocketTransport")
 
   private let sendOperationIdentifiers: Bool
   private let reconnectionInterval: TimeInterval

--- a/Tests/ApolloServerIntegrationTests/StarWarsSubscriptionTests.swift
+++ b/Tests/ApolloServerIntegrationTests/StarWarsSubscriptionTests.swift
@@ -334,9 +334,9 @@ class StarWarsSubscriptionTests: XCTestCase {
     // dispatched with a barrier flag to make sure
     // this is performed after subscription calls
     concurrentQueue.sync(flags: .barrier) {
-      // dispatched on the processing queue to make sure
+      // dispatched on the processing queue with barrier flag to make sure
       // this is performed after subscribers are processed
-      self.webSocketTransport.websocket.callbackQueue.async {
+      self.webSocketTransport.processingQueue.async(flags: .barrier) {
         _ = self.client.perform(mutation: CreateReviewForEpisodeMutation(episode: .empire, review: ReviewInput(stars: 5, commentary: "The greatest movie ever!")))
       }
     }


### PR DESCRIPTION
The integration test for `testConcurrentSubscribing()` has been failing intermittently on CI. I can't tell for certain what's causing it, because it seems to be a race condition and I can't reproduce it locally.

My current hypothesis is that the mutation is sometimes being performed before the subscribers are actually subscribed. The barrier on the `concurrentQueue` guarantees that we've called `subscribe`, but not that the subscription has been added, which happens async on the `processingQueue`.  The test comment even said "dispatched on processing queue", but it wasn't. It was dispatched on the websocket's callback queue.