### PR TITLE
Refactor `MockFileManager`

### DIFF
--- a/Sources/ApolloCodegenLib/FileManager+Apollo.swift
+++ b/Sources/ApolloCodegenLib/FileManager+Apollo.swift
@@ -6,23 +6,10 @@ import ApolloUtils
 
 public typealias FileAttributes = [FileAttributeKey : Any]
 
-/// A protocol to decouple `ApolloExtension` from `FileManager`. Use it to build objects that can support
-/// `ApolloExtension` behavior.
-public protocol FileManagerProvider {
-  func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool
-  func removeItem(atPath path: String) throws
-  @discardableResult func createFile(atPath path: String, contents data: Data?, attributes attr: FileAttributes?) -> Bool
-  func createDirectory(atPath path: String, withIntermediateDirectories createIntermediates: Bool, attributes: FileAttributes?) throws
-}
-
 /// Enables the `.apollo` etension namespace.
 extension FileManager: ApolloCompatible {}
 
-/// `FileManager` conforms to the `FileManagerProvider` protocol. If it's method signatures change both the protocol and
-/// extension will need to be updated.
-extension FileManager: FileManagerProvider {}
-
-extension ApolloExtension where Base: FileManagerProvider {
+extension ApolloExtension where Base: FileManager {
 
   public enum PathError: Swift.Error, LocalizedError, Equatable {
     case notAFile(path: String)

--- a/Sources/ApolloCodegenTestSupport/MockFileManager.swift
+++ b/Sources/ApolloCodegenTestSupport/MockFileManager.swift
@@ -45,13 +45,17 @@ public class MockFileManager: FileManager {
 
   // MARK: FileManager overrides
 
+  private func missingClosureMessage(_ function: String) -> String {
+    return "\(function) closure must be set before calling it! Check your MockFileManager instance."
+  }
+
   public override func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
     let key = #function
 
     guard
       let closure = closures[key],
       case let .fileExists(handler) = closure else {
-        XCTFail("\(key) closure must be set before calling it!")
+        XCTFail(missingClosureMessage(key))
         return false
       }
 
@@ -68,7 +72,7 @@ public class MockFileManager: FileManager {
     guard
       let closure = closures[key],
       case let .removeItem(handler) = closure else {
-        XCTFail("\(key) closure must be set before calling it!")
+        XCTFail(missingClosureMessage(key))
         return
       }
 
@@ -85,7 +89,7 @@ public class MockFileManager: FileManager {
     guard
       let closure = closures[key],
       case let .createFile(handler) = closure else {
-        XCTFail("\(key) closure must be set before calling it!")
+        XCTFail(missingClosureMessage(key))
         return false
       }
 
@@ -102,7 +106,7 @@ public class MockFileManager: FileManager {
     guard
       let closure = closures[key],
       case let .createDirectory(handler) = closure else {
-        XCTFail("\(key) closure must be set before calling it!")
+        XCTFail(missingClosureMessage(key))
         return
       }
 

--- a/Sources/ApolloCodegenTestSupport/MockFileManager.swift
+++ b/Sources/ApolloCodegenTestSupport/MockFileManager.swift
@@ -12,6 +12,9 @@ public class MockFileManager: FileManager {
     case createFile(_ handler: (String, Data?, FileAttributes?) -> Bool)
     case createDirectory(_ handler: (String, Bool, FileAttributes?) throws -> Void)
 
+    // These are based on the return string from the #function macro. They are used in overriden
+    // functions to lookup the provided closure. Be aware that if the function signature changes
+    // these should be updated so the mocked closures can still be looked up.
     public var description: String {
       switch self {
       case .fileExists(_): return "fileExists(atPath:isDirectory:)"

--- a/Tests/ApolloCodegenTests/FileManagerExtensionsTests.swift
+++ b/Tests/ApolloCodegenTests/FileManagerExtensionsTests.swift
@@ -24,643 +24,714 @@ class FileManagerExtensionTests: XCTestCase {
 
   func test_doesFileExist_givenFileExistsAndIsDirectory_shouldReturnFalse() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesFileExist(atPath: self.uniquePath)).to(beFalse())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesFileExist_givenFileExistsAndIsNotDirectory_shouldReturnTrue() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesFileExist(atPath: self.uniquePath)).to(beTrue())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesFileExist_givenFileDoesNotExistAndIsDirectory_shouldReturnFalse() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesFileExist(atPath: self.uniquePath)).to(beFalse())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesFileExist_givenFileDoesNotExistAndIsNotDirectory_shouldReturnFalse() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesFileExist(atPath: self.uniquePath)).to(beFalse())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesDirectoryExist_givenFilesExistsAndIsDirectory_shouldReturnTrue() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesDirectoryExist(atPath: self.uniquePath)).to(beTrue())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesDirectoryExist_givenFileExistsAndIsNotDirectory_shouldReturnFalse() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesDirectoryExist(atPath: self.uniquePath)).to(beFalse())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesDirectoryExist_givenFileDoesNotExistAndIsDirectory_shouldReturnFalse() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesDirectoryExist(atPath: self.uniquePath)).to(beFalse())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_doesDirectoryExist_givenFileDoesNotExistAndIsNotDirectory_shouldFalse() {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
-    })
+    }))
 
     // then
     expect(mocked.apollo.doesDirectoryExist(atPath: self.uniquePath)).to(beFalse())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteFile_givenFileExistsAndIsDirectory_shouldThrow() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteFile(atPath: self.uniquePath))
       .to(throwError(MockFileManager.apollo.PathError.notAFile(path: self.uniquePath)))
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteFile_givenFileExistsAndIsNotDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
 
