### PR TITLE
Implements `InputObjectTemplate` for GraphQL schema `input` types

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -316,6 +316,8 @@
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
+		E64F7EBC27A11A510059C021 /* GraphQLNamedType+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */; };
+		E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */; };
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
 		E6630B8C26F0639B002D9E41 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB926EC05290094434A /* MockNetworkSession.swift */; };
 		E6630B8E26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */; };
@@ -323,10 +325,10 @@
 		E66F8899276C15580000BDA8 /* TypeFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */; };
 		E674DB41274C0A9B009BB90E /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB40274C0A9B009BB90E /* Glob.swift */; };
 		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
-		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
-		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
+		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
+		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6C9849327929EBE009481BE /* EnumTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C9849227929EBE009481BE /* EnumTemplate.swift */; };
@@ -984,6 +986,8 @@
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
+		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
+		E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+SwiftTests.swift"; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
 		E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeFileGeneratorTests.swift; sourceTree = "<group>"; };
@@ -1442,6 +1446,7 @@
 		9BAEEC0A234BB95B00808306 /* ApolloCodegenTests */ = {
 			isa = PBXGroup;
 			children = (
+				E64F7EBD27A11AEA0059C021 /* Extensions */,
 				DE223C3227221116004A0148 /* TestHelpers */,
 				DEAFB7762705270E00BE02F3 /* CodeGenIR */,
 				DE09F9C4270269F800795949 /* CodeGeneration */,
@@ -1484,6 +1489,7 @@
 				9B7B6F68233C2C0C00F32205 /* FileManager+Apollo.swift */,
 				9BAEEBF62346F0A000808306 /* StaticString+Apollo.swift */,
 				9B8C3FB1248DA2EA00707B13 /* URL+Apollo.swift */,
+				E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2170,6 +2176,14 @@
 				DEE1B3F5273B08D8007350E5 /* WarmBloodedDetails.graphql.swift */,
 			);
 			path = Generated;
+			sourceTree = "<group>";
+		};
+		E64F7EBD27A11AEA0059C021 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		E66F8895276C13330000BDA8 /* FileGenerators */ = {
@@ -2974,6 +2988,7 @@
 				E674DB41274C0A9B009BB90E /* Glob.swift in Sources */,
 				9F1A966C258F34BB00A06EEB /* GraphQLSchema.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
+				E64F7EBC27A11A510059C021 /* GraphQLNamedType+Swift.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,
 				DE2739112769AEBA00B886EF /* SelectionSetTemplate.swift in Sources */,
 				E6E3BBE2276A8D6200E5218B /* FileGenerator.swift in Sources */,
@@ -3040,6 +3055,7 @@
 				E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */,
 				9FDE0731258F3AA100DC0CA5 /* SchemaLoadingTests.swift in Sources */,
 				DE223C3327221144004A0148 /* IRMatchers.swift in Sources */,
+				E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */,
 				DE79642F2769A1EB00978A03 /* IROperationBuilderTests.swift in Sources */,
 				DE29653B279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift in Sources */,
 				DE29653A279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
 		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
 		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
+		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6C9849327929EBE009481BE /* EnumTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C9849227929EBE009481BE /* EnumTemplate.swift */; };
@@ -988,6 +989,7 @@
 		E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeFileGenerator.swift; sourceTree = "<group>"; };
 		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
 		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
+		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6C9849227929EBE009481BE /* EnumTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTemplate.swift; sourceTree = "<group>"; };
@@ -1932,6 +1934,7 @@
 			children = (
 				E6C9849227929EBE009481BE /* EnumTemplate.swift */,
 				DE5FD60A276970FC0033EE23 /* FragmentTemplate.swift */,
+				E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */,
 				E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */,
 				DE5FD5FC2769222D0033EE23 /* OperationDefinitionTemplate.swift */,
 				DE5FD60427694FA70033EE23 /* SchemaTemplate.swift */,
