### PR TITLE
Dependency Automation - Swift Package Manager

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -338,11 +338,11 @@
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E61EF713275EC99A00191DA7 /* ApolloCodegenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
-		E64F7EC127A122300059C021 /* TypeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC027A122300059C021 /* TypeTemplate.swift */; };
 		E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB727A0854E0059C021 /* UnionTemplate.swift */; };
 		E64F7EBA27A085D90059C021 /* UnionTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */; };
 		E64F7EBC27A11A510059C021 /* GraphQLNamedType+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */; };
 		E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */; };
+		E64F7EC127A122300059C021 /* TypeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC027A122300059C021 /* TypeTemplate.swift */; };
 		E657CDBA26FD01D4005834D6 /* ApolloSchemaInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */; };
 		E6630B8C26F0639B002D9E41 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D79AB926EC05290094434A /* MockNetworkSession.swift */; };
 		E6630B8E26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */; };
@@ -353,6 +353,7 @@
 		E68D824527A1D8A60040A46F /* TypeTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
+		E6B42D0927A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */; };
 		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
 		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
@@ -1027,12 +1028,12 @@
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
-		E64F7EC027A122300059C021 /* TypeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplate.swift; sourceTree = "<group>"; };
 		E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
 		E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
 		E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+SwiftTests.swift"; sourceTree = "<group>"; };
+		E64F7EC027A122300059C021 /* TypeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplate.swift; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
 		E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeFileGeneratorTests.swift; sourceTree = "<group>"; };
@@ -1041,6 +1042,7 @@
 		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
 		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
 		E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplateTests.swift; sourceTree = "<group>"; };
+		E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageManagerModuleTemplate.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6C9849227929EBE009481BE /* EnumTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTemplate.swift; sourceTree = "<group>"; };
@@ -1993,6 +1995,7 @@
 				DE5FD5FC2769222D0033EE23 /* OperationDefinitionTemplate.swift */,
 				DE5FD60427694FA70033EE23 /* SchemaTemplate.swift */,
 				DE2739102769AEBA00B886EF /* SelectionSetTemplate.swift */,
+				E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */,
 				E64F7EC027A122300059C021 /* TypeTemplate.swift */,
 				E64F7EB727A0854E0059C021 /* UnionTemplate.swift */,
 			);
@@ -3042,6 +3045,7 @@
 				9BAEEBF72346F0A000808306 /* StaticString+Apollo.swift in Sources */,
 				E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */,
 				DE4D54E727A3504B00D26B68 /* OperationFileGenerator.swift in Sources */,
+				E6B42D0927A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift in Sources */,
 				E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */,
 				E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */,
 				9BCA8C0926618226004FF2F6 /* UntypedGraphQLRequestBodyCreator.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
 		E6B42D0927A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */; };
+		E6B42D0D27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0C27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift */; };
 		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
 		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
 		E6BF98FC272C8FFC00C1FED8 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */; };
@@ -1043,6 +1044,7 @@
 		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
 		E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplateTests.swift; sourceTree = "<group>"; };
 		E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageManagerModuleTemplate.swift; sourceTree = "<group>"; };
+		E6B42D0C27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageManagerModuleTemplateTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
 		E6C9849227929EBE009481BE /* EnumTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumTemplate.swift; sourceTree = "<group>"; };
@@ -2014,6 +2016,7 @@
 				DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */,
 				E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */,
 				E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */,
+				E6B42D0C27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift */,
 			);
 			path = Templates;
 			sourceTree = "<group>";
@@ -3132,6 +3135,7 @@
 				9F62DFAE2590557F00E6E808 /* DocumentParsingAndValidationTests.swift in Sources */,
 				9F62E0102590728000E6E808 /* CompilationTests.swift in Sources */,
 				DEAFB77B2706444B00BE02F3 /* IRRootEntityFieldBuilderTests.swift in Sources */,
+				E6B42D0D27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift in Sources */,
 				9F62DFBF2590560000E6E808 /* Helpers.swift in Sources */,
 				DE296539279B3B8200BF9B49 /* SelectionSetTemplateTests.swift in Sources */,
 				DED18CC727023C0400F62977 /* OperationDefinitionTests.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -351,9 +351,11 @@
 		E674DB41274C0A9B009BB90E /* Glob.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB40274C0A9B009BB90E /* Glob.swift */; };
 		E674DB43274C0AD9009BB90E /* GlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E674DB42274C0AD9009BB90E /* GlobTests.swift */; };
 		E68D824527A1D8A60040A46F /* TypeTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */; };