-    }, removeItem: { (path: String) in
+    }))
+    mocked.set(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteFile(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .removeItem]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteFile_givenFileExistsAndIsNotDirectoryAndError_shouldThrow() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
 
-    }, removeItem: { (path: String) in
+    }))
+    mocked.set(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
 
       throw self.uniqueError
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteFile(atPath: self.uniquePath)).to(throwError(self.uniqueError))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .removeItem]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteFile_givenFileDoesNotExistAndIsDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteFile(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteFile_givenFileDoesNotExistAndIsNotDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteFile(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteDirectory_givenFileExistsAndIsDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
 
-    }, removeItem: { (path: String) in
+    }))
+    mocked.set(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteDirectory(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .removeItem]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteDirectory_givenFileExistsAndIsDirectoryAndError_shouldThrow() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
 
-    }, removeItem: { (path: String) in
+    }))
+    mocked.set(closure: .removeItem({ path in
       expect(path).to(equal(self.uniquePath))
 
       throw self.uniqueError
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteDirectory(atPath: self.uniquePath)).to(throwError(self.uniqueError))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .removeItem]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteDirectory_givenFileExistsAndIsNotDirectory_shouldThrow() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
 
-    }, removeItem: { (path: String) in
-      expect(path).to(equal(self.uniquePath))
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteDirectory(atPath: self.uniquePath))
       .to(throwError(MockFileManager.apollo.PathError.notADirectory(path: self.uniquePath)))
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteDirectory_givenFileDoesNotExistAndIsDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteDirectory(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_deleteDirectory_givenFileDoesNotExistAndIsNotDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
-    })
+    }))
 
     // then
     expect(try mocked.apollo.deleteDirectory(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createFile_givenContainingDirectoryDoesExistAndFileCreated_shouldNotThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
 
-    }, createFile: { (path: String, data: Data?, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
 
       return true
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attr: FileAttributes?) in
-      fail("The containing directory already exists, createDirectory should not be called.")
-    })
+    }))
 
     // then
     expect(
       try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
     ).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createFile]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createFile_givenContainingDirectoryDoesExistAndFileNotCreated_shouldThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
 
-    }, createFile: { (path: String, data: Data?, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
 
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attr: FileAttributes?) in
-      fail("The containing directory already exists, createDirectory should not be called.")
-    })
+    }))
 
     // then
     expect(
       try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
     ).to(throwError(MockFileManager.apollo.PathError.cannotCreateFile(at: self.uniquePath)))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createFile]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createFile_givenContainingDirectoryDoesNotExistAndFileCreated_shouldNotThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
 
-    }, createFile: { (path: String, data: Data?, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
 
       return true
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attr in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attr).to(beNil())
-    })
+    }))
 
     // then
     expect(
       try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
     ).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory, .createFile]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createFile_givenContainingDirectoryDoesNotExistAndFileNotCreated_shouldThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
 
-    }, createFile: { (path: String, data: Data?, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createFile({ path, data, attr in
       expect(path).to(equal(self.uniquePath))
       expect(data).to(equal(self.uniqueData))
       expect(attr).to(beNil())
 
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attr in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attr).to(beNil())
-    })
+    }))
 
     // then
     expect(
       try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData)
     ).to(throwError(MockFileManager.apollo.PathError.cannotCreateFile(at: self.uniquePath)))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory, .createFile]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createFile_givenContainingDirectoryDoesNotExistAndError_shouldThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
 
