### PR TITLE
Update FileManager extension function return

### DIFF
--- a/Sources/ApolloCodegenLib/FileManager+Apollo.swift
+++ b/Sources/ApolloCodegenLib/FileManager+Apollo.swift
@@ -27,6 +27,7 @@ extension ApolloExtension where Base: FileManagerProvider {
   public enum PathError: Swift.Error, LocalizedError, Equatable {
     case notAFile(path: String)
     case notADirectory(path: String)
+    case cannotCreateFile(at: String)
 
     public var errorDescription: String {
       switch self {
@@ -34,6 +35,8 @@ extension ApolloExtension where Base: FileManagerProvider {
         return "\(path) is not a file!"
       case .notADirectory(let path):
         return "\(path) is not a directory!"
+      case .cannotCreateFile(let path):
+        return "Cannot create file at \(path)"
       }
     }
   }
@@ -100,9 +103,12 @@ extension ApolloExtension where Base: FileManagerProvider {
   /// - Parameters:
   ///   - path: Path to the file.
   ///   - data: [optional] Data to write to the file path.
-  public func createFile(atPath path: String, data: Data? = nil) throws -> Bool {
+  public func createFile(atPath path: String, data: Data? = nil) throws {
     try createContainingDirectoryIfNeeded(forPath: path)
-    return base.createFile(atPath: path, contents: data, attributes: nil)
+
+    guard base.createFile(atPath: path, contents: data, attributes: nil) else {
+      throw PathError.cannotCreateFile(at: path)
+    }
   }
 
   /// Creates the containing directory (including all intermediate directories) for the given file URL if necessary. This method will not

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -74,7 +74,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                             output: .init(schemaTypes: .init(path: fileURL.path)))
 
     // when
-    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: fileURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -91,7 +91,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                             output: .init(schemaTypes: .init(path: invalidURL.path)))
 
     // when
-    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: fileURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -116,7 +116,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: nil))
 
     // when
-    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: fileURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -135,7 +135,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: nil))
 
     // when
-    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: fileURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -161,7 +161,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: directoryURL.path))
 
     // when
-    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: fileURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.to(
@@ -176,7 +176,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
 
     // when
     let expectedSchemaURL = directoryURL.appendingPathComponent(filename)
-    expect(try FileManager.default.apollo.createFile(atPath: expectedSchemaURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: expectedSchemaURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.notTo(throwError())
@@ -192,7 +192,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                                           operationIdentifiersPath: fileURL.path))
 
     // when
-    expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
+    try FileManager.default.apollo.createFile(atPath: fileURL.path)
 
     // then
     expect { try ApolloCodegen.validate(config) }.notTo(throwError())

--- a/Tests/ApolloCodegenTests/FileManagerExtensionsTests.swift
+++ b/Tests/ApolloCodegenTests/FileManagerExtensionsTests.swift
@@ -313,7 +313,7 @@ class FileManagerExtensionTests: XCTestCase {
     expect(mocked.blocksCalled).to(equal([.fileExists]))
   }
 
-  func test_createFile_givenContainingDirectoryDoesExistAndFileCreated_shouldReturnTrue() throws {
+  func test_createFile_givenContainingDirectoryDoesExistAndFileCreated_shouldNotThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
@@ -335,11 +335,13 @@ class FileManagerExtensionTests: XCTestCase {
     })
 
     // then
-    expect(try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)).to(beTrue())
+    expect(
+      try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
+    ).notTo(throwError())
     expect(mocked.blocksCalled).to(equal([.fileExists, .createFile]))
   }
 
-  func test_createFile_givenContainingDirectoryDoesExistAndFileNotCreated_shouldReturnFalse() throws {
+  func test_createFile_givenContainingDirectoryDoesExistAndFileNotCreated_shouldThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
@@ -361,11 +363,13 @@ class FileManagerExtensionTests: XCTestCase {
     })
 
     // then
-    expect(try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)).to(beFalse())
+    expect(
+      try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
+    ).to(throwError(MockFileManager.apollo.PathError.cannotCreateFile(at: self.uniquePath)))
     expect(mocked.blocksCalled).to(equal([.fileExists, .createFile]))
   }
 
-  func test_createFile_givenContainingDirectoryDoesNotExistAndFileCreated_shouldReturnTrue() throws {
+  func test_createFile_givenContainingDirectoryDoesNotExistAndFileCreated_shouldNotThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
@@ -389,11 +393,13 @@ class FileManagerExtensionTests: XCTestCase {
     })
 
     // then
-    expect(try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)).to(beTrue())
+    expect(
+      try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
+    ).notTo(throwError())
     expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory, .createFile]))
   }
 
-  func test_createFile_givenContainingDirectoryDoesNotExistAndFileNotCreated_shouldReturnFalse() throws {
+  func test_createFile_givenContainingDirectoryDoesNotExistAndFileNotCreated_shouldThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
@@ -417,7 +423,9 @@ class FileManagerExtensionTests: XCTestCase {
     })
 
     // then
-    expect(try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)).to(beFalse())
+    expect(
+      try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
+    ).to(throwError(MockFileManager.apollo.PathError.cannotCreateFile(at: self.uniquePath)))
     expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory, .createFile]))
   }
 

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -25,7 +25,7 @@ class GlobTests: XCTestCase {
 
   private func create(files: [String]) throws {
     for file in files {
-      expect(try self.fileManager.createFile(atPath: file)).to(beTrue())
+      try self.fileManager.createFile(atPath: file)
     }
   }
 


### PR DESCRIPTION
This was the only function that had a Boolean return when the rest are throwing functions. This change brings aligns it with the rest of the extension API. Tests were updated as needed.

_Another option considered was using `@discardableResult` but I believe this was the better choice._