+		E68D824727A228A80040A46F /* SchemaModuleFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
 		E6B42D0927A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */; };
+		E6B42D0B27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0A27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift */; };
 		E6B42D0D27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0C27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift */; };
 		E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */; };
 		E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */; };
@@ -1029,21 +1031,23 @@
 		E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenTests.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
-		E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
 		E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+Swift.swift"; sourceTree = "<group>"; };
 		E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+SwiftTests.swift"; sourceTree = "<group>"; };
 		E64F7EC027A122300059C021 /* TypeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplate.swift; sourceTree = "<group>"; };
+		E64F7EC227A1243A0059C021 /* TypeTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTemplateTests.swift; sourceTree = "<group>"; };
 		E657CDB926FD01D4005834D6 /* ApolloSchemaInternalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApolloSchemaInternalTests.swift; sourceTree = "<group>"; };
 		E6630B8D26F071F9002D9E41 /* SchemaRegistryApolloSchemaDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaRegistryApolloSchemaDownloaderTests.swift; sourceTree = "<group>"; };
 		E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeFileGenerator.swift; sourceTree = "<group>"; };
 		E674DB40274C0A9B009BB90E /* Glob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glob.swift; sourceTree = "<group>"; };
 		E674DB42274C0AD9009BB90E /* GlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobTests.swift; sourceTree = "<group>"; };
+		E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaModuleFileGenerator.swift; sourceTree = "<group>"; };
 		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
 		E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplateTests.swift; sourceTree = "<group>"; };
 		E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageManagerModuleTemplate.swift; sourceTree = "<group>"; };
+		E6B42D0A27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaModuleFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E6B42D0C27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageManagerModuleTemplateTests.swift; sourceTree = "<group>"; };
 		E6BF98FB272C8FFC00C1FED8 /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		E6C4267A26F16CB400904AD2 /* introspection_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = introspection_response.json; sourceTree = "<group>"; };
@@ -2276,6 +2280,7 @@
 				E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */,
 				E610D8DC278EB1500023E495 /* InterfaceFileGeneratorTests.swift */,
 				E6D90D0C278FFE35009CAC5D /* SchemaFileGeneratorTests.swift */,
+				E6B42D0A27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift */,
 				E66F8896276C136B0000BDA8 /* TypeFileGeneratorTests.swift */,
 				E610D8E0278F8F3D0023E495 /* UnionFileGeneratorTests.swift */,
 			);
@@ -2306,12 +2311,13 @@
 			isa = PBXGroup;
 			children = (
 				E610D8D6278EA2390023E495 /* EnumFileGenerator.swift */,
-				DE4D54E627A3504B00D26B68 /* OperationFileGenerator.swift */,
-				DE4D54E827A3518100D26B68 /* FragmentFileGenerator.swift */,
 				E6E3BBDD276A8D6200E5218B /* FileGenerator.swift */,
+				DE4D54E827A3518100D26B68 /* FragmentFileGenerator.swift */,
 				E6D90D06278FA595009CAC5D /* InputObjectFileGenerator.swift */,
 				E610D8DA278EB0900023E495 /* InterfaceFileGenerator.swift */,
+				DE4D54E627A3504B00D26B68 /* OperationFileGenerator.swift */,
 				E6D90D0A278FFDDA009CAC5D /* SchemaFileGenerator.swift */,
+				E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */,
 				E66F8898276C15580000BDA8 /* TypeFileGenerator.swift */,
 				E610D8DE278F8F1E0023E495 /* UnionFileGenerator.swift */,
 			);
@@ -3071,6 +3077,7 @@
 				9F628E9525935BE600F94F9D /* GraphQLType.swift in Sources */,
 				9BFE8DA9265D5D8F000BBF81 /* URLDownloader.swift in Sources */,
 				E6C9849327929EBE009481BE /* EnumTemplate.swift in Sources */,
+				E68D824727A228A80040A46F /* SchemaModuleFileGenerator.swift in Sources */,
 				9F1A966D258F34BB00A06EEB /* CompilationResult.swift in Sources */,
 				DE4D54E927A3518100D26B68 /* FragmentFileGenerator.swift in Sources */,
 				E610D8DB278EB0900023E495 /* InterfaceFileGenerator.swift in Sources */,
@@ -3160,6 +3167,7 @@
 				E6B4E9992798A8CB004EC8C4 /* InterfaceTemplateTests.swift in Sources */,
 				9F62DF8E2590539A00E6E808 /* SchemaIntrospectionTests.swift in Sources */,
 				E6D90D0D278FFE35009CAC5D /* SchemaFileGeneratorTests.swift in Sources */,
