### PR TITLE
fix: Update `Module` to be compatible with `ModuleType` changes

### DIFF
--- a/SwiftScripts/Sources/Codegen/Module.swift
+++ b/SwiftScripts/Sources/Codegen/Module.swift
@@ -1,37 +1,29 @@
 import Foundation
 import ApolloCodegenLib
 
-enum Module {
-  case swiftPackageManager(name: String)
-  case cocoapods(name: String)
-  case carthage(name: String)
-  case manuallyLinked(name: String)
+struct Module {
+  private let module: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType
 
-  init?(module: String, name: String) {
-    switch module {
-    case "SwiftPackageManager", "SPM": self = .swiftPackageManager(name: name)
-    case "CocoaPods": self = .cocoapods(name: name)
-    case "Carthage": self = .carthage(name: name)
-    case "ManuallyLinked": self = .manuallyLinked(name: name)
+  init?(module: String) {
+    switch module.lowercased() {
+    case "none": self.module = .none
+    case "swiftpackagemanager", "spm": self.module = .swiftPackageManager
+    case "other": self.module = .other
     default: return nil
     }
   }
 
-  func outputConfig(toTargetRoot targetRootURL: Foundation.URL) -> ApolloCodegenConfiguration.FileOutput {
+  func outputConfig(
+    toTargetRoot targetRootURL: Foundation.URL,
+    schemaName: String
+  ) -> ApolloCodegenConfiguration.FileOutput {
     let targetPath = targetRootURL.appendingPathComponent("Generated").path
-
-    let moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType
-    switch self {
-    case let .swiftPackageManager(name): moduleType = .swiftPackageManager(moduleName: name)
-    case let .cocoapods(name): moduleType = .cocoaPods(moduleName: name)
-    case let .carthage(name): moduleType = .carthage(moduleName: name)
-    case let .manuallyLinked(name): moduleType = .manuallyLinked(namespace: name)
-    }
 
     return ApolloCodegenConfiguration.FileOutput(
       schemaTypes: .init(
         path: targetPath,
-        dependencyAutomation: moduleType
+        schemaName: schemaName,
+        moduleType: module
       ),
       operations: .inSchemaModule,
       operationIdentifiersPath: nil

--- a/SwiftScripts/Sources/Codegen/main.swift
+++ b/SwiftScripts/Sources/Codegen/main.swift
@@ -40,7 +40,7 @@ struct Codegen: ParsableCommand {
       throw ArgumentError.invalidTargetName(name: targetName)
     }
 
-    guard let module = Module(module: packageManager, name: target.moduleName) else {
+    guard let module = Module(module: packageManager) else {
       throw ArgumentError.invalidPackageType(name: packageManager)
     }
 
@@ -55,7 +55,7 @@ struct Codegen: ParsableCommand {
 
     let targetURL = target.targetRootURL(fromSourceRoot: sourceRootURL)
     let inputConfig = target.inputConfig(fromSourceRoot: sourceRootURL)
-    let outputConfig = module.outputConfig(toTargetRoot: targetURL)
+    let outputConfig = module.outputConfig(toTargetRoot: targetURL, schemaName: target.moduleName)
 
     // This more necessary if you're using a sub-folder, but make sure
     // there's actually a place to write out what you're doing.


### PR DESCRIPTION
fix: Update the internal `Module` enum to simply parse the input and set `ModuleType` value, this is better than duplicating the enum values.