### PR TITLE
Ensure generated fragment Swift types use TitleCasing if GraphQL frag ment is lowercased

### DIFF
--- a/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
@@ -9,5 +9,5 @@ struct FragmentFileGenerator: FileGenerator {
   
   var template: TemplateRenderer { FragmentTemplate(fragment: irFragment, schema: schema) }
   var target: FileTarget { .fragment(irFragment.definition) }
-  var fileName: String { "\(irFragment.definition.name).swift" }
+  var fileName: String { "\(irFragment.definition.name.firstUppercased).swift" }
 }

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -13,7 +13,7 @@ struct FragmentTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    public struct \(fragment.name): \(schema.name).SelectionSet, Fragment {
+    public struct \(fragment.name.firstUppercased): \(schema.name).SelectionSet, Fragment {
       public static var fragmentDefinition: StaticString { ""\"
         \(fragment.definition.source)
         ""\" }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
@@ -55,11 +55,11 @@ class FragmentFileGeneratorTests: XCTestCase {
     expect(self.subject.target).to(equal(expected))
   }
 
-  func test__properties__givenGraphQLFragment_shouldReturnFileName_matchingFragmentDefinitionName() throws {
+  func test__properties__givenGraphQLFragment_shouldReturnFileName_firstUppercasedFragmentDefinitionName() throws {
     // given
     try buildSubject()
 
-    let expected = "\(irFragment.definition.name).swift"
+    let expected = "\(irFragment.definition.name.firstUppercased).swift"
 
     // then
     expect(self.subject.fileName).to(equal(expected))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -88,6 +88,42 @@ class FragmentTemplateTests: XCTestCase {
     expect(String(actual.reversed())).to(equalLineByLine("}", ignoringExtraLines: true))
   }
 
+  func test__render__givenLowercaseFragment_generatesTitleCaseTypeName() throws {
+    // given
+    document = """
+    fragment testFragment on Query {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    let expected =
+    """
+    public struct TestFragment: TestSchema.SelectionSet, Fragment {
+      public static var fragmentDefinition: StaticString { ""\"
+        fragment testFragment on Query {
+          __typename
+          allAnimals {
+            __typename
+            species
+          }
+        }
+        ""\" }
+
+      public let data: DataDict
+      public init(data: DataDict) { self.data = data }
+    """
+
+    // when
+    try buildSubjectAndFragment(named: "testFragment")
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   func test__render__givenFragmentWithUnderscoreInName_rendersDeclarationWithName() throws {
     // given
     schemaSDL = """


### PR DESCRIPTION
This causes compile-time failure as other parts of codegen assume that types are TitleCased.

Here's an example of a compile-time failure from the GitHub codebase:

| Fragment Defintion | Fragment Usage |
| --- | --- |
| <img width="1072" alt="Screen Shot 2022-04-13 at 6 54 31 PM" src="https://user-images.githubusercontent.com/1051453/163285372-db6b0e01-0c11-4647-8bb1-a61d93b13eff.png"> | <img width="1887" alt="Screen Shot 2022-04-13 at 6 55 23 PM" src="https://user-images.githubusercontent.com/1051453/163285371-0e56bd6a-9987-47ad-91b7-d542c412ae13.png"> |

cc @calvincestari since we were DM'ing about this!