+				E6B42D0B27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift in Sources */,
 				9B68F0552416B33300E97318 /* LineByLineComparison.swift in Sources */,
 				DE09F9C6270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift in Sources */,
 				9B4751AD2575B5070001FB87 /* PluralizerTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -66,7 +66,8 @@ public class ApolloCodegen {
         .generateFile()
     }
 
-    #warning("TODO - generate package manager manifest")
+    try SchemaModuleFileGenerator(configuration.output.schemaTypes)
+      .generateFile()
   }
 
   // MARK: Internal

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -30,7 +30,12 @@ struct SchemaModuleFileGenerator: FileGenerator, Equatable {
   }
 
   static func == (lhs: SchemaModuleFileGenerator, rhs: SchemaModuleFileGenerator) -> Bool {
-    return lhs.path == rhs.path
+    switch (lhs.fileGenerator, rhs.fileGenerator) {
+    case let (lhs as SwiftPackageManagerFileGenerator, rhs as SwiftPackageManagerFileGenerator):
+      return lhs == rhs
+    default:
+      return false
+    }
   }
 }
 

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Generates a package manifest file for the releveant depdency manager.
+struct SchemaModuleFileGenerator: FileGenerator, Equatable {
+  var path: String { fileGenerator.path }
+  var data: Data? { fileGenerator.data }
+
+  private let fileGenerator: FileGenerator
+
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///  - configuration: A configuration object that specifies properties such as which dependency manager and where the file
+  ///  should be output to.
+  init(_ configuration: ApolloCodegenConfiguration.SchemaTypesFileOutput) {
+    switch configuration.dependencyAutomation {
+    case let .swiftPackageManager(moduleName):
+      self.fileGenerator = SwiftPackageManagerFileGenerator(
+        moduleName: moduleName,
+        directoryPath: configuration.modulePath
+      )
+
+    default:
+      fatalError("Only Swift Package Manager is supported at the moment!")
+    }
+  }
+
+  func generateFile(fileManager: FileManager = FileManager.default) throws {
+    try fileGenerator.generateFile(fileManager: fileManager)
+  }
+
+  static func == (lhs: SchemaModuleFileGenerator, rhs: SchemaModuleFileGenerator) -> Bool {
+    return lhs.path == rhs.path
+  }
+}
+
+/// Generates a Package.swift file for Swift Package Manager support of the generated schema module files.
+fileprivate struct SwiftPackageManagerFileGenerator: FileGenerator, Equatable {
+  let path: String
+  /// The name of the library and target of the module.
+  let moduleName: String
+
+  var data: Data? {
+    SwiftPackageManagerModuleTemplate(moduleName: moduleName)
+      .render()
+      .data(using: .utf8)
+  }
+
+  /// Designated initializer.
+  ///
+  /// - Parameters:
+  ///   - moduleName: The name of the library and target of the module.
+  ///   - directoryPath: The directory path where the package manifest will be output.
+  init(moduleName: String, directoryPath: String) {
+    self.moduleName = moduleName
+    self.path = URL(fileURLWithPath: directoryPath).appendingPathComponent("Package.swift").path
+  }
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -12,7 +12,7 @@ struct SchemaModuleFileGenerator: FileGenerator, Equatable {
   /// - Parameters:
   ///  - configuration: A configuration object that specifies properties such as which dependency manager and where the file
   ///  should be output to.
-  init(_ configuration: ApolloCodegenConfiguration.SchemaTypesFileOutput) {
+  init(_ configuration: ApolloCodegenConfiguration.SchemaTypesFileOutput) throws {
     switch configuration.dependencyAutomation {
     case let .swiftPackageManager(moduleName):
       self.fileGenerator = SwiftPackageManagerFileGenerator(
@@ -21,7 +21,7 @@ struct SchemaModuleFileGenerator: FileGenerator, Equatable {
       )
 
     default:
-      fatalError("Only Swift Package Manager is supported at the moment!")
+      throw NSError(domain: "ApolloCodegen", code: -1, userInfo: [NSLocalizedDescriptionKey: "Only Swift Package Manager is supported at the moment!"])
     }
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -20,8 +20,13 @@ struct SwiftPackageManagerModuleTemplate {
       products: [
         .library(name: "\(moduleName)", targets: ["\(moduleName)"]),
       ],
+      dependencies: [
+        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0"),
+      ],
       targets: [
-        .target(name: "\(moduleName)"),
+        .target(name: "\(moduleName)", dependencies: [
+          .product(name: "ApolloAPI", package: "apollo-ios"),
+        ]),
       ]
     )
     """).value

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct SwiftPackageManagerModuleTemplate {
+  let moduleName: String
+
+  func render() -> String {
+    TemplateString("""
+    // swift-tools-version:5.3
+
+    import PackageDescription
+
+    let package = Package(
+      name: "\(moduleName)",
+      platforms: [
+        .iOS(.v12),
+        .macOS(.v10_14),
+        .tvOS(.v12),
+        .watchOS(.v5),
+      ],
+      products: [
+        .library(name: "\(moduleName)", targets: ["\(moduleName)"]),
+      ],
+      targets: [
+        .target(name: "\(moduleName)"),
+      ]
+    )
+    """).value
+  }
+}

--- a/Sources/ApolloCodegenTestSupport/MockApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenTestSupport/MockApolloCodegenConfiguration.swift
@@ -22,4 +22,16 @@ extension ApolloCodegenConfiguration {
       apqs: apqs
     )
   }
+
+  public static func mock(
+    _ moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
+    to path: String = "MockModulePath"
+  ) -> Self {
+    .init(
+      input: .init(schemaPath: "schema.graphqls",
+                   searchPaths: ["*.graphql"]),
+      output: .init(schemaTypes: .init(path: path,
+                                       dependencyAutomation: moduleType))
+    )
+  }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -16,19 +16,6 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     try FileManager.default.apollo.deleteDirectory(atPath: directoryURL.path)
   }
 
-  // MARK: Test Helper Methods
-
-  private func buildConfig(
-    forDependencyAutomation moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType
-  ) -> ApolloCodegenConfiguration {
-    ApolloCodegenConfiguration(
-      input: .init(schemaPath: "schema.graphqls",
-                   searchPaths: ["*.operation"]),
-      output: .init(schemaTypes: .init(path: directoryURL.path,
-                                       dependencyAutomation: moduleType))
-    )
-  }
-
   // MARK: Initializer Tests
 
   func test_init_givenBasePathAndSchemaFilename_shouldBuildDefaultPaths() {
@@ -237,7 +224,10 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_givenSwiftPackageManagerConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let moduleName = "SPMModule"
-    let config = buildConfig(forDependencyAutomation: .swiftPackageManager(moduleName: moduleName))
+    let config = ApolloCodegenConfiguration.mock(
+      .swiftPackageManager(moduleName: moduleName),
+      to: directoryURL.path
+    )
 
     // then
     expect(config.output.schemaTypes.moduleName).to(equal(moduleName))
@@ -248,7 +238,10 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_givenCocoaPodsConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let moduleName = "PodsModule"
-    let config = buildConfig(forDependencyAutomation: .cocoaPods(moduleName: moduleName))
+    let config = ApolloCodegenConfiguration.mock(
+      .cocoaPods(moduleName: moduleName),
+      to: directoryURL.path
+    )
 
     // then
     expect(config.output.schemaTypes.moduleName).to(equal(moduleName))
@@ -259,7 +252,10 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_givenCarthageConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let moduleName = "CarthageModule"
-    let config = buildConfig(forDependencyAutomation: .carthage(moduleName: moduleName))
+    let config = ApolloCodegenConfiguration.mock(
+      .carthage(moduleName: moduleName),
+      to: directoryURL.path
+    )
 
     // then
     expect(config.output.schemaTypes.moduleName).to(equal(moduleName))
@@ -270,7 +266,10 @@ class ApolloCodegenConfigurationTests: XCTestCase {
   func test_givenManuallyLinkedConfiguration_shouldBuildSchemaModuleProperties() {
     // given
     let namespace = "NamespaceModule"
-    let config = buildConfig(forDependencyAutomation: .manuallyLinked(namespace: namespace))
+    let config = ApolloCodegenConfiguration.mock(
+      .manuallyLinked(namespace: namespace),
+      to: directoryURL.path
+    )
 
     // then
     expect(config.output.schemaTypes.moduleName).to(equal(namespace))

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
@@ -13,9 +13,9 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
   func test__generate__givenSwiftPackageManagerConfiguration_shouldGenerateManifest() throws {
     // given
     let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
-    let fileURL = rootURL.appendingPathComponent("MockAPI/Package.swift")
+    let fileURL = rootURL.appendingPathComponent("TestModule/Package.swift")
     let configuration = ApolloCodegenConfiguration.mock(
-      .swiftPackageManager(moduleName: "MockAPI"),
+      .swiftPackageManager(moduleName: "TestModule"),
       to: rootURL.path
     )
     let mockFileManager = MockFileManager(strict: false)
@@ -31,5 +31,19 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
       .generateFile(fileManager: mockFileManager)
 
     expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+
+  func test__generate__givenUnimplementedConfigurations_shouldThrow() throws {
+    expect(try SchemaModuleFileGenerator(
+      ApolloCodegenConfiguration.mock(.cocoaPods(moduleName: "TestModule")).output.schemaTypes
+    )).to(throwError())
+
+    expect(try SchemaModuleFileGenerator(
+      ApolloCodegenConfiguration.mock(.carthage(moduleName: "TestModule")).output.schemaTypes
+    )).to(throwError())
+
+    expect(try SchemaModuleFileGenerator(
+      ApolloCodegenConfiguration.mock(.manuallyLinked(namespace: "TestModule")).output.schemaTypes
+    )).to(throwError())
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import ApolloCodegenLib
+import ApolloCodegenTestSupport
+import Nimble
+
+class SchemaModuleFileGeneratorTests: XCTestCase {
+  override func tearDown() {
+    CodegenTestHelper.deleteExistingOutputFolder()
+
+    super.tearDown()
+  }
+
+  func test__generate__givenSwiftPackageManagerConfiguration_shouldGenerateManifest() throws {
+    // given
+    let rootURL = URL(fileURLWithPath: CodegenTestHelper.outputFolderURL().path)
+    let fileURL = rootURL.appendingPathComponent("MockAPI/Package.swift")
+    let configuration = ApolloCodegenConfiguration.mock(
+      .swiftPackageManager(moduleName: "MockAPI"),
+      to: rootURL.path
+    )
+    let mockFileManager = MockFileManager(strict: false)
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      expect(path).to(equal(fileURL.path))
+
+      return true
+    }))
+
+    // then
+    try SchemaModuleFileGenerator(configuration.output.schemaTypes)
+      .generateFile(fileManager: mockFileManager)
+
+    expect(mockFileManager.allClosuresCalled).to(beTrue())
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import ApolloCodegenLib
+import Nimble
+
+class SwiftPackageManagerModuleTemplateTests: XCTestCase {
+  let subject = SwiftPackageManagerModuleTemplate(moduleName: "TestModule")
+
+  // MARK: Boilerplate Tests
+
+  func test__boilerplate__generatesCorrectSwiftToolsVersion() {
+    // given
+    let expected = """
+    // swift-tools-version:5.3
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_boilerplate__generatesRequiredImports() {
+    // given
+    let expected = """
+    import PackageDescription
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 3, ignoringExtraLines: true))
+  }
+
+  // MARK: PackageDescription tests
+
+  func test__packageDescription__generatesPackageDefinition() {
+    // given
+    let expected = """
+    let package = Package(
+      name: "TestModule",
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__generatesPlatforms() {
+    // given
+    let expected = """
+      platforms: [
+        .iOS(.v12),
+        .macOS(.v10_14),
+        .tvOS(.v12),
+        .watchOS(.v5),
+      ],
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__generatesProducts() {
+    // given
+    let expected = """
+      products: [
+        .library(name: "TestModule", targets: ["TestModule"]),
+      ],
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__generatesNoDependencies() {
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual.contains("dependencies: [")).to(beFalse())
+  }
+
+  func test__packageDescription__generatesTargets() {
+    // given
+    let expected = """
+      targets: [
+        .target(name: "TestModule"),
+      ]
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+  }
+}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -83,18 +83,26 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
   }
 
   func test__packageDescription__generatesNoDependencies() {
+    // given
+    let expected = """
+      dependencies: [
+        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0"),
+      ],
+    """
     // when
     let actual = subject.render()
 
     // then
-    expect(actual.contains("dependencies: [")).to(beFalse())
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__packageDescription__generatesTargets() {
     // given
     let expected = """
       targets: [
-        .target(name: "TestModule"),
+        .target(name: "TestModule", dependencies: [
+          .product(name: "ApolloAPI", package: "apollo-ios"),
+        ]),
       ]
     """
 
@@ -102,6 +110,6 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     let actual = subject.render()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
   }
 }


### PR DESCRIPTION
Adds support for Swift Package Manager dependency automation, generating an SPM manifest file.

_The other three automation types (`.cocoapods`, `.carthage` and `.manuallyLinked`) intentionally throw an exception._