### PR TITLE
Always provide a non-empty WebSocket connection close reason

### DIFF
--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -814,7 +814,7 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
       if receivedOpcode == .connectionClose {
         var closeReason = "connection closed by server"
         if let customCloseReason = String(data: data, encoding: .utf8),
-           customCloseReason.isEmpty {
+           customCloseReason.apollo.isNotEmpty {
           closeReason = customCloseReason
         } else {
           closeCode = CloseCode.protocolError.rawValue

--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -813,7 +813,8 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
 
       if receivedOpcode == .connectionClose {
         var closeReason = "connection closed by server"
-        if let customCloseReason = String(data: data, encoding: .utf8) {
+        if let customCloseReason = String(data: data, encoding: .utf8),
+           customCloseReason.isEmpty {
           closeReason = customCloseReason
         } else {
           closeCode = CloseCode.protocolError.rawValue


### PR DESCRIPTION
This is a tiny fix for something I encountered. When the connection close `data` was empty, it was being interpreted as a valid, zero-length string,  and therefore replacing the default `closeReason` of "connection closed by server". The default in this case is more informative, so it probably makes sense to guard against the empty case before replacing it.