### PR TITLE
Implements a glob path builder

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -292,6 +292,8 @@
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
 		E6630B8C26F0639B002D9E41 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB926EC05290094434A /* MockNetworkSession.swift */; };
 		E6630B8E26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */; };
+		E674DB41274C0A9B009BB90E /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB40274C0A9B009BB90E /* Glob.swift */; };
+		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */; };
@@ -938,6 +940,8 @@
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
+		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
+		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDownloaderTests.swift; sourceTree = "<group>"; };
@@ -1395,6 +1399,7 @@
 				9B8C3FB4248DA3E000707B13 /* URLExtensionsTests.swift */,
 				9BAEEC0C234BB95B00808306 /* Info.plist */,
 				E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */,
+				E674DB42274C0AD9009BB90E /* GlobTests.swift */,
 			);
 			path = ApolloCodegenTests;
 			sourceTree = "<group>";
@@ -1469,6 +1474,7 @@
 			children = (
 				9B7B6F57233C287100F32205 /* ApolloCodegen.swift */,
 				9B7B6F58233C287100F32205 /* ApolloCodegenConfiguration.swift */,
+				E674DB40274C0A9B009BB90E /* Glob.swift */,
 			);
 			name = Codegen;
 			sourceTree = "<group>";
@@ -2811,6 +2817,7 @@
 				9F1A966D258F34BB00A06EEB /* CompilationResult.swift in Sources */,
 				DE223C3527223E2A004A0148 /* CompilationResult+SelectionSetMerging.swift in Sources */,
 				9B7B6F69233C2C0C00F32205 /* FileManager+Apollo.swift in Sources */,
