### PR TITLE
File generators for other schema types

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -323,6 +323,8 @@
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */; };
+		E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */; };
+		E6D90D09278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */; };
 		E6E3BBE2276A8D6200E5218B /* FileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */; };
 		E86D8E05214B32FD0028EFE1 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86D8E03214B32DA0028EFE1 /* JSONTests.swift */; };
 		F16D083C21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */; };
@@ -976,6 +978,8 @@
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDownloaderTests.swift; sourceTree = "<group>"; };
 		E6D79AB926EC05290094434A /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
+		E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputObjectFileGenerator.swift; sourceTree = "<group>"; };
+		E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileGenerator.swift; sourceTree = "<group>"; };
 		E86D8E03214B32DA0028EFE1 /* JSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryFromJSONBuildingTests.swift; sourceTree = "<group>"; };
@@ -2133,8 +2137,9 @@
 			isa = PBXGroup;
 			children = (
 				E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */,
-				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
+				E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */,
 				E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */,
+				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
 				E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */,
 			);
 			path = FileGenerators;
@@ -2165,6 +2170,7 @@
 			children = (
 				E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */,
 				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
+				E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */,
 				E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */,
 				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
 				E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */,
@@ -2900,6 +2906,7 @@
 				DE796429276998B000978A03 /* IR+RootFieldBuilder.swift in Sources */,
 				9F1A966F258F34BB00A06EEB /* JavaScriptBridge.swift in Sources */,
 				9BAEEBF72346F0A000808306 /* StaticString+Apollo.swift in Sources */,
+				E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */,
 				9BCA8C0926618226004FF2F6 /* UntypedGraphQLRequestBodyCreator.swift in Sources */,
 				DE5FD60527694FA70033EE23 /* SchemaTemplate.swift in Sources */,
 				DEFBBC86273470F70088AABC /* IR+Field.swift in Sources */,
@@ -2970,6 +2977,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BAEEC10234BB95B00808306 /* FileManagerExtensionsTests.swift in Sources */,
+				E6D90D09278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift in Sources */,
 				DE5FD60D2769711E0033EE23 /* FragmentTemplateTests.swift in Sources */,
 				E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */,
 				DE223C1C271F3288004A0148 /* AnimalKingdomASTCreationTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -304,6 +304,8 @@
 		DED46051261CEAD20086EF63 /* StarWarsAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCE2CFA1E6C213D00E34457 /* StarWarsAPI.framework */; };
 		DEFBBC86273470F70088AABC /* IR+Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBBC85273470F70088AABC /* IR+Field.swift */; };
 		DEFE0FC52748822900FFA440 /* IR+MergedSelectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE0FC42748822900FFA440 /* IR+MergedSelectionTree.swift */; };
+		E610D8D7278EA2390023E495 /* EnumFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */; };
+		E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */; };
 		E616B6D126C3335600DB049E /* ExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616B6D026C3335600DB049E /* ExecutionTests.swift */; };
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
@@ -951,6 +953,8 @@
 		DEE1B3F5273B08D8007350E5 /* WarmBloodedDetails.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarmBloodedDetails.graphql.swift; sourceTree = "<group>"; };
 		DEFBBC85273470F70088AABC /* IR+Field.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+Field.swift"; sourceTree = "<group>"; };
 		DEFE0FC42748822900FFA440 /* IR+MergedSelectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+MergedSelectionTree.swift"; sourceTree = "<group>"; };
+		E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGenerator.swift; sourceTree = "<group>"; };
+		E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E616B6D026C3335600DB049E /* ExecutionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionTests.swift; sourceTree = "<group>"; };
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
@@ -2120,6 +2124,7 @@
 		E66F8895276C13330000BDA8 /* FileGenerators */ = {
 			isa = PBXGroup;
 			children = (
+				E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */,
 				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
 			);
 			path = FileGenerators;
@@ -2148,8 +2153,9 @@
 		E6E3BBDC276A8D6200E5218B /* FileGenerators */ = {
 			isa = PBXGroup;
 			children = (
-				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
+				E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */,
 				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
+				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
 			);
 			path = FileGenerators;
 			sourceTree = "<group>";
@@ -2872,6 +2878,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E610D8D7278EA2390023E495 /* EnumFileGenerator.swift in Sources */,
 				9BAEEBEE2346644600808306 /* ApolloSchemaDownloadConfiguration.swift in Sources */,
 				DE5FD5FF276922AA0033EE23 /* MockApolloCodegenConfiguration.swift in Sources */,
 				9B8C3FB3248DA2FE00707B13 /* URL+Apollo.swift in Sources */,
@@ -2962,6 +2969,7 @@
 				DE27390F2769AE9700B886EF /* SelectionSetTemplateTests.swift in Sources */,
 				DE79642B276999E700978A03 /* IRNamedFragmentBuilderTests.swift in Sources */,
 				9B8C3FB5248DA3E000707B13 /* URLExtensionsTests.swift in Sources */,
+				E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */,
 				9FDE0731258F3AA100DC0CA5 /* SchemaLoadingTests.swift in Sources */,
 				DE223C3327221144004A0148 /* ASTMatchers.swift in Sources */,
 				DE79642F2769A1EB00978A03 /* IROperationBuilderTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -325,6 +325,8 @@
 		E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */; };
 		E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */; };
 		E6D90D09278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */; };
+		E6D90D0B278FFDDA009CAC5D /* SchemaFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D0A278FFDDA009CAC5D /* SchemaFileGenerator.swift */; };
+		E6D90D0D278FFE35009CAC5D /* SchemaFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D0C278FFE35009CAC5D /* SchemaFileGeneratorTests.swift */; };
 		E6E3BBE2276A8D6200E5218B /* FileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */; };
 		E86D8E05214B32FD0028EFE1 /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86D8E03214B32DA0028EFE1 /* JSONTests.swift */; };
 		F16D083C21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */; };
@@ -980,6 +982,8 @@
 		E6D79AB926EC05290094434A /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
 		E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputObjectFileGenerator.swift; sourceTree = "<group>"; };
 		E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectFileGeneratorTests.swift; sourceTree = "<group>"; };
+		E6D90D0A278FFDDA009CAC5D /* SchemaFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaFileGenerator.swift; sourceTree = "<group>"; };
+		E6D90D0C278FFE35009CAC5D /* SchemaFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileGenerator.swift; sourceTree = "<group>"; };
 		E86D8E03214B32DA0028EFE1 /* JSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		F16D083B21EF6F7300C458B8 /* QueryFromJSONBuildingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryFromJSONBuildingTests.swift; sourceTree = "<group>"; };
@@ -2139,6 +2143,7 @@
 				E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */,
 				E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */,
 				E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */,
