### PR TITLE
Generate CompilationResult

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		DEFE0FC52748822900FFA440 /* IR+MergedSelectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE0FC42748822900FFA440 /* IR+MergedSelectionTree.swift */; };
 		E616B6D126C3335600DB049E /* ExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616B6D026C3335600DB049E /* ExecutionTests.swift */; };
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
+		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
 		E6630B8C26F0639B002D9E41 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB926EC05290094434A /* MockNetworkSession.swift */; };
 		E6630B8E26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */; };
@@ -919,6 +920,7 @@
 		DEFE0FC42748822900FFA440 /* IR+MergedSelectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+MergedSelectionTree.swift"; sourceTree = "<group>"; };
 		E616B6D026C3335600DB049E /* ExecutionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionTests.swift; sourceTree = "<group>"; };
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
+		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
 		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
@@ -1375,6 +1377,7 @@
 				E6BE04ED26F11B3500CF858D /* Resources */,
 				E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */,
 				9BAEEC16234C275600808306 /* ApolloSchemaPublicTests.swift */,
+				E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */,
 				9BAEEC18234C297800808306 /* ApolloCodegenConfigurationTests.swift */,
 				9BAEEC0D234BB95B00808306 /* FileManagerExtensionsTests.swift */,
 				9B68F0542416B33300E97318 /* LineByLineComparison.swift */,
@@ -2862,6 +2865,7 @@
 				DE223C3327221144004A0148 /* ASTMatchers.swift in Sources */,
 				E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */,
 				E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */,