+				E674DB41274C0A9B009BB90E /* Glob.swift in Sources */,
 				9F1A966C258F34BB00A06EEB /* GraphQLSchema.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,
@@ -2856,6 +2863,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BAEEC10234BB95B00808306 /* FileManagerExtensionsTests.swift in Sources */,
+				E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */,
 				DE223C1C271F3288004A0148 /* AnimalKingdomASTCreationTests.swift in Sources */,
 				9BAEEC17234C275600808306 /* ApolloSchemaPublicTests.swift in Sources */,
 				9F62DFAE2590557F00E6E808 /* DocumentParsingAndValidationTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -13,7 +13,7 @@ public struct ApolloCodegenConfiguration {
     /// - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
     /// - `?` matches any single character, eg: `file-?.graphql`
     /// - `**` matches all subdirectories (deep), eg: `**/*.graphql`
-    /// - `!` excludes any match, eg: `*.graphql,!file.graphql`
+    /// - `!` excludes any match only if the pattern starts with a `!` character, eg: `!file.graphql`
     public let includes: [String]
 
     /// Designated initializer.
@@ -25,7 +25,7 @@ public struct ApolloCodegenConfiguration {
     ///     - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
     ///     - `?` matches any single character, eg: `file-?.graphql`
     ///     - `**` matches all subdirectories (deep), eg: `**/*.graphql`
-    ///     - `!` excludes any match, eg: `*.graphql,!file.graphql`
+    ///     - `!` excludes any match only if the pattern starts with a `!` character, eg: `!file.graphql`
     public init(schemaPath: String, includes: [String]) {
       self.schemaPath = schemaPath
       self.includes = includes

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -13,9 +13,12 @@ public struct ApolloCodegenConfiguration {
     ///
     /// - Parameters:
     ///  - schemaPath: Local path to the GraphQL schema file. Can be in JSON or SDL format.
-    ///  - glob: Glob of files to search for GraphQL operations. This should be used to find queries and any client
-    ///  schema extensions. Defaults to `./**/*.graphql`, which will search for `.graphql` files throughout all subfolders of
-    ///  the folder where the script is run.
+    ///  - glob: Glob pattern used to search for GraphQL operations, such as queries and mutations. The pattern accepts a
+    ///  number of special characters:
+    ///      - `*` matches everything but the directory separator, eg: `*.graphql`
+    ///      - `?` matches any single character, eg: `file-?.graphql`
+    ///      - `{,}` matches all patterns separated by a comma, eg: `{query.*,operation.*}`
+    ///      - `**` matches all subdirectories, eg: `**/*.graphql`
     public init(schemaPath: String, glob: String = "./**/*.graphql") {
       self.schemaPath = schemaPath
       self.glob = glob

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -9,9 +9,10 @@ public struct ApolloCodegenConfiguration {
     /// A comma-delimited string of path matching patterns to search for GraphQL operations, such as queries and mutations.
     /// 
     /// Each path matching pattern can include the following characters:
-    /// - `*` matches 0 or more characters in a single path portion, eg: `*.graphql`
-    /// - `?` matches 1 character, eg: `file-?.graphql`
-    /// - `**` matches zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+    /// - `*` matches zero or more characters in a single path portion, eg: `*.graphql`
+    /// - `?` matches one character in a single path portion, eg: `file-?.graphql`
+    /// - `**` includes zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+    /// - `!` excludes any match, eg: `a/*.graphql,!a/file.graphql`
     public let includes: String
 
     /// Designated initializer.
@@ -20,9 +21,10 @@ public struct ApolloCodegenConfiguration {
     ///  - schemaPath: Local path to the GraphQL schema file. Can be in JSON or SDL format.
     ///  - includes: A comma-delimited string of path matching patterns to search for GraphQL operations, such as queries and
     ///  mutations. Each path matching pattern can include the following characters:
-    ///     - `*` matches 0 or more characters in a single path portion, eg: `*.graphql`
-    ///     - `?` matches 1 character, eg: `file-?.graphql`
-    ///     - `**` matches zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+    ///     - `*` matches zero or more characters in a single path portion, eg: `*.graphql`
+    ///     - `?` matches one character in a single path portion, eg: `file-?.graphql`
+    ///     - `**` includes zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+    ///     - `!` excludes any match, eg: `a/*.graphql,!a/file.graphql`
     public init(schemaPath: String, includes: String) {
       self.schemaPath = schemaPath
       self.includes = includes

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -15,13 +15,13 @@ public struct ApolloCodegenConfiguration {
     /// - `?` matches any single character, eg: `file-?.graphql`
     /// - `**` matches all subdirectories (deep), eg: `**/*.graphql`
     /// - `!` excludes any match only if the pattern starts with a `!` character, eg: `!file.graphql`
-    public let includes: [String]
+    public let searchPaths: [String]
 
     /// Designated initializer.
     ///
     /// - Parameters:
     ///  - schemaPath: Local path to the GraphQL schema file. Can be in JSON or SDL format.
-    ///  - includes: An array of path matching pattern strings used to find files, such as GraphQL operations (queries, mutations,
+    ///  - searchPaths: An array of path matching pattern strings used to find files, such as GraphQL operations (queries, mutations,
     ///  etc.), included for code generation. You can use absolute or relative paths for the path portion of the pattern. Relative paths
     ///  will be based off the current working directory from `FileManager`. Each path matching pattern can include the following
     ///  characters:
@@ -29,9 +29,9 @@ public struct ApolloCodegenConfiguration {
     ///     - `?` matches any single character, eg: `file-?.graphql`
     ///     - `**` matches all subdirectories (deep), eg: `**/*.graphql`
     ///     - `!` excludes any match only if the pattern starts with a `!` character, eg: `!file.graphql`
-    public init(schemaPath: String, includes: [String]) {
+    public init(schemaPath: String, searchPaths: [String]) {
       self.schemaPath = schemaPath
-      self.includes = includes
+      self.searchPaths = searchPaths
     }
   }
 
@@ -196,12 +196,12 @@ public struct ApolloCodegenConfiguration {
   public init(
     basePath: String,
     schemaFilename: String = "schema.graphqls",
-    includesPattern: String = "**/*.graphql"
+    searchPattern: String = "**/*.graphql"
   ) {
     let schemaURL = URL(fileURLWithPath: basePath).appendingPathComponent(schemaFilename)
-    let includesURL = URL(fileURLWithPath: basePath).appendingPathComponent(includesPattern)
+    let searchURL = URL(fileURLWithPath: basePath).appendingPathComponent(searchPattern)
 
-    self.init(input: FileInput(schemaPath: schemaURL.path, includes: [includesURL.path]),
+    self.init(input: FileInput(schemaPath: schemaURL.path, searchPaths: [searchURL.path]),
               output: FileOutput(schemaTypes: SchemaTypesFileOutput(path: basePath)))
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -6,22 +6,26 @@ public struct ApolloCodegenConfiguration {
   public struct FileInput {
     /// Local path to the GraphQL schema file. Can be in JSON or SDL format.
     public let schemaPath: String
-    /// Glob of files to search for GraphQL operations. This should be used to find queries and any client schema extensions.
-    public let glob: String
+    /// A comma-delimited string of path matching patterns to search for GraphQL operations, such as queries and mutations.
+    /// 
+    /// Each path matching pattern can include the following characters:
+    /// - `*` matches 0 or more characters in a single path portion, eg: `*.graphql`
+    /// - `?` matches 1 character, eg: `file-?.graphql`
+    /// - `**` matches zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+    public let includes: String
 
     /// Designated initializer.
     ///
     /// - Parameters:
     ///  - schemaPath: Local path to the GraphQL schema file. Can be in JSON or SDL format.
-    ///  - glob: Glob pattern used to search for GraphQL operations, such as queries and mutations. The pattern accepts a
-    ///  number of special characters:
-    ///      - `*` matches everything but the directory separator, eg: `*.graphql`
-    ///      - `?` matches any single character, eg: `file-?.graphql`
-    ///      - `{,}` matches all patterns separated by a comma, eg: `{query.*,operation.*}`
-    ///      - `**` matches all subdirectories, eg: `**/*.graphql`
-    public init(schemaPath: String, glob: String = "./**/*.graphql") {
+    ///  - includes: A comma-delimited string of path matching patterns to search for GraphQL operations, such as queries and
+    ///  mutations. Each path matching pattern can include the following characters:
+    ///     - `*` matches 0 or more characters in a single path portion, eg: `*.graphql`
+    ///     - `?` matches 1 character, eg: `file-?.graphql`
+    ///     - `**` matches zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+    public init(schemaPath: String, includes: String) {
       self.schemaPath = schemaPath
-      self.glob = glob
+      self.includes = includes
     }
   }
 
@@ -179,11 +183,18 @@ public struct ApolloCodegenConfiguration {
   /// Convenience initializer with all paths extended from a supplied base path.
   ///
   /// - Parameters:
-  ///  - basePath:
-  public init(basePath: String, schemaFilename: String = "schema.graphqls") {
+  ///  - basePath: The base path used to find the schema and operation files.
+  ///  - schemaFilename: The filename of the GraphQL schema. This will be combined with `basePath`.
+  ///  - includesPattern: The pattern used to match operation files. This will be combined with `basePath`.
+  public init(
+    basePath: String,
+    schemaFilename: String = "schema.graphqls",
+    includesPattern: String = "**/*.graphql"
+  ) {
     let schemaURL = URL(fileURLWithPath: basePath).appendingPathComponent(schemaFilename)
+    let includesURL = URL(fileURLWithPath: basePath).appendingPathComponent(includesPattern)
 
-    self.init(input: FileInput(schemaPath: schemaURL.path),
+    self.init(input: FileInput(schemaPath: schemaURL.path, includes: includesURL.path),
               output: FileOutput(schemaTypes: SchemaTypesFileOutput(path: basePath)))
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -6,8 +6,9 @@ public struct ApolloCodegenConfiguration {
   public struct FileInput {
     /// Local path to the GraphQL schema file. Can be in JSON or SDL format.
     public let schemaPath: String
-    /// An array of path matching pattern strings. This is used to find files, such as GraphQL operations (queries, mutations, etc.),
-    /// included for code generation.
+    /// An array of path matching pattern strings used to find files, such as GraphQL operations (queries, mutations, etc.), to be
+    /// included for code generation. You can use absolute or relative paths for the path portion of the pattern. Relative paths will be
+    /// based off the current working directory from `FileManager`.
     /// 
     /// Each path matching pattern can include the following characters:
     /// - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
@@ -20,8 +21,10 @@ public struct ApolloCodegenConfiguration {
     ///
     /// - Parameters:
     ///  - schemaPath: Local path to the GraphQL schema file. Can be in JSON or SDL format.
-    ///  - includes: An array of path matching pattern strings. This is used to find files, such as GraphQL operations (queries,
-    ///  mutations, etc.), included for code generation. Each path matching pattern can include the following characters:
+    ///  - includes: An array of path matching pattern strings used to find files, such as GraphQL operations (queries, mutations,
+    ///  etc.), included for code generation. You can use absolute or relative paths for the path portion of the pattern. Relative paths
+    ///  will be based off the current working directory from `FileManager`. Each path matching pattern can include the following
+    ///  characters:
     ///     - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
     ///     - `?` matches any single character, eg: `file-?.graphql`
     ///     - `**` matches all subdirectories (deep), eg: `**/*.graphql`

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -6,26 +6,27 @@ public struct ApolloCodegenConfiguration {
   public struct FileInput {
     /// Local path to the GraphQL schema file. Can be in JSON or SDL format.
     public let schemaPath: String
-    /// A comma-delimited string of path matching patterns to search for GraphQL operations, such as queries and mutations.
+    /// An array of path matching pattern strings. This is used to find files, such as GraphQL operations (queries, mutations, etc.),
+    /// included for code generation.
     /// 
     /// Each path matching pattern can include the following characters:
-    /// - `*` matches zero or more characters in a single path portion, eg: `*.graphql`
-    /// - `?` matches one character in a single path portion, eg: `file-?.graphql`
-    /// - `**` includes zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
-    /// - `!` excludes any match, eg: `a/*.graphql,!a/file.graphql`
-    public let includes: String
+    /// - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
+    /// - `?` matches any single character, eg: `file-?.graphql`
+    /// - `**` matches all subdirectories (deep), eg: `**/*.graphql`
+    /// - `!` excludes any match, eg: `*.graphql,!file.graphql`
+    public let includes: [String]
 
     /// Designated initializer.
     ///
     /// - Parameters:
     ///  - schemaPath: Local path to the GraphQL schema file. Can be in JSON or SDL format.
-    ///  - includes: A comma-delimited string of path matching patterns to search for GraphQL operations, such as queries and
-    ///  mutations. Each path matching pattern can include the following characters:
-    ///     - `*` matches zero or more characters in a single path portion, eg: `*.graphql`
-    ///     - `?` matches one character in a single path portion, eg: `file-?.graphql`
-    ///     - `**` includes zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
-    ///     - `!` excludes any match, eg: `a/*.graphql,!a/file.graphql`
-    public init(schemaPath: String, includes: String) {
+    ///  - includes: An array of path matching pattern strings. This is used to find files, such as GraphQL operations (queries,
+    ///  mutations, etc.), included for code generation. Each path matching pattern can include the following characters:
+    ///     - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
+    ///     - `?` matches any single character, eg: `file-?.graphql`
+    ///     - `**` matches all subdirectories (deep), eg: `**/*.graphql`
+    ///     - `!` excludes any match, eg: `*.graphql,!file.graphql`
+    public init(schemaPath: String, includes: [String]) {
       self.schemaPath = schemaPath
       self.includes = includes
     }
@@ -187,7 +188,8 @@ public struct ApolloCodegenConfiguration {
   /// - Parameters:
   ///  - basePath: The base path used to find the schema and operation files.
   ///  - schemaFilename: The filename of the GraphQL schema. This will be combined with `basePath`.
-  ///  - includesPattern: The pattern used to match operation files. This will be combined with `basePath`.
+  ///  - includesPattern: The pattern used to match operation files. This should be a relative path to `basePath`. If you want
+  ///  to use absolute paths or multiple patterns please use the designated initializer instead.
   public init(
     basePath: String,
     schemaFilename: String = "schema.graphqls",
@@ -196,7 +198,7 @@ public struct ApolloCodegenConfiguration {
     let schemaURL = URL(fileURLWithPath: basePath).appendingPathComponent(schemaFilename)
     let includesURL = URL(fileURLWithPath: basePath).appendingPathComponent(includesPattern)
 
-    self.init(input: FileInput(schemaPath: schemaURL.path, includes: includesURL.path),
+    self.init(input: FileInput(schemaPath: schemaURL.path, includes: [includesURL.path]),
               output: FileOutput(schemaTypes: SchemaTypesFileOutput(path: basePath)))
   }
 }

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -28,8 +28,8 @@ struct Glob {
     self.pattern = pattern
   }
 
-  func paths() throws -> [String] {
     var paths: [String] = []
+  func match() throws -> [String] {
 
     let patterns = pattern.includesGlobstar ? expandGlobstar(pattern) : [pattern]
     for pattern in patterns {

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -9,24 +9,28 @@ private extension String {
 }
 
 /// A path pattern matcher.
-struct Glob {
-  /// The pattern to match paths for.
+public struct Glob {
   let pattern: String
 
-  private let flags = GLOB_ERR | GLOB_MARK | GLOB_BRACE | GLOB_TILDE
+  // GLOB_ERR - Return on error
+  // GLOB_MARK - Append / to matching directories
+  // GLOB_NOSORT - Don't sort
+  // GLOB_BRACE - Expand braces ala csh
+  // GLOB_TILDE - Expand tilde names from the passwd file
+  private let flags = GLOB_ERR | GLOB_MARK | GLOB_NOSORT | GLOB_BRACE | GLOB_TILDE
 
   /// An error object that indicates why pattern matching failed.
-  public enum Error: Swift.Error, LocalizedError {
+  public enum MatchError: Error, LocalizedError {
     case noSpace // GLOB_NOSPACE
     case aborted // GLOB_ABORTED
-    case enumeration(path: String)
+    case cannotEnumerate(path: String)
     case unknown(code: Int)
 
     public var errorDescription: String? {
       switch self {
       case .noSpace: return "Malloc call failed" // From Darwin.POSIX.glob
       case .aborted: return "Unignored error" // From Darwin.POSIX.glob
-      case .enumeration(let path): return "Cannot enumerate \(path)"
+      case .cannotEnumerate(let path): return "Cannot enumerate \(path)"
       case .unknown(let code): return "Unknown error: \(code)"
       }
     }
@@ -35,7 +39,13 @@ struct Glob {
   /// The designated initializer
   ///
   /// - Parameters:
-  ///  - pattern: The pattern to match paths for.
+  ///  - pattern: A comma-delimited string of path matching patterns.
+  ///
+  /// Each path matching pattern can include the following characters:
+  /// - `*` matches zero or more characters in a single path portion, eg: `*.graphql`
+  /// - `?` matches one character in a single path portion, eg: `file-?.graphql`
+  /// - `**` includes zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
+  /// - `!` excludes any match, eg: `a/*.graphql,!a/file.graphql`
   init(_ pattern: String) {
     self.pattern = pattern
   }
@@ -44,48 +54,41 @@ struct Glob {
   ///
   /// - Returns: A set of matched file paths.
   func match() throws -> Set<String> {
-    var paths: Set<String> = []
+    let paths: Set<String> = try expand(self.pattern)
 
-    let patterns: Set<String> = pattern.includesGlobstar ? try expandGlobstar() : [pattern]
-    for pattern in patterns {
-      paths = paths.union(try matches(for: pattern))
+    var matches: Set<String> = []
+    for path in paths {
+      matches.formUnion(try self.matches(for: path))
+    }
+
+    return matches
+  }
+
+  /// Separates a comma-delimited string into paths, expanding any globstars, removing duplicates and negated path patterns.
+  private func expand(_ pattern: String) throws -> Set<String> {
+    // The ordered nature of an array is important here because we process negatives (!) in the
+    // order which they appear in the pattern.
+    let components: [String] = pattern.components(separatedBy: ",").compactMap({
+      let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    })
+
+    var paths: Set<String> = []
+    for item in components {
+      let expanded: Set<String> = item.includesGlobstar ? try expandGlobstar(item) : [item]
+
+      if item.first == "!" {
+        paths.subtract(expanded)
+      } else {
+        paths.formUnion(expanded)
+      }
     }
 
     return paths
   }
 
-  private func matches(for pattern: String) throws -> Set<String> {
-    var globT = glob_t()
-
-    defer {
-      globfree(&globT)
-    }
-
-    let response = glob(pattern, flags, nil, &globT)
-
-    switch response {
-    case 0: break // SUCCESS
-    case GLOB_NOMATCH: return []
-    case GLOB_NOSPACE: throw Error.noSpace
-    case GLOB_ABORTED: throw Error.aborted
-    default: throw Error.unknown(code: Int(response))
-    }
-
-    return Set<String>((0..<Int(globT.gl_matchc)).compactMap({ index in
-      if let path = String(validatingUTF8: globT.gl_pathv[index]!) {
-        return path
-      }
-
-      return nil
-    }))
-  }
-
-  #warning("TODO - should we support negation in globstar with braces?") // something like "{a/**/*,!a/b/c/*}
-
   /// Expands the globstar (`**`) to find all directory paths to search for the match pattern.
-  ///
-  /// - Returns: A set of directory file paths expanded with the match pattern.
-  func expandGlobstar() throws -> Set<String> {
+  private func expandGlobstar(_ pattern: String) throws -> Set<String> {
     guard pattern.contains("**") else { return [pattern] }
 
     var parts = pattern.components(separatedBy: String.Globstar)
@@ -94,14 +97,14 @@ struct Glob {
 
     let fileManager = FileManager.default
     let searchPath = firstPart.isEmpty ? fileManager.currentDirectoryPath : firstPart
-    var directories: Set<String> = [searchPath] // include files at the globstar root directory
+    var directories: Set<String> = [searchPath] // include searching the globstar root directory
 
     do {
       let searchURL = URL(fileURLWithPath: searchPath)
       let resourceKeys: [URLResourceKey] = [.isDirectoryKey]
-      var enumeratorError: Swift.Error?
+      var enumeratorError: Error?
 
-      let errorHandler: ((URL, Swift.Error) -> Bool) = { url, error in
+      let errorHandler: ((URL, Error) -> Bool) = { url, error in
         enumeratorError = error
         return false // aborts enumeration
       }
@@ -111,7 +114,7 @@ struct Glob {
         includingPropertiesForKeys: resourceKeys,
         errorHandler: errorHandler)
       else {
-        throw Error.enumeration(path: searchPath)
+        throw MatchError.cannotEnumerate(path: searchPath)
       }
 
       if let enumeratorError = enumeratorError { throw enumeratorError }
@@ -132,6 +135,33 @@ struct Glob {
 
     return Set<String>(directories.compactMap({ directory in
       URL(fileURLWithPath: directory).appendingPathComponent(lastPart).standardizedFileURL.path
+    }))
+  }
+
+  /// Performs the underlying file system path matching.
+  private func matches(for pattern: String) throws -> Set<String> {
+    var globT = glob_t()
+
+    defer {
+      globfree(&globT)
+    }
+
+    let response = glob(pattern, flags, nil, &globT)
+
+    switch response {
+    case 0: break // SUCCESS
+    case GLOB_NOMATCH: return []
+    case GLOB_NOSPACE: throw MatchError.noSpace
+    case GLOB_ABORTED: throw MatchError.aborted
+    default: throw MatchError.unknown(code: Int(response))
+    }
+
+    return Set<String>((0..<Int(globT.gl_matchc)).compactMap({ index in
+      if let path = String(validatingUTF8: globT.gl_pathv[index]!) {
+        return path
+      }
+
+      return nil
     }))
   }
 }

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -10,7 +10,7 @@ private extension String {
 
 /// A path pattern matcher.
 public struct Glob {
-  let pattern: String
+  let patterns: [String]
 
   // GLOB_ERR - Return on error
   // GLOB_MARK - Append / to matching directories
@@ -39,15 +39,15 @@ public struct Glob {
   /// The designated initializer
   ///
   /// - Parameters:
-  ///  - pattern: A comma-delimited string of path matching patterns.
+  ///  - pattern: An array of path matching pattern strings.
   ///
   /// Each path matching pattern can include the following characters:
-  /// - `*` matches zero or more characters in a single path portion, eg: `*.graphql`
-  /// - `?` matches one character in a single path portion, eg: `file-?.graphql`
-  /// - `**` includes zero or more directories and subdirectories searching for matches, eg: `**/*.graphql`
-  /// - `!` excludes any match, eg: `a/*.graphql,!a/file.graphql`
-  init(_ pattern: String) {
-    self.pattern = pattern
+  /// - `*` matches everything but the directory separator (shallow), eg: `*.graphql`
+  /// - `?` matches any single character, eg: `file-?.graphql`
+  /// - `**` matches all subdirectories (deep), eg: `**/*.graphql`
+  /// - `!` excludes any match, eg: `*.graphql,!file.graphql`
+  init(_ patterns: [String]) {
+    self.patterns = patterns
   }
 
   /// Executes the pattern match on the underlying file system.

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -23,9 +23,8 @@ public struct Glob {
   // GLOB_ERR - Return on error
   // GLOB_MARK - Append / to matching directories
   // GLOB_NOSORT - Don't sort
-  // GLOB_BRACE - Expand braces ala csh
   // GLOB_TILDE - Expand tilde names from the passwd file
-  private let flags = GLOB_ERR | GLOB_MARK | GLOB_NOSORT | GLOB_BRACE | GLOB_TILDE
+  private let flags = GLOB_ERR | GLOB_MARK | GLOB_NOSORT | GLOB_TILDE
 
   /// An error object that indicates why pattern matching failed.
   public enum MatchError: Error, LocalizedError, Equatable {

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -90,6 +90,9 @@ public struct Glob {
     var paths: Set<String> = []
     for pattern in patterns {
       if pattern.containsExclude && !pattern.isExclude {
+        // glob and fnmatch do support ! being used elsewhere in the path match pattern but for the
+        // purposes of Glob we reserve it exclusively for the exclude pattern and it is required to
+        // be the first character otherwise we throw.
         throw MatchError.invalidExclude(path: pattern)
       }
 
@@ -111,6 +114,8 @@ public struct Glob {
     let lastPart = parts.joined(separator: String.Globstar)
 
     if isExclude {
+      // Remove ! here otherwise the Linux glob function would not return any results. Results for
+      // the exclude path match patterns are needed because match() manually handles exclusion.
       firstPart = String(firstPart.dropFirst())
     }
 

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Glob {
+  public let pattern: String
+
+  init(_ pattern: String) {
+    self.pattern = pattern
+  }
+}

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -8,10 +8,14 @@ private extension String {
   }
 }
 
+/// A path pattern matcher.
 struct Glob {
+  /// The pattern to match paths for.
   let pattern: String
+
   private let flags = GLOB_ERR | GLOB_MARK | GLOB_BRACE | GLOB_TILDE
 
+  /// An error object that indicates why pattern matching failed.
   public enum Error: Swift.Error, LocalizedError {
     case noSpace // GLOB_NOSPACE
     case aborted // GLOB_ABORTED
@@ -28,10 +32,17 @@ struct Glob {
     }
   }
 
+  /// The designated initializer
+  ///
+  /// - Parameters:
+  ///  - pattern: The pattern to match paths for.
   init(_ pattern: String) {
     self.pattern = pattern
   }
 
+  /// Executes the pattern match on the underlying file system.
+  ///
+  /// - Returns: A set of matched file paths.
   func match() throws -> Set<String> {
     var paths: Set<String> = []
 
@@ -71,6 +82,9 @@ struct Glob {
 
   #warning("TODO - should we support negation in globstar with braces?") // something like "{a/**/*,!a/b/c/*}
 
+  /// Expands the globstar (`**`) to find all directory paths to search for the match pattern.
+  ///
+  /// - Returns: A set of directory file paths expanded with the match pattern.
   func expandGlobstar() throws -> Set<String> {
     guard pattern.contains("**") else { return [pattern] }
 

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -3,7 +3,48 @@ import Foundation
 struct Glob {
   public let pattern: String
 
+  enum Error: Swift.Error, LocalizedError {
+    case noSpace // GLOB_NOSPACE
+    case aborted // GLOB_ABORTED
+    case unknown(code: Int)
+
+    var errorDescription: String? {
+      switch self {
+      case .noSpace: return "Malloc call failed"
+      case .aborted: return "Unignored error"
+      case .unknown(let code): return "Unknown error: \(code)"
+      }
+    }
+  }
+
   init(_ pattern: String) {
     self.pattern = pattern
+  }
+
+  public func paths() throws -> [String] {
+    var globT = glob_t()
+
+    defer {
+      globfree(&globT)
+    }
+
+    let flags = GLOB_ERR | GLOB_MARK | GLOB_BRACE | GLOB_TILDE
+    let response = glob(pattern, flags, nil, &globT)
+
+    switch response {
+    case 0: break // SUCCESS
+    case GLOB_NOMATCH: return []
+    case GLOB_NOSPACE: throw Error.noSpace
+    case GLOB_ABORTED: throw Error.aborted
+    default: throw Error.unknown(code: Int(response))
+    }
+
+    return (0..<Int(globT.gl_matchc)).compactMap { index in
+      if let path = String(validatingUTF8: globT.gl_pathv[index]!) {
+        return path
+      }
+
+      return nil
+    }
   }
 }

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -28,21 +28,21 @@ struct Glob {
     self.pattern = pattern
   }
 
-    var paths: [String] = []
   func match() throws -> [String] {
+    var paths: Set<String> = []
 
     let patterns = pattern.includesGlobstar ? expandGlobstar(pattern) : [pattern]
     for pattern in patterns {
       paths.append(contentsOf: try matches(for: pattern))
     }
 
-    return paths
   }
 
   func expandGlobstar(_ pattern: String) -> [String] {
     guard pattern.contains("**") else { return [pattern] }
 
     return []
+    return Array(paths)
   }
 
   private func matches(for pattern: String) throws -> [String] {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -26,7 +26,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
 
     // then
     expect(config.input.schemaPath).to(equal(expectedSchemaURL.path))
-    expect(config.input.includes).to(equal(expectedIncludesURL.path))
+    expect(config.input.includes).to(equal([expectedIncludesURL.path]))
     expect(config.output.schemaTypes.path).to(equal(directoryURL.path))
   }
 
@@ -45,7 +45,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let schemaPath = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: schemaPath.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
@@ -57,7 +57,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenSchemaPath_isDirectory_shouldThrow() throws {
     // given
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: directoryURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
@@ -70,7 +70,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: fileURL.path)))
 
     // when
@@ -87,7 +87,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let invalidURL = fileURL.appendingPathComponent("nested")
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: invalidURL.path)))
 
     // when
@@ -110,7 +110,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: fileURL.path),
                                                           operationIdentifiersPath: nil))
@@ -129,7 +129,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let invalidURL = fileURL.appendingPathComponent("nested")
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: invalidURL.path),
                                                           operationIdentifiersPath: nil))
@@ -155,7 +155,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .relative(subpath: nil),
                                                           operationIdentifiersPath: directoryURL.path))
@@ -186,7 +186,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: "**/*.graphql"),
+                                                         includes: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: directoryURL.path),
                                                           operationIdentifiersPath: fileURL.path))

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -68,7 +68,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                             output: .init(schemaTypes: .init(path: fileURL.path)))
 
     // when
-    try FileManager.default.apollo.createFile(atPath: fileURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -84,7 +84,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                             output: .init(schemaTypes: .init(path: invalidURL.path)))
 
     // when
-    try FileManager.default.apollo.createFile(atPath: fileURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -108,7 +108,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: nil))
 
     // when
-    try FileManager.default.apollo.createFile(atPath: fileURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -126,7 +126,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: nil))
 
     // when
-    try FileManager.default.apollo.createFile(atPath: fileURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -151,7 +151,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: directoryURL.path))
 
     // when
-    try FileManager.default.apollo.createFile(atPath: fileURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -166,7 +166,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
 
     // when
     let expectedSchemaURL = directoryURL.appendingPathComponent(filename)
-    try FileManager.default.apollo.createFile(atPath: expectedSchemaURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: expectedSchemaURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.notTo(throwError())
@@ -181,7 +181,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: fileURL.path))
 
     // when
-    try FileManager.default.apollo.createFile(atPath: fileURL.path)
+    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
     expect { try ApolloCodegen.validate(config) }.notTo(throwError())

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -17,14 +17,17 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_init_givenBasePathAndSchemaFilename_shouldBuildDefaultPaths() {
     // given
     let filename = "could_be_anything"
+    let includes = "file.ext"
     let expectedSchemaURL = directoryURL.appendingPathComponent(filename)
-    let config = ApolloCodegenConfiguration(basePath: directoryURL.path, schemaFilename: filename)
+    let expectedIncludesURL = directoryURL.appendingPathComponent(includes)
+    let config = ApolloCodegenConfiguration(basePath: directoryURL.path,
+                                            schemaFilename: filename,
+                                            includesPattern: includes)
 
     // then
-    expect(config.input.schemaPath).to(
-      match(expectedSchemaURL.path)
-    )
-    expect(config.output.schemaTypes.path).to(match(directoryURL.path))
+    expect(config.input.schemaPath).to(equal(expectedSchemaURL.path))
+    expect(config.input.includes).to(equal(expectedIncludesURL.path))
+    expect(config.output.schemaTypes.path).to(equal(directoryURL.path))
   }
 
   func test_validation_givenSchemaFilename_doesNotExist_shouldThrow() throws {
@@ -41,7 +44,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenSchemaPath_doesNotExist_shouldThrow() throws {
     // given
     let schemaPath = directoryURL.appendingPathComponent(UUID().uuidString)
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: schemaPath.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: schemaPath.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
@@ -52,7 +56,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
 
   func test_validation_givenSchemaPath_isDirectory_shouldThrow() throws {
     // given
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: directoryURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: directoryURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
@@ -64,7 +69,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenSchemaTypesPath_isFile_shouldThrow() throws {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: fileURL.path)))
 
     // when
@@ -80,7 +86,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let invalidURL = fileURL.appendingPathComponent("nested")
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: invalidURL.path)))
 
     // when
@@ -102,7 +109,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenOperations_absolutePath_isFile_shouldThrow() throws {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: fileURL.path),
                                                           operationIdentifiersPath: nil))
@@ -120,7 +128,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let invalidURL = fileURL.appendingPathComponent("nested")
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: invalidURL.path),
                                                           operationIdentifiersPath: nil))
@@ -145,7 +154,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenOperationIdentifiersPath_isDirectory_shouldThrow() throws {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .relative(subpath: nil),
                                                           operationIdentifiersPath: directoryURL.path))
@@ -175,7 +185,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenValidConfiguration_designatedInitializer_shouldNotThrow() throws {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
-    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path),
+    let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
+                                                         includes: "**/*.graphql"),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: directoryURL.path),
                                                           operationIdentifiersPath: fileURL.path))

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -16,17 +16,17 @@ class ApolloCodegenConfigurationTests: XCTestCase {
 
   func test_init_givenBasePathAndSchemaFilename_shouldBuildDefaultPaths() {
     // given
-    let filename = "could_be_anything"
-    let includes = "file.ext"
-    let expectedSchemaURL = directoryURL.appendingPathComponent(filename)
-    let expectedIncludesURL = directoryURL.appendingPathComponent(includes)
+    let schemafilename = "could_be_anything"
+    let includeFilename = "file.ext"
+    let expectedSchemaURL = directoryURL.appendingPathComponent(schemafilename)
+    let expectedIncludeURL = directoryURL.appendingPathComponent(includeFilename)
     let config = ApolloCodegenConfiguration(basePath: directoryURL.path,
-                                            schemaFilename: filename,
-                                            includesPattern: includes)
+                                            schemaFilename: schemafilename,
+                                            searchPattern: includeFilename)
 
     // then
     expect(config.input.schemaPath).to(equal(expectedSchemaURL.path))
-    expect(config.input.includes).to(equal([expectedIncludesURL.path]))
+    expect(config.input.searchPaths).to(equal([expectedIncludeURL.path]))
     expect(config.output.schemaTypes.path).to(equal(directoryURL.path))
   }
 
@@ -45,7 +45,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let schemaPath = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: schemaPath.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
@@ -57,7 +57,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_validation_givenSchemaPath_isDirectory_shouldThrow() throws {
     // given
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: directoryURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
@@ -70,7 +70,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: fileURL.path)))
 
     // when
@@ -87,7 +87,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let invalidURL = fileURL.appendingPathComponent("nested")
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: invalidURL.path)))
 
     // when
@@ -110,7 +110,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: fileURL.path),
                                                           operationIdentifiersPath: nil))
@@ -129,7 +129,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let invalidURL = fileURL.appendingPathComponent("nested")
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: invalidURL.path),
                                                           operationIdentifiersPath: nil))
@@ -155,7 +155,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .relative(subpath: nil),
                                                           operationIdentifiersPath: directoryURL.path))
@@ -186,7 +186,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
     let config = ApolloCodegenConfiguration(input: .init(schemaPath: fileURL.path,
-                                                         includes: ["**/*.graphql"]),
+                                                         searchPaths: ["**/*.graphql"]),
                                             output: .init(schemaTypes: .init(path: directoryURL.path),
                                                           operations: .absolute(path: directoryURL.path),
                                                           operationIdentifiersPath: fileURL.path))

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -276,5 +276,28 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  #warning("TODO - test globstar negation")
+  func test_match_givenPattern_withExcludeNotFirst_shouldThrow() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/b/c/d/**/!file.swift").path
+
+    // then
+    expect(Glob([pattern]).match).to(throwError(Glob.MatchError.invalidExclude(path: pattern)))
+  }
+
+  func test_match_givenGlobstarPattern_usingPathExclude_whenMultipleMatch_shouldExclude() throws {
+    // given
+    let pattern = [
+      baseURL.appendingPathComponent("a/b/c/d/**/file.*").path,
+      "!" + baseURL.appendingPathComponent("a/b/c/d/**/file.two").path,
+    ]
+
+    // when
+    // <baseURL>/a/b/c/d/e/f/file.one
+    // <baseURL>/a/b/c/d/e/f/file.two
+
+    // then
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
+    ]))
+  }
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -45,6 +45,11 @@ class GlobTests: XCTestCase {
     ).to(beTrue())
 
     expect(
+      // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path)
+    ).to(beTrue())
+
+    expect(
       // <outputFolder>/Glob/other/file.one
       try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.one").path)
     ).to(beTrue())
