### PR TITLE
[Fix #2170] Do not refetch query watcher from server after cache miss when cache policy is cache only

### DIFF
--- a/Sources/ApolloTestSupport/AsyncResultObserver.swift
+++ b/Sources/ApolloTestSupport/AsyncResultObserver.swift
@@ -55,12 +55,12 @@ public class AsyncResultObserver<Success, Failure> where Failure: Error {
     }
         
     do {
+      defer { expectation.fulfill() }
       try expectation.handler(result)
+
     } catch {
       testCase.record(error, file: expectation.file, line: expectation.line)
     }
-    
-    expectation.fulfill()
     
     if expectation.apollo.numberOfFulfillments >= expectation.expectedFulfillmentCount {
       expectations.removeFirst()

--- a/Sources/ApolloTestSupport/AsyncResultObserver.swift
+++ b/Sources/ApolloTestSupport/AsyncResultObserver.swift
@@ -55,12 +55,12 @@ public class AsyncResultObserver<Success, Failure> where Failure: Error {
     }
         
     do {
-      defer { expectation.fulfill() }
       try expectation.handler(result)
-
     } catch {
       testCase.record(error, file: expectation.file, line: expectation.line)
     }
+    
+    expectation.fulfill()
     
     if expectation.apollo.numberOfFulfillments >= expectation.expectedFulfillmentCount {
       expectations.removeFirst()

--- a/Sources/ApolloTestSupport/MockGraphQLServer.swift
+++ b/Sources/ApolloTestSupport/MockGraphQLServer.swift
@@ -57,7 +57,7 @@ public class MockGraphQLServer {
   }
   
   private let queue = DispatchQueue(label: "com.apollographql.MockGraphQLServer")
-    
+
   public init() { }
   
   // Since RequestExpectation is generic over a specific GraphQLOperation, we can't store these in the dictionary
@@ -87,16 +87,20 @@ public class MockGraphQLServer {
   }
   
   func serve<Operation>(request: HTTPRequest<Operation>, completionHandler: @escaping (Result<JSONObject, Error>) -> Void) where Operation: GraphQLOperation {
-    // Dispatch after a small random delay to spread out concurrent requests and simulate somewhat real-world conditions.
-    queue.asyncAfter(deadline: .now() + .milliseconds(Int.random(in: 10...50))) {
-      let operationType = type(of: request.operation)
-      
-      if let expectation = self[operationType] {
+    let operationType = type(of: request.operation)
+
+    if let expectation = self[operationType] {
+      // Dispatch after a small random delay to spread out concurrent requests and simulate somewhat real-world conditions.
+      queue.asyncAfter(deadline: .now() + .milliseconds(Int.random(in: 10...50))) {
         completionHandler(.success(expectation.handler(request)))
         expectation.fulfill()
-      } else {
+      }
+
+    } else {
+      queue.async {
         completionHandler(.failure(ServerError.unexpectedRequest(String(describing: operationType))))
       }
     }
+
   }
 }

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -567,6 +567,93 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, refetchServerRequestExpectation, updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
   }
+
+  func testWatchedQuery_givenCachePolicyReturnCacheDataDontFetch_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
+    client.store.cacheKeyForObject = { $0["id"] }
+
+    let watchedQuery = HeroAndFriendsNamesWithIDsQuery()
+
+    let resultObserver = makeResultObserver(for: watchedQuery)
+
+    let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
+    addTeardownBlock { watcher.cancel() }
+
+    runActivity("Write data to cache") { _ in
+      let writeToStoreExpectation = expectation(description: "Initial Data written to store")
+
+      client.store.withinReadWriteTransaction({ transaction in
+        let data = HeroAndFriendsNamesWithIDsQuery.Data(
+          unsafeResultMap: [
+            "hero": [
+              "id": "2001",
+              "name": "R2-D2",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "id": "1000", "name": "Luke Skywalker"],
+                ["__typename": "Human", "id": "1002", "name": "Han Solo"],
+                ["__typename": "Human", "id": "1003", "name": "Leia Organa"],
+              ]
+            ]
+          ])
+        
+        try transaction.write(data: data, forQuery: HeroAndFriendsNamesWithIDsQuery())
+      }) { result in
+        XCTAssertSuccessResult(result)
+        writeToStoreExpectation.fulfill()
+      }
+
+      wait(for: [writeToStoreExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Initial fetch from cache") { _ in
+      let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from cache") { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .cache)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero?.name, "R2-D2")
+          let friendsNames = data.hero?.friends?.compactMap { $0?.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+        }
+      }
+
+      watcher.fetch(cachePolicy: .returnCacheDataDontFetch)
+
+      wait(for: [initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Fetch other query with list of updated keys from server") { _ in
+      let serverRequestExpectation = server.expect(HeroAndFriendsIDsQuery.self) { request in
+        [
+          "data": [
+            "hero": [
+              "id": "2001",
+              "name": "Artoo",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "id": "1003"],
+                ["__typename": "Human", "id": "1004"],
+                ["__typename": "Human", "id": "1000"],
+              ]
+            ]
+          ]
+        ]
+      }
+
+      let noRefetchExpectation = resultObserver.expectation(description: "Initial query shouldn't trigger refetch") { _ in }
+      noRefetchExpectation.isInverted = true
+
+      let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
+
+      client.fetch(query: HeroAndFriendsIDsQuery(), cachePolicy: .fetchIgnoringCacheData) { result in
+        defer { otherFetchCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      }
+
+      wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, noRefetchExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
   
   func testWatchedQueryGetsUpdatedWhenObjectIsChangedByDirectStoreUpdate() throws {
     let watchedQuery = HeroAndFriendsNamesQuery()


### PR DESCRIPTION
Closes #2170