### PR TITLE
Render Selection Set Template [2/X]

### DIFF
--- a/Sources/ApolloCodegenLib/IR/IR+Field.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+Field.swift
@@ -7,6 +7,7 @@ extension IR {
 
     var name: String { underlyingField.name }
     var alias: String? { underlyingField.alias }
+    var responseKey: String { underlyingField.responseKey }
     var type: GraphQLType { underlyingField.type }
 
     fileprivate init(_ field: CompilationResult.Field) {

--- a/Sources/ApolloCodegenLib/TemplateString.swift
+++ b/Sources/ApolloCodegenLib/TemplateString.swift
@@ -98,10 +98,11 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
 
     mutating func appendInterpolation<T>(
     ifLet optional: Optional<T>,
+    where whereBlock: ((T) -> Bool)? = nil,
     _ includeBlock: (T) -> TemplateString,
     else: TemplateString? = nil
     ) {
-      if let element = optional {
+      if let element = optional, whereBlock?(element) ?? true {
         appendInterpolation(includeBlock(element))
       } else if let elseTemplate = `else` {
         appendInterpolation(elseTemplate.value)

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -38,6 +38,10 @@ struct SelectionSetTemplate {
 
     \(ParentTypeTemplate(field.selectionSet.parentType))
     \(ifLet: field.selectionSet.selections.direct, { SelectionsTemplate($0) }, else: "\n")
+
+    \(ifLet: field.selectionSet.selections.direct?.fields.values, {
+      "\($0.map { FieldAccessorTemplate($0) }, separator: "\n")"
+    }, else: "\n")
     """
   }
 
@@ -81,6 +85,12 @@ struct SelectionSetTemplate {
   private func FragmentSelectionTemplate(_ fragment: IR.FragmentSpread) -> TemplateString {
     """
     .fragment(\(fragment.definition.name.firstUppercased).self)
+    """
+  }
+
+  private func FieldAccessorTemplate(_ field: IR.Field) -> TemplateString {
+    """
+    public var \(field.responseKey): \(field.type.rendered) { data["\(field.responseKey)"] }
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -39,9 +39,11 @@ struct SelectionSetTemplate {
     \(ParentTypeTemplate(field.selectionSet.parentType))
     \(ifLet: field.selectionSet.selections.direct, { SelectionsTemplate($0) }, else: "\n")
 
-    \(ifLet: field.selectionSet.selections.direct?.fields.values, {
-      "\($0.map { FieldAccessorTemplate($0) }, separator: "\n")"
-    }, else: "\n")
+    \(ifLet: field.selectionSet.selections.direct?.fields.values,
+      where: { !$0.isEmpty }, {
+        "\($0.map { FieldAccessorTemplate($0) }, separator: "\n")"
+      },
+      else: "\n")
     """
   }
 
@@ -116,10 +118,14 @@ fileprivate extension GraphQLType {
     switch self {
     case let .entity(type as GraphQLNamedType),
       let .scalar(type as GraphQLNamedType),
-      let .enum(type as GraphQLNamedType),
       let .inputObject(type as GraphQLNamedType):
 
       return containedInNonNull ? type.name : "\(type.name)?"
+
+    case let .enum(type as GraphQLNamedType):
+      let enumType = "GraphQLEnum<\(type.name)>"
+
+      return containedInNonNull ? enumType : "\(enumType)?"
 
     case let .nonNull(ofType):
       return ofType.rendered(containedInNonNull: true)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -314,6 +314,55 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 
+  func test__render_selections__givenEnumField_rendersFieldSelections() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      testEnum: TestEnum!
+      testEnumOptional: TestEnumOptional
+    }
+
+    enum TestEnum {
+      CASE_ONE
+    }
+
+    enum TestEnumOptional {
+      CASE_ONE
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        testEnum
+        testEnumOptional
+      }
+    }
+    """
+
+    let expected = """
+      public static var selections: [Selection] { [
+        .field("testEnum", GraphQLEnum<TestEnum>.self),
+        .field("testEnumOptional", GraphQLEnum<TestEnumOptional>?.self),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
+  }
+
   func test__render_selections__givenFieldWithAlias_rendersFieldSelections() throws {
     // given
     schemaSDL = """
@@ -549,7 +598,52 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 27, ignoringExtraLines: true))
   }
 
-  // MARK: - Field Accessors - Scalar
+  func test__render_fieldAccessors__givenEnumField_rendersFieldAccessors() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      testEnum: TestEnum!
+      testEnumOptional: TestEnumOptional
+    }
+
+    enum TestEnum {
+      CASE_ONE
+    }
+
+    enum TestEnumOptional {
+      CASE_ONE
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        testEnum
+        testEnumOptional
+      }
+    }
+    """
+
+    let expected = """
+      public var testEnum: GraphQLEnum<TestEnum> { data["testEnum"] }
+      public var testEnumOptional: GraphQLEnum<TestEnumOptional>? { data["testEnumOptional"] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+  }
 
   func test__render_fieldAccessors__givenFieldWithAlias_rendersAllFieldAccessors() throws {
     // given

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -18,6 +18,7 @@ class SelectionSetTemplateTests: XCTestCase {
   override func tearDown() {
     schemaSDL = nil
     document = nil
+    ir = nil
     operation = nil
     subject = nil
     super.tearDown()
@@ -222,7 +223,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
   // MARK: Selections - Fields
 
-  func test__render_selections__givenFieldSelections_rendersAllFieldSelections() throws {
+  func test__render_selections__givenScalarFieldSelections_rendersAllFieldSelections() throws {
     // given
     schemaSDL = """
     type Query {
@@ -454,6 +455,138 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
+  }
+
+
+  // MARK: - Field Accessors - Scalar
+
+  func test__render_fieldAccessors__givenScalarFields_rendersAllFieldAccessors() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      string: String!
+      string_optional: String
+      int: Int!
+      int_optional: Int
+      custom: Custom!
+      custom_optional: Custom
+      list_required_required: [String!]!
+      list_optional_required: [String!]
+      list_required_optional: [String]!
+      list_optional_optional: [String]
+      nestedList_required_required_required: [[String!]!]!
+      nestedList_required_required_optional: [[String]!]!
+      nestedList_required_optional_optional: [[String]]!
+      nestedList_required_optional_required: [[String!]]!
+      nestedList_optional_required_required: [[String!]!]
+      nestedList_optional_required_optional: [[String]!]
+      nestedList_optional_optional_required: [[String!]]
+      nestedList_optional_optional_optional: [[String]]
+    }
+
+    scalar Custom
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        string
+        string_optional
+        int
+        int_optional
+        custom
+        custom_optional
+        list_required_required
+        list_optional_required
+        list_required_optional
+        list_optional_optional
+        nestedList_required_required_required
+        nestedList_required_required_optional
+        nestedList_required_optional_optional
+        nestedList_required_optional_required
+        nestedList_optional_required_required
+        nestedList_optional_required_optional
+        nestedList_optional_optional_required
+        nestedList_optional_optional_optional
+      }
+    }
+    """
+
+    let expected = """
+      public var string: String { data["string"] }
+      public var string_optional: String? { data["string_optional"] }
+      public var int: Int { data["int"] }
+      public var int_optional: Int? { data["int_optional"] }
+      public var custom: Custom { data["custom"] }
+      public var custom_optional: Custom? { data["custom_optional"] }
+      public var list_required_required: [String] { data["list_required_required"] }
+      public var list_optional_required: [String]? { data["list_optional_required"] }
+      public var list_required_optional: [String?] { data["list_required_optional"] }
+      public var list_optional_optional: [String?]? { data["list_optional_optional"] }
+      public var nestedList_required_required_required: [[String]] { data["nestedList_required_required_required"] }
+      public var nestedList_required_required_optional: [[String?]] { data["nestedList_required_required_optional"] }
+      public var nestedList_required_optional_optional: [[String?]?] { data["nestedList_required_optional_optional"] }
+      public var nestedList_required_optional_required: [[String]?] { data["nestedList_required_optional_required"] }
+      public var nestedList_optional_required_required: [[String]]? { data["nestedList_optional_required_required"] }
+      public var nestedList_optional_required_optional: [[String?]]? { data["nestedList_optional_required_optional"] }
+      public var nestedList_optional_optional_required: [[String]?]? { data["nestedList_optional_optional_required"] }
+      public var nestedList_optional_optional_optional: [[String?]?]? { data["nestedList_optional_optional_optional"] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 27, ignoringExtraLines: true))
+  }
+
+  // MARK: - Field Accessors - Scalar
+
+  func test__render_fieldAccessors__givenFieldWithAlias_rendersAllFieldAccessors() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      string: String!
+    }
+
+    scalar Custom
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        aliasedFieldName: string
+      }
+    }
+    """
+
+    let expected = """
+      public var aliasedFieldName: String { data["aliasedFieldName"] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderFragment_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderFragment_Tests.swift
@@ -18,6 +18,7 @@ class SelectionSetTemplate_RenderFragment_Tests: XCTestCase {
   override func tearDown() {
     schemaSDL = nil
     document = nil
+    ir = nil
     fragment = nil
     subject = nil
     super.tearDown()

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
@@ -18,6 +18,7 @@ class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
   override func tearDown() {
     schemaSDL = nil
     document = nil
+    ir = nil
     operation = nil
     subject = nil
     super.tearDown()


### PR DESCRIPTION
Includes:
- Selections
  - Enum
- Field Accessors (direct)
  - Scalar
  - Custom Scalar
  - Enum

ToDo in Future PRs:
- Field Accessors (direct)
  - Entity
- Field Accessors (merged)
  - Scalar
  - Custom Scalar
  - Enum
  - Entity
- TypeCase Accessors
- Fragment Accessors
- Nested Selections Sets
- Merged Only Selection Sets
  - Shared Merged Only Selection Sets 