### PR TITLE
SelectionSet Template Generator [1/X]

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -201,8 +201,10 @@
 		DE223C292720B897004A0148 /* StringInterpolation+NestedIndentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE223C282720B897004A0148 /* StringInterpolation+NestedIndentation.swift */; };
 		DE223C2D2721FCE8004A0148 /* ScopedSelectionSetHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE223C2C2721FCE8004A0148 /* ScopedSelectionSetHashable.swift */; };
 		DE223C3327221144004A0148 /* IRMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE223C2A2721FAD6004A0148 /* IRMatchers.swift */; };
-		DE27390F2769AE9700B886EF /* SelectionSetTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE27390E2769AE9700B886EF /* SelectionSetTemplateTests.swift */; };
 		DE2739112769AEBA00B886EF /* SelectionSetTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2739102769AEBA00B886EF /* SelectionSetTemplate.swift */; };
+		DE296539279B3B8200BF9B49 /* SelectionSetTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE296536279B3B8200BF9B49 /* SelectionSetTemplateTests.swift */; };
+		DE29653A279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE296537279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift */; };
+		DE29653B279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE296538279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift */; };
 		DE2FCF1D26E806710057EA67 /* SchemaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FCF1C26E806710057EA67 /* SchemaConfiguration.swift */; };
 		DE2FCF1F26E807CC0057EA67 /* CacheTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FCF1E26E807CC0057EA67 /* CacheTransaction.swift */; };
 		DE2FCF2126E807EF0057EA67 /* Cacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FCF2026E807EF0057EA67 /* Cacheable.swift */; };
@@ -303,13 +305,13 @@
 		DED46042261CEA8A0086EF63 /* TestServerURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED45C172615308E0086EF63 /* TestServerURLs.swift */; };
 		DED46051261CEAD20086EF63 /* StarWarsAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCE2CFA1E6C213D00E34457 /* StarWarsAPI.framework */; };
 		DEFBBC86273470F70088AABC /* IR+Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBBC85273470F70088AABC /* IR+Field.swift */; };
+		DEFE0FC52748822900FFA440 /* IR+EntitySelectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE0FC42748822900FFA440 /* IR+EntitySelectionTree.swift */; };
 		E610D8D7278EA2390023E495 /* EnumFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */; };
 		E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */; };
 		E610D8DB278EB0900023E495 /* InterfaceFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */; };
 		E610D8DD278EB1500023E495 /* InterfaceFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */; };
 		E610D8DF278F8F1E0023E495 /* UnionFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */; };
 		E610D8E1278F8F3D0023E495 /* UnionFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */; };