@@ -169,5 +174,82 @@ class GlobTests: XCTestCase {
       baseURL.appendingPathComponent("a/file.one").path
     ]))
   }
+
+  func test_expandGlobstar_givenRootGlobstar_shouldExpandAllDirectoriesWithPattern() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("**/*.one").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+    // <outputFolder>/Glob/a/file.one
+    // <outputFolder>/Glob/a/b/file.one
+    // <outputFolder>/Glob/a/b/c/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).expandGlobstar).to(equal([
+      baseURL.path.appending("/*.one"),
+      baseURL.appendingPathComponent("a/*.one").path,
+      baseURL.appendingPathComponent("a/b/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/*.one").path,
+      baseURL.appendingPathComponent("other/*.one").path
+    ]))
+  }
+
+  func test_expandGlobstar_givenPathGlobstar_shouldExpandSubdirectoriesWithPattern() {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/**/*.one").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+    // <outputFolder>/Glob/a/file.one
+    // <outputFolder>/Glob/a/b/file.one
+    // <outputFolder>/Glob/a/b/c/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).expandGlobstar).to(equal([
+      baseURL.appendingPathComponent("a/*.one").path,
+      baseURL.appendingPathComponent("a/b/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/*.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/*.one").path
+    ]))
+  }
+
+  func test_paths_givenRootGlobstar_whenSubdirectoryMatches_shouldReturnAllMatches() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("**/*.two").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+    // <outputFolder>/Glob/a/file.one
+    // <outputFolder>/Glob/a/b/file.one
+    // <outputFolder>/Glob/a/b/c/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+    // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ]))
+  }
+
   #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -300,4 +300,60 @@ class GlobTests: XCTestCase {
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
     ]))
   }
