### PR TITLE
Update apollo-tooling to v2.33.9

### DIFF
--- a/Sources/ApolloCodegenLib/CLIDownloader.swift
+++ b/Sources/ApolloCodegenLib/CLIDownloader.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Helper for downloading the CLI Zip file so we don't have to include it in the repo.
 struct CLIDownloader {
   /// The URL string for getting the current version of the CLI
-  static let downloadURLString = "https://install.apollographql.com/legacy-cli/darwin/2.33.6"
+  static let downloadURLString = "https://install.apollographql.com/legacy-cli/darwin/2.33.9"
   
   /// Downloads the appropriate Apollo CLI in a zip file.
   ///

--- a/Sources/ApolloCodegenLib/CLIExtractor.swift
+++ b/Sources/ApolloCodegenLib/CLIExtractor.swift
@@ -25,7 +25,7 @@ struct CLIExtractor {
     }
   }
   
-  static let expectedSHASUM = "496b4de6a4a1f5a1c4a093c8d2378054ebf0dc19361a7dad847f82feeccad2be"
+  static let expectedSHASUM = "cb73089deb2a720a7d2f5a39ad449e1cfbdc22771130cd6e2a405aaa887c343e"
   
   /// Checks to see if the CLI has already been extracted and is the correct version, and extracts or re-extracts as necessary
   ///

--- a/Sources/StarWarsAPI/API.swift
+++ b/Sources/StarWarsAPI/API.swift
@@ -1333,6 +1333,7 @@ public final class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
           ...CharacterName
         }
         ... on Droid {
+          __typename
           friends {
             __typename
             ...CharacterName
@@ -1344,7 +1345,7 @@ public final class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
 
   public let operationName: String = "HeroAndFriendsNamesWithFragmentTwice"
 
-  public let operationIdentifier: String? = "e02ef22e116ad1ca35f0298ed3badb60eeb986203f0088575a5f137768c322fc"
+  public let operationIdentifier: String? = "b5f4eca712a136f0d5d9f96203ef7d03cd119d8388f093f4b78ae124acb904cb"
 
   public var queryDocument: String {
     var document: String = operationDefinition
@@ -1527,6 +1528,7 @@ public final class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("friends", type: .list(.object(Friend.selections))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("friends", type: .list(.object(Friend.selections))),
           ]
         }
@@ -2288,6 +2290,7 @@ public final class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
       hero {
         __typename
         ... @include(if: $includeDetails) {
+          __typename
           name
           appearsIn
         }
@@ -2297,7 +2300,7 @@ public final class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
 
   public let operationName: String = "HeroDetailsInlineConditionalInclusion"
 
-  public let operationIdentifier: String? = "fcd9d7acb4e7c97e3ae5ad3cbf4e83556626149de589f0c2fce2f8ede31b0d90"
+  public let operationIdentifier: String? = "3091d9d3f1d2374e2f835ce05d332e50b3fe61502d73213b9aa511f0f94f091c"
 
   public var includeDetails: Bool
 
@@ -2344,6 +2347,7 @@ public final class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
         return [
           GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
           GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
             GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
           ]),
@@ -2410,7 +2414,7 @@ public final class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
 
   public let operationName: String = "HeroDetailsFragmentConditionalInclusion"
 
-  public let operationIdentifier: String? = "b31aec7d977249e185922e4cc90318fd2c7197631470904bf937b0626de54b4f"
+  public let operationIdentifier: String? = "b0fa7927ff93b4a579c3460fb04d093072d34c8018e41197c7e080aeeec5e19b"
 
   public var queryDocument: String {
     var document: String = operationDefinition
@@ -2559,6 +2563,7 @@ public final class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("height", type: .scalar(Double.self)),
             ]),
           ]
@@ -2656,6 +2661,7 @@ public final class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("primaryFunction", type: .scalar(String.self)),
             ]),
           ]
@@ -2739,6 +2745,7 @@ public final class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
         __typename
         name @include(if: $includeName)
         ... on Droid {
+          __typename
           name
         }
       }
@@ -2747,7 +2754,7 @@ public final class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
 
   public let operationName: String = "HeroNameTypeSpecificConditionalInclusion"
 
-  public let operationIdentifier: String? = "4d465fbc6e3731d011025048502f16278307d73300ea9329a709d7e2b6815e40"
+  public let operationIdentifier: String? = "76aecc75265295818d3990000b17e32d5524ca85a4bc159ae8a3f8ec7ce91cc3"
 
   public var episode: Episode?
   public var includeName: Bool
