### PR TITLE
Implements a glob path builder

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -292,6 +292,8 @@
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
 		E6630B8C26F0639B002D9E41 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB926EC05290094434A /* MockNetworkSession.swift */; };
 		E6630B8E26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */; };
+		E674DB41274C0A9B009BB90E /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB40274C0A9B009BB90E /* Glob.swift */; };
+		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */; };
@@ -938,6 +940,8 @@
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
+		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
+		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDownloaderTests.swift; sourceTree = "<group>"; };
@@ -1395,6 +1399,7 @@
 				9B8C3FB4248DA3E000707B13 /* URLExtensionsTests.swift */,
 				9BAEEC0C234BB95B00808306 /* Info.plist */,
 				E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */,
+				E674DB42274C0AD9009BB90E /* GlobTests.swift */,
 			);
 			path = ApolloCodegenTests;
 			sourceTree = "<group>";
@@ -1469,6 +1474,7 @@
 			children = (
 				9B7B6F57233C287100F32205 /* ApolloCodegen.swift */,
 				9B7B6F58233C287100F32205 /* ApolloCodegenConfiguration.swift */,
+				E674DB40274C0A9B009BB90E /* Glob.swift */,
 			);
 			name = Codegen;
 			sourceTree = "<group>";
@@ -2811,6 +2817,7 @@
 				9F1A966D258F34BB00A06EEB /* CompilationResult.swift in Sources */,
 				DE223C3527223E2A004A0148 /* CompilationResult+SelectionSetMerging.swift in Sources */,
 				9B7B6F69233C2C0C00F32205 /* FileManager+Apollo.swift in Sources */,