@@ -2977,6 +2980,7 @@
 				9F1A966B258F34BB00A06EEB /* GraphQLJSFrontend.swift in Sources */,
 				DE09114E27288B1F000648E5 /* SortedSelections.swift in Sources */,
 				DE5FD607276950CC0033EE23 /* IR+Schema.swift in Sources */,
+				E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
 		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
+		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
 		E6C4267B26F16CB400904AD2 /* introspection_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C4267A26F16CB400904AD2 /* introspection_response.json */; };
 		E6C9849327929EBE009481BE /* EnumTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C9849227929EBE009481BE /* EnumTemplate.swift */; };
@@ -990,6 +991,7 @@
 		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
 		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
 		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
+		E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplateTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6C9849227929EBE009481BE /* EnumTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTemplate.swift; sourceTree = "<group>"; };
@@ -1949,6 +1951,7 @@
 				DE296535279B3B8200BF9B49 /* SelectionSet */,
 				E6C9849427929FED009481BE /* EnumTemplateTests.swift */,
 				DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */,
+				E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */,
 				E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */,
 				DE09F9C5270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift */,
 				DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */,
@@ -3032,6 +3035,7 @@
 				DED18CC727023C0400F62977 /* OperationDefinitionTests.swift in Sources */,
 				E66F8897276C136B0000BDA8 /* TypeFileGeneratorTests.swift in Sources */,
 				DE79642B276999E700978A03 /* IRNamedFragmentBuilderTests.swift in Sources */,
