### PR TITLE
[v1.0.0 Alpha 1] JavascriptError @unchecked Sendable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,28 @@ version: 2.1
 parameters:
   xcode_version:
     type: string
-    default: "13.0.0"
+    default: "13.2.1"
   ios_current_version:
     type: string
-    default: "15.0"
+    default: "15.2"
   ios_previous_version:
     type: string
     default: "14.5"
   ios_sdk:
     type: string
-    default: "iphonesimulator15.0"
+    default: "iphonesimulator15.2"
   macos_version: # The user-facing version string for macOS builds
     type: string
-    default: "11.5.2"
+    default: "11.6.2"
   macos_sdk: # The full SDK string to use for macOS builds
     type: string
-    default: "macosx11.3"
+    default: "macosx12.1"
   tvos_version: # The user-facing version string of tvOS builds
     type: string
-    default: "15.0"
+    default: "15.2"
   tvos_sdk:
     type: string
-    default: "appletvsimulator15.0"
+    default: "appletvsimulator15.2"
 
 commands:
   integration_test_setup:

--- a/Sources/ApolloCodegenLib/Frontend/JavaScriptBridge.swift
+++ b/Sources/ApolloCodegenLib/Frontend/JavaScriptBridge.swift
@@ -6,7 +6,7 @@ import JavaScriptCore
 
 /// An errror thrown during JavaScript execution.
 /// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
-public class JavaScriptError: JavaScriptObject, Error {
+public class JavaScriptError: JavaScriptObject, Error, @unchecked Sendable {
   lazy var name: String? = self["name"]
   
   lazy var message: String? = self["message"]

--- a/Sources/ApolloCodegenLib/Frontend/JavaScriptBridge.swift
+++ b/Sources/ApolloCodegenLib/Frontend/JavaScriptBridge.swift
@@ -4,7 +4,7 @@ import JavaScriptCore
 // and can be safely force unwrapped. (Even when an exception is thrown they would still return
 // a `JSValue` representing a JavaScript `undefined` value.)
 
-/// An errror thrown during JavaScript execution.
+/// An error thrown during JavaScript execution.
 /// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 public class JavaScriptError: JavaScriptObject, Error, @unchecked Sendable {
   // These properties were changed to read-only when `@unchecked Sendable` was added for

--- a/Sources/ApolloCodegenLib/Frontend/JavaScriptBridge.swift
+++ b/Sources/ApolloCodegenLib/Frontend/JavaScriptBridge.swift
@@ -7,11 +7,12 @@ import JavaScriptCore
 /// An errror thrown during JavaScript execution.
 /// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 public class JavaScriptError: JavaScriptObject, Error, @unchecked Sendable {
-  lazy var name: String? = self["name"]
-  
-  lazy var message: String? = self["message"]
-  
-  lazy var stack: String? = self["stack"]
+  // These properties were changed to read-only when `@unchecked Sendable` was added for
+  // Xcode 13.3. If you make them publicly writable or alter their values within the class
+  // you will need to do so with thread-safety in mind.
+  var name: String? { self["name"] }
+  var message: String? { self["message"] }
+  var stack: String? { self["stack"] }
 }
 
 extension JavaScriptError: CustomStringConvertible {


### PR DESCRIPTION
Added unchecked sendable to JavascriptError to be able to compile with Swift 5.6.

Since this is just an `Error` object I don't foresee big trouble out of this change. Sure, I would prefer to not have this issue in the first place (using value types instead of classes, and composition instead of inheritance), but that's a bigger refactor that the core team needs to evaluate separately.

Fixes #2146 