+				E674DB41274C0A9B009BB90E /* Glob.swift in Sources */,
 				9F1A966C258F34BB00A06EEB /* GraphQLSchema.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,
@@ -2856,6 +2863,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BAEEC10234BB95B00808306 /* FileManagerExtensionsTests.swift in Sources */,
+				E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */,
 				DE223C1C271F3288004A0148 /* AnimalKingdomASTCreationTests.swift in Sources */,
 				9BAEEC17234C275600808306 /* ApolloSchemaPublicTests.swift in Sources */,
 				9F62DFAE2590557F00E6E808 /* DocumentParsingAndValidationTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -28,8 +28,8 @@ struct Glob {
     self.pattern = pattern
   }
 
-  func paths() throws -> [String] {
     var paths: [String] = []
+  func match() throws -> [String] {
 
     let patterns = pattern.includesGlobstar ? expandGlobstar(pattern) : [pattern]
     for pattern in patterns {

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Glob {
+  public let pattern: String
+
+  init(_ pattern: String) {
+    self.pattern = pattern
+  }
+}

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -8,10 +8,14 @@ private extension String {
   }
 }
 
+/// A path pattern matcher.
 struct Glob {
+  /// The pattern to match paths for.
   let pattern: String
+
   private let flags = GLOB_ERR | GLOB_MARK | GLOB_BRACE | GLOB_TILDE
 
+  /// An error object that indicates why pattern matching failed.
   public enum Error: Swift.Error, LocalizedError {
     case noSpace // GLOB_NOSPACE
     case aborted // GLOB_ABORTED
@@ -28,10 +32,17 @@ struct Glob {
     }
   }
 
+  /// The designated initializer
+  ///
+  /// - Parameters:
+  ///  - pattern: The pattern to match paths for.
   init(_ pattern: String) {
     self.pattern = pattern
   }
 
+  /// Executes the pattern match on the underlying file system.
+  ///
+  /// - Returns: A set of matched file paths.
   func match() throws -> Set<String> {
     var paths: Set<String> = []
 
@@ -71,6 +82,9 @@ struct Glob {
 
   #warning("TODO - should we support negation in globstar with braces?") // something like "{a/**/*,!a/b/c/*}
 
+  /// Expands the globstar (`**`) to find all directory paths to search for the match pattern.
+  ///
+  /// - Returns: A set of directory file paths expanded with the match pattern.
   func expandGlobstar() throws -> Set<String> {
     guard pattern.contains("**") else { return [pattern] }
 

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -3,7 +3,48 @@ import Foundation
 struct Glob {
   public let pattern: String
 
+  enum Error: Swift.Error, LocalizedError {
+    case noSpace // GLOB_NOSPACE
+    case aborted // GLOB_ABORTED
+    case unknown(code: Int)
+
+    var errorDescription: String? {
+      switch self {
+      case .noSpace: return "Malloc call failed"
+      case .aborted: return "Unignored error"
+      case .unknown(let code): return "Unknown error: \(code)"
+      }
+    }
+  }
+
   init(_ pattern: String) {
     self.pattern = pattern
+  }
+
+  public func paths() throws -> [String] {
+    var globT = glob_t()
+
+    defer {
+      globfree(&globT)
+    }
+
+    let flags = GLOB_ERR | GLOB_MARK | GLOB_BRACE | GLOB_TILDE
+    let response = glob(pattern, flags, nil, &globT)
+
+    switch response {
+    case 0: break // SUCCESS
+    case GLOB_NOMATCH: return []
+    case GLOB_NOSPACE: throw Error.noSpace
+    case GLOB_ABORTED: throw Error.aborted
+    default: throw Error.unknown(code: Int(response))
+    }
+
+    return (0..<Int(globT.gl_matchc)).compactMap { index in
+      if let path = String(validatingUTF8: globT.gl_pathv[index]!) {
+        return path
+      }
+
+      return nil
+    }
   }
 }

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -28,21 +28,21 @@ struct Glob {
     self.pattern = pattern
   }
 
-    var paths: [String] = []
   func match() throws -> [String] {
+    var paths: Set<String> = []
 
     let patterns = pattern.includesGlobstar ? expandGlobstar(pattern) : [pattern]
     for pattern in patterns {
       paths.append(contentsOf: try matches(for: pattern))
     }
 
-    return paths
   }
 
   func expandGlobstar(_ pattern: String) -> [String] {
     guard pattern.contains("**") else { return [pattern] }
 
     return []
+    return Array(paths)
   }
 
   private func matches(for pattern: String) throws -> [String] {

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -45,6 +45,11 @@ class GlobTests: XCTestCase {
     ).to(beTrue())
 
     expect(
+      // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path)
+    ).to(beTrue())
+
+    expect(
       // <outputFolder>/Glob/other/file.one
       try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.one").path)
     ).to(beTrue())
@@ -169,5 +174,82 @@ class GlobTests: XCTestCase {
       baseURL.appendingPathComponent("a/file.one").path
     ]))
   }
+
+  func test_expandGlobstar_givenRootGlobstar_shouldExpandAllDirectoriesWithPattern() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("**/*.one").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+    // <outputFolder>/Glob/a/file.one
+    // <outputFolder>/Glob/a/b/file.one
+    // <outputFolder>/Glob/a/b/c/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).expandGlobstar).to(equal([
+      baseURL.path.appending("/*.one"),
+      baseURL.appendingPathComponent("a/*.one").path,
+      baseURL.appendingPathComponent("a/b/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/*.one").path,
+      baseURL.appendingPathComponent("other/*.one").path
+    ]))
+  }
+
+  func test_expandGlobstar_givenPathGlobstar_shouldExpandSubdirectoriesWithPattern() {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/**/*.one").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+    // <outputFolder>/Glob/a/file.one
+    // <outputFolder>/Glob/a/b/file.one
+    // <outputFolder>/Glob/a/b/c/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).expandGlobstar).to(equal([
+      baseURL.appendingPathComponent("a/*.one").path,
+      baseURL.appendingPathComponent("a/b/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/*.one").path
+    ]))
+  }
+
+  func test_paths_givenRootGlobstar_whenSubdirectoryMatches_shouldReturnAllMatches() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("**/*.two").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+    // <outputFolder>/Glob/a/file.one
+    // <outputFolder>/Glob/a/b/file.one
+    // <outputFolder>/Glob/a/b/c/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ]))
+  }
+
   #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+import Nimble