-		DEFE0FC52748822900FFA440 /* IR+EntitySelectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE0FC42748822900FFA440 /* IR+EntitySelectionTree.swift */; };
 		E616B6D126C3335600DB049E /* ExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616B6D026C3335600DB049E /* ExecutionTests.swift */; };
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
@@ -849,8 +851,10 @@
 		DE223C282720B897004A0148 /* StringInterpolation+NestedIndentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringInterpolation+NestedIndentation.swift"; sourceTree = "<group>"; };
 		DE223C2A2721FAD6004A0148 /* IRMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRMatchers.swift; sourceTree = "<group>"; };
 		DE223C2C2721FCE8004A0148 /* ScopedSelectionSetHashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopedSelectionSetHashable.swift; sourceTree = "<group>"; };
-		DE27390E2769AE9700B886EF /* SelectionSetTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionSetTemplateTests.swift; sourceTree = "<group>"; };
 		DE2739102769AEBA00B886EF /* SelectionSetTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionSetTemplate.swift; sourceTree = "<group>"; };
+		DE296536279B3B8200BF9B49 /* SelectionSetTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionSetTemplateTests.swift; sourceTree = "<group>"; };
+		DE296537279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionSetTemplate_RenderFragment_Tests.swift; sourceTree = "<group>"; };
+		DE296538279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionSetTemplate_RenderOperation_Tests.swift; sourceTree = "<group>"; };
 		DE2FCF1C26E806710057EA67 /* SchemaConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemaConfiguration.swift; sourceTree = "<group>"; };
 		DE2FCF1E26E807CC0057EA67 /* CacheTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTransaction.swift; sourceTree = "<group>"; };
 		DE2FCF2026E807EF0057EA67 /* Cacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cacheable.swift; sourceTree = "<group>"; };
@@ -966,13 +970,13 @@
 		DEE1B3F4273B08D8007350E5 /* Types.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Types.graphql.swift; sourceTree = "<group>"; };
 		DEE1B3F5273B08D8007350E5 /* WarmBloodedDetails.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarmBloodedDetails.graphql.swift; sourceTree = "<group>"; };
 		DEFBBC85273470F70088AABC /* IR+Field.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+Field.swift"; sourceTree = "<group>"; };
+		DEFE0FC42748822900FFA440 /* IR+EntitySelectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+EntitySelectionTree.swift"; sourceTree = "<group>"; };
 		E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGenerator.swift; sourceTree = "<group>"; };
 		E610D8D8278EA2560023E495 /* EnumFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceFileGenerator.swift; sourceTree = "<group>"; };
 		E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionFileGenerator.swift; sourceTree = "<group>"; };
 		E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionFileGeneratorTests.swift; sourceTree = "<group>"; };
-		DEFE0FC42748822900FFA440 /* IR+EntitySelectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+EntitySelectionTree.swift"; sourceTree = "<group>"; };
 		E616B6D026C3335600DB049E /* ExecutionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionTests.swift; sourceTree = "<group>"; };
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
@@ -1861,6 +1865,16 @@
 			path = TestHelpers;
 			sourceTree = "<group>";
 		};
+		DE296535279B3B8200BF9B49 /* SelectionSet */ = {
+			isa = PBXGroup;
+			children = (
+				DE296536279B3B8200BF9B49 /* SelectionSetTemplateTests.swift */,
+				DE296537279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift */,
+				DE296538279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift */,
+			);
+			path = SelectionSet;
+			sourceTree = "<group>";
+		};
 		DE2FCF2226E8082A0057EA67 /* SchemaTypes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1929,12 +1943,12 @@
 		DE31A438276A789B0020DC44 /* Templates */ = {
 			isa = PBXGroup;
 			children = (
+				DE296535279B3B8200BF9B49 /* SelectionSet */,
 				E6C9849427929FED009481BE /* EnumTemplateTests.swift */,
 				DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */,
 				E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */,
 				DE09F9C5270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift */,
 				DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */,
-				DE27390E2769AE9700B886EF /* SelectionSetTemplateTests.swift */,
 			);
 			path = Templates;
 			sourceTree = "<group>";
@@ -3010,15 +3024,17 @@
 				9F62E0102590728000E6E808 /* CompilationTests.swift in Sources */,
 				DEAFB77B2706444B00BE02F3 /* IRRootEntityFieldBuilderTests.swift in Sources */,
 				9F62DFBF2590560000E6E808 /* Helpers.swift in Sources */,
+				DE296539279B3B8200BF9B49 /* SelectionSetTemplateTests.swift in Sources */,
 				DED18CC727023C0400F62977 /* OperationDefinitionTests.swift in Sources */,
 				E66F8897276C136B0000BDA8 /* TypeFileGeneratorTests.swift in Sources */,
-				DE27390F2769AE9700B886EF /* SelectionSetTemplateTests.swift in Sources */,
 				DE79642B276999E700978A03 /* IRNamedFragmentBuilderTests.swift in Sources */,
 				9B8C3FB5248DA3E000707B13 /* URLExtensionsTests.swift in Sources */,
 				E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */,
 				9FDE0731258F3AA100DC0CA5 /* SchemaLoadingTests.swift in Sources */,
 				DE223C3327221144004A0148 /* IRMatchers.swift in Sources */,
 				DE79642F2769A1EB00978A03 /* IROperationBuilderTests.swift in Sources */,
+				DE29653B279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift in Sources */,
+				DE29653A279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift in Sources */,
 				E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */,
 				E6D79AB826E9D59C0094434A /* URLDownloaderTests.swift in Sources */,
 				E6C9849527929FED009481BE /* EnumTemplateTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/IR/IR+Field.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+Field.swift
@@ -6,6 +6,7 @@ extension IR {
     let underlyingField: CompilationResult.Field
 
     var name: String { underlyingField.name }
+    var alias: String? { underlyingField.alias }
     var type: GraphQLType { underlyingField.type }
 
     fileprivate init(_ field: CompilationResult.Field) {

--- a/Sources/ApolloCodegenLib/IR/IR+Field.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+Field.swift
@@ -5,6 +5,9 @@ extension IR {
   class Field: Equatable, CustomDebugStringConvertible {
     let underlyingField: CompilationResult.Field
 
+    var name: String { underlyingField.name }
+    var type: GraphQLType { underlyingField.type }
+
     fileprivate init(_ field: CompilationResult.Field) {
       self.underlyingField = field
     }

--- a/Sources/ApolloCodegenLib/TemplateString.swift
+++ b/Sources/ApolloCodegenLib/TemplateString.swift
@@ -73,11 +73,11 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
 
     mutating func appendInterpolation(
       if bool: Bool,
-      _ template: TemplateString,
+      _ template: @autoclosure () -> TemplateString,
       else: TemplateString? = nil
     ) {
       if bool {
-        appendInterpolation(template.value)
+        appendInterpolation(template().value)
       } else if let elseTemplate = `else` {
         appendInterpolation(elseTemplate.value)
       } else {
@@ -126,4 +126,9 @@ fileprivate extension Array where Element == Substring {
 
     return string
   }
+}
+
+extension StringProtocol {
+    var firstUppercased: String { prefix(1).uppercased() + dropFirst() }
+    var firstCapitalized: String { prefix(1).capitalized + dropFirst() }
 }

--- a/Sources/ApolloCodegenLib/TemplateString.swift
+++ b/Sources/ApolloCodegenLib/TemplateString.swift
@@ -38,16 +38,16 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
     private static let whitespaceNotNewline = Set(" \t")
 
     mutating func appendInterpolation(_ string: String) {
-      let indent = output.reversed().prefix {
+      let indent = String(output.reversed().prefix {
         TemplateString.StringInterpolation.whitespaceNotNewline.contains($0)
-      }
+      })
 
       if indent.isEmpty {
         appendLiteral(string)
       } else {
         let indentedString = string
           .split(separator: "\n", omittingEmptySubsequences: false)
-          .joined(separator: "\n" + indent)
+          .joinedAsLines(withIndent: indent)
 
         appendLiteral(indentedString)
       }
@@ -91,5 +91,21 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
     private func substringToStartOfLine() -> Slice<ReversedCollection<String>> {
       return output.reversed().prefix { !$0.isNewline }
     }
+  }
+}
+
+fileprivate extension Array where Element == Substring {
+  func joinedAsLines(withIndent indent: String) -> String {
+    var iterator = self.makeIterator()
+    var string = iterator.next()?.description ?? ""
+
+    while let nextLine = iterator.next() {
+      string += "\n"
+      if !nextLine.isEmpty {
+        string += indent + nextLine
+      }
+    }
+
+    return string
   }
 }

--- a/Sources/ApolloCodegenLib/TemplateString.swift
+++ b/Sources/ApolloCodegenLib/TemplateString.swift
@@ -71,7 +71,11 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
       appendInterpolation(elementsString)
     }
 
-    mutating func appendInterpolation(if bool: Bool, _ template: TemplateString, else: TemplateString? = nil) {
+    mutating func appendInterpolation(
+      if bool: Bool,
+      _ template: TemplateString,
+      else: TemplateString? = nil
+    ) {
       if bool {
         appendInterpolation(template.value)
       } else if let elseTemplate = `else` {
@@ -90,6 +94,20 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
 
     private func substringToStartOfLine() -> Slice<ReversedCollection<String>> {
       return output.reversed().prefix { !$0.isNewline }
+    }
+
+    mutating func appendInterpolation<T>(
+    ifLet optional: Optional<T>,
+    _ includeBlock: (T) -> TemplateString,
+    else: TemplateString? = nil
+    ) {
+      if let element = optional {
+        appendInterpolation(includeBlock(element))
+      } else if let elseTemplate = `else` {
+        appendInterpolation(elseTemplate.value)
+      } else {
+        removeLineIfEmpty()
+      }
     }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
@@ -9,10 +9,10 @@ struct SchemaTemplate {
 
     public typealias ID = String
 
-    public protocol SelectionSet: ApolloAPI.SelectionSet & RootSelectionSet
+    public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
     where Schema == \(schema.name).Schema {}
     
-    public protocol TypeCase: ApolloAPI.SelectionSet & RootSelectionSet
+    public protocol TypeCase: ApolloAPI.SelectionSet & ApolloAPI.TypeCase
     where Schema == \(schema.name).Schema {}
 
     public enum Schema: SchemaConfiguration {

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -7,6 +7,7 @@ struct SelectionSetTemplate {
     """
     public struct Data: \(schema.name).SelectionSet {
       \(BodyTemplate(operation.rootField))
+    }
     """
     ).description
   }
@@ -16,6 +17,7 @@ struct SelectionSetTemplate {
     """
     public struct \(fragment.name): \(schema.name).SelectionSet, Fragment {
       \(BodyTemplate(fragment.rootField))
+    }
     """
     ).description
   }
@@ -25,6 +27,7 @@ struct SelectionSetTemplate {
     """
     public struct TODO: \(schema.name).SelectionSet {
       \(BodyTemplate(field))
+    }
     """
     ).description
   }
@@ -34,7 +37,7 @@ struct SelectionSetTemplate {
     \(Self.DataFieldAndInitializerTemplate)
 
     \(ParentTypeTemplate(field.selectionSet.parentType))
-    \(ifLet: field.selectionSet.selections.direct, { SelectionsTemplate($0) })
+    \(ifLet: field.selectionSet.selections.direct, { SelectionsTemplate($0) }, else: "\n")
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -50,9 +50,12 @@ struct SelectionSetTemplate {
   private func SelectionsTemplate(_ selections: IR.DirectSelections) -> TemplateString {
     """
     public static var selections: [Selection] { [
-      \(selections.fields.values.map {
-        FieldSelectionTemplate($0)
-      }),
+      \(if: !selections.fields.values.isEmpty, """
+        \(selections.fields.values.map { FieldSelectionTemplate($0) }),
+        """)
+      \(if: !selections.typeCases.values.isEmpty, """
+        \(selections.typeCases.values.map { TypeCaseSelectionTemplate($0.typeInfo) }),
+        """)
     ] }
     """
   }
@@ -60,6 +63,12 @@ struct SelectionSetTemplate {
   private func FieldSelectionTemplate(_ field: IR.Field) -> TemplateString {
     """
     .field("\(field.name)", \(ifLet: field.alias, {"alias: \"\($0)\", "})\(field.type.rendered).self)
+    """
+  }
+
+  private func TypeCaseSelectionTemplate(_ typeCase: IR.SelectionSet.TypeInfo) -> TemplateString {
+    """
+    .typeCase(As\(typeCase.parentType.name.firstUppercased).self)
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -34,7 +34,7 @@ struct SelectionSetTemplate {
     \(Self.DataFieldAndInitializerTemplate)
 
     \(ParentTypeTemplate(field.selectionSet.parentType))
-    \(SelectionsTemplate(field.selectionSet.selections))
+    \(ifLet: field.selectionSet.selections.direct, { SelectionsTemplate($0) })
     """
   }
 
@@ -47,7 +47,7 @@ struct SelectionSetTemplate {
     "public static var __parentType: ParentType { .\(type.parentTypeEnumType)(\(schema.name).\(type.name).self) }"
   }
 
-  private func SelectionsTemplate(_ selections: IR.SortedSelections) -> TemplateString {
+  private func SelectionsTemplate(_ selections: IR.DirectSelections) -> TemplateString {
     """
     public static var selections: [Selection] { [
       \(selections.fields.values.map {
@@ -59,7 +59,7 @@ struct SelectionSetTemplate {
 
   private func FieldSelectionTemplate(_ field: IR.Field) -> TemplateString {
     """
-    .field("\(field.name)", \(field.type.rendered).self)
+    .field("\(field.name)", \(ifLet: field.alias, {"alias: \"\($0)\", "})\(field.type.rendered).self)
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -94,7 +94,9 @@ fileprivate extension GraphQLType {
       return ofType.rendered(containedInNonNull: true)
 
     case let .list(ofType):
-      return "[\(ofType.rendered(containedInNonNull: false))]"
+      let inner = "[\(ofType.rendered(containedInNonNull: false))]"
+
+      return containedInNonNull ? inner : "\(inner)?"
     }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -2,12 +2,50 @@ struct SelectionSetTemplate {
 
   let schema: IR.Schema
 
-  func render() -> String {
+  func render(for operation: IR.Operation) -> String {
     TemplateString(
     """
-
+    public struct Data: \(schema.name).SelectionSet {
+      \(BodyTemplate(operation.rootField))
     """
-    ).value
+    ).description
   }
 
+  func render(for fragment: IR.NamedFragment) -> String {
+    TemplateString(
+    """
+    public struct \(fragment.name): \(schema.name).SelectionSet, Fragment {
+      \(BodyTemplate(fragment.rootField))
+    """
+    ).description
+  }
+
+  func BodyTemplate(_ field: IR.EntityField) -> TemplateString {
+    """
+    \(Self.DataFieldAndInitializerTemplate)
+
+    \(ParentTypeTemplate(field.selectionSet.parentType))
+    """
+  }
+
+  static let DataFieldAndInitializerTemplate = """
+    public let data: ResponseDict
+    public init(data: ResponseDict) { self.data = data }
+    """
+
+  func ParentTypeTemplate(_ type: GraphQLCompositeType) -> String {
+    "public static var __parentType: ParentType { .\(type.parentTypeEnumType)(\(schema.name).\(type.name).self) }"
+  }
+
+}
+
+fileprivate extension GraphQLCompositeType {
+  var parentTypeEnumType: String {
+    switch self {
+    case is GraphQLObjectType: return "Object"
+    case is GraphQLInterfaceType: return "Interface"
+    case is GraphQLUnionType: return "Union"
+    default: fatalError("Invalid parentType for Selection Set: \(self)")
+    }
+  }
 }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -56,6 +56,9 @@ struct SelectionSetTemplate {
       \(if: !selections.typeCases.values.isEmpty, """
         \(selections.typeCases.values.map { TypeCaseSelectionTemplate($0.typeInfo) }),
         """)
+      \(if: !selections.fragments.values.isEmpty, """
+        \(selections.fragments.values.map { FragmentSelectionTemplate($0) }),
+        """)
     ] }
     """
   }
@@ -69,6 +72,12 @@ struct SelectionSetTemplate {
   private func TypeCaseSelectionTemplate(_ typeCase: IR.SelectionSet.TypeInfo) -> TemplateString {
     """
     .typeCase(As\(typeCase.parentType.name.firstUppercased).self)
+    """
+  }
+
+  private func FragmentSelectionTemplate(_ fragment: IR.FragmentSpread) -> TemplateString {
+    """
+    .fragment(\(fragment.definition.name.firstUppercased).self)
     """
   }
 

--- a/Sources/ApolloCodegenTestSupport/MockIRSubscripts.swift
+++ b/Sources/ApolloCodegenTestSupport/MockIRSubscripts.swift
@@ -127,6 +127,11 @@ extension IR.Schema {
 }
 
 extension CompilationResult {
+
+  public subscript(operation name: String) -> CompilationResult.OperationDefinition? {
+    return operations.first { $0.name == name }
+  }
+
   public subscript(fragment name: String) -> CompilationResult.FragmentDefinition? {
     return fragments.first { $0.name == name }
   }

--- a/Sources/ApolloTestSupport/XCTAssertHelpers.swift
+++ b/Sources/ApolloTestSupport/XCTAssertHelpers.swift
@@ -153,7 +153,7 @@ public struct XCTFailure: Error, CustomNSError {
 }
 
 public extension Optional {
-  func xctUnwrapped(file: String = #file, line: Int = #line) throws -> Wrapped {
-    try XCTUnwrap(self)
+  func xctUnwrapped(file: StaticString = #filePath, line: UInt = #line) throws -> Wrapped {
+    try XCTUnwrap(self, file: file, line: line)
   }
 }

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Schema.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Schema.swift
@@ -5,7 +5,7 @@ public typealias ID = String
 public protocol SelectionSet: ApolloAPI.SelectionSet & RootSelectionSet
 where Schema == AnimalKingdomAPI.Schema {}
 
-public protocol TypeCase: ApolloAPI.SelectionSet & RootSelectionSet
+public protocol TypeCase: ApolloAPI.SelectionSet & TypeCase
 where Schema == AnimalKingdomAPI.Schema {}
 
 public enum Schema: SchemaConfiguration {

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRNamedFragmentBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRNamedFragmentBuilderTests.swift
@@ -29,7 +29,7 @@ class IRNamedFragmentBuilderTests: XCTestCase {
     super.tearDown()
   }
 
-  // MARK: = Helpers
+  // MARK: - Helpers
 
   func buildSubjectFragment() throws {
     ir = try .mock(schema: schemaSDL, document: document)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaTemplateTests.swift
@@ -15,10 +15,10 @@ class SchemaTemplateTests: XCTestCase {
 
     public typealias ID = String
 
-    public protocol SelectionSet: ApolloAPI.SelectionSet & RootSelectionSet
+    public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
     where Schema == TestSchemaName.Schema {}
 
-    public protocol TypeCase: ApolloAPI.SelectionSet & RootSelectionSet
+    public protocol TypeCase: ApolloAPI.SelectionSet & ApolloAPI.TypeCase
     where Schema == TestSchemaName.Schema {}
 
     public enum Schema: SchemaConfiguration {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -34,6 +34,39 @@ class SelectionSetTemplateTests: XCTestCase {
 
   // MARK: - Tests
 
+  func test__render_rendersClosingBracket() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(String(actual.reversed())).to(equalLineByLine("}", ignoringExtraLines: true))
+  }
+
   // MARK: Parent Type
 
   func test__render_parentType__givenParentTypeAs_Object_rendersParentType() throws {
@@ -175,7 +208,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __parentType: ParentType { .Object(TestSchema.Animal.self) }
-
+    
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -149,7 +149,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
   }
 
-  // MARK: Selections
+  // MARK: Selections - Fields
 
   func test__render_selections__givenFieldSelections_rendersAllFieldSelections() throws {
     // given
@@ -227,6 +227,46 @@ class SelectionSetTemplateTests: XCTestCase {
         .field("nestedList_optional_required_optional", [[String?]]?.self),
         .field("nestedList_optional_optional_required", [[String]?]?.self),
         .field("nestedList_optional_optional_optional", [[String?]?]?.self),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
+  }
+
+  func test__render_selections__givenFieldWithAlias_rendersFieldSelections() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      string: String!
+    }
+
+    scalar Custom
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        aliased: string
+      }
+    }
+    """
+
+    let expected = """
+      public static var selections: [Selection] { [
+        .field("string", alias: "aliased", String.self),
       ] }
     """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -57,23 +57,20 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-    public static var __parentType: ParentType { .Object(TestSchema.Animal.self) }
+      public static var __parentType: ParentType { .Object(TestSchema.Animal.self) }
     """
 
     // when
     try buildSubjectAndOperation()
 
     let allAnimals = try XCTUnwrap(
-      operation[
-      field: "query"]?[
-        field: "allAnimals"]?
-        .selectionSet
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )
 
-    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+    let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected))
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
   }
 
   func test__render_parentType__givenParentTypeAs_Interface_rendersParentType() throws {
@@ -97,22 +94,19 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-    public static var __parentType: ParentType { .Interface(TestSchema.Animal.self) }
+      public static var __parentType: ParentType { .Interface(TestSchema.Animal.self) }
     """
 
     // when
     try buildSubjectAndOperation()
     let allAnimals = try XCTUnwrap(
-      operation[
-      field: "query"]?[
-        field: "allAnimals"]?
-        .selectionSet
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )
 
-    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+    let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected))
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
   }
 
   func test__render_parentType__givenParentTypeAs_Union_rendersParentType() throws {
@@ -140,22 +134,19 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-    public static var __parentType: ParentType { .Union(TestSchema.Animal.self) }
+      public static var __parentType: ParentType { .Union(TestSchema.Animal.self) }
     """
 
     // when
     try buildSubjectAndOperation()
     let allAnimals = try XCTUnwrap(
-      operation[
-      field: "query"]?[
-        field: "allAnimals"]?
-        .selectionSet
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )
 
-    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+    let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected))
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
   }
 
   // MARK: Selections
@@ -167,41 +158,35 @@ class SelectionSetTemplateTests: XCTestCase {
       allAnimals: [Animal!]
     }
 
-    type Dog {
+    type Animal {
       species: String!
     }
-
-    union Animal = Dog
     """
 
     document = """
     query TestOperation {
       allAnimals {
-        ... on Dog {
-          species
-        }
+        species
       }
     }
     """
 
     let expected = """
-    public static var __parentType: ParentType { .Union(TestSchema.Animal.self) }
+      public static var selections: [Selection] { [
+        .field("species", String.self),
+      ] }
     """
 
     // when
     try buildSubjectAndOperation()
     let allAnimals = try XCTUnwrap(
-      operation[
-      field: "query"]?[
-        field: "allAnimals"]?
-        .selectionSet
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )
 
-    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+    let actual = subject.render(field: allAnimals)
 
     // then
-    fail()
-    expect(actual).to(equalLineByLine(expected))
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -151,7 +151,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
   // MARK: Selections
 
-  func test__render_selections__givenStringField() throws {
+  func test__render_selections__givenFieldSelections_rendersAllFieldSelections() throws {
     // given
     schemaSDL = """
     type Query {
@@ -159,21 +159,74 @@ class SelectionSetTemplateTests: XCTestCase {
     }
 
     type Animal {
-      species: String!
+      string: String!
+      string_optional: String
+      int: Int!
+      int_optional: Int
+      custom: Custom!
+      custom_optional: Custom
+      list_required_required: [String!]!
+      list_optional_required: [String!]
+      list_required_optional: [String]!
+      list_optional_optional: [String]
+      nestedList_required_required_required: [[String!]!]!
+      nestedList_required_required_optional: [[String]!]!
+      nestedList_required_optional_optional: [[String]]!
+      nestedList_required_optional_required: [[String!]]!
+      nestedList_optional_required_required: [[String!]!]
+      nestedList_optional_required_optional: [[String]!]
+      nestedList_optional_optional_required: [[String!]]
+      nestedList_optional_optional_optional: [[String]]
     }
+
+    scalar Custom
     """
 
     document = """
     query TestOperation {
       allAnimals {
-        species
+        string
+        string_optional
+        int
+        int_optional
+        custom
+        custom_optional
+        list_required_required
+        list_optional_required
+        list_required_optional
+        list_optional_optional
+        nestedList_required_required_required
+        nestedList_required_required_optional
+        nestedList_required_optional_optional
+        nestedList_required_optional_required
+        nestedList_optional_required_required
+        nestedList_optional_required_optional
+        nestedList_optional_optional_required
+        nestedList_optional_optional_optional
       }
     }
     """
 
     let expected = """
       public static var selections: [Selection] { [
-        .field("species", String.self),
+        .field("string", String.self),
+        .field("string_optional", String?.self),
+        .field("int", Int.self),
+        .field("int_optional", Int?.self),
+        .field("custom", Custom.self),
+        .field("custom_optional", Custom?.self),
+        .field("list_required_required", [String].self),
+        .field("list_optional_required", [String]?.self),
+        .field("list_required_optional", [String?].self),
+        .field("list_optional_optional", [String?]?.self),
+        .field("nestedList_required_required_required", [[String]].self),
+        .field("nestedList_required_required_optional", [[String?]].self),
+        .field("nestedList_required_optional_optional", [[String?]?].self),
+        .field("nestedList_required_optional_required", [[String]?].self),
+        .field("nestedList_optional_required_required", [[String]]?.self),
+        .field("nestedList_optional_required_optional", [[String?]]?.self),
+        .field("nestedList_optional_optional_required", [[String]?]?.self),
+        .field("nestedList_optional_optional_optional", [[String?]?]?.self),
       ] }
     """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -372,4 +372,55 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 
+  // MARK: Selections - Fragments
+
+  func test__render_selections__givenFragments_rendersFragmentSelections() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      string: String!
+      int: Int!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ...FragmentA
+        ...lowercaseFragment
+      }
+    }
+
+    fragment FragmentA on Animal {
+      int
+    }
+
+    fragment lowercaseFragment on Animal {
+      string
+    }
+    """
+
+    let expected = """
+      public static var selections: [Selection] { [
+        .fragment(FragmentA.self),
+        .fragment(LowercaseFragment.self),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
+  }
+
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class SelectionSetTemplateTests: XCTestCase {
+
+  var schemaSDL: String!
+  var document: String!
+  var ir: IR!
+  var operation: IR.Operation!
+  var subject: SelectionSetTemplate!
+
+  override func setUp() {
+    super.setUp()
+  }
+
+  override func tearDown() {
+    schemaSDL = nil
+    document = nil
+    operation = nil
+    subject = nil
+    super.tearDown()
+  }
+
+  // MARK: - Helpers
+
+  func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
+    ir = try .mock(schema: schemaSDL, document: document)
+    let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
+    operation = ir.build(operation: operationDefinition)
+    subject = SelectionSetTemplate(schema: ir.schema)
+  }
+
+  // MARK: - Tests
+
+  // MARK: Parent Type
+
+  func test__render_parentType__givenParentTypeAs_Object_rendersParentType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    let expected = """
+    public static var __parentType: ParentType { .Object(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(
+      operation[
+      field: "query"]?[
+        field: "allAnimals"]?
+        .selectionSet
+    )
+
+    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render_parentType__givenParentTypeAs_Interface_rendersParentType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    let expected = """
+    public static var __parentType: ParentType { .Interface(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[
+      field: "query"]?[
+        field: "allAnimals"]?
+        .selectionSet
+    )
+
+    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render_parentType__givenParentTypeAs_Union_rendersParentType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Dog {
+      species: String!
+    }
+
+    union Animal = Dog
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+    public static var __parentType: ParentType { .Union(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[
+      field: "query"]?[
+        field: "allAnimals"]?
+        .selectionSet
+    )
+
+    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  // MARK: Selections
+
+  func test__render_selections__givenStringField() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Dog {
+      species: String!
+    }
+
+    union Animal = Dog
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+    public static var __parentType: ParentType { .Union(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[
+      field: "query"]?[
+        field: "allAnimals"]?
+        .selectionSet
+    )
+
+    let actual = subject.ParentTypeTemplate(allAnimals.parentType)
+
+    // then
+    fail()
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderFragment_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderFragment_Tests.swift
@@ -190,6 +190,7 @@ class SelectionSetTemplate_RenderFragment_Tests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+    expect(String(actual.reversed())).to(equalLineByLine("}", ignoringExtraLines: true))
   }
   
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderFragment_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderFragment_Tests.swift
@@ -1,0 +1,195 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class SelectionSetTemplate_RenderFragment_Tests: XCTestCase {
+
+  var schemaSDL: String!
+  var document: String!
+  var ir: IR!
+  var fragment: IR.NamedFragment!
+  var subject: SelectionSetTemplate!
+
+  override func setUp() {
+    super.setUp()
+  }
+
+  override func tearDown() {
+    schemaSDL = nil
+    document = nil
+    fragment = nil
+    subject = nil
+    super.tearDown()
+  }
+
+  // MARK: - Helpers
+
+  func buildSubjectAndFragment(named fragmentName: String = "TestFragment") throws {
+    ir = try .mock(schema: schemaSDL, document: document)
+    let fragmentDefinition = try XCTUnwrap(ir.compilationResult[fragment: fragmentName])
+    fragment = ir.build(fragment: fragmentDefinition)
+    subject = SelectionSetTemplate(schema: ir.schema)
+  }
+
+  // MARK: - Tests
+
+  func test__render__givenFragmentWithName_rendersDeclarationWithName() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    fragment TestFragment on Animal {
+      species
+    }
+    """
+
+    let expected = """
+    public struct TestFragment: TestSchema.SelectionSet, Fragment {
+      public let data: ResponseDict
+      public init(data: ResponseDict) { self.data = data }
+    """
+
+    // when
+    try buildSubjectAndFragment()
+    let actual = subject.render(for: fragment)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenFragmentWithUnderscoreInName_rendersDeclarationWithName() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    fragment Test_Fragment on Animal {
+      species
+    }
+    """
+
+    let expected = """
+    public struct Test_Fragment: TestSchema.SelectionSet, Fragment {
+      public let data: ResponseDict
+      public init(data: ResponseDict) { self.data = data }
+    """
+
+    // when
+    try buildSubjectAndFragment(named: "Test_Fragment")
+    let actual = subject.render(for: fragment)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render_parentType__givenFragmentTypeConditionAs_Object_rendersParentType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    fragment TestFragment on Animal {
+      species
+    }
+    """
+
+    let expected = """
+      public static var __parentType: ParentType { .Object(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndFragment()
+    let actual = subject.render(for: fragment)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+  }
+
+  func test__render_parentType__givenFragmentTypeConditionAs_Interface_rendersParentType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    fragment TestFragment on Animal {
+      species
+    }
+    """
+
+    let expected = """
+      public static var __parentType: ParentType { .Interface(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndFragment()
+    let actual = subject.render(for: fragment)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+  }
+
+  func test__render_parentType__givenFragmentTypeConditionAs_Union_rendersParentType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Dog {
+      species: String!
+    }
+
+    union Animal = Dog
+    """
+
+    document = """
+    fragment TestFragment on Animal {
+      ... on Dog {
+        species
+      }
+    }
+    """
+
+    let expected = """
+      public static var __parentType: ParentType { .Union(TestSchema.Animal.self) }
+    """
+
+    // when
+    try buildSubjectAndFragment()
+    let actual = subject.render(for: fragment)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+  }
+  
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
@@ -68,6 +68,7 @@ class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+    expect(String(actual.reversed())).to(equalLineByLine("}", ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
+
+  var schemaSDL: String!
+  var document: String!
+  var ir: IR!
+  var operation: IR.Operation!
+  var subject: SelectionSetTemplate!
+
+  override func setUp() {
+    super.setUp()
+  }
+
+  override func tearDown() {
+    schemaSDL = nil
+    document = nil
+    operation = nil
+    subject = nil
+    super.tearDown()
+  }
+
+  // MARK: - Helpers
+
+  func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
+    ir = try .mock(schema: schemaSDL, document: document)
+    let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
+    operation = ir.build(operation: operationDefinition)
+    subject = SelectionSetTemplate(schema: ir.schema)
+  }
+
+  // MARK: - Tests
+
+  func test__render__givenOperationWithName_rendersDeclarationWithName() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    let expected = """
+    public struct Data: TestSchema.SelectionSet {
+      public let data: ResponseDict
+      public init(data: ResponseDict) { self.data = data }
+
+      public static var __parentType: ParentType { .Object(TestSchema.Query.self) }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let actual = subject.render(for: operation)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSetTemplateTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-import Nimble
-@testable import ApolloCodegenLib
-import ApolloCodegenTestSupport
-
-class SelectionSetTemplateTests: XCTestCase {
-
-}

--- a/Tests/ApolloCodegenTests/TestHelpers/LineByLineComparison.swift
+++ b/Tests/ApolloCodegenTests/TestHelpers/LineByLineComparison.swift
@@ -20,7 +20,7 @@ public func equalLineByLine(
     guard let actualLines = try actual.evaluate()?.lines(startingAt: startLine) else {
       return PredicateResult(
         status: .fail,
-        message: .expectedActualValueTo("equal <\(expectedValue)>")
+        message: .fail("Insufficient Lines. Check `atLine` value.")
       )
     }
 
@@ -60,8 +60,9 @@ public func equalLineByLine(
 }
 
 extension String {
-  fileprivate func lines(startingAt startLine: Int) -> ArraySlice<String> {
+  fileprivate func lines(startingAt startLine: Int) -> ArraySlice<String>? {
     let allLines = self.components(separatedBy: "\n")
+    guard allLines.count >= startLine else { return nil }
     return allLines[(startLine - 1)..<allLines.endIndex]
   }
 }


### PR DESCRIPTION
Begins the implementation of the generation of the `SelectionSetTemplate`.

Includes:
- Declaration
- Boiler plate for Data field and initializer
- ParentType
- Direct Selections array
  - Field Selections
  - Type Case Selections
  - Fragment Selections

ToDo in Future PRs:
- Field Accessors
  - Scalar
  - Custom Scalar
  - Entity
- TypeCase Accessors
- Fragment Accessors
- Nested Selections Sets
- Merged Only Selection Sets
  - Shared Merged Only Selection Sets 