+				E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */,
 				9F62DF8E2590539A00E6E808 /* SchemaIntrospectionTests.swift in Sources */,
 				9B68F0552416B33300E97318 /* LineByLineComparison.swift in Sources */,
 				DE09F9C6270269F800795949 /* Generate_OperationDefinition_Tests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -42,7 +42,9 @@ public class ApolloCodegen {
 
     let graphqlErrors = try frontend.validateDocument(schema: graphqlSchema, document: mergedDocument)
     guard graphqlErrors.isEmpty else {
-      throw Error.validationFailed(atLines: graphqlErrors.flatMap({ $0.logLines }))
+      let errorlines = graphqlErrors.flatMap({ $0.logLines })
+      CodegenLogger.log(String(describing: errorlines), logLevel: .error)
+      throw Error.validationFailed(atLines: errorlines)
     }
 
     return try frontend.compile(schema: graphqlSchema, document: mergedDocument)

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -5,12 +5,47 @@ import Foundation
 
 /// A class to facilitate running code generation
 public class ApolloCodegen {
+  public enum Error: Swift.Error, LocalizedError {
+    case validationFailed(atLines: [String])
+
+    public var errorDescription: String? {
+      switch self {
+      case let .validationFailed(lines):
+        return "Schema and Operation validation failed! Check \(lines)"
+      }
+    }
+  }
   /// Executes the code generation engine with a specified configuration.
   ///
   /// - Parameters:
   ///   - configuration: The configuration to use to build the code generation.
   public static func build(with configuration: ApolloCodegenConfiguration) throws {
     try configuration.validate()
+
+    let compilationResult = try compileResults(using: configuration.input)
+    #warning("TODO - compilationResult will be passed into the next step")
+  }
+
+  static func compileResults(
+    using input: ApolloCodegenConfiguration.FileInput
+  ) throws -> CompilationResult {
+    let frontend = try ApolloCodegenFrontend()
+
+    let schemaURL = URL(fileURLWithPath: input.schemaPath)
+    let graphqlSchema = try frontend.loadSchema(from: schemaURL)
+
+    let matches = try Glob(input.searchPaths).match()
+    let documents = try matches.map({ path in
+      return try frontend.parseDocument(from: URL(fileURLWithPath: path))
+    })
+    let mergedDocument = try frontend.mergeDocuments(documents)
+
+    let graphqlErrors = try frontend.validateDocument(schema: graphqlSchema, document: mergedDocument)
+    guard graphqlErrors.isEmpty else {
+      throw Error.validationFailed(atLines: graphqlErrors.flatMap({ $0.logLines }))
+    }
+
+    return try frontend.compile(schema: graphqlSchema, document: mergedDocument)
   }
 }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -29,7 +29,7 @@ public class ApolloCodegen {
   static func compileResults(
     using input: ApolloCodegenConfiguration.FileInput
   ) throws -> CompilationResult {
-    let frontend = try ApolloCodegenFrontend()
+    let frontend = try GraphQLJSFrontend()
 
     let schemaURL = URL(fileURLWithPath: input.schemaPath)
     let graphqlSchema = try frontend.loadSchema(from: schemaURL)

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+import ApolloCodegenTestSupport
+@testable import ApolloCodegenLib
+import Nimble
+
+class ApolloCodegenTests: XCTestCase {
+  private let schemaSDL: String = {
+    """
+    type Query {
+      books: [Book!]!
+      authors: [Author!]!
+    }
+
+    type Book {
+      title: String!
+      author: Author!
+    }
+
+    type Author {
+      name: String!
+      books: [Book!]!
+    }
+    """
+  }()
+
+  let directoryURL = CodegenTestHelper.outputFolderURL().appendingPathComponent("Codegen")
+
+  override func setUpWithError() throws {
+    try FileManager.default.apollo.createDirectoryIfNeeded(atPath: directoryURL.path)
+  }
+
+  override func tearDownWithError() throws {
+    try cleanTestOutput()
+  }
+
+  // MARK: Helpers
+
+  private func cleanTestOutput() throws {
+    try FileManager.default.apollo.deleteDirectory(atPath: directoryURL.path)
+  }
+
+  private func createSchema(at path: String) {
+    expect(
+      try FileManager.default.apollo.createFile(
+        atPath: path,
+        data: self.schemaSDL.data(using: .utf8)!
+      )
+    ).notTo(throwError())
+  }
+
+  private func createOperationFile(for data: Data, inDirectory directoryURL: URL) {
+    expect(
+      try FileManager.default.apollo.createFile(
+        atPath: directoryURL.appendingPathComponent("\(UUID().uuidString).graphql").path,
+        data: data
+      )
+    ).notTo(throwError())
+  }
+
+  // MARK: Tests
+
+  func test_build_givenInvalidConfiguration_shouldThrow() throws {
+    // given
+    let config = ApolloCodegenConfiguration(basePath: "not_a_path")
+
+    // then
+    expect(try ApolloCodegen.build(with: config)).to(throwError())
+  }
+
+  /// ```
+  /// SCHEMA:
+  /// type Query {
+  ///   books: [Book!]!
+  ///   authors: [Author!]!
+  /// }
+  ///
+  /// type Book {
+  ///   title: String!
+  ///   author: Author!
+  /// }
+  ///
+  /// type Author {
+  ///   name: String!
+  ///   books: [Book!]!
+  /// }
+  ///
+  /// OPERATION:
+  /// query getBooks {
+  ///   books {
+  ///     title
+  ///     name (this will cause the validation error)
+  ///   }
+  /// }
+  /// ```
+  func test_compileResults_givenOperation_withGraphQLErrors_shouldThrow() throws {
+    // given
+    let schemaPath = directoryURL.appendingPathComponent("schema.graphqls").path
+    createSchema(at: schemaPath)
+
+    let searchPath = directoryURL.appendingPathComponent("*.graphql").path
+    let data: Data =
+      """
+      query getBooks {
+        books {
+          title
+          name
+        }
+      }
+      """.data(using: .utf8)!
+    createOperationFile(for: data, inDirectory: directoryURL)
+
+    let config = ApolloCodegenConfiguration.FileInput(
+      schemaPath: schemaPath,
+      searchPaths: [searchPath]
+    )
+
+    // then
+    expect(try ApolloCodegen.compileResults(using: config))
+    .to(throwError { error in
+      guard case let ApolloCodegen.Error.validationFailed(lines) = error else {
+        fail("Expected .validationFailed, got .\(error)")
+        return
+      }
+      expect(lines).notTo(beEmpty())
+    })
+  }
+
+  /// ```
+  /// SCHEMA:
+  /// type Query {
+  ///   books: [Book!]!
+  ///   authors: [Author!]!
+  /// }
+  ///
+  /// type Book {
+  ///   title: String!
+  ///   author: Author!
+  /// }
+  ///
+  /// type Author {
+  ///   name: String!
+  ///   books: [Book!]!
+  /// }
+  ///
+  /// OPERATION 1:
+  /// query getBooks {
+  ///   books {
+  ///     title
+  ///   }
+  /// }
+  ///
+  /// OPERATION 2:
+  /// query getAuthors {
+  ///   authors {
+  ///     name
+  ///   }
+  /// }
+  /// ```
+  func test_compileResults_givenOperations_withNoErrors_shouldReturn() throws {
+    // given
+    let schemaPath = directoryURL.appendingPathComponent("schema.graphqls").path
+    createSchema(at: schemaPath)
+
+    let searchPath = directoryURL.appendingPathComponent("*.graphql").path
+    let booksData: Data =
+      """
+      query getBooks {
+        books {
+          title
+        }
+      }
+      """.data(using: .utf8)!
+    createOperationFile(for: booksData, inDirectory: directoryURL)
+
+    let authorsData: Data =
+      """
+      query getAuthors {
+        authors {
+          name
+        }
+      }
+      """.data(using: .utf8)!
+    createOperationFile(for: authorsData, inDirectory: directoryURL)
+
+    let config = ApolloCodegenConfiguration.FileInput(
+      schemaPath: schemaPath,
+      searchPaths: [searchPath]
+    )
+
+    // then
+    expect(try ApolloCodegen.compileResults(using: config).operations).to(haveCount(2))
+  }
+}

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -67,31 +67,6 @@ class ApolloCodegenTests: XCTestCase {
     expect(try ApolloCodegen.build(with: config)).to(throwError())
   }
 
-  /// ```
-  /// SCHEMA:
-  /// type Query {
-  ///   books: [Book!]!
-  ///   authors: [Author!]!
-  /// }
-  ///
-  /// type Book {
-  ///   title: String!
-  ///   author: Author!
-  /// }
-  ///
-  /// type Author {
-  ///   name: String!
-  ///   books: [Book!]!
-  /// }
-  ///
-  /// OPERATION:
-  /// query getBooks {
-  ///   books {
-  ///     title
-  ///     name (this will cause the validation error)
-  ///   }
-  /// }
-  /// ```
   func test_compileResults_givenOperation_withGraphQLErrors_shouldThrow() throws {
     // given
     let schemaPath = directoryURL.appendingPathComponent("schema.graphqls").path
@@ -114,6 +89,11 @@ class ApolloCodegenTests: XCTestCase {
       searchPaths: [searchPath]
     )
 
+    // with
+    //
+    // Fetching `books.name` will cause a GraphQL validation error because `name`
+    // is not a property of the `Book` type.
+
     // then
     expect(try ApolloCodegen.compileResults(using: config))
     .to(throwError { error in
@@ -125,37 +105,6 @@ class ApolloCodegenTests: XCTestCase {
     })
   }
 
-  /// ```
-  /// SCHEMA:
-  /// type Query {
-  ///   books: [Book!]!
-  ///   authors: [Author!]!
-  /// }
-  ///
-  /// type Book {
-  ///   title: String!
-  ///   author: Author!
-  /// }
-  ///
-  /// type Author {
-  ///   name: String!
-  ///   books: [Book!]!
-  /// }
-  ///
-  /// OPERATION 1:
-  /// query getBooks {
-  ///   books {
-  ///     title
-  ///   }
-  /// }
-  ///
-  /// OPERATION 2:
-  /// query getAuthors {
-  ///   authors {
-  ///     name
-  ///   }
-  /// }
-  /// ```
   func test_compileResults_givenOperations_withNoErrors_shouldReturn() throws {
     // given
     let schemaPath = directoryURL.appendingPathComponent("schema.graphqls").path


### PR DESCRIPTION
~_Created as a draft until needed changes to the graphql-js frontend are available._~

This calls into the graphql-js frontend to load, parse, merge, validate and compile all the GraphQL inputs (schema + operations) needed for code generation. The results from here will go on to the coordinator and get fed into the Swift AST generators which is coming in #2033.

Closes #2035 