+import ApolloCodegenLib
+
+class GlobTests: XCTestCase {
+  
+}

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -14,50 +14,21 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/
     try fileManager.createDirectoryIfNeeded(atPath: baseURL.path)
 
-    expect(
-      // <outputFolder>/Glob/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.one").path)
-    ).to(beTrue())
+    let files = [
+      self.baseURL.appendingPathComponent("file.one").path, // <outputFolder>/Glob/file.one
+      self.baseURL.appendingPathComponent("file.two").path, // <outputFolder>/Glob/file.two
+      self.baseURL.appendingPathComponent("a/file.one").path, // <outputFolder>/Glob/a/file.one
+      self.baseURL.appendingPathComponent("a/b/file.one").path, // <outputFolder>/Glob/a/b/file.one
+      self.baseURL.appendingPathComponent("a/b/c/file.one").path, // <outputFolder>/Glob/a/b/c/file.one
+      self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path, // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+      self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path, // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+      self.baseURL.appendingPathComponent("other/file.one").path, // <outputFolder>/Glob/other/file.one
+      self.baseURL.appendingPathComponent("other/file.oye").path // <outputFolder>/Glob/other/file.oye
+    ]
 
-    expect(
-      // <outputFolder>/Glob/file.two
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.two").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/c/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/c/d/e/f/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/c/d/e/f/file.two
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/other/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/other/file.oye
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.oye").path)
-    ).to(beTrue())
+    for file in files {
+      expect(try fileManager.createFile(atPath: file)).to(beTrue())
+    }
   }
 
   override func tearDownWithError() throws {
@@ -250,6 +221,4 @@ class GlobTests: XCTestCase {
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
     ]))
   }
-
-  #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -70,7 +70,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(beEmpty())
+    expect(Glob(pattern).match).to(beEmpty())
   }
 
   func test_paths_givenSingleMatch_whenMultipleFiles_shouldReturnSingle() throws {
@@ -82,7 +82,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(1))
+    expect(Glob(pattern).match).to(haveCount(1))
   }
 
   func test_paths_givenMultipleMatches_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -94,7 +94,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(2))
+    expect(Glob(pattern).match).to(haveCount(2))
   }
 
   func test_paths_givenMultipleMatchBraces_whenSingleFile_shouldReturnSingle() throws {
@@ -104,7 +104,7 @@ class GlobTests: XCTestCase {
     // when
     // <outputFolder>/Glob/a/file.one
 
-    expect(Glob(pattern).paths).to(haveCount(1))
+    expect(Glob(pattern).match).to(haveCount(1))
   }
 
   func test_paths_givenMultipleMatchBraces_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -116,7 +116,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(2))
+    expect(Glob(pattern).match).to(haveCount(2))
   }
 
   func test_paths_givenMultipleMatchBraces_withNegation_whenMultipleFiles_shouldReturnSingle() throws {
@@ -128,7 +128,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(1))
+    expect(Glob(pattern).match).to(haveCount(1))
   }
 
   func test_paths_givenMultipleMatches_withWildcardCharacter_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -140,7 +140,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/other/file.oye
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(2))
+    expect(Glob(pattern).match).to(haveCount(2))
   }
 
   #warning("TODO - memory leak test")

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -82,7 +82,9 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path
+    ]))
   }
 
   func test_paths_givenMultipleMatches_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -94,7 +96,10 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(2))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ]))
   }
 
   func test_paths_givenMultipleMatchBraces_whenSingleFile_shouldReturnSingle() throws {
@@ -104,7 +109,9 @@ class GlobTests: XCTestCase {
     // when
     // <outputFolder>/Glob/a/file.one
 
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("a/file.one").path
+    ]))
   }
 
   func test_paths_givenMultipleMatchBraces_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -116,7 +123,10 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(2))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ]))
   }
 
   func test_paths_givenMultipleMatchBraces_withNegation_whenMultipleFiles_shouldReturnSingle() throws {
@@ -128,7 +138,9 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path
+    ]))
   }
 
   func test_paths_givenMultipleMatches_withWildcardCharacter_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -140,7 +152,10 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/other/file.oye
 
     // then
