### PR TITLE
Fix/cache watcher

### DIFF
--- a/Sources/Apollo/CacheWriteInterceptor.swift
+++ b/Sources/Apollo/CacheWriteInterceptor.swift
@@ -53,9 +53,10 @@ public struct CacheWriteInterceptor: ApolloInterceptor {
       guard chain.isNotCancelled else {
         return
       }
+      let queryName = request.operation.operationType == .query ? request.operation.operationName : nil
       
       if let records = records {
-        self.store.publish(records: records, identifier: request.contextIdentifier)
+        self.store.publish(records: records, identifier: request.contextIdentifier, queryName: queryName)
       }
       
       chain.proceedAsync(request: request,

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -377,9 +377,11 @@ extension WebSocketTransport: NetworkTransport {
               callCompletion(with: .success(graphQLResult))
               return
             }
+            let queryName = operation.operationType == .query ? operation.operationName : nil
 
             store.publish(records: records,
                           identifier: contextIdentifier,
+                          queryName: queryName,
                           callbackQueue: callbackQueue) { result in
               switch result {
               case .success:


### PR DESCRIPTION
This is my take on fixing very long standing issue https://github.com/apollographql/apollo-ios/issues/99 of Query watcher not triggering at all if query watcher is created when:

- Cache is empty and `returnCacheDataDontFetch` is used (I did not test this scenario)
- Most importantly for me, if cache is empty and no network access to server is available when Query Watcher is created

This leads to scenario in which dependant keys are newer correctly initialized and thus QueryWatcher does never trigger when following queries receive valid responses.

I made a new test case which tests the latter scenario. 