@@ -2859,6 +2866,7 @@ public final class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
             GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
             ]),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
           ]
         }
@@ -2907,6 +2915,7 @@ public final class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
           __typename
           name
           ... on Droid {
+            __typename
             primaryFunction
           }
         }
@@ -2916,7 +2925,7 @@ public final class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
 
   public let operationName: String = "HeroFriendsDetailsConditionalInclusion"
 
-  public let operationIdentifier: String? = "9bdfeee789c1d22123402a9c3e3edefeb66799b3436289751be8f47905e3babd"
+  public let operationIdentifier: String? = "8cada231691ff2f5a0a07c54b7332114588f11b947795da345c5b054211fbcfd"
 
   public var includeFriendsDetails: Bool
 
@@ -3067,6 +3076,7 @@ public final class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
             return [
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("name", type: .nonNull(.scalar(String.self))),
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("primaryFunction", type: .scalar(String.self)),
             ]
           }
@@ -3130,6 +3140,7 @@ public final class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: 
           __typename
           name
           ... on Droid {
+            __typename
             primaryFunction
           }
         }
@@ -3139,7 +3150,7 @@ public final class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: 
 
   public let operationName: String = "HeroFriendsDetailsUnconditionalAndConditionalInclusion"
 
-  public let operationIdentifier: String? = "501fcb710e5ffeeab2c65b7935fbded394ffea92e7b5dd904d05d5deab6f39c6"
+  public let operationIdentifier: String? = "65381a20574db4b458a0821328252deb0da1a107f9ab77c99fb2467e66a5f12d"
 
   public var includeFriendsDetails: Bool
 
@@ -3302,6 +3313,7 @@ public final class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: 
               GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
                 GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("primaryFunction", type: .scalar(String.self)),
               ]),
             ]
@@ -3360,9 +3372,11 @@ public final class HeroDetailsQuery: GraphQLQuery {
         __typename
         name
         ... on Human {
+          __typename
           height
         }
         ... on Droid {
+          __typename
           primaryFunction
         }
       }
@@ -3371,7 +3385,7 @@ public final class HeroDetailsQuery: GraphQLQuery {
 
   public let operationName: String = "HeroDetails"
 
-  public let operationIdentifier: String? = "2b67111fd3a1c6b2ac7d1ef7764e5cefa41d3f4218e1d60cb67c22feafbd43ec"
+  public let operationIdentifier: String? = "207d29944f5822bff08a07db4a55274ea14035bacfe20699da41a47454f1181e"
 
   public var episode: Episode?
 
@@ -3477,6 +3491,7 @@ public final class HeroDetailsQuery: GraphQLQuery {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("height", type: .scalar(Double.self)),
           ]
         }
@@ -3539,6 +3554,7 @@ public final class HeroDetailsQuery: GraphQLQuery {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("primaryFunction", type: .scalar(String.self)),
           ]
         }
@@ -3600,7 +3616,7 @@ public final class HeroDetailsWithFragmentQuery: GraphQLQuery {
 
   public let operationName: String = "HeroDetailsWithFragment"
 
-  public let operationIdentifier: String? = "d20fa2f460058b8eec3d227f2f6088a708cf35dfa2b5ebf1414e34f9674ecfce"
+  public let operationIdentifier: String? = "b55bd9d56d1b5972345412b6adb88ceb64d6086c8051d2588d8ab701f0ee7c2f"
 
   public var queryDocument: String {
     var document: String = operationDefinition
@@ -3742,6 +3758,7 @@ public final class HeroDetailsWithFragmentQuery: GraphQLQuery {
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("height", type: .scalar(Double.self)),
           ]
         }
@@ -3833,6 +3850,7 @@ public final class HeroDetailsWithFragmentQuery: GraphQLQuery {
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("primaryFunction", type: .scalar(String.self)),
           ]
         }
@@ -5084,19 +5102,23 @@ public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         __typename
         name
         ... on Human {
+          __typename
           friends {
             __typename
             name
             ... on Human {
+              __typename
               height(unit: FOOT)
             }
           }
         }
         ... on Droid {
+          __typename
           friends {
             __typename
             name
             ... on Human {
+              __typename
               height(unit: METER)
             }
           }
@@ -5107,7 +5129,7 @@ public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
 
   public let operationName: String = "HeroParentTypeDependentField"
 
-  public let operationIdentifier: String? = "561e22ac4da5209f254779b70e01557fb2fc57916b9914088429ec809e166cad"
+  public let operationIdentifier: String? = "39eb41b5a9477c36fa529c23d6f0de6ebcc0312daf5bdcfe208d5baec752dc5b"
 
   public var episode: Episode?
 
@@ -5213,6 +5235,7 @@ public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("friends", type: .list(.object(Friend.selections))),
           ]
         }
