### PR TITLE
[v1.0.0 alpha] Make fragments property public

### DIFF
--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -83,5 +83,5 @@ extension SelectionSet {
 
 extension SelectionSet where Fragments: FragmentContainer {
   /// Contains accessors for all of the fragments the `SelectionSet` can be converted to.
-  var fragments: Fragments { Fragments(data: data) }
+  public var fragments: Fragments { Fragments(data: data) }
 }


### PR DESCRIPTION
I'm getting a lot of compiler errors in my project using the alpha since the `fragments` property isn't accessible. I'm hoping that it was meant to be `public` 😄