+
+  func test_match_givenRelativePattern_usingNoPrefix_shouldUseCurrentDirectory() throws {
+    // given
+    let pattern = ["**/*.one"]
+
+    FileManager.default.changeCurrentDirectoryPath(baseURL.path)
+
+    // when
+    // <baseURL>/file.one
+    // <baseURL>/file.two
+    // <baseURL>/a/file.one
+    // <baseURL>/a/b/file.one
+    // <baseURL>/a/b/c/file.one
+    // <baseURL>/a/b/c/d/e/f/file.one
+    // <baseURL>/a/b/c/d/e/f/file.two
+    // <baseURL>/other/file.one
+    // <baseURL>/other/file.oye
+
+    // then
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("other/file.one").path
+    ]))
+  }
+
+  func test_match_givenRelativePattern_usingSingleDotPrefix_shouldUseCurrentDirectory() throws {
+    // given
+    let pattern = ["./**/*.one"]
+
+    FileManager.default.changeCurrentDirectoryPath(baseURL.path)
+
+    // when
+    // <baseURL>/file.one
+    // <baseURL>/file.two
+    // <baseURL>/a/file.one
+    // <baseURL>/a/b/file.one
+    // <baseURL>/a/b/c/file.one
+    // <baseURL>/a/b/c/d/e/f/file.one
+    // <baseURL>/a/b/c/d/e/f/file.two
+    // <baseURL>/other/file.one
+    // <baseURL>/other/file.oye
+
+    // then
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("other/file.one").path
+    ]))
+  }
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+import Nimble
+import ApolloCodegenLib
+
+class GlobTests: XCTestCase {
+  
+}

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -362,6 +362,34 @@ class GlobTests: XCTestCase {
     ]))
   }
 