+				E6D90D0C278FFE35009CAC5D /* SchemaFileGeneratorTests.swift */,
 				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
 				E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */,
 			);
@@ -2172,6 +2177,7 @@
 				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
 				E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */,
 				E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */,
+				E6D90D0A278FFDDA009CAC5D /* SchemaFileGenerator.swift */,
 				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
 				E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */,
 			);
@@ -2920,6 +2926,7 @@
 				DE223C2D2721FCE8004A0148 /* ScopedSelectionSetHashable.swift in Sources */,
 				DE79642D27699A6A00978A03 /* IR+NamedFragmentBuilder.swift in Sources */,
 				9B47518D2575AA850001FB87 /* Pluralizer.swift in Sources */,
+				E6D90D0B278FFDDA009CAC5D /* SchemaFileGenerator.swift in Sources */,
 				DE7C183C272A12EB00727031 /* TypeScopeDescriptor.swift in Sources */,
 				DE7C183E272A154400727031 /* IR.swift in Sources */,
 				9F628E9525935BE600F94F9D /* GraphQLType.swift in Sources */,
@@ -3001,6 +3008,7 @@
 				DE5FD609276956C70033EE23 /* SchemaTemplateTests.swift in Sources */,
 				E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */,
 				9F62DF8E2590539A00E6E808 /* SchemaIntrospectionTests.swift in Sources */,
+				E6D90D0D278FFE35009CAC5D /* SchemaFileGeneratorTests.swift in Sources */,
 				9B68F0552416B33300E97318 /* LineByLineComparison.swift in Sources */,
 				DE09F9C6270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift in Sources */,
 				9B4751AD2575B5070001FB87 /* PluralizerTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -306,6 +306,8 @@
 		DEFE0FC52748822900FFA440 /* IR+MergedSelectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE0FC42748822900FFA440 /* IR+MergedSelectionTree.swift */; };
 		E610D8D7278EA2390023E495 /* EnumFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */; };
 		E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */; };
+		E610D8DB278EB0900023E495 /* InterfaceFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */; };
+		E610D8DD278EB1500023E495 /* InterfaceFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */; };
 		E616B6D126C3335600DB049E /* ExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616B6D026C3335600DB049E /* ExecutionTests.swift */; };
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
@@ -955,6 +957,8 @@
 		DEFE0FC42748822900FFA440 /* IR+MergedSelectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+MergedSelectionTree.swift"; sourceTree = "<group>"; };
 		E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGenerator.swift; sourceTree = "<group>"; };
 		E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGeneratorTests.swift; sourceTree = "<group>"; };
+		E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceFileGenerator.swift; sourceTree = "<group>"; };
+		E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E616B6D026C3335600DB049E /* ExecutionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionTests.swift; sourceTree = "<group>"; };
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
@@ -2126,6 +2130,7 @@
 			children = (
 				E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */,
 				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
+				E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */,
 			);
 			path = FileGenerators;
 			sourceTree = "<group>";
@@ -2155,6 +2160,7 @@
 			children = (
 				E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */,
 				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
+				E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */,
 				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
 			);
 			path = FileGenerators;
@@ -2905,6 +2911,7 @@
 				9F628E9525935BE600F94F9D /* GraphQLType.swift in Sources */,
 				9BFE8DA9265D5D8F000BBF81 /* URLDownloader.swift in Sources */,
 				9F1A966D258F34BB00A06EEB /* CompilationResult.swift in Sources */,
+				E610D8DB278EB0900023E495 /* InterfaceFileGenerator.swift in Sources */,
 				9B7B6F69233C2C0C00F32205 /* FileManager+Apollo.swift in Sources */,
 				E674DB41274C0A9B009BB90E /* Glob.swift in Sources */,
 				9F1A966C258F34BB00A06EEB /* GraphQLSchema.swift in Sources */,
@@ -2960,6 +2967,7 @@
 				E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */,
 				DE223C1C271F3288004A0148 /* AnimalKingdomASTCreationTests.swift in Sources */,
 				9BAEEC17234C275600808306 /* ApolloSchemaPublicTests.swift in Sources */,
+				E610D8DD278EB1500023E495 /* InterfaceFileGeneratorTests.swift in Sources */,
 				9F62DFAE2590557F00E6E808 /* DocumentParsingAndValidationTests.swift in Sources */,
 				9F62E0102590728000E6E808 /* CompilationTests.swift in Sources */,
 				DEAFB77B2706444B00BE02F3 /* IRRootEntityFieldBuilderTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -308,6 +308,8 @@
 		E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */; };
 		E610D8DB278EB0900023E495 /* InterfaceFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */; };
 		E610D8DD278EB1500023E495 /* InterfaceFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */; };
+		E610D8DF278F8F1E0023E495 /* UnionFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */; };
+		E610D8E1278F8F3D0023E495 /* UnionFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */; };
 		E616B6D126C3335600DB049E /* ExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616B6D026C3335600DB049E /* ExecutionTests.swift */; };
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
@@ -959,6 +961,8 @@
 		E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceFileGenerator.swift; sourceTree = "<group>"; };
 		E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceFileGeneratorTests.swift; sourceTree = "<group>"; };
+		E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionFileGenerator.swift; sourceTree = "<group>"; };
+		E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E616B6D026C3335600DB049E /* ExecutionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionTests.swift; sourceTree = "<group>"; };
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
@@ -2131,6 +2135,7 @@
 				E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */,
 				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
 				E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */,
+				E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */,
 			);
 			path = FileGenerators;
 			sourceTree = "<group>";
@@ -2162,6 +2167,7 @@
 				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
 				E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */,
 				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
+				E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */,
 			);
 			path = FileGenerators;
 			sourceTree = "<group>";
@@ -2903,6 +2909,7 @@
 				9F628EB52593651B00F94F9D /* GraphQLValue.swift in Sources */,
 				DE5FD5FD2769222D0033EE23 /* OperationDefinitionTemplate.swift in Sources */,
 				DE3484622746FF8F0065B77E /* IR+OperationBuilder.swift in Sources */,
+				E610D8DF278F8F1E0023E495 /* UnionFileGenerator.swift in Sources */,
 				DE223C2D2721FCE8004A0148 /* ScopedSelectionSetHashable.swift in Sources */,
 				DE79642D27699A6A00978A03 /* IR+NamedFragmentBuilder.swift in Sources */,
 				9B47518D2575AA850001FB87 /* Pluralizer.swift in Sources */,
