### PR TITLE
`GraphQLObjectType` File Generator

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -310,11 +310,14 @@
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
 		E6630B8C26F0639B002D9E41 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB926EC05290094434A /* MockNetworkSession.swift */; };
 		E6630B8E26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */; };
+		E66F8897276C136B0000BDA8 /* TypeFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */; };
+		E66F8899276C15580000BDA8 /* TypeFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */; };
 		E674DB41274C0A9B009BB90E /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB40274C0A9B009BB90E /* Glob.swift */; };
 		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */; };
+		E6E3BBE2276A8D6200E5218B /* FileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */; };
 		E86D8E05214B32FD0028EFE1 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86D8E03214B32DA0028EFE1 /* JSONTests.swift */; };
 		F16D083C21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */; };
 		F82E62E122BCD223000C311B /* AutomaticPersistedQueriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82E62E022BCD223000C311B /* AutomaticPersistedQueriesTests.swift */; };
@@ -953,12 +956,15 @@
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
+		E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeFileGeneratorTests.swift; sourceTree = "<group>"; };
+		E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeFileGenerator.swift; sourceTree = "<group>"; };
 		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
 		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDownloaderTests.swift; sourceTree = "<group>"; };
 		E6D79AB926EC05290094434A /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
+		E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileGenerator.swift; sourceTree = "<group>"; };
 		E86D8E03214B32DA0028EFE1 /* JSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryFromJSONBuildingTests.swift; sourceTree = "<group>"; };
 		F82E62E022BCD223000C311B /* AutomaticPersistedQueriesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomaticPersistedQueriesTests.swift; sourceTree = "<group>"; };
@@ -1493,7 +1499,7 @@
 				E674DB40274C0A9B009BB90E /* Glob.swift */,
 				DE5FD600276923620033EE23 /* TemplateString.swift */,
 				DE31A437276A78140020DC44 /* Templates */,
-				DE5FD5FB276922200033EE23 /* Generators */,
+				E6E3BBDC276A8D6200E5218B /* FileGenerators */,
 			);
 			name = Codegen;
 			sourceTree = "<group>";
@@ -1803,6 +1809,7 @@
 		DE09F9C4270269F800795949 /* CodeGeneration */ = {
 			isa = PBXGroup;
 			children = (
+				E66F8895276C13330000BDA8 /* FileGenerators */,
 				DE31A438276A789B0020DC44 /* Templates */,
 			);
 			path = CodeGeneration;
@@ -1944,13 +1951,6 @@
 				DED45FB3261CDEC60086EF63 /* Apollo-CodegenTestPlan.xctestplan */,
 			);
 			path = TestPlans;