+  func test_match_givenRelativePattern_usingNoPrefix_andSubfolderCurrentDirectory_shouldUseCurrentDirectory() throws {
+    // given
+    let pattern = ["**/*.one"]
+
+    // when
+    try changeCurrentDirectory(to: baseURL.appendingPathComponent("a/").path)
+
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
+
+    // then
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
+    ]))
+  }
+
   func test_match_givenRelativePattern_usingSingleDotPrefix_shouldUseCurrentDirectory() throws {
     // given
     let pattern = ["./**/*.one"]

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -14,50 +14,21 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/
     try fileManager.createDirectoryIfNeeded(atPath: baseURL.path)
 
-    expect(
-      // <outputFolder>/Glob/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.one").path)
-    ).to(beTrue())
+    let files = [
+      self.baseURL.appendingPathComponent("file.one").path, // <outputFolder>/Glob/file.one
+      self.baseURL.appendingPathComponent("file.two").path, // <outputFolder>/Glob/file.two
+      self.baseURL.appendingPathComponent("a/file.one").path, // <outputFolder>/Glob/a/file.one
+      self.baseURL.appendingPathComponent("a/b/file.one").path, // <outputFolder>/Glob/a/b/file.one
+      self.baseURL.appendingPathComponent("a/b/c/file.one").path, // <outputFolder>/Glob/a/b/c/file.one
+      self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path, // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+      self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path, // <outputFolder>/Glob/a/b/c/d/e/f/file.two
+      self.baseURL.appendingPathComponent("other/file.one").path, // <outputFolder>/Glob/other/file.one
+      self.baseURL.appendingPathComponent("other/file.oye").path // <outputFolder>/Glob/other/file.oye
+    ]
 
-    expect(
-      // <outputFolder>/Glob/file.two
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.two").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/c/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/c/d/e/f/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/a/b/c/d/e/f/file.two
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/other/file.one
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.one").path)
-    ).to(beTrue())
-
-    expect(
-      // <outputFolder>/Glob/other/file.oye
-      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.oye").path)
-    ).to(beTrue())
+    for file in files {
+      expect(try fileManager.createFile(atPath: file)).to(beTrue())
+    }
   }
 
   override func tearDownWithError() throws {
@@ -250,6 +221,4 @@ class GlobTests: XCTestCase {
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
     ]))
   }
