### PR TITLE
EnumFileGenerator Template Content

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
+		E6C9849327929EBE009481BE /* EnumTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C9849227929EBE009481BE /* EnumTemplate.swift */; };
+		E6C9849527929FED009481BE /* EnumTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C9849427929FED009481BE /* EnumTemplateTests.swift */; };
 		E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */; };
 		E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */; };
 		E6D90D09278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */; };
@@ -982,6 +984,8 @@
 		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
+		E6C9849227929EBE009481BE /* EnumTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTemplate.swift; sourceTree = "<group>"; };
+		E6C9849427929FED009481BE /* EnumTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTemplateTests.swift; sourceTree = "<group>"; };
 		E6D79AB626E97D0D0094434A /* URLDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDownloaderTests.swift; sourceTree = "<group>"; };
 		E6D79AB926EC05290094434A /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
 		E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputObjectFileGenerator.swift; sourceTree = "<group>"; };
@@ -1910,6 +1914,7 @@
 		DE31A437276A78140020DC44 /* Templates */ = {
 			isa = PBXGroup;
 			children = (
+				E6C9849227929EBE009481BE /* EnumTemplate.swift */,
 				DE5FD60A276970FC0033EE23 /* FragmentTemplate.swift */,
 				E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */,
 				DE5FD5FC2769222D0033EE23 /* OperationDefinitionTemplate.swift */,
@@ -1922,6 +1927,7 @@
 		DE31A438276A789B0020DC44 /* Templates */ = {
 			isa = PBXGroup;
 			children = (
+				E6C9849427929FED009481BE /* EnumTemplateTests.swift */,
 				DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */,
 				E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */,
 				DE09F9C5270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift */,
@@ -2938,6 +2944,7 @@
 				DE7C183E272A154400727031 /* IR.swift in Sources */,
 				9F628E9525935BE600F94F9D /* GraphQLType.swift in Sources */,
 				9BFE8DA9265D5D8F000BBF81 /* URLDownloader.swift in Sources */,
+				E6C9849327929EBE009481BE /* EnumTemplate.swift in Sources */,
 				9F1A966D258F34BB00A06EEB /* CompilationResult.swift in Sources */,
 				E610D8DB278EB0900023E495 /* InterfaceFileGenerator.swift in Sources */,
 				9B7B6F69233C2C0C00F32205 /* FileManager+Apollo.swift in Sources */,
@@ -3011,6 +3018,7 @@
 				DE79642F2769A1EB00978A03 /* IROperationBuilderTests.swift in Sources */,
 				E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */,
 				E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */,
+				E6C9849527929FED009481BE /* EnumTemplateTests.swift in Sources */,
 				DE5FD609276956C70033EE23 /* SchemaTemplateTests.swift in Sources */,
 				E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */,
 				E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
@@ -7,8 +7,9 @@ struct EnumFileGenerator: FileGenerator, Equatable {
   let path: String
 
   var data: Data? {
-    #warning("TODO: need correct data template")
-    return "public enum \(enumType.name) {}".data(using: .utf8)
+    EnumTemplate(graphqlEnum: self.enumType)
+      .render()
+      .data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -4,7 +4,7 @@ struct EnumTemplate {
   func render() -> String {
     TemplateString(
     """
-    public enum \(graphqlEnum.name): String, CaseIterable {
+    public enum \(graphqlEnum.name): String, EnumType {
       \(graphqlEnum.values.map({
         "case \($0.name)"
       }), separator: "\n")

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -1,0 +1,15 @@
+struct EnumTemplate {
+  let graphqlEnum: GraphQLEnumType
+
+  func render() -> String {
+    TemplateString(
+    """
+    public enum \(graphqlEnum.name): String, CaseIterable {
+      \(graphqlEnum.values.map({
+        "case \($0.name)"
+      }), separator: "\n")
+    }
+    """
+    ).value
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -13,7 +13,7 @@ class EnumTemplateTests: XCTestCase {
     let template = EnumTemplate(graphqlEnum: graphqlEnum)
 
     let expected = """
-    public enum TestEnum: String, CaseIterable {
+    public enum TestEnum: String, EnumType {
       case ONE
       case TWO
     }
@@ -35,7 +35,7 @@ class EnumTemplateTests: XCTestCase {
     let template = EnumTemplate(graphqlEnum: graphqlEnum)
 
     let expected = """
-    public enum CasedEnum: String, CaseIterable {
+    public enum CasedEnum: String, EnumType {
       case lower
       case UPPER
       case Capitalized

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class EnumTemplateTests: XCTestCase {
+  func test_render_givenSchemaEnum_generatesSwiftEnum() throws {
+    // given
+    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([
+      GraphQLEnumType.mock(name: "TestEnum", values: ["ONE", "TWO"])
+    ]))
+    let graphqlEnum = try schema[enum: "TestEnum"].xctUnwrapped()
+    let template = EnumTemplate(graphqlEnum: graphqlEnum)
+
+    let expected = """
+    public enum TestEnum: String, CaseIterable {
+      case ONE
+      case TWO
+    }
+    """
+
+    // when
+    let actual = template.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test_render_givenSchemaEnum_generatesSwiftEnumRespectingCase() throws {
+    // given
+    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([
+      GraphQLEnumType.mock(name: "CasedEnum", values: ["lower", "UPPER", "Capitalized"])
+    ]))
+    let graphqlEnum = try schema[enum: "CasedEnum"].xctUnwrapped()
+    let template = EnumTemplate(graphqlEnum: graphqlEnum)
+
+    let expected = """
+    public enum CasedEnum: String, CaseIterable {
+      case lower
+      case UPPER
+      case Capitalized
+    }
+    """
+
+    // when
+    let actual = template.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -6,10 +6,7 @@ import ApolloCodegenTestSupport
 class EnumTemplateTests: XCTestCase {
   func test_render_givenSchemaEnum_generatesSwiftEnum() throws {
     // given
-    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([
-      GraphQLEnumType.mock(name: "TestEnum", values: ["ONE", "TWO"])
-    ]))
-    let graphqlEnum = try schema[enum: "TestEnum"].xctUnwrapped()
+    let graphqlEnum = GraphQLEnumType.mock(name: "TestEnum", values: ["ONE", "TWO"])
     let template = EnumTemplate(graphqlEnum: graphqlEnum)
 
     let expected = """
@@ -28,10 +25,10 @@ class EnumTemplateTests: XCTestCase {
 
   func test_render_givenSchemaEnum_generatesSwiftEnumRespectingCase() throws {
     // given
-    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([
-      GraphQLEnumType.mock(name: "CasedEnum", values: ["lower", "UPPER", "Capitalized"])
-    ]))
-    let graphqlEnum = try schema[enum: "CasedEnum"].xctUnwrapped()
+    let graphqlEnum = GraphQLEnumType.mock(
+      name: "CasedEnum",
+      values: ["lower", "UPPER", "Capitalized"]
+    )
     let template = EnumTemplate(graphqlEnum: graphqlEnum)
 
     let expected = """


### PR DESCRIPTION
This implements `TemplateString` for Swift Enum types, uses it in `EnumFileGenerator`, completing the schema enum file generator.