@@ -5322,6 +5345,7 @@ public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               return [
                 GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("height", arguments: ["unit": "FOOT"], type: .scalar(Double.self)),
               ]
             }
@@ -5386,6 +5410,7 @@ public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("friends", type: .list(.object(Friend.selections))),
           ]
         }
@@ -5495,6 +5520,7 @@ public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               return [
                 GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("height", arguments: ["unit": "METER"], type: .scalar(Double.self)),
               ]
             }
@@ -5552,9 +5578,11 @@ public final class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
       hero(episode: $episode) {
         __typename
         ... on Human {
+          __typename
           property: homePlanet
         }
         ... on Droid {
+          __typename
           property: primaryFunction
         }
       }
@@ -5563,7 +5591,7 @@ public final class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
 
   public let operationName: String = "HeroTypeDependentAliasedField"
 
-  public let operationIdentifier: String? = "b5838c22bac1c5626023dac4412ca9b86bebfe16608991fb632a37c44e12811e"
+  public let operationIdentifier: String? = "eac5a52f9020fc2e9b5dc5facfd6a6295683b8d57ea62ee84254069fcd5e504c"
 
   public var episode: Episode?
 
@@ -5657,6 +5685,7 @@ public final class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("homePlanet", alias: "property", type: .scalar(String.self)),
           ]
         }
@@ -5707,6 +5736,7 @@ public final class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
 
         public static var selections: [GraphQLSelection] {
           return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("primaryFunction", alias: "property", type: .scalar(String.self)),
           ]
