### PR TITLE
Workaround: Add option to use Homebrew's ARM64 node binary for Apple Silicon users

### DIFF
--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -99,12 +99,12 @@ download_apollo_cli_if_needed
 # Make sure we're using an up-to-date and valid version of the Apollo CLI
 validate_codegen_and_extract_if_needed
 
+# Add the binary directory to the beginning of PATH so included binary verson of node is used.
+ PATH="${SCRIPT_DIR}/apollo/bin:${PATH}"
+
 # Give Apple Silicon users the option to install & use an ARM-based binary of node through Homebrew
 if [[ `uname -m` == 'arm64' ]]; then
-  PATH="/opt/homebrew/bin:${SCRIPT_DIR}/apollo/bin:${PATH}"
-else
-  # Add the binary directory to the beginning of PATH so included binary verson of node is used.
-  PATH="${SCRIPT_DIR}/apollo/bin:${PATH}"
+  PATH="/opt/homebrew/bin:${PATH}
 fi
 
 # Use the bundled executable of the Apollo CLI to generate code

--- a/scripts/run-bundled-codegen.sh
+++ b/scripts/run-bundled-codegen.sh
@@ -99,8 +99,13 @@ download_apollo_cli_if_needed
 # Make sure we're using an up-to-date and valid version of the Apollo CLI
 validate_codegen_and_extract_if_needed
 
-# Add the binary directory to the beginning of PATH so included binary verson of node is used.
-PATH="${SCRIPT_DIR}/apollo/bin:${PATH}"
+# Give Apple Silicon users the option to install & use an ARM-based binary of node through Homebrew
+if [[ `uname -m` == 'arm64' ]]; then
+  PATH="/opt/homebrew/bin:${SCRIPT_DIR}/apollo/bin:${PATH}"
+else
+  # Add the binary directory to the beginning of PATH so included binary verson of node is used.
+  PATH="${SCRIPT_DIR}/apollo/bin:${PATH}"
+fi
 
 # Use the bundled executable of the Apollo CLI to generate code
 APOLLO_CLI="${SCRIPT_DIR}/apollo/bin/run"


### PR DESCRIPTION
In context of the discussions held about [issue #1611](https://github.com/apollographql/apollo-ios/issues/1611) , this workaround will allow Apple Silicon users to make use of Homebrew's ARM64 `node` binary without changing anything about the current workings of the system.