@@ -2990,6 +2997,7 @@
 				DE09F9C6270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift in Sources */,
 				9B4751AD2575B5070001FB87 /* PluralizerTests.swift in Sources */,
 				9BAEEC19234C297800808306 /* ApolloCodegenConfigurationTests.swift in Sources */,
+				E610D8E1278F8F3D0023E495 /* UnionFileGeneratorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -44,8 +44,9 @@ public class ApolloCodegen {
       .forEach({ try $0.generateFile() })
     try fileGenerators(for: ir.schema.referencedTypes.unions, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
+    try fileGenerators(for: ir.schema.referencedTypes.inputObjects, directoryPath: modulePath)
+      .forEach({ try $0.generateFile() })
 
-    #warning("TODO - generate schema union files")
     #warning("TODO - generate schema file")
     #warning("TODO - generate operation/fragment files")
     #warning("TODO - generate package manager manifest")
@@ -110,6 +111,15 @@ public class ApolloCodegen {
   ) -> [UnionFileGenerator] {
     return unionTypes.map({ graphqlUnionType in
       UnionFileGenerator(unionType: graphqlUnionType, directoryPath: path)
+    })
+  }
+
+  static func fileGenerators(
+    for inputObjectTypes: OrderedSet<GraphQLInputObjectType>,
+    directoryPath path: String
+  ) -> [InputObjectFileGenerator] {
+    return unionTypes.map({ graphqlInputObjectType in
+      InputObjectFileGenerator(inputObjectType: graphqlInputObjectType, directoryPath: path)
     })
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -46,7 +46,6 @@ public class ApolloCodegen {
       .forEach({ try $0.generateFile() })
     try fileGenerators(for: ir.schema.referencedTypes.inputObjects, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
-
     try SchemaFileGenerator(
       name: configuration.output.schemaTypes.moduleName,
       objectTypes: ir.schema.referencedTypes.objects,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -47,7 +47,12 @@ public class ApolloCodegen {
     try fileGenerators(for: ir.schema.referencedTypes.inputObjects, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
 
-    #warning("TODO - generate schema file")
+    try SchemaFileGenerator(
+      name: configuration.output.schemaTypes.moduleName,
+      objectTypes: ir.schema.referencedTypes.objects,
+      directoryPath: modulePath
+    ).generateFile()
+
     #warning("TODO - generate operation/fragment files")
     #warning("TODO - generate package manager manifest")
   }

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -42,6 +42,8 @@ public class ApolloCodegen {
       .forEach({ try $0.generateFile() })
     try fileGenerators(for: ir.schema.referencedTypes.interfaces, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
+    try fileGenerators(for: ir.schema.referencedTypes.unions, directoryPath: modulePath)
+      .forEach({ try $0.generateFile() })
 
     #warning("TODO - generate schema union files")
     #warning("TODO - generate schema file")
@@ -99,6 +101,15 @@ public class ApolloCodegen {
   ) -> [InterfaceFileGenerator] {
     return interfaceTypes.map({ graphqlInterfaceType in
       InterfaceFileGenerator(interfaceType: graphqlInterfaceType, directoryPath: path)
+    })
+  }
+
+  static func fileGenerators(
+    for unionTypes: OrderedSet<GraphQLUnionType>,
+    directoryPath path: String
+  ) -> [UnionFileGenerator] {
+    return unionTypes.map({ graphqlUnionType in
+      UnionFileGenerator(unionType: graphqlUnionType, directoryPath: path)
     })
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -40,13 +40,16 @@ public class ApolloCodegen {
       .forEach({ try $0.generateFile() })
     try fileGenerators(for: ir.schema.referencedTypes.enums, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
+    try fileGenerators(for: ir.schema.referencedTypes.interfaces, directoryPath: modulePath)
+      .forEach({ try $0.generateFile() })
 
-    #warning("TODO - generate schema interface files")
     #warning("TODO - generate schema union files")
     #warning("TODO - generate schema file")
     #warning("TODO - generate operation/fragment files")
     #warning("TODO - generate package manager manifest")
   }
+
+  // MARK: Internal
 
   static func compileGraphQLResult(
     using input: ApolloCodegenConfiguration.FileInput
@@ -87,6 +90,15 @@ public class ApolloCodegen {
   ) -> [EnumFileGenerator] {
     return enumTypes.map({ graphqlEnumType in
       EnumFileGenerator(enumType: graphqlEnumType, directoryPath: path)
+    })
+  }
+
+  static func fileGenerators(
+    for interfaceTypes: OrderedSet<GraphQLInterfaceType>,
+    directoryPath path: String
+  ) -> [InterfaceFileGenerator] {
+    return interfaceTypes.map({ graphqlInterfaceType in
+      InterfaceFileGenerator(interfaceType: graphqlInterfaceType, directoryPath: path)
     })
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -120,7 +120,7 @@ public class ApolloCodegen {
   }
 
   static func fileGenerators(
-    for inputObjectTypes: OrderedSet<GraphQLInputObjectType>,
+    for unionTypes: OrderedSet<GraphQLInputObjectType>,
     directoryPath path: String
   ) -> [InputObjectFileGenerator] {
     return unionTypes.map({ graphqlInputObjectType in

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -35,12 +35,12 @@ public class ApolloCodegen {
       compilationResult: compilationResult
     )
 
-    try fileGenerators(
-      for: ir.schema.referencedTypes.objects,
-      directoryPath: configuration.output.schemaTypes.modulePath
-    ).forEach({ try $0.generateFile() })
+    let modulePath = configuration.output.schemaTypes.modulePath
+    try fileGenerators(for: ir.schema.referencedTypes.objects, directoryPath: modulePath)
+      .forEach({ try $0.generateFile() })
+    try fileGenerators(for: ir.schema.referencedTypes.enums, directoryPath: modulePath)
+      .forEach({ try $0.generateFile() })
 
-    #warning("TODO - generate schema enum files")
     #warning("TODO - generate schema interface files")
     #warning("TODO - generate schema union files")
     #warning("TODO - generate schema file")
@@ -78,6 +78,15 @@ public class ApolloCodegen {
   ) -> [TypeFileGenerator] {
     return objectTypes.map({ graphqlObjectType in
       TypeFileGenerator(objectType: graphqlObjectType, directoryPath: path)
+    })
+  }
+
+  static func fileGenerators(
+    for enumTypes: OrderedSet<GraphQLEnumType>,
+    directoryPath path: String
+  ) -> [EnumFileGenerator] {
+    return enumTypes.map({ graphqlEnumType in
+      EnumFileGenerator(enumType: graphqlEnumType, directoryPath: path)
     })
   }
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Generates a file containing the Swift representation of a [GraphQL Enum](https://spec.graphql.org/draft/#sec-Enums).
 struct EnumFileGenerator: FileGenerator, Equatable {
+  /// The `GraphQLEnumType` object used to build the file content.
   let enumType: GraphQLEnumType
   let path: String
 
@@ -10,6 +11,11 @@ struct EnumFileGenerator: FileGenerator, Equatable {
     return "public enum \(enumType.name) {}".data(using: .utf8)!
   }
 
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///  - enumType: The `GraphQLEnumType` object used to build the file content.
+  ///  - directoryPath: The **directory** path that the file should be written to, used to build the `path` property value.
   init(enumType: GraphQLEnumType, directoryPath: String) {
     self.enumType = enumType
 

--- a/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Generates a file containing the Swift representation of a [GraphQL Enum](https://spec.graphql.org/draft/#sec-Enums).
+struct EnumFileGenerator: FileGenerator, Equatable {
+  let enumType: GraphQLEnumType
+  let path: String
+
+  var data: Data {
+    return "public enum \(enumType.name) {}".data(using: .utf8)!
+  }
+
+  init(enumType: GraphQLEnumType, directoryPath: String) {
+    self.enumType = enumType
+
+    self.path = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(enumType.name).swift").path
+  }
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
@@ -6,6 +6,7 @@ struct EnumFileGenerator: FileGenerator, Equatable {
   let path: String
 
   var data: Data {
+    #warning("TODO: need correct data template")
     return "public enum \(enumType.name) {}".data(using: .utf8)!
   }
 

--- a/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
@@ -6,9 +6,9 @@ struct EnumFileGenerator: FileGenerator, Equatable {
   let enumType: GraphQLEnumType
   let path: String
 
-  var data: Data {
+  var data: Data? {
     #warning("TODO: need correct data template")
-    return "public enum \(enumType.name) {}".data(using: .utf8)!
+    return "public enum \(enumType.name) {}".data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -3,9 +3,12 @@ import ApolloUtils
 
 /// The methods to conform to when building a code generation Swift file generator.
 protocol FileGenerator {
+  /// The output path that the file will be written to.
   var path: String { get }
+  /// The file content in UTF-8 encoding.
   var data: Data { get }
 
+  /// Writes `data` to a file at the designated `path`. If the file already exists it will be overwritten.
   func generateFile(fileManager: FileManager) throws
 }
 

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -6,7 +6,7 @@ protocol FileGenerator {
   /// The output path that the file will be written to.
   var path: String { get }
   /// The file content in UTF-8 encoding.
-  var data: Data { get }
+  var data: Data? { get }
 
   /// Writes `data` to a file at the designated `path`. If the file already exists it will be overwritten.
   func generateFile(fileManager: FileManager) throws

--- a/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Generates a file containing the Swift representation of a [GraphQL Input Object](https://spec.graphql.org/draft/#sec-Input-Objects).
 struct InputObjectFileGenerator: FileGenerator, Equatable {
+  /// The `GraphQLInputObjectType` object used to build the file content.
   let inputObjectType: GraphQLInputObjectType
   let path: String
 
@@ -10,6 +11,11 @@ struct InputObjectFileGenerator: FileGenerator, Equatable {
     return "public struct \(inputObjectType.name) {}".data(using: .utf8)!
   }
 
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///  - inputObjectType: The `GraphQLInputObjectType` object used to build the file content.
+  ///  - directoryPath: The **directory** path that the file should be written to, used to build the `path` property value.
   init(inputObjectType: GraphQLInputObjectType, directoryPath: String) {
     self.inputObjectType = inputObjectType
 

--- a/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
@@ -6,9 +6,9 @@ struct InputObjectFileGenerator: FileGenerator, Equatable {
   let inputObjectType: GraphQLInputObjectType
   let path: String
 
-  var data: Data {
+  var data: Data? {
     #warning("TODO: need correct data template")
-    return "public struct \(inputObjectType.name) {}".data(using: .utf8)!
+    return "public struct \(inputObjectType.name) {}".data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Generates a file containing the Swift representation of a [GraphQL Input Object](https://spec.graphql.org/draft/#sec-Input-Objects).
+struct InputObjectFileGenerator: FileGenerator, Equatable {
+  let inputObjectType: GraphQLInputObjectType
+  let path: String
+
+  var data: Data {
+    #warning("TODO: need correct data template")
+    return "public struct \(inputObjectType.name) {}".data(using: .utf8)!
+  }
+
+  init(inputObjectType: GraphQLInputObjectType, directoryPath: String) {
+    self.inputObjectType = inputObjectType
+
+    self.path = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(inputObjectType.name).swift").path
+  }
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/InterfaceFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InterfaceFileGenerator.swift
@@ -6,9 +6,9 @@ struct InterfaceFileGenerator: FileGenerator, Equatable {
   let interfaceType: GraphQLInterfaceType
   let path: String
 
-  var data: Data {
+  var data: Data? {
     #warning("TODO: need correct data template")
-    return "public class \(interfaceType.name) {}".data(using: .utf8)!
+    return "public class \(interfaceType.name) {}".data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenLib/FileGenerators/InterfaceFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InterfaceFileGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Generates a file containing the Swift representation of a [GraphQL Interface](https://spec.graphql.org/draft/#sec-Interfaces).
 struct InterfaceFileGenerator: FileGenerator, Equatable {
+  /// The `GraphQLInterfaceType` object used to build the file content.
   let interfaceType: GraphQLInterfaceType
   let path: String
 
@@ -10,6 +11,11 @@ struct InterfaceFileGenerator: FileGenerator, Equatable {
     return "public class \(interfaceType.name) {}".data(using: .utf8)!
   }
 
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///  - interfaceType: The `GraphQLInterfaceType` object used to build the file content.
+  ///  - directoryPath: The **directory** path that the file should be written to, used to build the `path` property value.
   init(interfaceType: GraphQLInterfaceType, directoryPath: String) {
     self.interfaceType = interfaceType
 

--- a/Sources/ApolloCodegenLib/FileGenerators/InterfaceFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InterfaceFileGenerator.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Generates a file containing the Swift representation of a [GraphQL Interface](https://spec.graphql.org/draft/#sec-Interfaces).
+struct InterfaceFileGenerator: FileGenerator, Equatable {
+  let interfaceType: GraphQLInterfaceType
+  let path: String
+
+  var data: Data {
+    #warning("TODO: need correct data template")
+    return "public class \(interfaceType.name) {}".data(using: .utf8)!
+  }
+
+  init(interfaceType: GraphQLInterfaceType, directoryPath: String) {
+    self.interfaceType = interfaceType
+
+    self.path = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(interfaceType.name).swift").path
+  }
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
@@ -1,0 +1,22 @@
+import Foundation
+import OrderedCollections
+
+/// Generates a file containing schema metadata used when converting data to `Object` types at runtime.
+struct SchemaFileGenerator: FileGenerator, Equatable {
+  let name: String
+  let objectTypes: OrderedSet<GraphQLObjectType>
+  let path: String
+
+  var data: Data {
+    #warning("TODO: need correct data template")
+    return "public enum Schema {}".data(using: .utf8)!
+  }
+
+  init(name: String, objectTypes: OrderedSet<GraphQLObjectType>, directoryPath: String) {
+    self.name = name
+    self.objectTypes = objectTypes
+
+    self.path = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("Schema.swift").path
+  }
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
@@ -3,7 +3,9 @@ import OrderedCollections
 
 /// Generates a file containing schema metadata used when converting data to `Object` types at runtime.
 struct SchemaFileGenerator: FileGenerator, Equatable {
+  /// The schema module name.
   let name: String
+  /// The `OrderedSet` of `GraphQLObjectType` objects used to build the file content.
   let objectTypes: OrderedSet<GraphQLObjectType>
   let path: String
 
@@ -12,6 +14,12 @@ struct SchemaFileGenerator: FileGenerator, Equatable {
     return "public enum Schema {}".data(using: .utf8)!
   }
 
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///  - name: The schema module name.
+  ///  - interfaceType: The `OrderedSet` of `GraphQLObjectType` objects used to build the file content.
+  ///  - directoryPath: The **directory** path that the file should be written to, used to build the `path` property value.
   init(name: String, objectTypes: OrderedSet<GraphQLObjectType>, directoryPath: String) {
     self.name = name
     self.objectTypes = objectTypes

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
@@ -9,9 +9,9 @@ struct SchemaFileGenerator: FileGenerator, Equatable {
   let objectTypes: OrderedSet<GraphQLObjectType>
   let path: String
 
-  var data: Data {
+  var data: Data? {
     #warning("TODO: need correct data template")
-    return "public enum Schema {}".data(using: .utf8)!
+    return "public enum Schema {}".data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -5,9 +5,9 @@ struct TypeFileGenerator: FileGenerator, Equatable {
   let objectType: GraphQLObjectType
   let path: String
 
-  var data: Data {
+  var data: Data? {
     #warning("TODO: need correct data template")
-    return "public class \(objectType.name) {}".data(using: .utf8)!
+    return "public class \(objectType.name) {}".data(using: .utf8)
   }
 
   init(objectType: GraphQLObjectType, directoryPath: String) {

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -6,6 +6,7 @@ struct TypeFileGenerator: FileGenerator, Equatable {
   let path: String
 
   var data: Data {
+    #warning("TODO: need correct data template")
     return "public class \(objectType.name) {}".data(using: .utf8)!
   }
 

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -1,7 +1,6 @@
 import Foundation
-import ApolloUtils
 
-/// Generates a file containing the Swift representation of a [GraphQL Object type](https://spec.graphql.org/draft/#sec-Objects).
+/// Generates a file containing the Swift representation of a [GraphQL Object](https://spec.graphql.org/draft/#sec-Objects).
 struct TypeFileGenerator: FileGenerator, Equatable {
   let objectType: GraphQLObjectType
   let path: String

--- a/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Generates a file containing the Swift representation of a [GraphQL Union](https://spec.graphql.org/draft/#sec-Unions).
+struct UnionFileGenerator: FileGenerator, Equatable {
+  let unionType: GraphQLUnionType
+  let path: String
+
+  var data: Data {
+    #warning("TODO: need correct data template")
+    return "public enum \(unionType.name) {}".data(using: .utf8)!
+  }
+
+  init(unionType: GraphQLUnionType, directoryPath: String) {
+    self.unionType = unionType
+
+    self.path = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent("\(unionType.name).swift").path
+  }
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Generates a file containing the Swift representation of a [GraphQL Union](https://spec.graphql.org/draft/#sec-Unions).
 struct UnionFileGenerator: FileGenerator, Equatable {
+  /// The `GraphQLUnionType` object used to build the file content.
   let unionType: GraphQLUnionType
   let path: String
 
@@ -10,6 +11,11 @@ struct UnionFileGenerator: FileGenerator, Equatable {
     return "public enum \(unionType.name) {}".data(using: .utf8)!
   }
 
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///  - unionType: The `GraphQLUnionType` object used to build the file content.
+  ///  - directoryPath: The **directory** path that the file should be written to, used to build the `path` property value.
   init(unionType: GraphQLUnionType, directoryPath: String) {
     self.unionType = unionType
 

--- a/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
@@ -6,9 +6,9 @@ struct UnionFileGenerator: FileGenerator, Equatable {
   let unionType: GraphQLUnionType
   let path: String
 
-  var data: Data {
+  var data: Data? {
     #warning("TODO: need correct data template")
-    return "public enum \(unionType.name) {}".data(using: .utf8)!
+    return "public enum \(unionType.name) {}".data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenTestSupport/MockIRSubscripts.swift
+++ b/Sources/ApolloCodegenTestSupport/MockIRSubscripts.swift
@@ -91,6 +91,10 @@ extension IR.Schema {
   public subscript(scalar name: String) -> GraphQLScalarType? {
     return referencedTypes.scalars.first { $0.name == name }
   }
+
+  public subscript(enum name: String) -> GraphQLEnumType? {
+    return referencedTypes.enums.first { $0.name == name }
+  }
 }
 
 extension CompilationResult {

--- a/Sources/ApolloCodegenTestSupport/MockIRSubscripts.swift
+++ b/Sources/ApolloCodegenTestSupport/MockIRSubscripts.swift
@@ -95,6 +95,10 @@ extension IR.Schema {
   public subscript(enum name: String) -> GraphQLEnumType? {
     return referencedTypes.enums.first { $0.name == name }
   }
+
+  public subscript(inputObject name: String) -> GraphQLInputObjectType? {
+    return referencedTypes.inputObjects.first { $0.name == name }
+  }
 }
 
 extension CompilationResult {

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -153,7 +153,7 @@ class ApolloCodegenTests: XCTestCase {
 
   // MARK: File Generator Tests
 
-  func test_fileGenerators_givenGraphQLObjectType_shouldOnlyCreateGeneratorsForUsedTypes() throws {
+  func test_fileGenerators_givenSchema_shouldCreateFileGeneratorsForUsedSchema1Types() throws {
     // given
     let schema = """
     type Query {

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -241,6 +241,7 @@ class ApolloCodegenTests: XCTestCase {
 
     let directoryPath = CodegenTestHelper.outputFolderURL().path
 
+    // then
     expect(ApolloCodegen.fileGenerators(
       for: ir.schema.referencedTypes.interfaces,
       directoryPath:directoryPath

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -153,41 +153,129 @@ class ApolloCodegenTests: XCTestCase {
 
   // MARK: File Generator Tests
 
-  func test_fileGenerators_givenSchema_shouldCreateFileGeneratorsForUsedSchema1Types() throws {
+  func test_fileGenerators_givenSchema_shouldCreateFileGeneratorsForUsedSchemaTypes() throws {
     // given
     let schema = """
+    interface NamedEntity {
+      name: String
+    }
+
+    type Person implements NamedEntity {
+      name: String
+      age: Int
+    }
+
+    type Business implements NamedEntity {
+      name: String
+      type: BUSINESS_TYPE
+    }
+
+    enum BUSINESS_TYPE {
+      MOM_AND_POP
+      BIG_RETAIL
+    }
+
+    type Contact {
+      entity: NamedEntity!
+      address: String
+      phoneNumber: String
+    }
+
+    union SearchResult = Person | Business
+
+    input ContactInput {
+      name: String
+      address: String
+      phoneNumber: String
+    }
+
     type Query {
-      books: [Book!]!
+      contacts: [Contact!]
+      searchResult: SearchResult
     }
 
-    type Book {
-      name: String!
-      author: Author!
-    }
-
-    type Author {
-      name: String!
+    type Mutation {
+      createContact(contact: ContactInput!): Contact
     }
     """
 
-    let operation = """
-    query getBooks {
-      books {
-        name
+    let operations = """
+    query AllContacts {
+      contacts {
+        entity {
+          name
+        }
+      }
+    }
+
+    query FindEntity {
+      searchResult {
+        ... on Person {
+          name
+          age
+        }
+        ... on Business {
+          name
+          type
+        }
+      }
+    }
+
+    mutation CreateContact($contact: ContactInput!) {
+      createContact(contact: $contact) {
+        entity {
+          name
+        }
       }
     }
     """
 
-    let ir = try IR.mock(schema: schema, document: operation)
-    let bookType = try ir.schema[object: "Book"].xctUnwrapped()
+    let ir = try IR.mock(schema: schema, document: operations)
+    let namedEntityInterface = try ir.schema[interface: "NamedEntity"].xctUnwrapped()
+    let personObject = try ir.schema[object: "Person"].xctUnwrapped()
+    let businessObject = try ir.schema[object: "Business"].xctUnwrapped()
+    let contactObject = try ir.schema[object: "Contact"].xctUnwrapped()
+    let businessTypeEnum = try ir.schema[enum: "BUSINESS_TYPE"].xctUnwrapped()
+    let searchResultUnion = try ir.schema[union: "SearchResult"].xctUnwrapped()
+    let contactInput = try ir.schema[inputObject: "ContactInput"].xctUnwrapped()
 
     let directoryPath = CodegenTestHelper.outputFolderURL().path
+
+    expect(ApolloCodegen.fileGenerators(
+      for: ir.schema.referencedTypes.interfaces,
+      directoryPath:directoryPath
+    )).to(equal([
+      InterfaceFileGenerator(interfaceType: namedEntityInterface, directoryPath: directoryPath)
+    ]))
 
     expect(ApolloCodegen.fileGenerators(
       for: ir.schema.referencedTypes.objects,
       directoryPath: directoryPath
     )).to(equal([
-      TypeFileGenerator(objectType: bookType, directoryPath: directoryPath)
+      TypeFileGenerator(objectType: contactObject, directoryPath: directoryPath),
+      TypeFileGenerator(objectType: personObject, directoryPath: directoryPath),
+      TypeFileGenerator(objectType: businessObject, directoryPath: directoryPath)
+    ]))
+
+    expect(ApolloCodegen.fileGenerators(
+      for: ir.schema.referencedTypes.enums,
+      directoryPath: directoryPath
+    )).to(equal([
+      EnumFileGenerator(enumType: businessTypeEnum, directoryPath: directoryPath)
+    ]))
+
+    expect(ApolloCodegen.fileGenerators(
+      for: ir.schema.referencedTypes.unions,
+      directoryPath: directoryPath
+    )).to(equal([
+      UnionFileGenerator(unionType: searchResultUnion, directoryPath: directoryPath)
+    ]))
+
+    expect(ApolloCodegen.fileGenerators(
+      for: ir.schema.referencedTypes.inputObjects,
+      directoryPath: directoryPath
+    )).to(equal([
+      InputObjectFileGenerator(inputObjectType: contactInput, directoryPath: directoryPath)
     ]))
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/EnumFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/EnumFileGeneratorTests.swift
@@ -12,50 +12,19 @@ class EnumFileGeneratorTests: XCTestCase {
 
   func test_generate_givenSchemaType_shouldOutputToPath() throws {
     // given
-    let schema = """
-    type Query {
-      books: [Book!]!
-    }
-
-    type Book {
-      name: String!
-      rating: Rating!
-    }
-
-    enum Rating {
-      GOOD
-      BAD
-    }
-    """
-
-    let operation = """
-    query getBooks {
-      books {
-        name
-        rating
-      }
-    }
-    """
-
-    let ir = try IR.mock(schema: schema, document: operation)
-    let ratingType = try ir.schema[enum: "Rating"].xctUnwrapped()
-
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
-    let fileURL = rootURL.appendingPathComponent("Rating.swift")
-
+    let fileURL = rootURL.appendingPathComponent("MockEnum.swift")
     let mockFileManager = MockFileManager(strict: false)
 
     mockFileManager.mock(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
-        .to(equal("public enum Rating {}"))
 
       return true
     }))
 
     // then
     try EnumFileGenerator(
-      enumType: ratingType,
+      enumType: GraphQLEnumType.mock(name: "MockEnum"),
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/EnumFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/EnumFileGeneratorTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class EnumFileGeneratorTests: XCTestCase {
+  override func tearDown() {
+    CodegenTestHelper.deleteExistingOutputFolder()
+
+    super.tearDown()
+  }
+
+  func test_generate_givenSchemaType_shouldOutputToPath() throws {
+    // given
+    let schema = """
+    type Query {
+      books: [Book!]!
+    }
+
+    type Book {
+      name: String!
+      rating: Rating!
+    }
+
+    enum Rating {
+      GOOD
+      BAD
+    }
+    """
+
+    let operation = """
+    query getBooks {
+      books {
+        name
+        rating
+      }
+    }
+    """
+
+    let ir = try IR.mock(schema: schema, document: operation)
+    let ratingType = try ir.schema[enum: "Rating"].xctUnwrapped()
+
+    let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
+    let fileURL = rootURL.appendingPathComponent("Rating.swift")
+
+    let mockFileManager = MockFileManager(strict: false)
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
+        .to(equal("public enum Rating {}"))
+
+      return true
+    }))
+
+    // then
+    try EnumFileGenerator(
+      enumType: ratingType,
+      directoryPath: rootURL.path
+    ).generateFile(fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InputObjectFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InputObjectFileGeneratorTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class InputObjectFileGeneratorTests: XCTestCase {
+  override func tearDown() {
+    CodegenTestHelper.deleteExistingOutputFolder()
+
+    super.tearDown()
+  }
+
+  func test_generate_givenSchemaType_shouldOutputToPath() throws {
+    // given
+    let schema = """
+    input MessageInput {
+      author: String
+      content: String
+    }
+
+    type Message {
+      author: String
+      content: String
+    }
+
+    type Query {
+      messages: [Message!]!
+    }
+
+    type Mutation {
+      createMessage(input: MessageInput): Message
+    }
+    """
+
+    let operation = """
+    mutation CreateMessage($input: MessageInput) {
+      createMessage(input: $input) {
+        author
+        content
+      }
+    }
+    """
+
+    let ir = try IR.mock(schema: schema, document: operation)
+    let inputObjectType = try ir.schema[inputObject: "MessageInput"].xctUnwrapped()
+
+    let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
+    let fileURL = rootURL.appendingPathComponent("MessageInput.swift")
+
+    let mockFileManager = MockFileManager(strict: false)
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
+        .to(equal("public struct MessageInput {}"))
+
+      return true
+    }))
+
+    // then
+    try InputObjectFileGenerator(
+      inputObjectType: inputObjectType,
+      directoryPath: rootURL.path
+    ).generateFile(fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InputObjectFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InputObjectFileGeneratorTests.swift
@@ -12,54 +12,19 @@ class InputObjectFileGeneratorTests: XCTestCase {
 
   func test_generate_givenSchemaType_shouldOutputToPath() throws {
     // given
-    let schema = """
-    input MessageInput {
-      author: String
-      content: String
-    }
-
-    type Message {
-      author: String
-      content: String
-    }
-
-    type Query {
-      messages: [Message!]!
-    }
-
-    type Mutation {
-      createMessage(input: MessageInput): Message
-    }
-    """
-
-    let operation = """
-    mutation CreateMessage($input: MessageInput) {
-      createMessage(input: $input) {
-        author
-        content
-      }
-    }
-    """
-
-    let ir = try IR.mock(schema: schema, document: operation)
-    let inputObjectType = try ir.schema[inputObject: "MessageInput"].xctUnwrapped()
-
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
-    let fileURL = rootURL.appendingPathComponent("MessageInput.swift")
-
+    let fileURL = rootURL.appendingPathComponent("MockInputObject.swift")
     let mockFileManager = MockFileManager(strict: false)
 
     mockFileManager.mock(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
-        .to(equal("public struct MessageInput {}"))
 
       return true
     }))
 
     // then
     try InputObjectFileGenerator(
-      inputObjectType: inputObjectType,
+      inputObjectType: GraphQLInputObjectType.mock("MockInputObject"),
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InterfaceFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InterfaceFileGeneratorTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class InterfaceFileGeneratorTests: XCTestCase {
+  override func tearDown() {
+    CodegenTestHelper.deleteExistingOutputFolder()
+
+    super.tearDown()
+  }
+
+  func test_generate_givenSchemaType_shouldOutputToPath() throws {
+    // given
+    let schema = """
+    interface NamedEntity {
+      name: String
+    }
+
+    type Contact {
+      entity: NamedEntity
+      phoneNumber: String
+      address: String
+    }
+
+    type Query {
+      contacts: [Contact!]!
+    }
+    """
+
+    let operation = """
+    query AllContacts {
+      contacts {
+        entity {
+          name
+        }
+      }
+    }
+    """
+
+    let ir = try IR.mock(schema: schema, document: operation)
+    let interfaceType = try ir.schema[interface: "NamedEntity"].xctUnwrapped()
+
+    let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
+    let fileURL = rootURL.appendingPathComponent("NamedEntity.swift")
+
+    let mockFileManager = MockFileManager(strict: false)
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
+        .to(equal("public class NamedEntity {}"))
+
+      return true
+    }))
+
+    // then
+    try InterfaceFileGenerator(
+      interfaceType: interfaceType,
+      directoryPath: rootURL.path
+    ).generateFile(fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InterfaceFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InterfaceFileGeneratorTests.swift
@@ -12,51 +12,19 @@ class InterfaceFileGeneratorTests: XCTestCase {
 
   func test_generate_givenSchemaType_shouldOutputToPath() throws {
     // given
-    let schema = """
-    interface NamedEntity {
-      name: String
-    }
-
-    type Contact {
-      entity: NamedEntity
-      phoneNumber: String
-      address: String
-    }
-
-    type Query {
-      contacts: [Contact!]!
-    }
-    """
-
-    let operation = """
-    query AllContacts {
-      contacts {
-        entity {
-          name
-        }
-      }
-    }
-    """
-
-    let ir = try IR.mock(schema: schema, document: operation)
-    let interfaceType = try ir.schema[interface: "NamedEntity"].xctUnwrapped()
-
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
-    let fileURL = rootURL.appendingPathComponent("NamedEntity.swift")
-
+    let fileURL = rootURL.appendingPathComponent("MockInterface.swift")
     let mockFileManager = MockFileManager(strict: false)
 
     mockFileManager.mock(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
-        .to(equal("public class NamedEntity {}"))
 
       return true
     }))
 
     // then
     try InterfaceFileGenerator(
-      interfaceType: interfaceType,
+      interfaceType: GraphQLInterfaceType.mock("MockInterface", fields: [:], interfaces: []),
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaFileGeneratorTests.swift
@@ -12,52 +12,20 @@ class SchemaFileGeneratorTests: XCTestCase {
 
   func test_generate_givenSchemaTypes_shouldOutputToPath() throws {
     // given
-    let schema = """
-    type Query {
-      books: [Book!]!
-      authors: [Author]!
-    }
-
-    type Book {
-      name: String!
-      author: String!
-    }
-
-    type Author {
-      name: String!
-    }
-    """
-
-    let operation = """
-    query getBooks {
-      books {
-        name
-        author {
-          name
-        }
-      }
-    }
-    """
-
-    let ir = try IR.mock(schema: schema, document: operation)
-
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
     let fileURL = rootURL.appendingPathComponent("Schema.swift")
-
     let mockFileManager = MockFileManager(strict: false)
 
     mockFileManager.mock(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
-        .to(equal("public enum Schema {}"))
 
       return true
     }))
 
     // then
     try SchemaFileGenerator(
-      name: "ModuleName",
-      objectTypes: ir.schema.referencedTypes.objects,
+      name: "MockSchema",
+      objectTypes: IR.Schema(name: "MockSchema", referencedTypes: .init([])).referencedTypes.objects,
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaFileGeneratorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class SchemaFileGeneratorTests: XCTestCase {
+  override func tearDown() {
+    CodegenTestHelper.deleteExistingOutputFolder()
+
+    super.tearDown()
+  }
+
+  func test_generate_givenSchemaTypes_shouldOutputToPath() throws {
+    // given
+    let schema = """
+    type Query {
+      books: [Book!]!
+      authors: [Author]!
+    }
+
+    type Book {
+      name: String!
+      author: String!
+    }
+
+    type Author {
+      name: String!
+    }
+    """
+
+    let operation = """
+    query getBooks {
+      books {
+        name
+        author {
+          name
+        }
+      }
+    }
+    """
+
+    let ir = try IR.mock(schema: schema, document: operation)
+
+    let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
+    let fileURL = rootURL.appendingPathComponent("Schema.swift")
+
+    let mockFileManager = MockFileManager(strict: false)
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
+        .to(equal("public enum Schema {}"))
+
+      return true
+    }))
+
+    // then
+    try SchemaFileGenerator(
+      name: "ModuleName",
+      objectTypes: ir.schema.referencedTypes.objects,
+      directoryPath: rootURL.path
+    ).generateFile(fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/TypeFileGeneratorTests.swift
@@ -12,43 +12,19 @@ class TypeFileGeneratorTests: XCTestCase {
 
   func test_generate_givenSchemaType_shouldOutputToPath() throws {
     // given
-    let schema = """
-    type Query {
-      books: [Book!]!
-    }
-
-    type Book {
-      name: String!
-    }
-    """
-
-    let operation = """
-    query getBooks {
-      books {
-        name
-      }
-    }
-    """
-
-    let ir = try IR.mock(schema: schema, document: operation)
-    let bookType = try ir.schema[object: "Book"].xctUnwrapped()
-
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
-    let fileURL = rootURL.appendingPathComponent("Book.swift")
-
+    let fileURL = rootURL.appendingPathComponent("MockObject.swift")
     let mockFileManager = MockFileManager(strict: false)
 
     mockFileManager.mock(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
-        .to(equal("public class Book {}"))
 
       return true
     }))
 
     // then
     try TypeFileGenerator(
-      objectType: bookType,
+      objectType: GraphQLObjectType.mock("MockObject", fields: [:], interfaces: []),
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
@@ -12,58 +12,19 @@ class UnionFileGeneratorTests: XCTestCase {
 
   func test_generate_givenSchemaType_shouldOutputToPath() throws {
     // given
-    let schema = """
-    union SearchResult = Person | Business
-
-    type Person {
-      name: String
-      age: Int
-    }
-
-    type Business {
-      name: String
-      employeeCount: Int
-    }
-
-    type Query {
-      searchResult: SearchResult
-    }
-    """
-
-    let operation = """
-    query SearchResult {
-      searchResult {
-        ... on Person {
-          name
-          age
-        }
-        ... on Business {
-          name
-          employeeCount
-        }
-      }
-    }
-    """
-
-    let ir = try IR.mock(schema: schema, document: operation)
-    let unionType = try ir.schema[union: "SearchResult"].xctUnwrapped()
-
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
-    let fileURL = rootURL.appendingPathComponent("SearchResult.swift")
-
+    let fileURL = rootURL.appendingPathComponent("MockUnion.swift")
     let mockFileManager = MockFileManager(strict: false)
 
     mockFileManager.mock(closure: .createFile({ path, data, attributes in
       expect(path).to(equal(fileURL.path))
-      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
-        .to(equal("public enum SearchResult {}"))
 
       return true
     }))
 
     // then
     try UnionFileGenerator(
-      unionType: unionType,
+      unionType: GraphQLUnionType.mock("MockUnion", types: []),
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class UnionFileGeneratorTests: XCTestCase {
+  override func tearDown() {
+    CodegenTestHelper.deleteExistingOutputFolder()
+
+    super.tearDown()
+  }
+
+  func test_generate_givenSchemaType_shouldOutputToPath() throws {
+    // given
+    let schema = """
+    union SearchResult = Person | Business
+
+    type Person {
+      name: String
+      age: Int
+    }
+
+    type Business {
+      name: String
+      employeeCount: Int
+    }
+
+    type Query {
+      searchResult: SearchResult
+    }
+    """
+
+    let operation = """
+    query SearchResult {
+      searchResult {
+        ... on Person {
+          name
+          age
+        }
+        ... on Business {
+          name
+          employeeCount
+        }
+      }
+    }
+    """
+
+    let ir = try IR.mock(schema: schema, document: operation)
+    let unionType = try ir.schema[union: "SearchResult"].xctUnwrapped()
+
+    let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
+    let fileURL = rootURL.appendingPathComponent("SearchResult.swift")
+
+    let mockFileManager = MockFileManager(strict: false)
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+      expect(String(data: try! data.xctUnwrapped(), encoding: .utf8))
+        .to(equal("public enum SearchResult {}"))
+
+      return true
+    }))
+
+    // then
+    try UnionFileGenerator(
+      unionType: unionType,
+      directoryPath: rootURL.path
+    ).generateFile(fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}


### PR DESCRIPTION
This PR adds file generators for the schema types Enum, Interface, Union, InputObject and the schema metadata file.

_This is replication of the file generation pattern from #2076. The next set of PRs will implement each template to begin generating real Swift content. There will likely be changes to some of the file generators as the template requires more or less data upon initialization but I expect the `FileGenerator` protocol shouldn't need to change._