-
-  #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -33,6 +33,8 @@ class GlobTests: XCTestCase {
 
   override func tearDownWithError() throws {
     try FileManager.default.apollo.deleteDirectory(atPath: baseURL.path)
+
+    try super.tearDownWithError()
   }
 
   // MARK: Tests

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -70,7 +70,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(beEmpty())
+    expect(Glob(pattern).match).to(beEmpty())
   }
 
   func test_paths_givenSingleMatch_whenMultipleFiles_shouldReturnSingle() throws {
@@ -82,7 +82,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(1))
+    expect(Glob(pattern).match).to(haveCount(1))
   }
 
   func test_paths_givenMultipleMatches_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -94,7 +94,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(2))
+    expect(Glob(pattern).match).to(haveCount(2))
   }
 
   func test_paths_givenMultipleMatchBraces_whenSingleFile_shouldReturnSingle() throws {
@@ -104,7 +104,7 @@ class GlobTests: XCTestCase {
     // when
     // <outputFolder>/Glob/a/file.one
 
-    expect(Glob(pattern).paths).to(haveCount(1))
+    expect(Glob(pattern).match).to(haveCount(1))
   }
 
   func test_paths_givenMultipleMatchBraces_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -116,7 +116,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(2))
+    expect(Glob(pattern).match).to(haveCount(2))
   }
 
   func test_paths_givenMultipleMatchBraces_withNegation_whenMultipleFiles_shouldReturnSingle() throws {
@@ -128,7 +128,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(1))
+    expect(Glob(pattern).match).to(haveCount(1))
   }
 
   func test_paths_givenMultipleMatches_withWildcardCharacter_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -140,7 +140,7 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/other/file.oye
 
     // then
-    expect(Glob(pattern).paths).to(haveCount(2))
+    expect(Glob(pattern).match).to(haveCount(2))
   }
 
   #warning("TODO - memory leak test")

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -37,7 +37,7 @@ class GlobTests: XCTestCase {
 
   // MARK: Tests
 
-  func test_paths_givenSinglePattern_whenNoMatch_shouldReturnEmpty() throws {
+  func test_match_givenSinglePattern_whenNoMatch_shouldReturnEmpty() throws {
     // given
     let pattern = baseURL.appendingPathComponent("*.xyz").path
 
@@ -51,7 +51,7 @@ class GlobTests: XCTestCase {
     expect(results).to(beEmpty())
   }
 
-  func test_paths_givenSinglePattern_usingAnyWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenSinglePattern_usingAnyWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = baseURL.appendingPathComponent("*.one").path
 
@@ -65,7 +65,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenSinglePattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenSinglePattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = baseURL.appendingPathComponent("file.*").path
 
@@ -80,7 +80,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenSinglePattern_usingSingleWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenSinglePattern_usingSingleWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = baseURL.appendingPathComponent("fil?.one").path
 
@@ -94,7 +94,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenSinglePattern_usingSingleWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenSinglePattern_usingSingleWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = baseURL.appendingPathComponent("other/file.o?e").path
 
@@ -109,7 +109,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenMultiplePattern_usingAnyWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenMultiplePattern_usingAnyWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = [
       baseURL.appendingPathComponent("a/file.*").path,
@@ -125,7 +125,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenMultiplePattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenMultiplePattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = [
       baseURL.appendingPathComponent("a/file.*").path,
@@ -145,7 +145,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenMultiplePattern_usingSingleWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenMultiplePattern_usingSingleWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = [
       baseURL.appendingPathComponent("a/file.?ne").path,
@@ -163,7 +163,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenMultiplePattern_usingSingleWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenMultiplePattern_usingSingleWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = [
       baseURL.appendingPathComponent("a/file.o?e").path,
@@ -183,7 +183,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenSinglePattern_usingCombinedWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenSinglePattern_usingCombinedWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = baseURL.appendingPathComponent("*.o?e").path
 
@@ -196,7 +196,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenMultiplePattern_usingCombinedWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenMultiplePattern_usingCombinedWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = [
       baseURL.appendingPathComponent("file.*").path,
@@ -218,7 +218,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenGlobstarPattern_usingAnyWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenGlobstarPattern_usingAnyWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/*.one").path
 
@@ -232,7 +232,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenGlobstarPattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenGlobstarPattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/file.*").path
 
@@ -247,7 +247,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenGlobstarPattern_usingSingleWildcard_whenSingleMatch_shouldReturnSingle() throws {
+  func test_match_givenGlobstarPattern_usingSingleWildcard_whenSingleMatch_shouldReturnSingle() throws {
     // given
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/?ile.one").path
 
@@ -261,7 +261,7 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_paths_givenGlobstarPattern_usingCombinedWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
+  func test_match_givenGlobstarPattern_usingCombinedWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/fil?.*").path
 

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -29,6 +29,11 @@ class GlobTests: XCTestCase {
     }
   }
 
+  private func changeCurrentDirectory(to directory: String) throws {
+    try fileManager.createDirectoryIfNeeded(atPath: directory)
+    expect(self.fileManager.base.changeCurrentDirectoryPath(directory)).to(beTrue())
+  }
+
   // MARK: Tests
 
   func test_match_givenSinglePattern_whenNoMatch_shouldReturnEmpty() throws {
@@ -327,13 +332,13 @@ class GlobTests: XCTestCase {
     ]))
   }
 
-  func test_match_givenRelativePattern_usingNoPrefix_shouldUseCurrentDirectory() throws {
+  func test_match_givenRelativePattern_usingNoPrefix_andRootCurrentDirectory_shouldUseCurrentDirectory() throws {
     // given
     let pattern = ["**/*.one"]
 
-    FileManager.default.changeCurrentDirectoryPath(baseURL.path)
-
     // when
+    try changeCurrentDirectory(to: baseURL.path)
+
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("file.two").path,
@@ -361,9 +366,9 @@ class GlobTests: XCTestCase {
     // given
     let pattern = ["./**/*.one"]
 
-    FileManager.default.changeCurrentDirectoryPath(baseURL.path)
-
     // when
+    try changeCurrentDirectory(to: baseURL.path)
+
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("file.two").path,

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -82,7 +82,9 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path
+    ]))
   }
 
   func test_paths_givenMultipleMatches_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -94,7 +96,10 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(2))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ]))
   }
 
   func test_paths_givenMultipleMatchBraces_whenSingleFile_shouldReturnSingle() throws {
@@ -104,7 +109,9 @@ class GlobTests: XCTestCase {
     // when
     // <outputFolder>/Glob/a/file.one
 
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("a/file.one").path
+    ]))
   }
 
   func test_paths_givenMultipleMatchBraces_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -116,7 +123,10 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(2))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ]))
   }
 
   func test_paths_givenMultipleMatchBraces_withNegation_whenMultipleFiles_shouldReturnSingle() throws {
@@ -128,7 +138,9 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/file.two
 
     // then
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("file.one").path
+    ]))
   }
 
   func test_paths_givenMultipleMatches_withWildcardCharacter_whenMultipleFiles_shouldReturnMultiple() throws {
@@ -140,7 +152,10 @@ class GlobTests: XCTestCase {
     // <outputFolder>/Glob/other/file.oye
 
     // then
-    expect(Glob(pattern).match).to(haveCount(2))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ]))
   }
 
   func test_paths_givenDuplicateMatches_whenMatches_shouldNotReturnDuplicates() throws {
@@ -150,7 +165,9 @@ class GlobTests: XCTestCase {
     // when
     // <outputFolder>/Glob/a/file.one
 
-    expect(Glob(pattern).match).to(haveCount(1))
+    expect(Glob(pattern).match).to(equal([
+      baseURL.appendingPathComponent("a/file.one").path
+    ]))
   }
   #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -143,5 +143,14 @@ class GlobTests: XCTestCase {
     expect(Glob(pattern).match).to(haveCount(2))
   }
 