-			sourceTree = "<group>";
-		};
-		DE5FD5FB276922200033EE23 /* Generators */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Generators;
 			sourceTree = "<group>";
 		};
 		DE6B15AD26152BE10068D642 /* ApolloServerIntegrationTests */ = {
@@ -2117,6 +2117,14 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		E66F8895276C13330000BDA8 /* FileGenerators */ = {
+			isa = PBXGroup;
+			children = (
+				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
+			);
+			path = FileGenerators;
+			sourceTree = "<group>";
+		};
 		E676C11F26CB05F90091215A /* DefaultImplementation */ = {
 			isa = PBXGroup;
 			children = (
@@ -2135,6 +2143,15 @@
 				E6C4267A26F16CB400904AD2 /* introspection_response.json */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		E6E3BBDC276A8D6200E5218B /* FileGenerators */ = {
+			isa = PBXGroup;
+			children = (
+				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
+				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
+			);
+			path = FileGenerators;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2858,6 +2875,7 @@
 				9BAEEBEE2346644600808306 /* ApolloSchemaDownloadConfiguration.swift in Sources */,
 				DE5FD5FF276922AA0033EE23 /* MockApolloCodegenConfiguration.swift in Sources */,
 				9B8C3FB3248DA2FE00707B13 /* URL+Apollo.swift in Sources */,
+				E66F8899276C15580000BDA8 /* TypeFileGenerator.swift in Sources */,
 				9BAEEBEF2346644B00808306 /* ApolloSchemaDownloader.swift in Sources */,
 				DE5FD601276923620033EE23 /* TemplateString.swift in Sources */,
 				DE796429276998B000978A03 /* IR+RootFieldBuilder.swift in Sources */,
@@ -2886,6 +2904,7 @@
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,
 				DE2739112769AEBA00B886EF /* SelectionSetTemplate.swift in Sources */,
+				E6E3BBE2276A8D6200E5218B /* FileGenerator.swift in Sources */,
 				DEFE0FC52748822900FFA440 /* IR+MergedSelectionTree.swift in Sources */,
 				9F62E03F2590896400E6E808 /* GraphQLError.swift in Sources */,
 				9B7B6F5A233C287200F32205 /* ApolloCodegenConfiguration.swift in Sources */,
@@ -2939,6 +2958,7 @@
 				DEAFB77B2706444B00BE02F3 /* IRRootEntityFieldBuilderTests.swift in Sources */,
 				9F62DFBF2590560000E6E808 /* Helpers.swift in Sources */,
 				DED18CC727023C0400F62977 /* OperationDefinitionTests.swift in Sources */,
+				E66F8897276C136B0000BDA8 /* TypeFileGeneratorTests.swift in Sources */,
 				DE27390F2769AE9700B886EF /* SelectionSetTemplateTests.swift in Sources */,
 				DE79642B276999E700978A03 /* IRNamedFragmentBuilderTests.swift in Sources */,
 				9B8C3FB5248DA3E000707B13 /* URLExtensionsTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -27,8 +27,16 @@ public class ApolloCodegen {
   public static func build(with configuration: ApolloCodegenConfiguration) throws {
     try configuration.validate()
 
-    #warning("TODO - compilationResult will be passed into the next step")
     let compilationResult = try compileGraphQLResult(using: configuration.input)
+
+    let ir = IR(
+      schemaName: configuration.output.schemaTypes.moduleName,
+      compilationResult: compilationResult
+    )
+
+    try generateSchemaTypeFiles(for: ir.schema.referencedTypes, configuration: configuration)
+    #warning("TODO - generate operation files")
+    #warning("TODO - generate package manager manifest")
   }
 
   static func compileGraphQLResult(
@@ -53,6 +61,21 @@ public class ApolloCodegen {
     }
 
     return try frontend.compile(schema: graphqlSchema, document: mergedDocument)
+  }
+
+  static func generateSchemaTypeFiles(
+    for referencedTypes: IR.Schema.ReferencedTypes,
+    configuration: ApolloCodegenConfiguration
+  ) throws {
+    let schemaTypesDirectory = configuration.output.schemaTypes.modulePath
+
+    try referencedTypes.objects.forEach { graphqlObject in
+      try TypeFileGenerator.generate(for: graphqlObject, in: schemaTypesDirectory)
+    }
+
+    #warning("TODO - generate enum files")
+    #warning("TODO - generate interface files")
+    #warning("TODO - generate union files")
   }
 }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OrderedCollections
 
 // Only available on macOS
 #if os(macOS)
@@ -34,10 +35,15 @@ public class ApolloCodegen {
       compilationResult: compilationResult
     )
 
-    try generateSchemaFiles(
-      for: ir.schema.referencedTypes,
-      configuration: configuration.output.schemaTypes
-    )
+    try fileGenerators(
+      for: ir.schema.referencedTypes.objects,
+      directoryPath: configuration.output.schemaTypes.modulePath
+    ).forEach({ try $0.generateFile() })
+
+    #warning("TODO - generate schema enum files")
+    #warning("TODO - generate schema interface files")
+    #warning("TODO - generate schema union files")
+    #warning("TODO - generate schema file")
     #warning("TODO - generate operation/fragment files")
     #warning("TODO - generate package manager manifest")
   }
@@ -66,20 +72,13 @@ public class ApolloCodegen {
     return try frontend.compile(schema: graphqlSchema, document: mergedDocument)
   }
 
-  static func generateSchemaFiles(
-    for referencedTypes: IR.Schema.ReferencedTypes,
-    configuration: ApolloCodegenConfiguration.SchemaTypesFileOutput
-  ) throws {
-    let schemaTypesDirectory = configuration.modulePath
-
-    try referencedTypes.objects.forEach { graphqlObject in
-      try TypeFileGenerator.generateFile(for: graphqlObject, directoryPath: schemaTypesDirectory)
-    }
-
-    #warning("TODO - generate enum files")
-    #warning("TODO - generate interface files")
-    #warning("TODO - generate union files")
-    #warning("TODO - generate schema file")
+  static func fileGenerators(
+    for objectTypes: OrderedSet<GraphQLObjectType>,
+    directoryPath path: String
+  ) -> [TypeFileGenerator] {
+    return objectTypes.map({ graphqlObjectType in
+      TypeFileGenerator(objectType: graphqlObjectType, directoryPath: path)
+    })
   }
 }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -73,7 +73,7 @@ public class ApolloCodegen {
     let schemaTypesDirectory = configuration.modulePath
 
     try referencedTypes.objects.forEach { graphqlObject in
-      try TypeFileGenerator.generate(for: graphqlObject, in: schemaTypesDirectory)
+      try TypeFileGenerator.generateFile(for: graphqlObject, directoryPath: schemaTypesDirectory)
     }
 
     #warning("TODO - generate enum files")

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -11,11 +11,11 @@ public class ApolloCodegen {
   /// Errors that can occur during code generation.
   public enum Error: Swift.Error, LocalizedError {
     /// An error occured during validation of the GraphQL schema or operations.
-    case graphQLSourceValidationFailed(atLines: [String])
+    case graphQLSourceValidationFailure(atLines: [String])
 
     public var errorDescription: String? {
       switch self {
-      case let .graphQLSourceValidationFailed(lines):
+      case let .graphQLSourceValidationFailure(lines):
         return "An error occured during validation of the GraphQL schema or operations! Check \(lines)"
       }
     }
@@ -66,7 +66,7 @@ public class ApolloCodegen {
     guard graphqlErrors.isEmpty else {
       let errorlines = graphqlErrors.flatMap({ $0.logLines })
       CodegenLogger.log(String(describing: errorlines), logLevel: .error)
-      throw Error.graphQLSourceValidationFailed(atLines: errorlines)
+      throw Error.graphQLSourceValidationFailure(atLines: errorlines)
     }
 
     return try frontend.compile(schema: graphqlSchema, document: mergedDocument)

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -38,7 +38,7 @@ public class ApolloCodegen {
       for: ir.schema.referencedTypes,
       configuration: configuration.output.schemaTypes
     )
-    #warning("TODO - generate operation files")
+    #warning("TODO - generate operation/fragment files")
     #warning("TODO - generate package manager manifest")
   }
 
@@ -79,6 +79,7 @@ public class ApolloCodegen {
     #warning("TODO - generate enum files")
     #warning("TODO - generate interface files")
     #warning("TODO - generate union files")
+    #warning("TODO - generate schema file")
   }
 }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -5,28 +5,33 @@ import Foundation
 
 /// A class to facilitate running code generation
 public class ApolloCodegen {
+  // MARK: Public
+
+  /// Errors that can occur during code generation.
   public enum Error: Swift.Error, LocalizedError {
-    case validationFailed(atLines: [String])
+    /// An error occured during validation of the GraphQL schema or operations.
+    case graphQLSourceValidationFailed(atLines: [String])
 
     public var errorDescription: String? {
       switch self {
-      case let .validationFailed(lines):
-        return "Schema and Operation validation failed! Check \(lines)"
+      case let .graphQLSourceValidationFailed(lines):
+        return "An error occured during validation of the GraphQL schema or operations! Check \(lines)"
       }
     }
   }
+
   /// Executes the code generation engine with a specified configuration.
   ///
   /// - Parameters:
-  ///   - configuration: The configuration to use to build the code generation.
+  ///   - configuration: A configuration object that specifies inputs, outputs and behaviours used during code generation.
   public static func build(with configuration: ApolloCodegenConfiguration) throws {
     try configuration.validate()
 
-    let compilationResult = try compileResults(using: configuration.input)
     #warning("TODO - compilationResult will be passed into the next step")
+    let compilationResult = try compileGraphQLResult(using: configuration.input)
   }
 
-  static func compileResults(
+  static func compileGraphQLResult(
     using input: ApolloCodegenConfiguration.FileInput
   ) throws -> CompilationResult {
     let frontend = try GraphQLJSFrontend()
@@ -44,7 +49,7 @@ public class ApolloCodegen {
     guard graphqlErrors.isEmpty else {
       let errorlines = graphqlErrors.flatMap({ $0.logLines })
       CodegenLogger.log(String(describing: errorlines), logLevel: .error)
-      throw Error.validationFailed(atLines: errorlines)
+      throw Error.graphQLSourceValidationFailed(atLines: errorlines)
     }
 
     return try frontend.compile(schema: graphqlSchema, document: mergedDocument)

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -34,7 +34,10 @@ public class ApolloCodegen {
       compilationResult: compilationResult
     )
 
-    try generateSchemaTypeFiles(for: ir.schema.referencedTypes, configuration: configuration)
+    try generateSchemaTypeFiles(
+      for: ir.schema.referencedTypes,
+      configuration: configuration.output.schemaTypes
+    )
     #warning("TODO - generate operation files")
     #warning("TODO - generate package manager manifest")
   }
@@ -65,9 +68,9 @@ public class ApolloCodegen {
 
   static func generateSchemaTypeFiles(
     for referencedTypes: IR.Schema.ReferencedTypes,
-    configuration: ApolloCodegenConfiguration
+    configuration: ApolloCodegenConfiguration.SchemaTypesFileOutput
   ) throws {
-    let schemaTypesDirectory = configuration.output.schemaTypes.modulePath
+    let schemaTypesDirectory = configuration.modulePath
 
     try referencedTypes.objects.forEach { graphqlObject in
       try TypeFileGenerator.generate(for: graphqlObject, in: schemaTypesDirectory)

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -34,7 +34,7 @@ public class ApolloCodegen {
       compilationResult: compilationResult
     )
 
-    try generateSchemaTypeFiles(
+    try generateSchemaFiles(
       for: ir.schema.referencedTypes,
       configuration: configuration.output.schemaTypes
     )
@@ -66,7 +66,7 @@ public class ApolloCodegen {
     return try frontend.compile(schema: graphqlSchema, document: mergedDocument)
   }
 
-  static func generateSchemaTypeFiles(
+  static func generateSchemaFiles(
     for referencedTypes: IR.Schema.ReferencedTypes,
     configuration: ApolloCodegenConfiguration.SchemaTypesFileOutput
   ) throws {

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// A configuration object that defines behavior for code generation.
 public struct ApolloCodegenConfiguration {
+
+  // MARK: Input Types
+
   /// The input paths and files required for code generation.
   public struct FileInput {
     /// Local path to the GraphQL schema file. Can be in JSON or SDL format.
@@ -34,6 +37,8 @@ public struct ApolloCodegenConfiguration {
       self.searchPaths = searchPaths
     }
   }
+
+  // MARK: Output Types
 
   /// The paths and files output by code generation.
   public struct FileOutput {
@@ -118,6 +123,8 @@ public struct ApolloCodegenConfiguration {
     case absolute(path: String)
   }
 
+  // MARK: General Types
+
   /// Specify the formatting of the GraphQL query string literal.
   public enum QueryStringLiteralFormat {
     /// The query string will be copied into the operation object with all line break formatting removed.
@@ -165,6 +172,8 @@ public struct ApolloCodegenConfiguration {
     case persistedOperationsOnly
   }
 
+  // MARK: Properties
+
   /// The input files required for code generation.
   public let input: FileInput
   /// The paths and files output by code generation.
@@ -184,6 +193,8 @@ public struct ApolloCodegenConfiguration {
   ///
   /// See `APQConfig` for more information on Automatic Persisted Queries.
   public let apqs: APQConfig
+
+  // MARK: Initializers
 
   /// Designated initializer.
   ///
@@ -241,6 +252,8 @@ public struct ApolloCodegenConfiguration {
               output: FileOutput(schemaTypes: SchemaTypesFileOutput(path: basePath)))
   }
 }
+
+// MARK: Validation Extension
 
 extension ApolloCodegenConfiguration {
   public enum PathType {
@@ -346,5 +359,22 @@ extension ApolloCodegenConfiguration {
       throw PathError.folderCreationFailed(pathType, underlyingError: underlyingError)
         .logging(withPath: path)
     }
+  }
+}
+
+// MARK: Helper Extensions (Internal Only)
+
+extension ApolloCodegenConfiguration.SchemaTypesFileOutput {
+  var moduleName: String {
+    switch self.dependencyAutomation {
+    case let .manuallyLinked(namespace):
+      return namespace
+    case let .carthage(moduleName), let .cocoaPods(moduleName), let .swiftPackageManager(moduleName):
+      return moduleName
+    }
+  }
+
+  var modulePath: String {
+    URL(fileURLWithPath: self.path).appendingPathComponent(self.moduleName).path
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -367,10 +367,12 @@ extension ApolloCodegenConfiguration {
 extension ApolloCodegenConfiguration.SchemaTypesFileOutput {
   var moduleName: String {
     switch self.dependencyAutomation {
-    case let .manuallyLinked(namespace):
-      return namespace
-    case let .carthage(moduleName), let .cocoaPods(moduleName), let .swiftPackageManager(moduleName):
-      return moduleName
+    case
+      let .manuallyLinked(name),
+      let .carthage(name),
+      let .cocoaPods(name),
+      let .swiftPackageManager(name):
+        return name
     }
   }
 

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -5,9 +5,8 @@ import ApolloUtils
 protocol FileGenerator {
   associatedtype graphQLType
 
-  static func generateFile(
-    for object: graphQLType,
-    directoryPath: String,
-    fileManager: FileManager
-  ) throws
+  var objectType: GraphQLObjectType { get }
+  var filePath: String { get }
+
+  func generateFile() throws
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -1,0 +1,13 @@
+import Foundation
+import ApolloUtils
+
+/// The methods to conform to when building a code generation Swift file generator.
+protocol FileGenerator {
+  associatedtype graphQLType
+
+  static func generate(
+    for object: graphQLType,
+    in rootPath: String,
+    fileManager: FileManager
+  ) throws
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -5,9 +5,9 @@ import ApolloUtils
 protocol FileGenerator {
   associatedtype graphQLType
 
-  static func generate(
+  static func generateFile(
     for object: graphQLType,
-    in rootPath: String,
+    directoryPath: String,
     fileManager: FileManager
   ) throws
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -2,11 +2,15 @@ import Foundation
 import ApolloUtils
 
 /// The methods to conform to when building a code generation Swift file generator.
-protocol FileGenerator: Equatable {
-  associatedtype graphQLType
+protocol FileGenerator {
+  var path: String { get }
+  var data: Data { get }
 
-  var objectType: GraphQLObjectType { get }
-  var filePath: String { get }
+  func generateFile(fileManager: FileManager) throws
+}
 
-  func generateFile() throws
+extension FileGenerator {
+  func generateFile(fileManager: FileManager = FileManager.default) throws {
+    try fileManager.apollo.createFile(atPath: path, data: data)
+  }
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -2,7 +2,7 @@ import Foundation
 import ApolloUtils
 
 /// The methods to conform to when building a code generation Swift file generator.
-protocol FileGenerator {
+protocol FileGenerator: Equatable {
   associatedtype graphQLType
 
   var objectType: GraphQLObjectType { get }

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -10,9 +10,8 @@ struct TypeFileGenerator: FileGenerator {
     directoryPath: String,
     fileManager: FileManager = FileManager.default
   ) throws {
-    let filename = object.name
     let filePath = URL(fileURLWithPath: directoryPath)
-      .appendingPathComponent("\(filename).swift").path
+      .appendingPathComponent("\(object.name).swift").path
 
     #warning("TODO: Build correct content with template string")
     let data = "public class \(object.name) {}".data(using: .utf8)

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -2,30 +2,18 @@ import Foundation
 import ApolloUtils
 
 /// Generates a file containing the Swift representation of a [GraphQL Object type](https://spec.graphql.org/draft/#sec-Objects).
-struct TypeFileGenerator: FileGenerator {
-  typealias graphQLType = GraphQLObjectType
-
+struct TypeFileGenerator: FileGenerator, Equatable {
   let objectType: GraphQLObjectType
-  let filePath: String
+  let path: String
 
-  private let fileManager: FileManager
-
-  init(
-    objectType: GraphQLObjectType,
-    directoryPath: String,
-    fileManager: FileManager = FileManager.default
-  ) {
-    self.objectType = objectType
-    self.fileManager = fileManager
-
-    self.filePath = URL(fileURLWithPath: directoryPath)
-      .appendingPathComponent("\(objectType.name).swift").path
+  var data: Data {
+    return "public class \(objectType.name) {}".data(using: .utf8)!
   }
 
-  func generateFile() throws {
-    #warning("TODO: Build correct content with template string")
-    let data = "public class \(objectType.name) {}".data(using: .utf8)
+  init(objectType: GraphQLObjectType, directoryPath: String) {
+    self.objectType = objectType
 
-    try fileManager.apollo.createFile(atPath: filePath, data: data)
+    self.path = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(objectType.name).swift").path
   }
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -5,18 +5,27 @@ import ApolloUtils
 struct TypeFileGenerator: FileGenerator {
   typealias graphQLType = GraphQLObjectType
 
-  static func generateFile(
-    for object: GraphQLObjectType,
+  let objectType: GraphQLObjectType
+  let filePath: String
+
+  private let fileManager: FileManager
+
+  init(
+    objectType: GraphQLObjectType,
     directoryPath: String,
     fileManager: FileManager = FileManager.default
-  ) throws {
-    let filePath = URL(fileURLWithPath: directoryPath)
-      .appendingPathComponent("\(object.name).swift").path
+  ) {
+    self.objectType = objectType
+    self.fileManager = fileManager
 
+    self.filePath = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(objectType.name).swift").path
+  }
+
+  func generateFile() throws {
     #warning("TODO: Build correct content with template string")
-    let data = "public class \(object.name) {}".data(using: .utf8)
+    let data = "public class \(objectType.name) {}".data(using: .utf8)
 
     try fileManager.apollo.createFile(atPath: filePath, data: data)
   }
 }
-

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -5,13 +5,14 @@ import ApolloUtils
 struct TypeFileGenerator: FileGenerator {
   typealias graphQLType = GraphQLObjectType
 
-  static func generate(
+  static func generateFile(
     for object: GraphQLObjectType,
-    in rootPath: String,
+    directoryPath: String,
     fileManager: FileManager = FileManager.default
   ) throws {
-    let filename = object.jsValue.toString()!
-    let filePath = URL(fileURLWithPath: rootPath).appendingPathComponent("\(filename).swift").path
+    let filename = object.name
+    let filePath = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(filename).swift").path
 
     #warning("TODO: Build correct content with template string")
     let data = "public class \(object.name) {}".data(using: .utf8)

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ApolloUtils
+
+/// Generates a file containing the Swift representation of a [GraphQL Object type](https://spec.graphql.org/draft/#sec-Objects).
+struct TypeFileGenerator: FileGenerator {
+  typealias graphQLType = GraphQLObjectType
+
+  static func generate(
+    for object: GraphQLObjectType,
+    in rootPath: String,
+    fileManager: FileManager = FileManager.default
+  ) throws {
+    let filename = object.jsValue.toString()!
+    let filePath = URL(fileURLWithPath: rootPath).appendingPathComponent("\(filename).swift").path
+
+    #warning("TODO: Build correct content with template string")
+    let data = "public class \(object.name) {}".data(using: .utf8)
+
+    try fileManager.apollo.createFile(atPath: filePath, data: data)
+  }
+}
+

--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -26,7 +26,11 @@ public class CompilationResult: JavaScriptObject {
     lazy var operationIdentifier: String = {
       #warning("TODO: Compute this from source + referenced fragments")
       return ""
-    }()
+    }()    
+
+    override public var debugDescription: String {
+      "\(name) on \(rootType.debugDescription)"
+    }
   }
   
   public enum OperationType: String, Equatable, JavaScriptValueDecodable {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -219,12 +219,14 @@ class ApolloCodegenConfigurationTests: XCTestCase {
 
   // MARK: Helper Tests
 
-  func test_givenDefaultConfiguration_shouldBuildHelperValues() {
+  func test_givenDefaultConfiguration_shouldBuildDefaultSchemaModuleProperties() {
     // given
     let fileURL = directoryURL.appendingPathComponent(UUID().uuidString)
-    let config = ApolloCodegenConfiguration(basePath: fileURL.path,
-                                            schemaFilename: "different_schema.graphql",
-                                            searchPattern: "*.operation")
+    let config = ApolloCodegenConfiguration(
+      basePath: fileURL.path,
+      schemaFilename: "different_schema.graphql",
+      searchPattern: "*.operation"
+    )
 
     // then
     expect(config.output.schemaTypes.moduleName).to(equal("API"))
@@ -232,41 +234,45 @@ class ApolloCodegenConfigurationTests: XCTestCase {
       .to(equal(fileURL.appendingPathComponent("API").path))
   }
 
-  func test_givenSwiftPackageManagerConfiguration_shouldBuildHelperValues() {
+  func test_givenSwiftPackageManagerConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let moduleName = "SPMModule"
     let config = buildConfig(forDependencyAutomation: .swiftPackageManager(moduleName: moduleName))
 
+    // then
     expect(config.output.schemaTypes.moduleName).to(equal(moduleName))
     expect(config.output.schemaTypes.modulePath)
       .to(equal(directoryURL.appendingPathComponent(moduleName).path))
   }
 
-  func test_givenCocoaPodsConfiguration_shouldBuildHelperValues() {
+  func test_givenCocoaPodsConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let moduleName = "PodsModule"
     let config = buildConfig(forDependencyAutomation: .cocoaPods(moduleName: moduleName))
 
+    // then
     expect(config.output.schemaTypes.moduleName).to(equal(moduleName))
     expect(config.output.schemaTypes.modulePath)
       .to(equal(directoryURL.appendingPathComponent(moduleName).path))
   }
 
-  func test_givenCarthageConfiguration_shouldBuildHelperValues() {
+  func test_givenCarthageConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let moduleName = "CarthageModule"
     let config = buildConfig(forDependencyAutomation: .carthage(moduleName: moduleName))
 
+    // then
     expect(config.output.schemaTypes.moduleName).to(equal(moduleName))
     expect(config.output.schemaTypes.modulePath)
       .to(equal(directoryURL.appendingPathComponent(moduleName).path))
   }
 
-  func test_givenManuallyLinkedConfiguration_shouldBuildHelperValues() {
+  func test_givenManuallyLinkedConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let namespace = "NamespaceModule"
     let config = buildConfig(forDependencyAutomation: .manuallyLinked(namespace: namespace))
 
+    // then
     expect(config.output.schemaTypes.moduleName).to(equal(namespace))
     expect(config.output.schemaTypes.modulePath)
       .to(equal(directoryURL.appendingPathComponent(namespace).path))

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -97,8 +97,8 @@ class ApolloCodegenTests: XCTestCase {
     // then
     expect(try ApolloCodegen.compileGraphQLResult(using: config))
     .to(throwError { error in
-      guard case let ApolloCodegen.Error.graphQLSourceValidationFailed(lines) = error else {
-        fail("Expected .validationFailed, got .\(error)")
+      guard case let ApolloCodegen.Error.graphQLSourceValidationFailure(lines) = error else {
+        fail("Expected .graphQLSourceValidationFailure, got .\(error)")
         return
       }
       expect(lines).notTo(beEmpty())

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -93,9 +93,9 @@ class ApolloCodegenTests: XCTestCase {
     // is not a property of the `Book` type.
 
     // then
-    expect(try ApolloCodegen.compileResults(using: config))
+    expect(try ApolloCodegen.compileGraphQLResult(using: config))
     .to(throwError { error in
-      guard case let ApolloCodegen.Error.validationFailed(lines) = error else {
+      guard case let ApolloCodegen.Error.graphQLSourceValidationFailed(lines) = error else {
         fail("Expected .validationFailed, got .\(error)")
         return
       }
@@ -133,6 +133,6 @@ class ApolloCodegenTests: XCTestCase {
     )
 
     // then
-    expect(try ApolloCodegen.compileResults(using: config).operations).to(haveCount(2))
+    expect(try ApolloCodegen.compileGraphQLResult(using: config).operations).to(haveCount(2))
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -135,4 +135,17 @@ class ApolloCodegenTests: XCTestCase {
     // then
     expect(try ApolloCodegen.compileGraphQLResult(using: config).operations).to(haveCount(2))
   }
+
+  func test_compileResults_givenSchema_withNoOperations_shouldReturnEmpty() throws {
+    // given
+    let schemaPath = createFile(containing: schemaData, named: "schema.graphqls")
+
+    let config = ApolloCodegenConfiguration.FileInput(
+      schemaPath: schemaPath,
+      searchPaths: [directoryURL.appendingPathComponent("*.graphql").path]
+    )
+
+    // then
+    expect(try ApolloCodegen.compileGraphQLResult(using: config).operations).to(beEmpty())
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
@@ -47,7 +47,11 @@ class TypeFileGeneratorTests: XCTestCase {
     }))
 
     // then
-    try TypeFileGenerator.generate(for: bookType, in: rootURL.path, fileManager: mockFileManager)
+    try TypeFileGenerator.generateFile(
+      for: bookType,
+      directoryPath: rootURL.path,
+      fileManager: mockFileManager
+    )
 
     expect(mockFileManager.allClosuresCalled).to(beTrue())
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+import ApolloUtils
+
+class TypeFileGeneratorTests: XCTestCase {
+  func test_generate_givenSchemaType_shouldWriteTemplateToPath() throws {
+    // given
+    let schema = """
+    type Query {
+      books: [Book!]!
+    }
+
+    type Book {
+      name: String!
+    }
+    """
+
+    let operation = """
+    query getBooks {
+      books {
+        name
+      }
+    }
+    """
+
+    let ir = try IR.mock(schema: schema, document: operation)
+    let bookType = try ir.schema[object: "Book"].xctUnwrapped()
+
+    let rootURL = URL(fileURLWithPath: "a/path")
+    let fileURL = rootURL.appendingPathComponent("Book.swift")
+    let mockFileManager = MockFileManager()
+
+    mockFileManager.set(closure: .fileExists({ path, isDirectory in
+      // This is a directory-level check, not a file-level check.
+      return false
+    }))
+    mockFileManager.set(closure: .createDirectory({ path, createIntermediates, attributes in
+      return
+    }))
+    mockFileManager.set(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8)).to(equal("public class Book {}"))
+
+      return true
+    }))
+
+    // then
+    try TypeFileGenerator.generate(for: bookType, in: rootURL.path, fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
@@ -2,10 +2,9 @@ import XCTest
 import Nimble
 @testable import ApolloCodegenLib
 import ApolloCodegenTestSupport
-import ApolloUtils
 
 class TypeFileGeneratorTests: XCTestCase {
-  func test_generate_givenSchemaType_shouldWriteTemplateToPath() throws {
+  func test_generate_givenSchemaType_shouldOutputToPath() throws {
     // given
     let schema = """
     type Query {
@@ -41,7 +40,8 @@ class TypeFileGeneratorTests: XCTestCase {
     }))
     mockFileManager.set(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8)).to(equal("public class Book {}"))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
+        .to(equal("public class Book {}"))
 
       return true
     }))

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
@@ -49,9 +49,8 @@ class TypeFileGeneratorTests: XCTestCase {
     // then
     try TypeFileGenerator(
       objectType: bookType,
-      directoryPath: rootURL.path,
-      fileManager: mockFileManager
-    ).generateFile()
+      directoryPath: rootURL.path
+    ).generateFile(fileManager: mockFileManager)
 
     expect(mockFileManager.allClosuresCalled).to(beTrue())
   }

--- a/Tests/ApolloCodegenTests/FileManagerExtensionsTests.swift
+++ b/Tests/ApolloCodegenTests/FileManagerExtensionsTests.swift
@@ -26,7 +26,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -43,7 +43,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -60,7 +60,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -77,7 +77,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -94,7 +94,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -111,7 +111,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -128,7 +128,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -145,7 +145,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -158,11 +158,13 @@ class FileManagerExtensionTests: XCTestCase {
     expect(mocked.allClosuresCalled).to(beTrue())
   }
 
+  // MARK: Deletion
+
   func test_deleteFile_givenFileExistsAndIsDirectory_shouldThrow() throws {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -180,7 +182,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -188,7 +190,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .removeItem({ path in
+    mocked.mock(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
     }))
 
@@ -201,7 +203,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -209,7 +211,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .removeItem({ path in
+    mocked.mock(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
 
       throw self.uniqueError
@@ -224,7 +226,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -241,7 +243,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -258,7 +260,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -266,7 +268,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .removeItem({ path in
+    mocked.mock(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
     }))
 
@@ -279,7 +281,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -287,7 +289,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .removeItem({ path in
+    mocked.mock(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
 
       throw self.uniqueError
@@ -302,7 +304,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -321,7 +323,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -338,7 +340,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -351,12 +353,14 @@ class FileManagerExtensionTests: XCTestCase {
     expect(mocked.allClosuresCalled).to(beTrue())
   }
 
+  // MARK: Creation
+
   func test_createFile_givenContainingDirectoryDoesExistAndFileCreated_shouldNotThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -364,7 +368,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .createFile({ path, data, attr in
+    mocked.mock(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
@@ -385,7 +389,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -393,7 +397,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .createFile({ path, data, attr in
+    mocked.mock(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
@@ -414,7 +418,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -422,7 +426,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createFile({ path, data, attr in
+    mocked.mock(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
@@ -430,7 +434,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attr in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attr in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attr).to(beNil())
@@ -448,7 +452,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -456,7 +460,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createFile({ path, data, attr in
+    mocked.mock(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
@@ -464,7 +468,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attr in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attr in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attr).to(beNil())
@@ -482,7 +486,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -490,7 +494,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attr in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attr in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attr).to(beNil())
@@ -509,7 +513,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -528,7 +532,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -536,7 +540,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -552,7 +556,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -560,7 +564,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -576,7 +580,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -584,7 +588,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -600,7 +604,7 @@ class FileManagerExtensionTests: XCTestCase {
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
@@ -608,7 +612,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -626,7 +630,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -644,7 +648,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -652,7 +656,7 @@ class FileManagerExtensionTests: XCTestCase {
       return true
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -667,7 +671,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -675,7 +679,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -690,7 +694,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -698,7 +702,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
@@ -713,7 +717,7 @@ class FileManagerExtensionTests: XCTestCase {
     // given
     let mocked = MockFileManager()
 
-    mocked.set(closure: .fileExists({ path, isDirectory in
+    mocked.mock(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
@@ -721,7 +725,7 @@ class FileManagerExtensionTests: XCTestCase {
       return false
 
     }))
-    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
+    mocked.mock(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())


### PR DESCRIPTION
This is the first of the Swift file generators based on output from the IR. For this first PR I chose to implement the Schema Object (Type) file generator. There are a number of other Schema files to be generated too (Interfaces, Enums, Unions) so once we're happy with the pattern for this PR the others will be quick to implement.