### PR TITLE
Refactor `SchemaTypesFileOutput.ModuleType`

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -32,7 +32,7 @@ public class ApolloCodegen {
     let compilationResult = try compileGraphQLResult(configuration.input)
 
     let ir = IR(
-      schemaName: configuration.output.schemaTypes.moduleName,
+      schemaName: configuration.output.schemaTypes.schemaName,
       compilationResult: compilationResult
     )
 
@@ -111,7 +111,7 @@ public class ApolloCodegen {
       try autoreleasepool {
         try UnionFileGenerator.generate(
           graphQLUnion,
-          moduleName: config.output.schemaTypes.moduleName,
+          moduleName: config.output.schemaTypes.schemaName,
           directoryPath: config.output.resolvePath(.union),
           fileManager: fileManager
         )

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -145,43 +145,45 @@ public struct ApolloCodegenConfiguration {
     /// Compatible dependency manager automation.
     public enum ModuleType {
       /// No module will be created for the generated schema types.
-      /// Generated files must be manually added to the main application target.
-      /// The generated files will be namespaced to prevent naming conflicts.
       ///
-      /// - Parameters:
-      ///  - namespace: The namespace to use for generated operation objects.
-      case manuallyLinked(namespace: String)
-      /// Generates a module with a podspec file that is suitable for linking to your project using CocoaPods.
+      /// Generated files must be manually added to your application target. The generated schema
+      /// types files will be namespaced with the value of `schemaName` to prevent naming conflicts.
+      case none
+      /// Generates a `package.swift` file that is suitable for linking the generated schema types
+      /// files to your project using Swift Package Manager.
+      case swiftPackageManager
+      /// No module will be created for the generated types and you are required to create the
+      /// module to support your preferred dependency manager. You must specify the name of the
+      /// module you will create in the `schemaName` property as this will be used in `import`
+      /// statements of generated operation files.
       ///
-      /// - Parameters:
-      ///  - moduleName: The name for the new shared module that will be created.
-      case cocoaPods(moduleName: String)
-      /// Generates a module with a cartfile that is suitable for linking to your project using Carthage.
-      ///
-      /// - Parameters:
-      ///  - moduleName: The name for the new shared module that will be created.
-      case carthage(moduleName: String)
-      /// Generates a module with a package.swift file that is suitable for linking to your project using Swift Package Manager
-      ///
-      /// - Parameters:
-      ///  - moduleName: The name for the new shared module that will be created.
-      case swiftPackageManager(moduleName: String)
+      /// Use this option for dependency managers, such as CocoaPods or Carthage. Example usage
+      /// would be to create the podspec file (CocoaPods) or Xcode project file (Carthage) that
+      /// is expecting the generated files in the configured output location.
+      case other
     }
 
     /// Local path where the generated schema types files should be stored.
     public let path: String
     /// Automation to ease the integration of the generated schema types file with compatible dependency managers.
-    public let dependencyAutomation: ModuleType
+    public let moduleType: ModuleType
+    /// Name used to scope the generated schema type files.
+    public let schemaName: String
 
     /// Designated initializer.
     ///
     /// - Parameters:
     ///  - path: Local path where the generated schema type files should be stored.
-    ///  - dependencyAutomation: Automation to ease the integration of the generated schema types file with compatible
-    ///  dependency managers. Defaults to `.manuallyLinked` with a `namespace` of `"API"`.
-    public init(path: String, dependencyAutomation: ModuleType = .manuallyLinked(namespace: "API")) {
+    ///  - schemaName: Name used to scope the generated schema type files.
+    ///  - moduleType: Type of module that will be created for the schema types files. Defaults to `.none`.
+    public init(
+      path: String,
+      schemaName: String,
+      moduleType: ModuleType = .none
+    ) {
       self.path = path
-      self.dependencyAutomation = dependencyAutomation
+      self.schemaName = schemaName
+      self.moduleType = moduleType
     }
   }
 
@@ -416,19 +418,4 @@ extension ApolloCodegenConfiguration {
         .logging(withPath: path)
     }
   }
-}
-
-// MARK: Helper Extensions (Internal Only)
-
-extension ApolloCodegenConfiguration.SchemaTypesFileOutput {
-  var moduleName: String {
-    switch self.dependencyAutomation {
-    case
-      let .manuallyLinked(name),
-      let .carthage(name),
-      let .cocoaPods(name),
-      let .swiftPackageManager(name):
-        return name
-    }
-  }  
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct SchemaModuleFileGenerator {
-  /// Generates a package manifest file for the releveant depdency manager.
+  /// Generates a module for the chosen dependency manager.
   ///
   /// - Parameters:
   ///   - config: A configuration object specifying output behavior.
@@ -10,10 +10,10 @@ struct SchemaModuleFileGenerator {
     _ config: ApolloCodegenConfiguration.SchemaTypesFileOutput,
     fileManager: FileManager = FileManager.default
   ) throws {
-    switch config.dependencyAutomation {
-    case let .swiftPackageManager(moduleName):
+    switch config.moduleType {
+    case .swiftPackageManager:
       try SwiftPackageManagerFileGenerator.generate(
-        moduleName,
+        config.schemaName,
         directoryPath: config.path,
         fileManager: fileManager
       )

--- a/Sources/ApolloCodegenLib/Templates/ImportStatementTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/ImportStatementTemplate.swift
@@ -14,7 +14,7 @@ struct ImportStatementTemplate {
     static func render(_ config: ApolloCodegenConfiguration.FileOutput) -> TemplateString {
       """
       \(template.description)
-      \(if: shouldImportSchemaModule(config), "import \(config.schemaTypes.moduleName)")
+      \(if: shouldImportSchemaModule(config), "import \(config.schemaTypes.schemaName)")
       """
     }
 
@@ -28,9 +28,9 @@ struct ImportStatementTemplate {
 
 fileprivate extension ApolloCodegenConfiguration.SchemaTypesFileOutput {
   var isInModule: Bool {
-    switch dependencyAutomation {
-    case .manuallyLinked: return false
-    case .swiftPackageManager, .cocoaPods, .carthage: return true
+    switch moduleType {
+    case .none: return false
+    case .swiftPackageManager, .other: return true
     }
   }
 }

--- a/Sources/ApolloCodegenTestSupport/MockApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenTestSupport/MockApolloCodegenConfiguration.swift
@@ -3,7 +3,7 @@
 extension ApolloCodegenConfiguration {
   public static func mock(
     input: FileInput = .init(schemaPath: "MockSchemaPath", searchPaths: []),
-    output: FileOutput = .init(schemaTypes: .init(path: "MockSchemaTypes")),
+    output: FileOutput = .init(schemaTypes: .init(path: "MockSchemaTypes", schemaName: "MockSchemaTypes")),
     additionalInflectionRules: [ApolloCodegenLib.InflectionRule] = [],
     queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
     customScalarFormat: CustomScalarFormat = .defaultAsString,
@@ -25,28 +25,31 @@ extension ApolloCodegenConfiguration {
 
   public static func mock(
     _ moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
+    schemaName: String = "MockSchemaTypes",
     to path: String = "MockModulePath"
   ) -> Self {
     .init(
       input: .init(schemaPath: "schema.graphqls",
                    searchPaths: ["*.graphql"]),
       output: .init(schemaTypes: .init(path: path,
-                                       dependencyAutomation: moduleType))
+                                       schemaName: schemaName,
+                                       moduleType: moduleType))
     )
   }
 }
 
 extension ApolloCodegenConfiguration.FileOutput {
   public static func mock(
-    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType =
-      .manuallyLinked(namespace: "MockSchemaTypes"),
+    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .none,
+    schemaName: String = "MockSchemaTypes",
     operations: ApolloCodegenConfiguration.OperationsFileOutput,
     path: String = ""
   ) -> Self {
     .init(
       schemaTypes: .init(
         path: path,
-        dependencyAutomation: moduleType
+        schemaName: schemaName,
+        moduleType: moduleType
       ),
       operations: operations
     )

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfiguration_ResolvePath_Tests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfiguration_ResolvePath_Tests.swift
@@ -9,10 +9,15 @@ class ApolloCodegenConfiguration_ResolvePath_Tests: XCTestCase {
   var config: ApolloCodegenConfiguration.FileOutput!
 
   private func buildOutputConfig(
-    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .manuallyLinked(namespace: "TestAPI"),
+    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .none,
     operations: ApolloCodegenConfiguration.OperationsFileOutput
   ) {
-    config = .mock(moduleType: moduleType, operations: operations, path: directoryURL.path)
+    config = .mock(
+      moduleType: moduleType,
+      schemaName: "TestAPI",
+      operations: operations,
+      path: directoryURL.path
+    )
   }
 
   // MARK: OperationsFileOutput.relative
@@ -323,7 +328,7 @@ class ApolloCodegenConfiguration_ResolvePath_Tests: XCTestCase {
   func test_resolvePath_givenFragmentFilenameWithExtension_shouldNotIncludeExtension() throws {
     // given
     let config = ApolloCodegenConfiguration.FileOutput(
-      schemaTypes: .init(path: directoryURL.path, dependencyAutomation: .swiftPackageManager(moduleName: "API")),
+      schemaTypes: .init(path: directoryURL.path, schemaName: "API", moduleType: .swiftPackageManager),
       operations: .relative(subpath: nil),
       operationIdentifiersPath: nil
     )
@@ -339,7 +344,7 @@ class ApolloCodegenConfiguration_ResolvePath_Tests: XCTestCase {
   func test_resolvePath_givenOperationFilenameWithExtension_shouldNotIncludeExtension() throws {
     // given
     let config = ApolloCodegenConfiguration.FileOutput(
-      schemaTypes: .init(path: directoryURL.path, dependencyAutomation: .swiftPackageManager(moduleName: "API")),
+      schemaTypes: .init(path: directoryURL.path, schemaName: "API", moduleType: .swiftPackageManager),
       operations: .relative(subpath: nil),
       operationIdentifiersPath: nil
     )

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -165,7 +165,8 @@ class ApolloCodegenTests: XCTestCase {
     let config = ApolloCodegenConfiguration(
       input: .init(schemaPath: schemaPath, searchPaths: [operationsPath]),
       output: .mock(
-        moduleType: .swiftPackageManager(moduleName: "AnimalKingdomAPI"),
+        moduleType: .swiftPackageManager,
+        schemaName: "AnimalKingdomAPI",
         operations: .inSchemaModule,
         path: directoryURL.path
       )
@@ -207,7 +208,7 @@ class ApolloCodegenTests: XCTestCase {
     let compilationResult = try ApolloCodegen.compileGraphQLResult(config.input)
 
     let ir = IR(
-      schemaName: config.output.schemaTypes.moduleName,
+      schemaName: config.output.schemaTypes.schemaName,
       compilationResult: compilationResult
     )
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
@@ -16,7 +16,8 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
     let fileURL = rootURL.appendingPathComponent("Package.swift")
 
     let configuration = ApolloCodegenConfiguration.mock(
-      .swiftPackageManager(moduleName: "TestModule"),
+      .swiftPackageManager,
+      schemaName: "TestModule",
       to: rootURL.path
     )
     let mockFileManager = MockFileManager(strict: false)
@@ -38,15 +39,11 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
 
   func test__generate__givenUnimplementedConfigurations_shouldThrow() throws {
     expect(try SchemaModuleFileGenerator.generate(
-      ApolloCodegenConfiguration.mock(.cocoaPods(moduleName: "TestModule")).output.schemaTypes
+      ApolloCodegenConfiguration.mock(.other, schemaName: "TestModule").output.schemaTypes
     )).to(throwError())
 
     expect(try SchemaModuleFileGenerator.generate(
-      ApolloCodegenConfiguration.mock(.carthage(moduleName: "TestModule")).output.schemaTypes
-    )).to(throwError())
-
-    expect(try SchemaModuleFileGenerator.generate(
-      ApolloCodegenConfiguration.mock(.manuallyLinked(namespace: "TestModule")).output.schemaTypes
+      ApolloCodegenConfiguration.mock(.none, schemaName: "TestModule").output.schemaTypes
     )).to(throwError())
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -63,7 +63,8 @@ class FragmentTemplateTests: XCTestCase {
   func test__render__generatesHeaderComment() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .manuallyLinked(namespace: "TestModuleName"),
+      moduleType: .none,
+      schemaName: "TestModuleName",
       operations: .inSchemaModule
     ))
 
@@ -88,7 +89,8 @@ class FragmentTemplateTests: XCTestCase {
   func test__render__givenFileOutput_inSchemaModule_schemaModuleManuallyLinked_generatesImportNotIncludingSchemaModule() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .manuallyLinked(namespace: "TestModuleName"),
+      moduleType: .none,
+      schemaName: "TestModuleName",
       operations: .inSchemaModule
     ))
 
@@ -110,7 +112,8 @@ class FragmentTemplateTests: XCTestCase {
   func test__render__givenFileOutput_inSchemaModule_schemaModuleNotManuallyLinked_generatesImportNotIncludingSchemaModule() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .swiftPackageManager(moduleName: "TestModuleName"),
+      moduleType: .swiftPackageManager,
+      schemaName: "TestModuleName",
       operations: .inSchemaModule
     ))
 
@@ -132,7 +135,8 @@ class FragmentTemplateTests: XCTestCase {
   func test__render__givenFileOutput_notInSchemaModule_schemaModuleNotManuallyLinked_generatesImportIncludingSchemaModule() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .swiftPackageManager(moduleName: "TestModuleName"),
+      moduleType: .swiftPackageManager,
+      schemaName: "TestModuleName",
       operations: .absolute(path: "")
     ))
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -83,7 +83,8 @@ class OperationDefinitionTemplateTests: XCTestCase {
   func test__generate__givenFileOutput_inSchemaModule_schemaModuleManuallyLinked_generatesImportNotIncludingSchemaModule() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .manuallyLinked(namespace: "TestModuleName"),
+      moduleType: .none,
+      schemaName: "TestModuleName",
       operations: .inSchemaModule
     ))
 
@@ -105,7 +106,8 @@ class OperationDefinitionTemplateTests: XCTestCase {
   func test__generate__givenFileOutput_inSchemaModule_schemaModuleNotManuallyLinked_generatesImportNotIncludingSchemaModule() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .swiftPackageManager(moduleName: "TestModuleName"),
+      moduleType: .swiftPackageManager,
+      schemaName: "TestModuleName",
       operations: .inSchemaModule
     ))
 
@@ -127,7 +129,8 @@ class OperationDefinitionTemplateTests: XCTestCase {
   func test__generate__givenFileOutput_notInSchemaModule_schemaModuleNotManuallyLinked_generatesImportIncludingSchemaModule() throws {
     // given
     config = .mock(output: .mock(
-      moduleType: .swiftPackageManager(moduleName: "TestModuleName"),
+      moduleType: .swiftPackageManager,
+      schemaName: "TestModuleName",
       operations: .absolute(path: "")
     ))
 


### PR DESCRIPTION
PR 1 of 3 for #2034 

* Refactors `ModuleType` to be more general in the third-party dependency managers that can be supported.
* Refactored `ApolloCodegenConfigurationTests` with more reusable code, dropped a few tests that are no longer relevant with the module helpers being removed.