### PR TITLE
Remove `ApolloAPI` import

### DIFF
--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -1,6 +1,5 @@
 import OrderedCollections
 import ApolloUtils
-import ApolloAPI
 
 class IR {
 


### PR DESCRIPTION
~IR.Swift introduced the `ApolloAPI` framework to `ApolloCodegenLib` - [diff](https://github.com/apollographql/apollo-ios/pull/2045/files#diff-32108a7446a136617be773da0ed4e7ec65a7aeeda8fd594a4d62dfe2914772e7R3). The `ApolloAPI` framework was not linked to the `ApolloCodegenLib` framework though - this fixes that.~

IR.Swift incorrectly introduced the `ApolloAPI` framework to `ApolloCodegenLib` - this fixes that. See https://github.com/apollographql/apollo-ios/pull/2051#issuecomment-988212303.

#### How to test
1. Clean and build the `release/1.0-alpha-incubating` branch (latest head is d20d795a)
2. The build will fail with the error `"No such module 'ApolloAPI'"` in [IR.Swift](https://github.com/apollographql/apollo-ios/blob/release/1.0-alpha-incubating/Sources/ApolloCodegenLib/IR/IR.swift#L3).
3. Clean and build the branch for this PR (`1.0/fix-framework-linking`)
4. No more errors 🎉 