+				E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */,
 				9B8C3FB5248DA3E000707B13 /* URLExtensionsTests.swift in Sources */,
 				E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */,
 				9FDE0731258F3AA100DC0CA5 /* SchemaLoadingTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
@@ -7,8 +7,9 @@ struct InputObjectFileGenerator: FileGenerator, Equatable {
   let path: String
 
   var data: Data? {
-    #warning("TODO: need correct data template")
-    return "public struct \(inputObjectType.name) {}".data(using: .utf8)
+    InputObjectTemplate(graphqlInputObject: inputObjectType)
+      .render()
+      .data(using: .utf8)
   }
 
   /// Designated initializer.

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
@@ -68,13 +68,13 @@ public class GraphQLInputObjectType: GraphQLNamedType {
 }
 
 public class GraphQLInputField: JavaScriptObject {
-  private(set) lazy var name: String = self["name"]
+  lazy var name: String = self["name"]
   
-  private(set) lazy var type: GraphQLType = self["type"]
+  lazy var type: GraphQLType = self["type"]
   
   private(set) lazy var description: String? = self["description"]
   
-  private(set) lazy var defaultValue: Any? = self["defaultValue"]
+  lazy var defaultValue: Any? = self["defaultValue"]
     
   private(set) lazy var deprecationReason: String? = self["deprecationReason"]
 }

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
@@ -1,4 +1,5 @@
 import JavaScriptCore
+import OrderedCollections
 
 // These classes correspond directly to the ones in
 // https://github.com/graphql/graphql-js/tree/master/src/type
@@ -63,8 +64,8 @@ public class GraphQLEnumValue: JavaScriptObject {
 
 public class GraphQLInputObjectType: GraphQLNamedType {
   private(set) lazy var description: String? = self["description"]
-  
-  private(set) lazy var fields: [String: GraphQLInputField] = try! invokeMethod("getFields")
+
+  lazy var fields: OrderedDictionary<String, GraphQLInputField> = try! invokeMethod("getFields")
 }
 
 public class GraphQLInputField: JavaScriptObject {

--- a/Sources/ApolloCodegenLib/GraphQLNamedType+Swift.swift
+++ b/Sources/ApolloCodegenLib/GraphQLNamedType+Swift.swift
@@ -1,0 +1,8 @@
+extension GraphQLNamedType {
+  /// Provides a Swift type name for GraphQL-specific type names that are not compatible with Swift.
+  var swiftName: String {
+    if name == "Boolean" { return "Bool" }
+
+    return name
+  }
+}

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -1,0 +1,108 @@
+import Foundation
+import JavaScriptCore
+
+struct InputObjectTemplate {
+  let graphqlInputObject: GraphQLInputObjectType
+
+  func render() -> String {
+    TemplateString(
+    """
+    struct \(graphqlInputObject.name.firstUppercased): InputObject {
+      private(set) public var dict: InputDict
+
+      init(
+        \(InitializerParametersTemplate())
+      ) {
+        dict = InputDict([
+          \(InputDictInitializerTemplate())
+        ])
+      }
+
+      \(graphqlInputObject.fields.map({ "\(FieldPropertyTemplate($1))" }), separator: "\n\n")
+    }
+    """
+    ).value
+  }
+
+  private func InitializerParametersTemplate() -> TemplateString {
+    TemplateString("""
+    \(graphqlInputObject.fields.map({
+      "\($1.name): \($1.renderType(includeDefault: true))"
+    }), separator: ",\n")
+    """)
+  }
+
+  private func InputDictInitializerTemplate() -> TemplateString {
+    TemplateString("""
+    \(graphqlInputObject.fields.map({ "\"\($1.name)\": \($1.name)" }), separator: ",\n")
+    """)
+  }
+
+  private func FieldPropertyTemplate(_ field: GraphQLInputField) -> String {
+    """
+    var \(field.name): \(field.renderType()) {
+      get { dict[\"\(field.name)\"] }
+      set { dict[\"\(field.name)\"] = newValue }
+    }
+    """
+  }
+}
+
+fileprivate extension GraphQLInputField {
+  func renderType(includeDefault: Bool = false) -> String {
+    "\(type.render())\(isSwiftOptional ? "?" : "")\(includeDefault && hasSwiftNilDefault ? " = nil" : "")"
+  }
+
+  private var isSwiftOptional: Bool {
+    !isNullable && hasSchemaDefault
+  }
+
+  private var hasSwiftNilDefault: Bool {
+    isNullable && !hasSchemaDefault
+  }
+
+  private var isNullable: Bool {
+    switch type {
+    case .nonNull(_): return false
+    default: return true
+    }
+  }
+
+  private var hasSchemaDefault: Bool {
+    switch defaultValue {
+    case .none, .some(nil):
+      return false
+    case let .some(value):
+      guard let value = value as? JSValue else {
+        fatalError("Cannot determine default value for Input field: \(self)")
+      }
+
+      return !value.isUndefined
+    }
+  }
+}
+
+fileprivate extension GraphQLType {
+  func render(containedInNonNull: Bool = false) -> String {
+    switch self {
+    case let .entity(type as GraphQLNamedType),
+      let .enum(type as GraphQLNamedType),
+      let .inputObject(type as GraphQLNamedType):
+
+      return containedInNonNull ? type.name : "GraphQLNullable<\(type.name)>"
+
+    case let .scalar(type as GraphQLNamedType):
+      let typeName = (type.name == "Boolean" ? "Bool" : type.name)
+
+      return containedInNonNull ? typeName : "GraphQLNullable<\(typeName)>"
+
+    case let .nonNull(ofType):
+      return ofType.render(containedInNonNull: true)
+
+    case let .list(ofType):
+      let inner = "[\(ofType.render(containedInNonNull: false))]"
+
+      return containedInNonNull ? inner : "GraphQLNullable<\(inner)>"
+    }
+  }
+}

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -53,22 +53,22 @@ fileprivate extension GraphQLInputField {
     "\(type.render())\(isSwiftOptional ? "?" : "")\(includeDefault && hasSwiftNilDefault ? " = nil" : "")"
   }
 
-  private var isSwiftOptional: Bool {
+  var isSwiftOptional: Bool {
     !isNullable && hasSchemaDefault
   }
 
-  private var hasSwiftNilDefault: Bool {
+  var hasSwiftNilDefault: Bool {
     isNullable && !hasSchemaDefault
   }
 
-  private var isNullable: Bool {
+  var isNullable: Bool {
     switch type {
     case .nonNull(_): return false
     default: return true
     }
   }
 
-  private var hasSchemaDefault: Bool {
+  var hasSchemaDefault: Bool {
     switch defaultValue {
     case .none, .some(nil):
       return false
@@ -87,14 +87,10 @@ fileprivate extension GraphQLType {
     switch self {
     case let .entity(type as GraphQLNamedType),
       let .enum(type as GraphQLNamedType),
+      let .scalar(type as GraphQLNamedType),
       let .inputObject(type as GraphQLNamedType):
 
-      return containedInNonNull ? type.name : "GraphQLNullable<\(type.name)>"
-
-    case let .scalar(type as GraphQLNamedType):
-      let typeName = (type.name == "Boolean" ? "Bool" : type.name)
-
-      return containedInNonNull ? typeName : "GraphQLNullable<\(typeName)>"
+      return containedInNonNull ? type.swiftName : "GraphQLNullable<\(type.swiftName)>"
 
     case let .nonNull(ofType):
       return ofType.render(containedInNonNull: true)

--- a/Sources/ApolloCodegenTestSupport/MockGraphQLType.swift
+++ b/Sources/ApolloCodegenTestSupport/MockGraphQLType.swift
@@ -1,4 +1,5 @@
 @testable import ApolloCodegenLib
+import OrderedCollections
 
 public extension GraphQLObjectType {
   class func mock(
@@ -44,6 +45,7 @@ public extension GraphQLScalarType {
   class func string() -> Self { mock(name: "String") }
   class func integer() -> Self { mock(name: "Int") }
   class func boolean() -> Self { mock(name: "Boolean") }
+  class func float() -> Self { mock(name: "Float") }
 
   class func mock(name: String) -> Self {
     let mock = Self.emptyMockObject()
@@ -81,9 +83,27 @@ public extension GraphQLEnumValue {
 }
 
 public extension GraphQLInputObjectType {
-  class func mock(_ name: String) -> Self {
+  class func mock(
+    _ name: String,
+    fields: [GraphQLInputField] = []
+  ) -> Self {
     let mock = Self.emptyMockObject()
     mock.name = name
+    mock.fields = OrderedDictionary.init(uniqueKeysWithValues: fields.map({ ($0.name, $0) }))
+    return mock
+  }
+}
+
+public extension GraphQLInputField {
+  class func mock(
+    _ name: String,
+    type: GraphQLType,
+    defaultValue: Any?
+  ) -> Self {
+    let mock = Self.emptyMockObject()
+    mock.name = name
+    mock.type = type
+    mock.defaultValue = defaultValue
     return mock
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -1,0 +1,312 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import JavaScriptCore
+
+class InputObjectTemplateTests: XCTestCase {
+  var jsVM: JSVirtualMachine!
+  var jsContext: JSContext!
+
+  override func setUp() {
+    super.setUp()
+
+    jsVM = JSVirtualMachine()
+    jsContext = JSContext(virtualMachine: jsVM)
+  }
+
+  override func tearDown() {
+    jsContext = nil
+    jsVM = nil
+
+    super.tearDown()
+  }
+
+  // MARK: Casing Tests
+
+  func test_render_givenLowercasedInputObjectField_generatesCorrectlyCasedSwiftDefinition() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("mockInput", fields: [
+      GraphQLInputField.mock("field", type: .scalar(.integer()), defaultValue: nil)
+    ])
+
+    let expected = "struct MockInput: InputObject {"
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_render_givenUppercasedInputObjectField_generatesCorrectlyCasedSwiftDefinition() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MOCKInput", fields: [
+      GraphQLInputField.mock("field", type: .scalar(.integer()), defaultValue: nil)
+    ])
+
+    let expected = "struct MOCKInput: InputObject {"
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_render_givenMixedCaseInputObjectField_generatesCorrectlyCasedSwiftDefinition() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("mOcK_Input", fields: [
+      GraphQLInputField.mock("field", type: .scalar(.integer()), defaultValue: nil)
+    ])
+
+    let expected = "struct MOcK_Input: InputObject {"
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  // MARK: Field Type Tests
+
+  func test_render_givenSingleFieldType_generatesCorrectParameterAndInitializer_withClosingBrace() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("field", type: .scalar(.string()), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        field: GraphQLNullable<String> = nil
+      ) {
+        dict = InputDict([
+          "field": field
+        ])
+      }
+
+      var field: GraphQLNullable<String> {
+        get { dict["field"] }
+        set { dict["field"] = newValue }
+      }
+    }
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: false))
+  }
+
+  func test_render_givenAllPossibleSchemaInputFieldTypes_generatesCorrectParametersAndInitializer() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock(
+        "stringField",
+        type: .scalar(.string()),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "intField",
+        type: .scalar(.integer()),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "boolField",
+        type: .scalar(.boolean()),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "floatField",
+        type: .scalar(.float()),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "enumField",
+        type: .enum(.mock(name: "EnumValue")),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "inputField",
+        type: .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            GraphQLInputField.mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        )),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "listField",
+        type: .list(.scalar(.string())),
+        defaultValue: nil
+      )
+    ])
+
+    let expected = """
+      init(
+        stringField: GraphQLNullable<String> = nil,
+        intField: GraphQLNullable<Int> = nil,
+        boolField: GraphQLNullable<Bool> = nil,
+        floatField: GraphQLNullable<Float> = nil,
+        enumField: GraphQLNullable<EnumValue> = nil,
+        inputField: GraphQLNullable<InnerInputObject> = nil,
+        listField: GraphQLNullable<[GraphQLNullable<String>]> = nil
+      ) {
+        dict = InputDict([
+          "stringField": stringField,
+          "intField": intField,
+          "boolField": boolField,
+          "floatField": floatField,
+          "enumField": enumField,
+          "inputField": inputField,
+          "listField": listField
+        ])
+      }
+
+      var stringField: GraphQLNullable<String> {
+        get { dict["stringField"] }
+        set { dict["stringField"] = newValue }
+      }
+
+      var intField: GraphQLNullable<Int> {
+        get { dict["intField"] }
+        set { dict["intField"] = newValue }
+      }
+
+      var boolField: GraphQLNullable<Bool> {
+        get { dict["boolField"] }
+        set { dict["boolField"] = newValue }
+      }
+
+      var floatField: GraphQLNullable<Float> {
+        get { dict["floatField"] }
+        set { dict["floatField"] = newValue }
+      }
+
+      var enumField: GraphQLNullable<EnumValue> {
+        get { dict["enumField"] }
+        set { dict["enumField"] = newValue }
+      }
+
+      var inputField: GraphQLNullable<InnerInputObject> {
+        get { dict["inputField"] }
+        set { dict["inputField"] = newValue }
+      }
+
+      var listField: GraphQLNullable<[GraphQLNullable<String>]> {
+        get { dict["listField"] }
+        set { dict["listField"] = newValue }
+      }
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  // MARK: Nullable Field Tests
+
+  func test_render_givenNullableFieldNoDefault_generatesNullableParameterWithInitializerNilDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nullable", type: .scalar(.integer()), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        nullable: GraphQLNullable<Int> = nil
+      ) {
+        dict = InputDict([
+          "nullable": nullable
+        ])
+      }
+
+      var nullable: GraphQLNullable<Int> {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test_render_givenNullableFieldWithDefault_generatesNullableParameterWithoutInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nullableWithDefault", type: .scalar(.integer()), defaultValue: JSValue(int32: 3, in: jsContext))
+    ])
+
+    let expected = """
+      init(
+        nullableWithDefault: GraphQLNullable<Int>
+      ) {
+        dict = InputDict([
+          "nullableWithDefault": nullableWithDefault
+        ])
+      }
+
+      var nullableWithDefault: GraphQLNullable<Int> {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test_render_givenNonNullableFieldNoDefault_generatesNonNullableNonOptionalParameterWithoutInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nonNullable", type: .nonNull(.scalar(.integer())), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        nonNullable: Int
+      ) {
+        dict = InputDict([
+          "nonNullable": nonNullable
+        ])
+      }
+
+      var nonNullable: Int {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test_render_givenNonNullableFieldWithDefault_generatesOptionalParameterWithoutInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nonNullableWithDefault", type: .nonNull(.scalar(.integer())), defaultValue: JSValue(int32: 3, in: jsContext))
+    ])
+
+    let expected = """
+      init(
+        nonNullableWithDefault: Int?
+      ) {
+        dict = InputDict([
+          "nonNullableWithDefault": nonNullableWithDefault
+        ])
+      }
+
+      var nonNullableWithDefault: Int? {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -309,4 +309,204 @@ class InputObjectTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
   }
+
+  func test__render__given_NullableList_NullableItem_NoDefault__generates_NullableParameter_OptionalItem_InitializerNilDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nullableListNullableItem", type: .list(.scalar(.string())), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        nullableListNullableItem: GraphQLNullable<[String?]> = nil
+      ) {
+        dict = InputDict([
+          "nullableListNullableItem": nullableListNullableItem
+        ])
+      }
+
+      var nullableListNullableItem: GraphQLNullable<[String?]> {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NullableList_NullableItem_WithDefault__generates_NullableParameter_OptionalItem_NoInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nullableListNullableItemWithDefault", type: .list(.scalar(.string())), defaultValue: JSValue(object: ["val"], in: jsContext))
+    ])
+
+    let expected = """
+      init(
+        nullableListNullableItemWithDefault: GraphQLNullable<[String?]>
+      ) {
+        dict = InputDict([
+          "nullableListNullableItemWithDefault": nullableListNullableItemWithDefault
+        ])
+      }
+
+      var nullableListNullableItemWithDefault: GraphQLNullable<[String?]> {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NullableList_NonNullableItem_NoDefault__generates_NullableParameter_NonOptionalItem_InitializerNilDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nullableListNonNullableItem", type: .list(.nonNull(.scalar(.string()))), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        nullableListNonNullableItem: GraphQLNullable<[String]> = nil
+      ) {
+        dict = InputDict([
+          "nullableListNonNullableItem": nullableListNonNullableItem
+        ])
+      }
+
+      var nullableListNonNullableItem: GraphQLNullable<[String]> {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NullableList_NonNullableItem_WithDefault__generates_NullableParameter_NonOptionalItem_NoInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nullableListNonNullableItemWithDefault", type: .list(.nonNull(.scalar(.string()))), defaultValue: JSValue(object: ["val"], in: jsContext))
+    ])
+
+    let expected = """
+      init(
+        nullableListNonNullableItemWithDefault: GraphQLNullable<[String]>
+      ) {
+        dict = InputDict([
+          "nullableListNonNullableItemWithDefault": nullableListNonNullableItemWithDefault
+        ])
+      }
+
+      var nullableListNonNullableItemWithDefault: GraphQLNullable<[String]> {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NonNullableList_NullableItem_NoDefault__generates_NonNullableNonOptionalParameter_OptionalItem_NoInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nonNullableListNullableItem", type: .nonNull(.list(.scalar(.string()))), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        nonNullableListNullableItem: [String?]
+      ) {
+        dict = InputDict([
+          "nonNullableListNullableItem": nonNullableListNullableItem
+        ])
+      }
+
+      var nonNullableListNullableItem: [String?] {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NonNullableList_NullableItem_WithDefault__generates_OptionalParameter_OptionalItem_NoInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nonNullableListNullableItemWithDefault", type: .nonNull(.list(.scalar(.string()))), defaultValue: JSValue(object: ["val"], in: jsContext))
+    ])
+
+    let expected = """
+      init(
+        nonNullableListNullableItemWithDefault: [String?]?
+      ) {
+        dict = InputDict([
+          "nonNullableListNullableItemWithDefault": nonNullableListNullableItemWithDefault
+        ])
+      }
+
+      var nonNullableListNullableItemWithDefault: [String?]? {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NonNullableList_NonNullableItem_NoDefault__generates_NonNullableNonOptionalParameter_NonOptionalItem_NoInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nonNullableListNonNullableItem", type: .nonNull(.list(.nonNull(.scalar(.string())))), defaultValue: nil)
+    ])
+
+    let expected = """
+      init(
+        nonNullableListNonNullableItem: [String]
+      ) {
+        dict = InputDict([
+          "nonNullableListNonNullableItem": nonNullableListNonNullableItem
+        ])
+      }
+
+      var nonNullableListNonNullableItem: [String] {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+
+  func test__render__given_NonNullableList_NonNullableItem_WithDefault__generates_OptionalParameter_NonOptionalItem_NoInitializerDefault() throws {
+    // given
+    let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
+      GraphQLInputField.mock("nonNullableListNonNullableItemWithDefault", type: .nonNull(.list(.nonNull(.scalar(.string())))), defaultValue: JSValue(object: ["val"], in: jsContext))
+    ])
+
+    let expected = """
+      init(
+        nonNullableListNonNullableItemWithDefault: [String]?
+      ) {
+        dict = InputDict([
+          "nonNullableListNonNullableItemWithDefault": nonNullableListNonNullableItemWithDefault
+        ])
+      }
+
+      var nonNullableListNonNullableItemWithDefault: [String]? {
+    """
+
+    // when
+    let actual = InputObjectTemplate(graphqlInputObject: graphqlInputObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -152,7 +152,7 @@ class InputObjectTemplateTests: XCTestCase {
         floatField: GraphQLNullable<Float> = nil,
         enumField: GraphQLNullable<EnumValue> = nil,
         inputField: GraphQLNullable<InnerInputObject> = nil,
-        listField: GraphQLNullable<[GraphQLNullable<String>]> = nil
+        listField: GraphQLNullable<[String?]> = nil
       ) {
         dict = InputDict([
           "stringField": stringField,
@@ -195,7 +195,7 @@ class InputObjectTemplateTests: XCTestCase {
         set { dict["inputField"] = newValue }
       }
 
-      var listField: GraphQLNullable<[GraphQLNullable<String>]> {
+      var listField: GraphQLNullable<[String?]> {
         get { dict["listField"] }
         set { dict["listField"] = newValue }
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -23,7 +23,7 @@ class InputObjectTemplateTests: XCTestCase {
 
   // MARK: Casing Tests
 
-  func test_render_givenLowercasedInputObjectField_generatesCorrectlyCasedSwiftDefinition() throws {
+  func test__render__givenLowercasedInputObjectField__generatesCorrectlyCasedSwiftDefinition() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("mockInput", fields: [
       GraphQLInputField.mock("field", type: .scalar(.integer()), defaultValue: nil)
@@ -38,7 +38,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenUppercasedInputObjectField_generatesCorrectlyCasedSwiftDefinition() throws {
+  func test__render__givenUppercasedInputObjectField__generatesCorrectlyCasedSwiftDefinition() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MOCKInput", fields: [
       GraphQLInputField.mock("field", type: .scalar(.integer()), defaultValue: nil)
@@ -53,7 +53,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenMixedCaseInputObjectField_generatesCorrectlyCasedSwiftDefinition() throws {
+  func test__render__givenMixedCaseInputObjectField__generatesCorrectlyCasedSwiftDefinition() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("mOcK_Input", fields: [
       GraphQLInputField.mock("field", type: .scalar(.integer()), defaultValue: nil)
@@ -70,7 +70,7 @@ class InputObjectTemplateTests: XCTestCase {
 
   // MARK: Field Type Tests
 
-  func test_render_givenSingleFieldType_generatesCorrectParameterAndInitializer_withClosingBrace() throws {
+  func test__render__givenSingleFieldType__generatesCorrectParameterAndInitializer_withClosingBrace() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
       GraphQLInputField.mock("field", type: .scalar(.string()), defaultValue: nil)
@@ -99,7 +99,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: false))
   }
 
-  func test_render_givenAllPossibleSchemaInputFieldTypes_generatesCorrectParametersAndInitializer() throws {
+  func test__render__givenAllPossibleSchemaInputFieldTypes__generatesCorrectParametersAndInitializer() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
       GraphQLInputField.mock(
@@ -210,7 +210,7 @@ class InputObjectTemplateTests: XCTestCase {
 
   // MARK: Nullable Field Tests
 
-  func test_render_givenNullableFieldNoDefault_generatesNullableParameterWithInitializerNilDefault() throws {
+  func test__render__given_NullableField_NoDefault__generates_NullableParameter_InitializerNilDefault() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
       GraphQLInputField.mock("nullable", type: .scalar(.integer()), defaultValue: nil)
@@ -235,7 +235,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
   }
 
-  func test_render_givenNullableFieldWithDefault_generatesNullableParameterWithoutInitializerDefault() throws {
+  func test__render__given_NullableField_WithDefault__generates_NullableParameter_NoInitializerDefault() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
       GraphQLInputField.mock("nullableWithDefault", type: .scalar(.integer()), defaultValue: JSValue(int32: 3, in: jsContext))
@@ -260,7 +260,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
   }
 
-  func test_render_givenNonNullableFieldNoDefault_generatesNonNullableNonOptionalParameterWithoutInitializerDefault() throws {
+  func test__render__given_NonNullableField_NoDefault__generates_NonNullableNonOptionalParameter_NoInitializerDefault() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
       GraphQLInputField.mock("nonNullable", type: .nonNull(.scalar(.integer())), defaultValue: nil)
@@ -285,7 +285,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
   }
 
-  func test_render_givenNonNullableFieldWithDefault_generatesOptionalParameterWithoutInitializerDefault() throws {
+  func test__render__given_NonNullableField_WithDefault__generates_OptionalParameter_NoInitializerDefault() throws {
     // given
     let graphqlInputObject = GraphQLInputObjectType.mock("MockInput", fields: [
       GraphQLInputField.mock("nonNullableWithDefault", type: .nonNull(.scalar(.integer())), defaultValue: JSValue(int32: 3, in: jsContext))

--- a/Tests/ApolloCodegenTests/Extensions/GraphQLNamedType+SwiftTests.swift
+++ b/Tests/ApolloCodegenTests/Extensions/GraphQLNamedType+SwiftTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+import Nimble
+
+class GraphQLNamedType_SwiftTests: XCTestCase {
+  func test_swiftName_givenGraphQLScalar_boolean_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.boolean())
+
+    expect(graphqlNamedType.namedType.swiftName).to(equal("Bool"))
+  }
+
+  func test_swiftName_givenGraphQLScalar_int_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.integer())
+
+    expect(graphqlNamedType.namedType.swiftName).to(equal("Int"))
+  }
+
+  func test_swiftName_givenGraphQLScalar_float_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.float())
+
+    expect(graphqlNamedType.namedType.swiftName).to(equal("Float"))
+  }
+
+  func test_swiftName_givenGraphQLScalar_string_providesCompatibleSwiftName() {
+    let graphqlNamedType = GraphQLType.scalar(.string())
+
+    expect(graphqlNamedType.namedType.swiftName).to(equal("String"))
+  }
+}


### PR DESCRIPTION
This is the template, and its use in the relevant file generator, that will generate Swift code for a GraphQL schema `input` object.

Supporting changes:
* Loosens the access control for `GraphQLInputField` properties to support mocking them
* Changes `GraphQLInputField.fields` to be an ordered collection for consistent output