+  func test_paths_givenDuplicateMatches_whenMatches_shouldNotReturnDuplicates() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/{*.one,*.one}").path
+
+    // when
+    // <outputFolder>/Glob/a/file.one
+
+    expect(Glob(pattern).match).to(haveCount(1))
+  }
   #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -5,36 +5,28 @@ import ApolloCodegenTestSupport
 
 class GlobTests: XCTestCase {
   let baseURL = CodegenTestHelper.outputFolderURL().appendingPathComponent("Glob")
+  let fileManager = FileManager.default.apollo
 
   // MARK: Setup
 
   override func setUpWithError() throws {
-    let fileManager = FileManager.default.apollo
+    try super.setUpWithError()
 
-    // <outputFolder>/Glob/
     try fileManager.createDirectoryIfNeeded(atPath: baseURL.path)
-
-    let files = [
-      self.baseURL.appendingPathComponent("file.one").path, // <outputFolder>/Glob/file.one
-      self.baseURL.appendingPathComponent("file.two").path, // <outputFolder>/Glob/file.two
-      self.baseURL.appendingPathComponent("a/file.one").path, // <outputFolder>/Glob/a/file.one
-      self.baseURL.appendingPathComponent("a/b/file.one").path, // <outputFolder>/Glob/a/b/file.one
-      self.baseURL.appendingPathComponent("a/b/c/file.one").path, // <outputFolder>/Glob/a/b/c/file.one
-      self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path, // <outputFolder>/Glob/a/b/c/d/e/f/file.one
-      self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path, // <outputFolder>/Glob/a/b/c/d/e/f/file.two
-      self.baseURL.appendingPathComponent("other/file.one").path, // <outputFolder>/Glob/other/file.one
-      self.baseURL.appendingPathComponent("other/file.oye").path // <outputFolder>/Glob/other/file.oye
-    ]
-
-    for file in files {
-      expect(try fileManager.createFile(atPath: file)).to(beTrue())
-    }
   }
 
   override func tearDownWithError() throws {
     try FileManager.default.apollo.deleteDirectory(atPath: baseURL.path)
 
     try super.tearDownWithError()
+  }
+
+  // MARK: Helpers
+
+  private func create(files: [String]) throws {
+    for file in files {
+      expect(try self.fileManager.createFile(atPath: file)).to(beTrue())
+    }
   }
 
   // MARK: Tests
@@ -44,8 +36,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("*.xyz").path
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ])
 
     // then
     let results = try Glob([pattern]).match()
@@ -58,8 +52,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("*.one").path
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -72,8 +68,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("file.*").path
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -87,8 +85,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("fil?.one").path
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -101,8 +101,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("other/file.o?e").path
 
     // when
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -119,7 +121,9 @@ class GlobTests: XCTestCase {
     ]
 
     // when