-    expect(Glob(pattern).match).to(haveCount(2))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ]))
   }
 
   func test_paths_givenDuplicateMatches_whenMatches_shouldNotReturnDuplicates() throws {
@@ -150,7 +165,9 @@ class GlobTests: XCTestCase {
     // when
     // <outputFolder>/Glob/a/file.one
 
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("a/file.one").path
+    ]))
   }
   #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -143,5 +143,14 @@ class GlobTests: XCTestCase {
     expect(Glob(pattern).match).to(haveCount(2))
   }
 
+  func test_paths_givenDuplicateMatches_whenMatches_shouldNotReturnDuplicates() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/{*.one,*.one}").path
+
+    // when
+    // <outputFolder>/Glob/a/file.one
+
+    expect(Glob(pattern).match).to(haveCount(1))
+  }
   #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -1,7 +1,147 @@
 import XCTest
 import Nimble
-import ApolloCodegenLib
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
 
 class GlobTests: XCTestCase {
-  
+  let baseURL = CodegenTestHelper.outputFolderURL().appendingPathComponent("Glob")
+
+  // MARK: Setup
+
+  override func setUpWithError() throws {
+    let fileManager = FileManager.default.apollo
+
+    // <outputFolder>/Glob/
+    try fileManager.createDirectoryIfNeeded(atPath: baseURL.path)
+
+    expect(
+      // <outputFolder>/Glob/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/file.two
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.two").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/b/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/b/c/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/other/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/other/file.oye
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.oye").path)
+    ).to(beTrue())
+  }
+
+  override func tearDownWithError() throws {
+    try FileManager.default.apollo.deleteDirectory(atPath: baseURL.path)
+  }
+
+  // MARK: Tests
+
+  func test_paths_givenNoMatch_whenMultipleFiles_shouldReturnEmpty() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("*.xyz").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(beEmpty())
+  }
+
+  func test_paths_givenSingleMatch_whenMultipleFiles_shouldReturnSingle() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("*.one").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(1))
+  }
+
+  func test_paths_givenMultipleMatches_whenMultipleFiles_shouldReturnMultiple() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("file.*").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(2))
+  }
+
+  func test_paths_givenMultipleMatchBraces_whenSingleFile_shouldReturnSingle() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/{*.one,*.two}").path
+
+    // when
+    // <outputFolder>/Glob/a/file.one
+
+    expect(Glob(pattern).paths).to(haveCount(1))
+  }
+
+  func test_paths_givenMultipleMatchBraces_whenMultipleFiles_shouldReturnMultiple() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("{*.one,*.two}").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(2))
+  }
+
+  func test_paths_givenMultipleMatchBraces_withNegation_whenMultipleFiles_shouldReturnSingle() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("{*.one,!*.two}").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(1))
+  }
+
+  func test_paths_givenMultipleMatches_withWildcardCharacter_whenMultipleFiles_shouldReturnMultiple() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("other/file.o?e").path
+
+    // when
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(2))
+  }
+
+  #warning("TODO - memory leak test")
 }


### PR DESCRIPTION
This is a path pattern matcher that will be used to ingest the glob pattern from `ApolloCodegenConfiguration.FileInput.glob` and output a set of matched file paths.

* There is no standard implementation for globstar (`**`) support, it is custom logic.
* It uses the underlying system function [glob](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/glob.3.html) to perform the actual file path matching. glob in turn uses [fnmatch](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fnmatch.3.html) pattern definitions.

| Pattern | Meaning |
| -- | -- |
| * | matches everything |
| ? | matches any single character |
| [seq] | matches any character in seq |
| [!seq] | matches any character not in seq |
| ** | searches all subdirectories for the path pattern |

Closes #2030.