### PR TITLE
Implements `UnionTemplate` for GraphQL schema `union` types

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
+		E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB727A0854E0059C021 /* UnionTemplate.swift */; };
 		E64F7EBC27A11A510059C021 /* GraphQLNamedType+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */; };
 		E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */; };
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
@@ -986,6 +987,7 @@
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
+		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
 		E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+SwiftTests.swift"; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
@@ -1947,6 +1949,7 @@
 				DE5FD5FC2769222D0033EE23 /* OperationDefinitionTemplate.swift */,
 				DE5FD60427694FA70033EE23 /* SchemaTemplate.swift */,
 				DE2739102769AEBA00B886EF /* SelectionSetTemplate.swift */,
+				E64F7EB727A0854E0059C021 /* UnionTemplate.swift */,
 			);
 			path = Templates;
 			sourceTree = "<group>";
@@ -2962,6 +2965,7 @@
 				9BAEEBF72346F0A000808306 /* StaticString+Apollo.swift in Sources */,
 				E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */,
 				E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */,
+				E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */,
 				9BCA8C0926618226004FF2F6 /* UntypedGraphQLRequestBodyCreator.swift in Sources */,
 				DE5FD60527694FA70033EE23 /* SchemaTemplate.swift in Sources */,
 				DEFBBC86273470F70088AABC /* IR+Field.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
 		E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB727A0854E0059C021 /* UnionTemplate.swift */; };
+		E64F7EBA27A085D90059C021 /* UnionTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */; };
 		E64F7EBC27A11A510059C021 /* GraphQLNamedType+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */; };
 		E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */; };
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
@@ -988,6 +989,7 @@
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
+		E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
 		E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+SwiftTests.swift"; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
@@ -1964,6 +1966,7 @@
 				E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */,
 				DE09F9C5270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift */,
 				DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */,
+				E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */,
 			);
 			path = Templates;
 			sourceTree = "<group>";
@@ -3056,6 +3059,7 @@
 				DE79642B276999E700978A03 /* IRNamedFragmentBuilderTests.swift in Sources */,
 				E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */,
 				9B8C3FB5248DA3E000707B13 /* URLExtensionsTests.swift in Sources */,