-    // <baseURL>/a/file.one
+    try create(files: [
+      baseURL.appendingPathComponent("a/file.one").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -135,9 +139,11 @@ class GlobTests: XCTestCase {
     ]
 
     // when
-    // <baseURL>/a/file.one
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -155,9 +161,11 @@ class GlobTests: XCTestCase {
     ]
 
     // when
-    // <baseURL>/a/file.one
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -173,9 +181,11 @@ class GlobTests: XCTestCase {
     ]
 
     // when
-    // <baseURL>/a/file.one
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -190,7 +200,9 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("*.o?e").path
 
     // when
-    // <baseURL>/file.one
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -206,10 +218,12 @@ class GlobTests: XCTestCase {
     ]
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -225,8 +239,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/*.one").path
 
     // when
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -239,8 +255,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/file.*").path
 
     // when
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -254,8 +272,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/?ile.one").path
 
     // when
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -268,8 +288,10 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/fil?.*").path
 
     // when
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
@@ -294,8 +316,10 @@ class GlobTests: XCTestCase {
     ]
 
     // when
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
+    try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -310,15 +334,17 @@ class GlobTests: XCTestCase {
     FileManager.default.changeCurrentDirectoryPath(baseURL.path)
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
-    // <baseURL>/a/file.one
-    // <baseURL>/a/b/file.one
-    // <baseURL>/a/b/c/file.one
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([
@@ -338,15 +364,17 @@ class GlobTests: XCTestCase {
     FileManager.default.changeCurrentDirectoryPath(baseURL.path)
 
     // when
-    // <baseURL>/file.one
-    // <baseURL>/file.two
-    // <baseURL>/a/file.one
-    // <baseURL>/a/b/file.one
-    // <baseURL>/a/b/c/file.one
-    // <baseURL>/a/b/c/d/e/f/file.one
-    // <baseURL>/a/b/c/d/e/f/file.two
-    // <baseURL>/other/file.one
-    // <baseURL>/other/file.oye
+    try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path,
+      baseURL.appendingPathComponent("other/file.oye").path
+    ])
 
     // then
     expect(Glob(pattern).match).to(equal([

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -1,7 +1,147 @@
 import XCTest
 import Nimble
-import ApolloCodegenLib
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
 
 class GlobTests: XCTestCase {
-  
+  let baseURL = CodegenTestHelper.outputFolderURL().appendingPathComponent("Glob")
+
+  // MARK: Setup
+
+  override func setUpWithError() throws {
+    let fileManager = FileManager.default.apollo
+
+    // <outputFolder>/Glob/
+    try fileManager.createDirectoryIfNeeded(atPath: baseURL.path)
+
+    expect(
+      // <outputFolder>/Glob/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/file.two
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("file.two").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/b/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/b/c/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/a/b/c/d/e/f/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/other/file.one
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.one").path)
+    ).to(beTrue())
+
+    expect(
+      // <outputFolder>/Glob/other/file.oye
+      try fileManager.createFile(atPath: self.baseURL.appendingPathComponent("other/file.oye").path)
+    ).to(beTrue())
+  }
+
+  override func tearDownWithError() throws {
+    try FileManager.default.apollo.deleteDirectory(atPath: baseURL.path)
+  }
+
+  // MARK: Tests
+
+  func test_paths_givenNoMatch_whenMultipleFiles_shouldReturnEmpty() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("*.xyz").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(beEmpty())
+  }
+
+  func test_paths_givenSingleMatch_whenMultipleFiles_shouldReturnSingle() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("*.one").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(1))
+  }
+
+  func test_paths_givenMultipleMatches_whenMultipleFiles_shouldReturnMultiple() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("file.*").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(2))
+  }
+
+  func test_paths_givenMultipleMatchBraces_whenSingleFile_shouldReturnSingle() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("a/{*.one,*.two}").path
+
+    // when
+    // <outputFolder>/Glob/a/file.one
+
+    expect(Glob(pattern).paths).to(haveCount(1))
+  }
+
+  func test_paths_givenMultipleMatchBraces_whenMultipleFiles_shouldReturnMultiple() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("{*.one,*.two}").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(2))
+  }
+
+  func test_paths_givenMultipleMatchBraces_withNegation_whenMultipleFiles_shouldReturnSingle() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("{*.one,!*.two}").path
+
+    // when
+    // <outputFolder>/Glob/file.one
+    // <outputFolder>/Glob/file.two
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(1))
+  }
+
+  func test_paths_givenMultipleMatches_withWildcardCharacter_whenMultipleFiles_shouldReturnMultiple() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("other/file.o?e").path
+
+    // when
+    // <outputFolder>/Glob/other/file.one
+    // <outputFolder>/Glob/other/file.oye
+
+    // then
+    expect(Glob(pattern).paths).to(haveCount(2))
+  }
+
+  #warning("TODO - memory leak test")
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -46,7 +46,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/file.two
 
     // then
-    let results = try Glob(pattern).match()
+    let results = try Glob([pattern]).match()
 
     expect(results).to(beEmpty())
   }
@@ -60,7 +60,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("file.one").path
     ]))
   }
@@ -74,7 +74,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("file.two").path
     ]))
@@ -89,7 +89,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("file.one").path
     ]))
   }
@@ -103,7 +103,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/other/file.oye
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("other/file.one").path,
       baseURL.appendingPathComponent("other/file.oye").path
     ]))
@@ -114,7 +114,7 @@ class GlobTests: XCTestCase {
     let pattern = [
       baseURL.appendingPathComponent("a/file.*").path,
       baseURL.appendingPathComponent("a/*.ext").path
-    ].joined(separator: ",")
+    ]
 
     // when
     // <baseURL>/a/file.one
@@ -130,7 +130,7 @@ class GlobTests: XCTestCase {
     let pattern = [
       baseURL.appendingPathComponent("a/file.*").path,
       baseURL.appendingPathComponent("other/file.*").path
-    ].joined(separator: ",")
+    ]
 
     // when
     // <baseURL>/a/file.one
@@ -150,7 +150,7 @@ class GlobTests: XCTestCase {
     let pattern = [
       baseURL.appendingPathComponent("a/file.?ne").path,
       baseURL.appendingPathComponent("other/file.?xt").path
-    ].joined(separator: ",")
+    ]
 
     // when
     // <baseURL>/a/file.one
@@ -168,7 +168,7 @@ class GlobTests: XCTestCase {
     let pattern = [
       baseURL.appendingPathComponent("a/file.o?e").path,
       baseURL.appendingPathComponent("other/file.o?e").path
-    ].joined(separator: ",")
+    ]
 
     // when
     // <baseURL>/a/file.one
@@ -191,7 +191,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/file.one
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("file.one").path
     ]))
   }
@@ -201,7 +201,7 @@ class GlobTests: XCTestCase {
     let pattern = [
       baseURL.appendingPathComponent("file.*").path,
       baseURL.appendingPathComponent("other/file.o?e").path
-    ].joined(separator: ",")
+    ]
 
     // when
     // <baseURL>/file.one
@@ -227,7 +227,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/a/b/c/d/e/f/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
     ]))
   }
@@ -241,7 +241,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/a/b/c/d/e/f/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
     ]))
@@ -256,7 +256,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/a/b/c/d/e/f/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
     ]))
   }
@@ -270,7 +270,7 @@ class GlobTests: XCTestCase {
     // <baseURL>/a/b/c/d/e/f/file.two
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(Glob([pattern]).match).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
     ]))

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -43,7 +43,8 @@ class GlobTests: XCTestCase {
     // when
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
-      baseURL.appendingPathComponent("file.two").path
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("other/file.xyz").path
     ])
 
     // then
@@ -59,7 +60,8 @@ class GlobTests: XCTestCase {
     // when
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
-      baseURL.appendingPathComponent("file.two").path
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
@@ -75,7 +77,9 @@ class GlobTests: XCTestCase {
     // when
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
-      baseURL.appendingPathComponent("file.two").path
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("another.one").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
@@ -92,7 +96,9 @@ class GlobTests: XCTestCase {
     // when
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
-      baseURL.appendingPathComponent("file.two").path
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("filez.one").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
@@ -107,8 +113,10 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("other/file.one").path,
-      baseURL.appendingPathComponent("other/file.oye").path
+      baseURL.appendingPathComponent("other/file.oye").path,
+      baseURL.appendingPathComponent("other/file.two").path
     ])
 
     // then
@@ -127,7 +135,11 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
-      baseURL.appendingPathComponent("a/file.one").path
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/another.file").path,
+      baseURL.appendingPathComponent("other/file.ext").path,
+      baseURL.appendingPathComponent("other/file.two").path
     ])
 
     // then
@@ -139,15 +151,20 @@ class GlobTests: XCTestCase {
   func test_match_givenMultiplePattern_usingAnyWildcard_whenMultipleMatch_shouldReturnMultiple() throws {
     // given
     let pattern = [
+      baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("a/file.*").path,
       baseURL.appendingPathComponent("other/file.*").path
     ]
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("file.ext").path,
       baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/another.file").path,
+      baseURL.appendingPathComponent("a/b/file.one").path,
       baseURL.appendingPathComponent("other/file.one").path,
-      baseURL.appendingPathComponent("other/file.oye").path
+      baseURL.appendingPathComponent("other/file.oye").path,
+      baseURL.appendingPathComponent("other/another.file").path
     ])
 
     // then
@@ -167,7 +184,9 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/file.two").path,
       baseURL.appendingPathComponent("other/file.one").path,
       baseURL.appendingPathComponent("other/file.oye").path
     ])
@@ -188,8 +207,10 @@ class GlobTests: XCTestCase {
     // when
     try create(files: [
       baseURL.appendingPathComponent("a/file.one").path,
+      baseURL.appendingPathComponent("a/file.two").path,
       baseURL.appendingPathComponent("other/file.one").path,
-      baseURL.appendingPathComponent("other/file.oye").path
+      baseURL.appendingPathComponent("other/file.oye").path,
+      baseURL.appendingPathComponent("other/file.two").path
     ])
 
     // then
@@ -206,7 +227,9 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
-      baseURL.appendingPathComponent("file.one").path
+      baseURL.appendingPathComponent("file.one").path,
+      baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
@@ -226,8 +249,10 @@ class GlobTests: XCTestCase {
     try create(files: [
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("file.two").path,
+      baseURL.appendingPathComponent("another.file").path,
       baseURL.appendingPathComponent("other/file.one").path,
-      baseURL.appendingPathComponent("other/file.oye").path
+      baseURL.appendingPathComponent("other/file.oye").path,
+      baseURL.appendingPathComponent("other/another.file").path
     ])
 
     // then
@@ -246,7 +271,9 @@ class GlobTests: XCTestCase {
     // when
     try create(files: [
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
-      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
@@ -261,12 +288,16 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("a/b/c/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
-      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
+      baseURL.appendingPathComponent("a/b/c/d/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
     ]))
@@ -278,8 +309,10 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
-      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
@@ -294,12 +327,16 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
-      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/another.file").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
     expect(Glob([pattern]).match).to(equal([
+      baseURL.appendingPathComponent("a/b/c/d/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
     ]))
@@ -322,13 +359,17 @@ class GlobTests: XCTestCase {
 
     // when
     try create(files: [
+      baseURL.appendingPathComponent("a/b/c/d/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
-      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.ext").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
+      baseURL.appendingPathComponent("other/file.one").path
     ])
 
     // then
     expect(Glob(pattern).match).to(equal([
-      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
+      baseURL.appendingPathComponent("a/b/c/d/e/f/file.ext").path
     ]))
   }
 


### PR DESCRIPTION
This is a path pattern matcher that will be used to ingest the glob pattern from `ApolloCodegenConfiguration.FileInput.glob` and output a set of matched file paths.

* There is no standard implementation for globstar (`**`) support, it is custom logic.
* It uses the underlying system function [glob](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/glob.3.html) to perform the actual file path matching. glob in turn uses [fnmatch](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fnmatch.3.html) pattern definitions. I intentionally only mention a few of the characters/patterns supported by glob/fnmatch because it's difficult to communicate the full ability of those libraries. I think the table below should be our only supported pattern matching options.

Each path matching pattern can include the following characters:
| Character | Meaning | Example |
| -- | -- | -- |
| `*` | matches everything but the directory separator (shallow) |`*.graphql` |
| `?` | matches any single character | `file-?.graphql` |
| `**` | matches all subdirectories (deep) | `**/*.graphql` |
| `!` | excludes any match | `*.graphql,!file.graphql` |

Closes #2030.