### PR TITLE
Move validation of ApolloCodegenConfiguration

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -5,115 +5,12 @@ import Foundation
 
 /// A class to facilitate running code generation
 public class ApolloCodegen {
-  static private let fileManager = FileManager.default.apollo
-
-  public enum PathType {
-    case schema
-    case schemaTypes
-    case operations
-    case operationIdentifiers
-
-    public var errorRecoverySuggestion: String {
-      switch self {
-      case .schema:
-        return "Check that the schema input path is an existing schema file containing SDL or JSON."
-      case .schemaTypes:
-        return "Check that the schema types output path exists and is a directory, or can be created."
-      case .operations:
-        return "Check that the operations output path exists and is a directory, or can be created."
-      case .operationIdentifiers:
-        return "Check that the operations identifiers path is an existing file or can be created."
-      }
-    }
-  }
-
-  /// Errors which can happen with code generation
-  public enum PathError: Swift.Error, LocalizedError, Equatable {
-    case notAFile(PathType)
-    case notADirectory(PathType)
-    case folderCreationFailed(PathType, underlyingError: Error)
-
-    public var errorDescription: String {
-      switch self {
-      case let .notAFile(pathType):
-        return "\(pathType) path must be a file!"
-      case let .notADirectory(pathType):
-        return "\(pathType) path must be a folder!"
-      case let .folderCreationFailed(pathType, underlyingError):
-        return "\(pathType) folder cannot be created! Error: \(underlyingError)"
-      }
-    }
-
-    public var recoverySuggestion: String {
-      switch self {
-      case let .notAFile(pathType),
-        let .notADirectory(pathType),
-        let .folderCreationFailed(pathType, _):
-        return pathType.errorRecoverySuggestion
-      }
-    }
-
-    public func logging(withPath path: String) -> PathError {
-      CodegenLogger.log(self.logMessage(forPath: path), logLevel: .error)
-      CodegenLogger.log(self.recoverySuggestion, logLevel: .debug)
-      return self
-    }
-
-    private func logMessage(forPath path: String) -> String {
-      self.errorDescription + "Path: \(path)"
-    }
-
-    public static func ==(lhs: PathError, rhs: PathError) -> Bool {
-      lhs.errorDescription == rhs.errorDescription
-    }
-
-  }
-  
   /// Executes the code generation engine with a specified configuration.
   ///
   /// - Parameters:
   ///   - configuration: The configuration to use to build the code generation.
   public static func build(with configuration: ApolloCodegenConfiguration) throws {
-    try validate(configuration)
-  }
-
-  /// This is a preflight check to ensure that the specified configuration is valid before attempting to build the code generation output.
-  static func validate(_ config: ApolloCodegenConfiguration) throws {
-    CodegenLogger.log(String(describing: config), logLevel: .debug)
-
-    // File inputs
-    guard fileManager.doesFileExist(atPath: config.input.schemaPath) else {
-      throw PathError.notAFile(.schema).logging(withPath: config.input.schemaPath)
-    }
-
-    // File outputs - schema types
-    try requireDirectory(atPath: config.output.schemaTypes.path, ofType: .schemaTypes)
-
-    // File outputs - operations
-    if case .absolute(let operationsOutputPath) = config.output.operations {
-      try requireDirectory(atPath: operationsOutputPath, ofType: .operations)
-    }
-
-    // File outputs - operation identifiers
-    if let operationIdentifiersPath = config.output.operationIdentifiersPath {
-      if fileManager.doesDirectoryExist(atPath: operationIdentifiersPath) {
-        throw PathError.notAFile(.operationIdentifiers).logging(withPath: operationIdentifiersPath)
-      }
-    }
-  }
-
-  /// Validates that if the given path exists it is a directory. If it does not exist it attempts to create it.
-  private static func requireDirectory(atPath path: String, ofType pathType: PathType) throws {
-    if fileManager.doesFileExist(atPath: path) {
-      throw PathError.notADirectory(pathType).logging(withPath: path)
-    }
-
-    do {
-      try fileManager.createDirectoryIfNeeded(atPath: path)
-    } catch (let underlyingError) {
-      throw PathError.folderCreationFailed(pathType, underlyingError: underlyingError)
-        .logging(withPath: path)
-    }
+    try configuration.validate()
   }
 }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -205,3 +205,109 @@ public struct ApolloCodegenConfiguration {
               output: FileOutput(schemaTypes: SchemaTypesFileOutput(path: basePath)))
   }
 }
