### PR TITLE
Allow Doubles as JSONDecodables too

### DIFF
--- a/Sources/Apollo/JSONStandardTypeConversions.swift
+++ b/Sources/Apollo/JSONStandardTypeConversions.swift
@@ -7,6 +7,8 @@ extension String: JSONDecodable, JSONEncodable {
         self = string
     case let int as Int:
         self = String(int)
+    case let double as Double:
+        self = String(double)
     default:
         throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
     }


### PR DESCRIPTION
I'm not sure why only Int would be parsed, so giving Doubles the same treatment as Int