### PR TITLE
Add GraphQLNullable nil coalescing operator

### DIFF
--- a/Sources/ApolloAPI/GraphQLNullable.swift
+++ b/Sources/ApolloAPI/GraphQLNullable.swift
@@ -119,3 +119,13 @@ public extension GraphQLNullable {
     self = .some(object)
   }
 }
+
+// MARK: - Nil Coalescing Operator
+
+public func ??<T>(lhs: T?, rhs: GraphQLNullable<T>) -> GraphQLNullable<T> {
+  if let lhs = lhs {
+    return .some(lhs)
+  }
+  return rhs
+}
+


### PR DESCRIPTION
This allows for optional variables to easily be used with `GraphQLNullable` parameters and a default value

```swift
class MyQuery: GraphQLQuery {

  var myVar: GraphQLNullable<String>

  init(myVar: GraphQLNullable<String> { ... }
 // ...
}

let optionalString: String?

// Before

let query = MyQuery(myVar: optionalString.map { .some($0) } ?? .none)

// After
let query = MyQuery(myVar: optionalString ?? .none)
```