### PR TITLE
Implements `TypeTemplate` for GraphQL schema object types

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
+		E64F7EC127A122300059C021 /* TypeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC027A122300059C021 /* TypeTemplate.swift */; };
 		E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB727A0854E0059C021 /* UnionTemplate.swift */; };
 		E64F7EBA27A085D90059C021 /* UnionTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */; };
 		E64F7EBC27A11A510059C021 /* GraphQLNamedType+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */; };
@@ -988,6 +989,7 @@
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
+		E64F7EC027A122300059C021 /* TypeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplate.swift; sourceTree = "<group>"; };
 		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
 		E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
@@ -1951,6 +1953,7 @@
 				DE5FD5FC2769222D0033EE23 /* OperationDefinitionTemplate.swift */,
 				DE5FD60427694FA70033EE23 /* SchemaTemplate.swift */,
 				DE2739102769AEBA00B886EF /* SelectionSetTemplate.swift */,
+				E64F7EC027A122300059C021 /* TypeTemplate.swift */,
 				E64F7EB727A0854E0059C021 /* UnionTemplate.swift */,
 			);
 			path = Templates;
@@ -2964,6 +2967,7 @@
 				9BAEEBEF2346644B00808306 /* ApolloSchemaDownloader.swift in Sources */,
 				DE5FD601276923620033EE23 /* TemplateString.swift in Sources */,
 				DE796429276998B000978A03 /* IR+RootFieldBuilder.swift in Sources */,
+				E64F7EC127A122300059C021 /* TypeTemplate.swift in Sources */,
 				9F1A966F258F34BB00A06EEB /* JavaScriptBridge.swift in Sources */,
 				9BAEEBF72346F0A000808306 /* StaticString+Apollo.swift in Sources */,
 				E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		E66F8899276C15580000BDA8 /* TypeFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */; };
 		E674DB41274C0A9B009BB90E /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB40274C0A9B009BB90E /* Glob.swift */; };
 		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
+		E68D824527A1D8A60040A46F /* TypeTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
 		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
@@ -990,6 +991,7 @@
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EC027A122300059C021 /* TypeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplate.swift; sourceTree = "<group>"; };
+		E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
 		E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
@@ -1969,6 +1971,7 @@
 				E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */,
 				DE09F9C5270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift */,
 				DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */,
+				E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */,
 				E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */,
 			);
 			path = Templates;
@@ -3069,6 +3072,7 @@
 				DE223C3327221144004A0148 /* IRMatchers.swift in Sources */,
 				E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */,
 				DE79642F2769A1EB00978A03 /* IROperationBuilderTests.swift in Sources */,
+				E68D824527A1D8A60040A46F /* TypeTemplateTests.swift in Sources */,
 				DE29653B279B3B8200BF9B49 /* SelectionSetTemplate_RenderOperation_Tests.swift in Sources */,
 				DE29653A279B3B8200BF9B49 /* SelectionSetTemplate_RenderFragment_Tests.swift in Sources */,
 				E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/TypeFileGenerator.swift
@@ -6,8 +6,9 @@ struct TypeFileGenerator: FileGenerator, Equatable {
   let path: String
 
   var data: Data? {
-    #warning("TODO: need correct data template")
-    return "public class \(objectType.name) {}".data(using: .utf8)
+    TypeTemplate(graphqlObject: objectType)
+      .render()
+      .data(using: .utf8)
   }
 
   init(objectType: GraphQLObjectType, directoryPath: String) {

--- a/Sources/ApolloCodegenLib/Templates/TypeTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/TypeTemplate.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct TypeTemplate {
+  let graphqlObject: GraphQLObjectType
+
+  func render() -> String {
+    TemplateString("""
+    public final class \(graphqlObject.name.firstUppercased): Object {
+      override public class var __typename: String { \"\(graphqlObject.name.firstUppercased)\" }
+
+      override public class var __metadata: Metadata { _metadata }
+      private static let _metadata: Metadata = Metadata(implements: [
+        \(graphqlObject.interfaces.map({ interface in
+      "\(interface.name.firstUppercased).self"
+        }), separator: ",\n")
+      ])
+    }
+    """).value
+  }
+}

--- a/Sources/ApolloCodegenTestSupport/MockGraphQLType.swift
+++ b/Sources/ApolloCodegenTestSupport/MockGraphQLType.swift
@@ -107,3 +107,15 @@ public extension GraphQLInputField {
     return mock
   }
 }
+
+public extension GraphQLField {
+  class func mock(
+    _ name: String,
+    type: GraphQLType
+  ) -> Self {
+    let mock = Self.emptyMockObject()
+    mock.name = name
+    mock.type = type
+    return mock
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TypeTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TypeTemplateTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Nimble
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+
+class TypeTemplateTests: XCTestCase {
+
+  // MARK: Boilerplate tests
+
+  func test_boilerplate_givenSchemaType_generatesSwiftClassDefinition() {
+    // given
+    let graphqlObject = GraphQLObjectType.mock("Dog")
+
+    let expected = """
+    public final class Dog: Object {
+      override public class var __typename: String { "Dog" }
+
+    """
+
+    // when
+    let actual = TypeTemplate(graphqlObject: graphqlObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_boilerplate_givenSchemaType_generatesClosingBrace() {
+    // given
+    let graphqlObject = GraphQLObjectType.mock("Dog")
+
+    // when
+    let actual = TypeTemplate(graphqlObject: graphqlObject).render()
+
+    // then
+    expect(String(actual.reversed())).to(equalLineByLine("}", ignoringExtraLines: true))
+  }
+
+  // MARK: Metadata Tests
+
+  func test_render_givenSchemaType_generatesTypeMetadata() {
+    // given
+    let graphqlObject = GraphQLObjectType.mock(
+      "Dog",
+      interfaces: [
+        GraphQLInterfaceType.mock("Animal", fields: ["species": GraphQLField.mock("species", type: .scalar(.string()))]),
+        GraphQLInterfaceType.mock("Pet", fields: ["name": GraphQLField.mock("name", type: .scalar(.string()))])
+      ]
+    )
+
+    let expected = """
+      override public class var __metadata: Metadata { _metadata }
+      private static let _metadata: Metadata = Metadata(implements: [
+        Animal.self,
+        Pet.self
+      ])
+    """
+
+    // when
+    let actual = TypeTemplate(graphqlObject: graphqlObject).render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
+  }
+}


### PR DESCRIPTION
This change is for the `TypeTemplate` Swift code template and using it in `TypeFileGenerator`.

I'm open to better names than `TypeTemplate` and `TypeFileGenerator` if you have any suggestions. I considered `ObjectTemplate` and `ObjectFileGenerator` but haven't committed yet. `Type` is very broad though so the `Object` name might be more representative of what is being generated. 🤷🏻 