-    }, createFile: { (path: String, data: Data?, attr: FileAttributes?) in
-      fail("createFile should not be called, due to error in createDirectory.")
-      return false
-
-    }, createDirectory: { (path: String, createIntermediates: Bool, attr: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attr in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attr).to(beNil())
 
       throw self.uniqueError
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createFile(atPath: self.uniquePath, data:self.uniqueData))
       .to(throwError(self.uniqueError))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createContainingDirectory_givenFileExistsAndIsDirectory_shouldReturnEarly() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
-      fail("The directory already exists, createDirectory should not be called.")
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createContainingDirectoryIfNeeded(forPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createContainingDirectory_givenFileExistsAndIsNotDirectory_shouldSucceed() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createContainingDirectoryIfNeeded(forPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createContainingDirectory_givenFileDoesNotExistAndIsDirectory_shouldSucceed() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createContainingDirectoryIfNeeded(forPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createContainingDirectory_givenFileDoesNotExistAndIsNotDirectory_shouldSucceed() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createContainingDirectoryIfNeeded(forPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createContainingDirectory_givenError_shouldThrow() throws {
     // given
     let parentPath = URL(fileURLWithPath: self.uniquePath).deletingLastPathComponent().path
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(parentPath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(parentPath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
 
       throw self.uniqueError
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createContainingDirectoryIfNeeded(forPath: self.uniquePath))
       .to(throwError(self.uniqueError))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createDirectory_givenFileExistsAndIsDirectory_shouldReturnEarly() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return true
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
-      fail("The directory already exists, createDirectory should not be called.")
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createDirectoryIfNeeded(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createDirectory_givenFileExistsAndIsNotDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return true
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createDirectoryIfNeeded(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createDirectory_givenFileDoesNotExistAndIsDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = true
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createDirectoryIfNeeded(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createDirectory_givenFileDoesNotExistAndIsNotDirectory_shouldSucceed() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createDirectoryIfNeeded(atPath: self.uniquePath)).notTo(throwError())
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 
   func test_createDirectory_givenError_shouldThrow() throws {
     // given
-    let mocked = MockFileManager(fileExists: { (path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) in
+    let mocked = MockFileManager()
+
+    mocked.set(closure: .fileExists({ path, isDirectory in
       expect(path).to(equal(self.uniquePath))
       expect(isDirectory).notTo(beNil())
 
       isDirectory?.pointee = false
       return false
 
-    }, createDirectory: { (path: String, createIntermediates: Bool, attributes: FileAttributes?) in
+    }))
+    mocked.set(closure: .createDirectory({ path, createIntermediates, attributes in
       expect(path).to(equal(self.uniquePath))
       expect(createIntermediates).to(beTrue())
       expect(attributes).to(beNil())
 
       throw self.uniqueError
-    })
+    }))
 
     // then
     expect(try mocked.apollo.createDirectoryIfNeeded(atPath: self.uniquePath))
       .to(throwError(self.uniqueError))
-    expect(mocked.blocksCalled).to(equal([.fileExists, .createDirectory]))
+    expect(mocked.allClosuresCalled).to(beTrue())
   }
 }


### PR DESCRIPTION
#### What
This is a refactor of my ill-fated attempt (PR #1999) at building a generic file manager provider that could easily be mocked. While the original `MockFileManager` worked for isolated testing of the `apollo` namespace extension it does not work in practice as a type that can be passed around with conformance to `ApolloCompatible`.

#### Why
A property of `FileManagerProvider` works fine with the previous `MockFileManager` but you then lose the `.apollo` namespace extension functions because extensions cannot inherit, so this fails.
```
extension FileManagerProvider: ApolloCompatible {}

Results in compiler error "Extension of protocol 'FileManagerProvider' cannot have an inheritance clause"
```

#### Changes
* `MockFileManager` is now just a subclass of `FileManager` with stub-able functions.
* It is 'strict' meaning that any stub-able function called without being stubbed will result in a failed test.
* A downside is that `FileManager` functions not in `MockFileManager.Closure` will pass through undetected - this was a problem with `FileManagerProvider` too. At the moment there are function stubs for all `base` functions called in the `apollo` extension. I acknowledge this is brittle though.