@@ -5904,14 +5934,17 @@ public final class SearchQuery: GraphQLQuery {
       search(text: $term) {
         __typename
         ... on Human {
+          __typename
           id
           name
         }
         ... on Droid {
+          __typename
           id
           name
         }
         ... on Starship {
+          __typename
           id
           name
         }
@@ -5921,7 +5954,7 @@ public final class SearchQuery: GraphQLQuery {
 
   public let operationName: String = "Search"
 
-  public let operationIdentifier: String? = "73536da2eec4d83e6e1003e674cb2299d9da2798f7bd310e57339a6bcd713b77"
+  public let operationIdentifier: String? = "477b77c476899915498a56ae7bb835667b1e875cb94f6daa7f75e05018be2c3a"
 
   public var term: String?
 
@@ -6019,6 +6052,7 @@ public final class SearchQuery: GraphQLQuery {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
           ]
@@ -6081,6 +6115,7 @@ public final class SearchQuery: GraphQLQuery {
         public static var selections: [GraphQLSelection] {
           return [
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
           ]
@@ -6142,6 +6177,7 @@ public final class SearchQuery: GraphQLQuery {
 
         public static var selections: [GraphQLSelection] {
           return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
             GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
             GraphQLField("name", type: .nonNull(.scalar(String.self))),
@@ -7091,6 +7127,7 @@ public struct CharacterNameAndDroidAppearsIn: GraphQLFragment {
       __typename
       name
       ... on Droid {
+        __typename
         appearsIn
       }
     }
@@ -7161,6 +7198,7 @@ public struct CharacterNameAndDroidAppearsIn: GraphQLFragment {
       return [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
       ]
     }
@@ -7553,12 +7591,14 @@ public struct CharacterNameWithInlineFragment: GraphQLFragment {
     fragment CharacterNameWithInlineFragment on Character {
       __typename
       ... on Human {
+        __typename
         friends {
           __typename
           appearsIn
         }
       }
       ... on Droid {
+        __typename
         ...CharacterName
         ...FriendsNames
       }
@@ -7617,6 +7657,7 @@ public struct CharacterNameWithInlineFragment: GraphQLFragment {
 
     public static var selections: [GraphQLSelection] {
       return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("friends", type: .list(.object(Friend.selections))),
       ]
@@ -7712,6 +7753,7 @@ public struct CharacterNameWithInlineFragment: GraphQLFragment {
 
     public static var selections: [GraphQLSelection] {
       return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
@@ -8001,9 +8043,11 @@ public struct HeroDetails: GraphQLFragment {
       __typename
       name
       ... on Human {
+        __typename
         height
       }
       ... on Droid {
+        __typename
         primaryFunction
       }
     }
@@ -8074,6 +8118,7 @@ public struct HeroDetails: GraphQLFragment {
       return [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("height", type: .scalar(Double.self)),
       ]
     }
@@ -8136,6 +8181,7 @@ public struct HeroDetails: GraphQLFragment {
       return [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("primaryFunction", type: .scalar(String.self)),
       ]
     }

--- a/Sources/StarWarsAPI/graphql/operationIDs.json
+++ b/Sources/StarWarsAPI/graphql/operationIDs.json
@@ -31,9 +31,9 @@
     "name": "HeroAndFriendsNamesWithFragment",
     "source": "query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ...FriendsNames\n  }\n}\nfragment FriendsNames on Character {\n  __typename\n  friends {\n    __typename\n    name\n  }\n}"
   },
-  "e02ef22e116ad1ca35f0298ed3badb60eeb986203f0088575a5f137768c322fc": {
+  "b5f4eca712a136f0d5d9f96203ef7d03cd119d8388f093f4b78ae124acb904cb": {
     "name": "HeroAndFriendsNamesWithFragmentTwice",
-    "source": "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      ...CharacterName\n    }\n    ... on Droid {\n      friends {\n        __typename\n        ...CharacterName\n      }\n    }\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
+    "source": "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      ...CharacterName\n    }\n    ... on Droid {\n      __typename\n      friends {\n        __typename\n        ...CharacterName\n      }\n    }\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
   },
   "22d772c0fc813281705e8f0a55fc70e71eeff6e98f3f9ef96cf67fb896914522": {
     "name": "HeroAppearsIn",
@@ -59,33 +59,33 @@
     "name": "HeroNameConditionalBothSeparate",
     "source": "query HeroNameConditionalBothSeparate($skipName: Boolean!, $includeName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName)\n    name @include(if: $includeName)\n  }\n}"
   },
-  "fcd9d7acb4e7c97e3ae5ad3cbf4e83556626149de589f0c2fce2f8ede31b0d90": {
+  "3091d9d3f1d2374e2f835ce05d332e50b3fe61502d73213b9aa511f0f94f091c": {
     "name": "HeroDetailsInlineConditionalInclusion",
-    "source": "query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ... @include(if: $includeDetails) {\n      name\n      appearsIn\n    }\n  }\n}"
+    "source": "query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ... @include(if: $includeDetails) {\n      __typename\n      name\n      appearsIn\n    }\n  }\n}"
   },
-  "b31aec7d977249e185922e4cc90318fd2c7197631470904bf937b0626de54b4f": {
+  "b0fa7927ff93b4a579c3460fb04d093072d34c8018e41197c7e080aeeec5e19b": {
     "name": "HeroDetailsFragmentConditionalInclusion",
-    "source": "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ...HeroDetails @include(if: $includeDetails)\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    height\n  }\n  ... on Droid {\n    primaryFunction\n  }\n}"
+    "source": "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ...HeroDetails @include(if: $includeDetails)\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    __typename\n    height\n  }\n  ... on Droid {\n    __typename\n    primaryFunction\n  }\n}"
   },
-  "4d465fbc6e3731d011025048502f16278307d73300ea9329a709d7e2b6815e40": {
+  "76aecc75265295818d3990000b17e32d5524ca85a4bc159ae8a3f8ec7ce91cc3": {
     "name": "HeroNameTypeSpecificConditionalInclusion",
-    "source": "query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n    ... on Droid {\n      name\n    }\n  }\n}"
+    "source": "query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n    ... on Droid {\n      __typename\n      name\n    }\n  }\n}"
   },
-  "9bdfeee789c1d22123402a9c3e3edefeb66799b3436289751be8f47905e3babd": {
+  "8cada231691ff2f5a0a07c54b7332114588f11b947795da345c5b054211fbcfd": {
     "name": "HeroFriendsDetailsConditionalInclusion",
-    "source": "query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        primaryFunction\n      }\n    }\n  }\n}"
+    "source": "query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        __typename\n        primaryFunction\n      }\n    }\n  }\n}"
   },
-  "501fcb710e5ffeeab2c65b7935fbded394ffea92e7b5dd904d05d5deab6f39c6": {
+  "65381a20574db4b458a0821328252deb0da1a107f9ab77c99fb2467e66a5f12d": {
     "name": "HeroFriendsDetailsUnconditionalAndConditionalInclusion",
-    "source": "query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends {\n      __typename\n      name\n    }\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        primaryFunction\n      }\n    }\n  }\n}"
+    "source": "query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends {\n      __typename\n      name\n    }\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        __typename\n        primaryFunction\n      }\n    }\n  }\n}"
   },
-  "2b67111fd3a1c6b2ac7d1ef7764e5cefa41d3f4218e1d60cb67c22feafbd43ec": {
+  "207d29944f5822bff08a07db4a55274ea14035bacfe20699da41a47454f1181e": {
     "name": "HeroDetails",
-    "source": "query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      height\n    }\n    ... on Droid {\n      primaryFunction\n    }\n  }\n}"
+    "source": "query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n    }\n  }\n}"
   },
-  "d20fa2f460058b8eec3d227f2f6088a708cf35dfa2b5ebf1414e34f9674ecfce": {
+  "b55bd9d56d1b5972345412b6adb88ceb64d6086c8051d2588d8ab701f0ee7c2f": {
     "name": "HeroDetailsWithFragment",
-    "source": "query HeroDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...HeroDetails\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    height\n  }\n  ... on Droid {\n    primaryFunction\n  }\n}"
+    "source": "query HeroDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...HeroDetails\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    __typename\n    height\n  }\n  ... on Droid {\n    __typename\n    primaryFunction\n  }\n}"
   },
   "7277e97563e911ac8f5c91d401028d218aae41f38df014d7fa0b037bb2a2e739": {
     "name": "DroidDetailsWithFragment",
@@ -119,21 +119,21 @@
     "name": "HeroNameAndAppearsInWithFragment",
     "source": "query HeroNameAndAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterNameAndAppearsIn\n  }\n}\nfragment CharacterNameAndAppearsIn on Character {\n  __typename\n  name\n  appearsIn\n}"
   },
-  "561e22ac4da5209f254779b70e01557fb2fc57916b9914088429ec809e166cad": {
+  "39eb41b5a9477c36fa529c23d6f0de6ebcc0312daf5bdcfe208d5baec752dc5b": {
     "name": "HeroParentTypeDependentField",
-    "source": "query HeroParentTypeDependentField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      friends {\n        __typename\n        name\n        ... on Human {\n          height(unit: FOOT)\n        }\n      }\n    }\n    ... on Droid {\n      friends {\n        __typename\n        name\n        ... on Human {\n          height(unit: METER)\n        }\n      }\n    }\n  }\n}"
+    "source": "query HeroParentTypeDependentField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      __typename\n      friends {\n        __typename\n        name\n        ... on Human {\n          __typename\n          height(unit: FOOT)\n        }\n      }\n    }\n    ... on Droid {\n      __typename\n      friends {\n        __typename\n        name\n        ... on Human {\n          __typename\n          height(unit: METER)\n        }\n      }\n    }\n  }\n}"
   },
-  "b5838c22bac1c5626023dac4412ca9b86bebfe16608991fb632a37c44e12811e": {
+  "eac5a52f9020fc2e9b5dc5facfd6a6295683b8d57ea62ee84254069fcd5e504c": {
     "name": "HeroTypeDependentAliasedField",
-    "source": "query HeroTypeDependentAliasedField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ... on Human {\n      property: homePlanet\n    }\n    ... on Droid {\n      property: primaryFunction\n    }\n  }\n}"
+    "source": "query HeroTypeDependentAliasedField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ... on Human {\n      __typename\n      property: homePlanet\n    }\n    ... on Droid {\n      __typename\n      property: primaryFunction\n    }\n  }\n}"
   },
   "2a8ad85a703add7d64622aaf6be76b58a1134caf28e4ff6b34dd00ba89541364": {
     "name": "SameHeroTwice",
     "source": "query SameHeroTwice {\n  hero {\n    __typename\n    name\n  }\n  r2: hero {\n    __typename\n    appearsIn\n  }\n}"
   },
-  "73536da2eec4d83e6e1003e674cb2299d9da2798f7bd310e57339a6bcd713b77": {
+  "477b77c476899915498a56ae7bb835667b1e875cb94f6daa7f75e05018be2c3a": {
     "name": "Search",
-    "source": "query Search($term: String) {\n  search(text: $term) {\n    __typename\n    ... on Human {\n      id\n      name\n    }\n    ... on Droid {\n      id\n      name\n    }\n    ... on Starship {\n      id\n      name\n    }\n  }\n}"
+    "source": "query Search($term: String) {\n  search(text: $term) {\n    __typename\n    ... on Human {\n      __typename\n      id\n      name\n    }\n    ... on Droid {\n      __typename\n      id\n      name\n    }\n    ... on Starship {\n      __typename\n      id\n      name\n    }\n  }\n}"
   },
   "a3734516185da9919e3e66d74fe92b60d65292a1943dc54913f7332637dfdd2a": {
     "name": "Starship",

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -54,7 +54,7 @@ class GETTransformerTests: XCTestCase {
     
     // Here, we know that everything should be encoded in a stable order,
     // and we can check the encoded URL string directly.
-    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroNameTypeSpecificConditionalInclusion&query=query%20HeroNameTypeSpecificConditionalInclusion($episode:%20Episode,%20$includeName:%20Boolean!)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%20@include(if:%20$includeName)%0A%20%20%20%20...%20on%20Droid%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22JEDI%22,%22includeName%22:true%7D")
+    XCTAssertEqual(url?.absoluteString,"http://localhost:8080/graphql?operationName=HeroNameTypeSpecificConditionalInclusion&query=query%20HeroNameTypeSpecificConditionalInclusion($episode:%20Episode,%20$includeName:%20Boolean!)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%20@include(if:%20$includeName)%0A%20%20%20%20...%20on%20Droid%20%7B%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22JEDI%22,%22includeName%22:true%7D")
   }
   
   func testEncodingQueryWith2DParameter() throws {

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -54,7 +54,7 @@ class GETTransformerTests: XCTestCase {
     
     // Here, we know that everything should be encoded in a stable order,
     // and we can check the encoded URL string directly.
-    XCTAssertEqual(url?.absoluteString,"http://localhost:8080/graphql?operationName=HeroNameTypeSpecificConditionalInclusion&query=query%20HeroNameTypeSpecificConditionalInclusion($episode:%20Episode,%20$includeName:%20Boolean!)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%20@include(if:%20$includeName)%0A%20%20%20%20...%20on%20Droid%20%7B%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22JEDI%22,%22includeName%22:true%7D")
+    XCTAssertEqual(url?.absoluteString, "http://localhost:8080/graphql?operationName=HeroNameTypeSpecificConditionalInclusion&query=query%20HeroNameTypeSpecificConditionalInclusion($episode:%20Episode,%20$includeName:%20Boolean!)%20%7B%0A%20%20hero(episode:%20$episode)%20%7B%0A%20%20%20%20__typename%0A%20%20%20%20name%20@include(if:%20$includeName)%0A%20%20%20%20...%20on%20Droid%20%7B%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22episode%22:%22JEDI%22,%22includeName%22:true%7D")
   }
   
   func testEncodingQueryWith2DParameter() throws {

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 # Get the SHASUM of the tarball
 ZIP_FILE="${SCRIPT_DIR}/apollo.tar.gz"
-ZIP_FILE_DOWNLOAD_URL="https://install.apollographql.com/legacy-cli/darwin/2.33.6"
+ZIP_FILE_DOWNLOAD_URL="https://install.apollographql.com/legacy-cli/darwin/2.33.9"
 SHASUM_FILE="${SCRIPT_DIR}/apollo/.shasum"
 APOLLO_DIR="${SCRIPT_DIR}"/apollo
 IS_RETRY="false"
@@ -58,7 +58,7 @@ extract_cli() {
 
 validate_codegen_and_extract_if_needed() {
   # Make sure the SHASUM matches the release for this version
-  EXPECTED_SHASUM="496b4de6a4a1f5a1c4a093c8d2378054ebf0dc19361a7dad847f82feeccad2be"
+  EXPECTED_SHASUM="cb73089deb2a720a7d2f5a39ad449e1cfbdc22771130cd6e2a405aaa887c343e"
   update_shasum
 
   if [[ ${SHASUM} = ${EXPECTED_SHASUM}* ]]; then


### PR DESCRIPTION
The apollo-tooling v2.33.9 [update](https://github.com/apollographql/apollo-tooling/blob/master/CHANGELOG.md#apollo2339) changes the placement of `__typename` fields in queries to match the expected output from the `client:push` command. Customers that are safelisting/whitelisting queries will need this update for iOS clients to successfully execute queries.

Closes #2027 