+
+extension ApolloCodegenConfiguration {
+  public enum PathType {
+    case schema
+    case schemaTypes
+    case operations
+    case operationIdentifiers
+
+    public var errorRecoverySuggestion: String {
+      switch self {
+      case .schema:
+        return "Check that the schema input path is an existing schema file containing SDL or JSON."
+      case .schemaTypes:
+        return "Check that the schema types output path exists and is a directory, or can be created."
+      case .operations:
+        return "Check that the operations output path exists and is a directory, or can be created."
+      case .operationIdentifiers:
+        return "Check that the operations identifiers path is an existing file or can be created."
+      }
+    }
+  }
+
+  /// Errors which can happen with code generation
+  public enum PathError: Swift.Error, LocalizedError, Equatable {
+    case notAFile(PathType)
+    case notADirectory(PathType)
+    case folderCreationFailed(PathType, underlyingError: Error)
+
+    public var errorDescription: String {
+      switch self {
+      case let .notAFile(pathType):
+        return "\(pathType) path must be a file!"
+      case let .notADirectory(pathType):
+        return "\(pathType) path must be a folder!"
+      case let .folderCreationFailed(pathType, underlyingError):
+        return "\(pathType) folder cannot be created! Error: \(underlyingError)"
+      }
+    }
+
+    public var recoverySuggestion: String {
+      switch self {
+      case let .notAFile(pathType),
+        let .notADirectory(pathType),
+        let .folderCreationFailed(pathType, _):
+        return pathType.errorRecoverySuggestion
+      }
+    }
+
+    public func logging(withPath path: String) -> PathError {
+      CodegenLogger.log(self.logMessage(forPath: path), logLevel: .error)
+      CodegenLogger.log(self.recoverySuggestion, logLevel: .debug)
+      return self
+    }
+
+    private func logMessage(forPath path: String) -> String {
+      self.errorDescription + "Path: \(path)"
+    }
+
+    public static func == (lhs: PathError, rhs: PathError) -> Bool {
+      lhs.errorDescription == rhs.errorDescription
+    }
+  }
+
+  /// Validates paths within the configuration ensuring that required files exist and that output directories can be created.
+  func validate() throws {
+    let fileManager = FileManager.default.apollo
+
+    CodegenLogger.log("Validating \(String(describing: self))", logLevel: .debug)
+
+    // File inputs
+    guard fileManager.doesFileExist(atPath: input.schemaPath) else {
+      throw PathError.notAFile(.schema).logging(withPath: input.schemaPath)
+    }
+
+    // File outputs - schema types
+    try requireDirectory(atPath: output.schemaTypes.path, ofType: .schemaTypes)
+
+    // File outputs - operations
+    if case .absolute(let operationsOutputPath) = output.operations {
+      try requireDirectory(atPath: operationsOutputPath, ofType: .operations)
+    }
+
+    // File outputs - operation identifiers
+    if let operationIdentifiersPath = output.operationIdentifiersPath {
+      if fileManager.doesDirectoryExist(atPath: operationIdentifiersPath) {
+        throw PathError.notAFile(.operationIdentifiers).logging(withPath: operationIdentifiersPath)
+      }
+    }
+  }
+
+  /// Validates that if the given path exists it is a directory. If it does not exist it attempts to create it.
+  private func requireDirectory(atPath path: String, ofType pathType: PathType) throws {
+    let fileManager = FileManager.default.apollo
+
+    if fileManager.doesFileExist(atPath: path) {
+      throw PathError.notADirectory(pathType).logging(withPath: path)
+    }
+
+    do {
+      try fileManager.createDirectoryIfNeeded(atPath: path)
+    } catch (let underlyingError) {
+      throw PathError.folderCreationFailed(pathType, underlyingError: underlyingError)
+        .logging(withPath: path)
+    }
+  }
+}

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -36,8 +36,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     let config = ApolloCodegenConfiguration(basePath: directoryURL.path, schemaFilename: filename)
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
-      throwError(ApolloCodegen.PathError.notAFile(.schema))
+    expect { try config.validate() }.to(
+      throwError(ApolloCodegenConfiguration.PathError.notAFile(.schema))
     )
   }
 
@@ -49,8 +49,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
-      throwError(ApolloCodegen.PathError.notAFile(.schema))
+    expect { try config.validate() }.to(
+      throwError(ApolloCodegenConfiguration.PathError.notAFile(.schema))
     )
   }
 
@@ -61,8 +61,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
                                             output: .init(schemaTypes: .init(path: directoryURL.path)))
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
-      throwError(ApolloCodegen.PathError.notAFile(.schema))
+    expect { try config.validate() }.to(
+      throwError(ApolloCodegenConfiguration.PathError.notAFile(.schema))
     )
   }
 
@@ -77,8 +77,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
-      throwError(ApolloCodegen.PathError.notADirectory(.schemaTypes))
+    expect { try config.validate() }.to(
+      throwError(ApolloCodegenConfiguration.PathError.notADirectory(.schemaTypes))
     )
   }
 
@@ -94,9 +94,9 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
+    expect { try config.validate() }.to(
       throwError { error in
-        guard case let ApolloCodegen.PathError
+        guard case let ApolloCodegenConfiguration.PathError
                 .folderCreationFailed(pathType, _) = error else {
                   fail()
                   return
@@ -119,8 +119,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
-      throwError(ApolloCodegen.PathError.notADirectory(.operations))
+    expect { try config.validate() }.to(
+      throwError(ApolloCodegenConfiguration.PathError.notADirectory(.operations))
     )
   }
 
@@ -138,9 +138,9 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
+    expect { try config.validate() }.to(
       throwError { error in        
-        guard case let ApolloCodegen.PathError
+        guard case let ApolloCodegenConfiguration.PathError
                 .folderCreationFailed(pathType, _) = error else {
                   fail()
                   return
@@ -164,8 +164,8 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.to(
-      throwError(ApolloCodegen.PathError.notAFile(.operationIdentifiers))
+    expect { try config.validate() }.to(
+      throwError(ApolloCodegenConfiguration.PathError.notAFile(.operationIdentifiers))
     )
   }
 
@@ -179,7 +179,7 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: expectedSchemaURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.notTo(throwError())
+    expect { try config.validate() }.notTo(throwError())
   }
 
   func test_validation_givenValidConfiguration_designatedInitializer_shouldNotThrow() throws {
@@ -195,6 +195,6 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(try FileManager.default.apollo.createFile(atPath: fileURL.path)).to(beTrue())
 
     // then
-    expect { try ApolloCodegen.validate(config) }.notTo(throwError())
+    expect { try config.validate() }.notTo(throwError())
   }
 }


### PR DESCRIPTION
Referring to the Single Responsibility Principle `ApolloCodegen` shouldn't be validating the config; it is correct for it to call the `validate()` function on build however.