+				E64F7EBA27A085D90059C021 /* UnionTemplateTests.swift in Sources */,
 				E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */,
 				9FDE0731258F3AA100DC0CA5 /* SchemaLoadingTests.swift in Sources */,
 				DE223C3327221144004A0148 /* IRMatchers.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -42,8 +42,11 @@ public class ApolloCodegen {
       .forEach({ try $0.generateFile() })
     try fileGenerators(for: ir.schema.referencedTypes.interfaces, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
-    try fileGenerators(for: ir.schema.referencedTypes.unions, directoryPath: modulePath)
-      .forEach({ try $0.generateFile() })
+    try fileGenerators(
+        for: ir.schema.referencedTypes.unions,
+        moduleName: configuration.output.schemaTypes.moduleName,
+        directoryPath: modulePath
+      ).forEach({ try $0.generateFile() })
     try fileGenerators(for: ir.schema.referencedTypes.inputObjects, directoryPath: modulePath)
       .forEach({ try $0.generateFile() })
     try SchemaFileGenerator(
@@ -110,10 +113,11 @@ public class ApolloCodegen {
 
   static func fileGenerators(
     for unionTypes: OrderedSet<GraphQLUnionType>,
+    moduleName: String,
     directoryPath path: String
   ) -> [UnionFileGenerator] {
     return unionTypes.map({ graphqlUnionType in
-      UnionFileGenerator(unionType: graphqlUnionType, directoryPath: path)
+      UnionFileGenerator(unionType: graphqlUnionType, moduleName: moduleName, directoryPath: path)
     })
   }
 

--- a/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
@@ -4,20 +4,25 @@ import Foundation
 struct UnionFileGenerator: FileGenerator, Equatable {
   /// The `GraphQLUnionType` object used to build the file content.
   let unionType: GraphQLUnionType
+  /// The name of the generated Swift code module.
+  let moduleName: String
   let path: String
 
   var data: Data? {
-    #warning("TODO: need correct data template")
-    return "public enum \(unionType.name) {}".data(using: .utf8)
+    UnionTemplate(moduleName: moduleName, graphqlUnion: unionType)
+      .render()
+      .data(using: .utf8)
   }
 
   /// Designated initializer.
   ///
   /// - Parameters:
   ///  - unionType: The `GraphQLUnionType` object used to build the file content.
+  ///  - moduleName: The name of the generated Swift code module.
   ///  - directoryPath: The **directory** path that the file should be written to, used to build the `path` property value.
-  init(unionType: GraphQLUnionType, directoryPath: String) {
+  init(unionType: GraphQLUnionType, moduleName: String, directoryPath: String) {
     self.unionType = unionType
+    self.moduleName = moduleName
 
     self.path = URL(fileURLWithPath: directoryPath)
       .appendingPathComponent("\(unionType.name).swift").path

--- a/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -1,0 +1,42 @@
+struct UnionTemplate {
+  let moduleName: String
+  let graphqlUnion: GraphQLUnionType
+
+  func render() -> String {
+    TemplateString(
+    """
+    import ApolloAPI
+
+    public enum \(graphqlUnion.name): UnionType, Equatable {
+      \(graphqlUnion.types.map({ type in
+      "case \(type.name.firstUppercased)(\(type.name.firstUppercased))"
+      }), separator: "\n")
+
+      public init?(_ object: Object) {
+        switch object {
+        \(graphqlUnion.types.map({ type in
+        "case let entity as \(type.name.firstUppercased): self = .\(type.name.firstUppercased)(entity)"
+        }), separator: "\n")
+        default: return nil
+        }
+      }
+
+      public var object: Object {
+        switch self {
+        case \(graphqlUnion.types.map({ type in
+        "let .\(type.name.firstUppercased)(object as Object)"
+        }), separator: ",\n     "):
+            return object
+        }
+      }
+
+      public static let possibleTypes: [Object.Type] = [
+        \(graphqlUnion.types.map({ type in
+          "\(moduleName).\(type.name.firstUppercased).self"
+        }), separator: ",\n")
+      ]
+    }
+    """
+    ).value
+  }
+}

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -267,9 +267,14 @@ class ApolloCodegenTests: XCTestCase {
 
     expect(ApolloCodegen.fileGenerators(
       for: ir.schema.referencedTypes.unions,
+      moduleName: ir.schema.name,
       directoryPath: directoryPath
     )).to(equal([
-      UnionFileGenerator(unionType: searchResultUnion, directoryPath: directoryPath)
+      UnionFileGenerator(
+        unionType: searchResultUnion,
+        moduleName: "TestSchema",
+        directoryPath: directoryPath
+      )
     ]))
 
     expect(ApolloCodegen.fileGenerators(

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
@@ -25,6 +25,7 @@ class UnionFileGeneratorTests: XCTestCase {
     // then
     try UnionFileGenerator(
       unionType: GraphQLUnionType.mock("MockUnion", types: []),
+      moduleName: "ModuleAPI",
       directoryPath: rootURL.path
     ).generateFile(fileManager: mockFileManager)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloAPI
+
+class UnionTemplateTests: XCTestCase {
+  let graphqlUnion = GraphQLUnionType.mock(
+    "ClassroomPet",
+    types: [
+      GraphQLObjectType.mock("Cat", fields: [:], interfaces: []),
+      GraphQLObjectType.mock("Bird", fields: [:], interfaces: []),
+      GraphQLObjectType.mock("Rat", fields: [:], interfaces: []),
+      GraphQLObjectType.mock("PetRock", fields: [:], interfaces: [])
+    ]
+  )
+
+  // MARK: Boiletplate tests
+
+  func test_boilerplate_importsApolloAPI_generatesSwiftEnumDefinition() throws {
+    // given
+    let expected = """
+    import ApolloAPI
+
+    public enum ClassroomPet: UnionType, Equatable {
+    """
+
+    // when
+    let actual = UnionTemplate(moduleName: "ModuleAPI", graphqlUnion: graphqlUnion).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_boilerplate_generatesEnumClosingBrace() throws {
+    let expected = """
+    }
+    """
+
+    // when
+    let actual = UnionTemplate(moduleName: "ModuleAPI", graphqlUnion: graphqlUnion).render()
+
+    // then
+    expect(String(actual.reversed())).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  // MARK: Enum Tests
+  func test_render_givenSchemaUnion_generatesEnumCases() throws {
+    let expected = """
+    public enum ClassroomPet: UnionType, Equatable {
+      case Cat(Cat)
+      case Bird(Bird)
+      case Rat(Rat)
+      case PetRock(PetRock)
+    """
+
+    // when
+    let actual = UnionTemplate(moduleName: "ModuleAPI", graphqlUnion: graphqlUnion).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 3, ignoringExtraLines: true))
+  }
+
+  func test_render_givenSchemaUnion_generatesEnumInitializer() throws {
+    let expected = """
+      public init?(_ object: Object) {
+        switch object {
+        case let entity as Cat: self = .Cat(entity)
+        case let entity as Bird: self = .Bird(entity)
+        case let entity as Rat: self = .Rat(entity)
+        case let entity as PetRock: self = .PetRock(entity)
+        default: return nil
+        }
+      }
+    """
+
+    // when
+    let actual = UnionTemplate(moduleName: "ModuleAPI", graphqlUnion: graphqlUnion).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
+  }
+
+  func test_render_givenSchemaUnion_generatesObjectProperty() throws {
+    let expected = """
+      public var object: Object {
+        switch self {
+        case let .Cat(object as Object),
+          let .Bird(object as Object),
+          let .Rat(object as Object),
+          let .PetRock(object as Object):
+            return object
+        }
+      }
+    """
+
+    // when
+    let actual = UnionTemplate(moduleName: "ModuleAPI", graphqlUnion: graphqlUnion).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+  }
+
+  func test_render_givenSchemaUnion_generatesPossibleTypesProperty() throws {
+    let expected = """
+      public static let possibleTypes: [Object.Type] = [
+        ModuleAPI.Cat.self,
+        ModuleAPI.Bird.self,
+        ModuleAPI.Rat.self,
+        ModuleAPI.PetRock.self
+      ]
+    """
+
+    // when
+    let actual = UnionTemplate(moduleName: "ModuleAPI", graphqlUnion: graphqlUnion).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 29, ignoringExtraLines: true))
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
@@ -7,14 +7,14 @@ class UnionTemplateTests: XCTestCase {
   let graphqlUnion = GraphQLUnionType.mock(
     "ClassroomPet",
     types: [
-      GraphQLObjectType.mock("Cat", fields: [:], interfaces: []),
-      GraphQLObjectType.mock("Bird", fields: [:], interfaces: []),
-      GraphQLObjectType.mock("Rat", fields: [:], interfaces: []),
-      GraphQLObjectType.mock("PetRock", fields: [:], interfaces: [])
+      GraphQLObjectType.mock("Cat"),
+      GraphQLObjectType.mock("Bird"),
+      GraphQLObjectType.mock("Rat"),
+      GraphQLObjectType.mock("PetRock")
     ]
   )
 
-  // MARK: Boiletplate tests
+  // MARK: Boilerplate tests
 
   func test_boilerplate_importsApolloAPI_generatesSwiftEnumDefinition() throws {
     // given
@@ -43,7 +43,8 @@ class UnionTemplateTests: XCTestCase {
     expect(String(actual.reversed())).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  // MARK: Enum Tests
+  // MARK: Enum Generation Tests
+
   func test_render_givenSchemaUnion_generatesEnumCases() throws {
     let expected = """
     public enum ClassroomPet: UnionType, Equatable {


### PR DESCRIPTION
This is the template and its use in `UnionFileGenerator` that will generate Swift code for a GraphQL schema `union` object.