### PR TITLE
refactor: All Swift type names must have first letter uppercased

### DIFF
--- a/Sources/ApolloCodegenLib/FileGenerators/CustomScalarFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/CustomScalarFileGenerator.swift
@@ -7,6 +7,6 @@ struct CustomScalarFileGenerator: FileGenerator {
 
   var template: TemplateRenderer { CustomScalarTemplate(graphqlScalar: graphqlScalar) }
   var target: FileTarget { .customScalar }
-  var fileName: String { "\(graphqlScalar.name.firstUppercased).swift" }
+  var fileName: String { "\(graphqlScalar.name).swift" }
   var overwrite: Bool { false }
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/EnumFileGenerator.swift
@@ -7,5 +7,5 @@ struct EnumFileGenerator: FileGenerator {
 
   var template: TemplateRenderer { EnumTemplate(graphqlEnum: graphqlEnum) }
   var target: FileTarget { .enum }
-  var fileName: String { "\(graphqlEnum.name.firstUppercased).swift" }
+  var fileName: String { "\(graphqlEnum.name).swift" }
 }

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -24,7 +24,8 @@ extension FileGenerator {
     fileManager: FileManager = FileManager.default
   ) throws {
     let directoryPath = target.resolvePath(forConfig: config)
-    let filePath = URL(fileURLWithPath: directoryPath).appendingPathComponent(fileName).path
+    let filePath = URL(fileURLWithPath: directoryPath)
+      .appendingPathComponent(fileName.firstUppercased).path
 
     let rendered: String = template.render(forConfig: config)
 

--- a/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
@@ -9,5 +9,5 @@ struct FragmentFileGenerator: FileGenerator {
   
   var template: TemplateRenderer { FragmentTemplate(fragment: irFragment, schema: schema) }
   var target: FileTarget { .fragment(irFragment.definition) }
-  var fileName: String { "\(irFragment.definition.name.firstUppercased).swift" }
+  var fileName: String { "\(irFragment.definition.name).swift" }
 }

--- a/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
@@ -11,7 +11,7 @@ struct InterfaceTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    public final class \(graphqlInterface.name): Interface { }
+    public final class \(graphqlInterface.name.firstUppercased): Interface { }
     """
     )
   }

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -32,7 +32,7 @@ struct OperationDefinitionTemplate: TemplateRenderer {
 
   private func OperationDeclaration(_ operation: CompilationResult.OperationDefinition) -> TemplateString {
     return """
-    public class \(operation.nameWithSuffix): \(operation.operationType.renderedProtocolName) {
+    public class \(operation.nameWithSuffix.firstUppercased): \(operation.operationType.renderedProtocolName) {
       public let operationName: String = "\(operation.name)"
     """
   }

--- a/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
@@ -10,7 +10,7 @@ struct SchemaModuleNamespaceTemplate: TemplateRenderer {
 
   var template: TemplateString {
     TemplateString("""
-    public enum \(namespace) { }
+    public enum \(namespace.firstUppercased) { }
     """)
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
@@ -14,16 +14,16 @@ struct SchemaTemplate: TemplateRenderer {
     public typealias ID = String
 
     public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
-    where Schema == \(schema.name).Schema {}
+    where Schema == \(schema.name.firstUppercased).Schema {}
     
     public protocol InlineFragment: ApolloAPI.SelectionSet & ApolloAPI.InlineFragment
-    where Schema == \(schema.name).Schema {}
+    where Schema == \(schema.name.firstUppercased).Schema {}
 
     public enum Schema: SchemaConfiguration {
       public static func objectType(forTypename __typename: String) -> Object.Type? {
         switch __typename {
         \(schema.referencedTypes.objects.map {
-        "case \"\($0.name)\": return \(schema.name).\($0.name).self"
+          "case \"\($0.name.firstUppercased)\": return \(schema.name.firstUppercased).\($0.name.firstUppercased).self"
         }, separator: "\n")
         default: return nil
         }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -15,7 +15,7 @@ struct SelectionSetTemplate {
   func render(for operation: IR.Operation) -> String {
     TemplateString(
     """
-    public struct Data: \(schema.name).SelectionSet {
+    public struct Data: \(schema.name.firstUppercased).SelectionSet {
       \(BodyTemplate(operation.rootField.selectionSet))
     }
     """
@@ -27,7 +27,7 @@ struct SelectionSetTemplate {
     TemplateString(
     """
     \(SelectionSetNameDocumentation(field.selectionSet))
-    public struct \(field.formattedFieldName): \(schema.name).SelectionSet {
+    public struct \(field.formattedFieldName): \(schema.name.firstUppercased).SelectionSet {
       \(BodyTemplate(field.selectionSet))
     }
     """
@@ -39,7 +39,7 @@ struct SelectionSetTemplate {
     TemplateString(
     """
     \(SelectionSetNameDocumentation(inlineFragment))
-    public struct \(inlineFragment.renderedTypeName): \(schema.name).InlineFragment {
+    public struct \(inlineFragment.renderedTypeName): \(schema.name.firstUppercased).InlineFragment {
       \(BodyTemplate(inlineFragment))
     }
     """
@@ -84,7 +84,7 @@ struct SelectionSetTemplate {
     """
 
   private func ParentTypeTemplate(_ type: GraphQLCompositeType) -> String {
-    "public static var __parentType: ParentType { .\(type.parentTypeEnumType)(\(schema.name).\(type.name).self) }"
+    "public static var __parentType: ParentType { .\(type.parentTypeEnumType)(\(schema.name.firstUppercased).\(type.name.firstUppercased).self) }"
   }
 
   // MARK: - Selections

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -17,7 +17,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
     import PackageDescription
 
     let package = Package(
-      name: "\(moduleName)",
+      name: "\(moduleName.firstUppercased)",
       platforms: [
         .iOS(.v12),
         .macOS(.v10_14),
@@ -25,14 +25,14 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
         .watchOS(.v5),
       ],
       products: [
-        .library(name: "\(moduleName)", targets: ["\(moduleName)"]),
+        .library(name: "\(moduleName.firstUppercased)", targets: ["\(moduleName.firstUppercased)"]),
       ],
       dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0-alpha.3"),
       ],
       targets: [
         .target(
-          name: "\(moduleName)",
+          name: "\(moduleName.firstUppercased)",
           dependencies: [
             .product(name: "ApolloAPI", package: "apollo-ios"),
           ],

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -94,7 +94,7 @@ extension TemplateString {
   fileprivate func wrappedInNamespace(_ namespace: String) -> Self {
     TemplateString(
     """
-    public extension \(namespace) {
+    public extension \(namespace.firstUppercased) {
       \(self)
     }
     """
@@ -130,7 +130,7 @@ private struct ImportStatementTemplate {
     static func template(forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>) -> TemplateString {
       """
       \(ImportStatementTemplate.template)
-      \(if: shouldImportSchemaModule(config.output), "import \(config.output.schemaTypes.schemaName)")
+      \(if: shouldImportSchemaModule(config.output), "import \(config.output.schemaTypes.schemaName.firstUppercased)")
       """
     }
 

--- a/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -13,7 +13,7 @@ struct UnionTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    public enum \(graphqlUnion.name): UnionType, Equatable {
+    public enum \(graphqlUnion.name.firstUppercased): UnionType, Equatable {
       \(graphqlUnion.types.map({ type in
       "case \(type.name.firstUppercased)(\(type.name.firstUppercased))"
       }), separator: "\n")
@@ -38,7 +38,7 @@ struct UnionTemplate: TemplateRenderer {
 
       public static let possibleTypes: [Object.Type] = [
         \(graphqlUnion.types.map({ type in
-          "\(moduleName).\(type.name.firstUppercased).self"
+          "\(moduleName.firstUppercased).\(type.name.firstUppercased).self"
         }), separator: ",\n")
       ]
     }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/CustomScalarFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/CustomScalarFileGeneratorTests.swift
@@ -27,11 +27,11 @@ class CustomScalarFileGeneratorTests: XCTestCase {
     expect(self.subject.target).to(equal(.customScalar))
   }
 
-  func test__properties__givenGraphQLScalar_shouldReturnFileName_matchingScalarNameFirstUppercased() {
+  func test__properties__givenGraphQLScalar_shouldReturnFileName_matchingScalarName() {
     // given
     buildSubject()
 
-    let expected = "\(graphqlScalar.name.firstUppercased).swift"
+    let expected = "\(graphqlScalar.name).swift"
 
     // then
     expect(self.subject.fileName).to(equal(expected))

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/EnumFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/EnumFileGeneratorTests.swift
@@ -27,7 +27,7 @@ class EnumFileGeneratorTests: XCTestCase {
     expect(self.subject.target).to(equal(.enum))
   }
 
-  func test__properties__givenGraphQLEnum_shouldReturnFileName_matchingEnumNameFirstUppercased() {
+  func test__properties__givenGraphQLEnum_shouldReturnFileName_matchingEnumName() {
     // given
     buildSubject()
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
@@ -55,11 +55,11 @@ class FragmentFileGeneratorTests: XCTestCase {
     expect(self.subject.target).to(equal(expected))
   }
 
-  func test__properties__givenGraphQLFragment_shouldReturnFileName_firstUppercasedFragmentDefinitionName() throws {
+  func test__properties__givenGraphQLFragment_shouldReturnFileName_matchingFragmentDefinitionName() throws {
     // given
     try buildSubject()
 
-    let expected = "\(irFragment.definition.name.firstUppercased).swift"
+    let expected = "\(irFragment.definition.name).swift"
 
     // then
     expect(self.subject.fileName).to(equal(expected))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/CustomScalarTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/CustomScalarTemplateTests.swift
@@ -24,7 +24,7 @@ class CustomScalarTemplateTests: XCTestCase {
   func test__render__givenCustomScalar_shouldGeneratePublicTypealias() throws {
     // given
     subject = CustomScalarTemplate(
-      graphqlScalar: GraphQLScalarType.mock(name: "MyCustomScalar")
+      graphqlScalar: GraphQLScalarType.mock(name: "myCustomScalar")
     )
 
     let expected = """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -14,7 +14,7 @@ class EnumTemplateTests: XCTestCase {
 
   // MARK: Helpers
 
-  private func buildSubject(name: String = "TestEnum", values: [String] = ["ONE", "TWO"]) {
+  private func buildSubject(name: String = "testEnum", values: [String] = ["ONE", "TWO"]) {
     subject = EnumTemplate(
       graphqlEnum: GraphQLEnumType.mock(name: name, values: values)
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -103,16 +103,6 @@ class FragmentTemplateTests: XCTestCase {
     public struct TestFragment: TestSchema.SelectionSet, Fragment {
       public static var fragmentDefinition: StaticString { ""\"
         fragment testFragment on Query {
-          __typename
-          allAnimals {
-            __typename
-            species
-          }
-        }
-        ""\" }
-
-      public let data: DataDict
-      public init(data: DataDict) { self.data = data }
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InterfaceTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InterfaceTemplateTests.swift
@@ -16,7 +16,7 @@ class InterfaceTemplateTests: XCTestCase {
 
   private func buildSubject() {
     subject = InterfaceTemplate(
-      graphqlInterface: GraphQLInterfaceType.mock("MockInterface", fields: [:], interfaces: [])
+      graphqlInterface: GraphQLInterfaceType.mock("mockInterface", fields: [:], interfaces: [])
     )
   }
 
@@ -26,7 +26,7 @@ class InterfaceTemplateTests: XCTestCase {
 
   // MARK: Class Definition Tests
 
-  func test_render_givenSchemaInterface_generatesSwiftClass() throws {
+  func test_render_givenSchemaInterface_generatesSwiftClassCorrectlyCased() throws {
     // given
     buildSubject()
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/ObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/ObjectTemplateTests.swift
@@ -14,7 +14,7 @@ class ObjectTemplateTests: XCTestCase {
 
   // MARK: Helpers
 
-  private func buildSubject(name: String = "Dog", interfaces: [GraphQLInterfaceType] = []) {
+  private func buildSubject(name: String = "dog", interfaces: [GraphQLInterfaceType] = []) {
     subject = ObjectTemplate(
       graphqlObject: GraphQLObjectType.mock(name, interfaces: interfaces)
     )
@@ -39,7 +39,7 @@ class ObjectTemplateTests: XCTestCase {
 
   // MARK: Class Definition Tests
 
-  func test_render_givenSchemaType_generatesSwiftClassDefinition() {
+  func test_render_givenSchemaType_generatesSwiftClassDefinitionCorrectlyCased() {
     // given
     buildSubject()
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -364,4 +364,44 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 
+  func test__generate__givenQueryWithLowercasing_generatesCorrectlyCasedQueryOperation() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query lowercaseOperation($variable: String = "TestVar") {
+      allAnimals {
+        species
+      }
+    }
+    """
+
+    let expected =
+    """
+    public class LowercaseOperationQuery: GraphQLQuery {
+      public let operationName: String = "lowercaseOperation"
+      public let document: DocumentType = .notPersisted(
+        definition: .init(
+          \"\"\"
+          query lowercaseOperation($variable: String = "TestVar") {
+    """
+
+    // when
+    try buildSubjectAndOperation(named: "lowercaseOperation")
+
+    let actual = renderSubject()
+
+//    print(actual)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
@@ -7,14 +7,14 @@ class SchemaModuleNamespaceTemplateTests: XCTestCase {
 
   // MARK: Definition Tests
 
-  func test__boilerplate__generatesPublicEnum() throws {
+  func test__boilerplate__generatesPublicEnumCorectlyCased() throws {
     // given
     let expected = """
     public enum NamespacedModule { }
     """
 
     // when
-    let subject = SchemaModuleNamespaceTemplate(namespace: "NamespacedModule")
+    let subject = SchemaModuleNamespaceTemplate(namespace: "namespacedModule")
     let actual = subject.template.description
 
     // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaTemplateTests.swift
@@ -14,7 +14,7 @@ class SchemaTemplateTests: XCTestCase {
 
   // MARK: Helpers
 
-  private func buildSubject(name: String = "TestSchema", referencedTypes: IR.Schema.ReferencedTypes = .init([])) {
+  private func buildSubject(name: String = "testSchema", referencedTypes: IR.Schema.ReferencedTypes = .init([])) {
     subject = SchemaTemplate(schema: IR.Schema(name: name, referencedTypes: referencedTypes))
   }
 
@@ -42,7 +42,7 @@ class SchemaTemplateTests: XCTestCase {
 
   // MARK: Protocol Tests
 
-  func test__render__givenSchemaName_generatesSelectionSetProtocol() {
+  func test__render__givenSchemaName_generatesSelectionSetProtocolCorrectlyCased() {
     // given
     buildSubject()
 
@@ -59,7 +59,7 @@ class SchemaTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 3, ignoringExtraLines: true))
   }
 
-  func test__render__givenSchemaName_generatesTypeCaseProtocol() {
+  func test__render__givenSchemaName_generatesTypeCaseProtocolCorrectlyCased() {
     // given
     buildSubject()
 
@@ -93,14 +93,14 @@ class SchemaTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
   }
 
-  func test__render__givenWithReferencedObjects_generatesObjectTypeFunction() {
+  func test__render__givenWithReferencedObjects_generatesObjectTypeFunctionCorrectlyCased() {
     // given
     buildSubject(
-      name: "ObjectSchema",
+      name: "objectSchema",
       referencedTypes: .init([
-        GraphQLObjectType.mock("ObjA"),
-        GraphQLObjectType.mock("ObjB"),
-        GraphQLObjectType.mock("ObjC"),
+        GraphQLObjectType.mock("objA"),
+        GraphQLObjectType.mock("objB"),
+        GraphQLObjectType.mock("objC"),
       ])
     )
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Nimble
 
 class SwiftPackageManagerModuleTemplateTests: XCTestCase {
-  let subject = SwiftPackageManagerModuleTemplate(moduleName: "TestModule")
+  let subject = SwiftPackageManagerModuleTemplate(moduleName: "testModule")
 
   // MARK: Helpers
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -18,7 +18,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
   private func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
-    schemaName: String = "TestSchema",
+    schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput
   ) {
     config = ReferenceWrapped(

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
@@ -18,7 +18,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
 
   private func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
-    schemaName: String = "TestSchema",
+    schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput
   ) {
     config = ReferenceWrapped(

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
@@ -16,14 +16,14 @@ class UnionTemplateTests: XCTestCase {
 
   private func buildSubject() {
     subject = UnionTemplate(
-      moduleName: "ModuleAPI",
+      moduleName: "moduleAPI",
       graphqlUnion: GraphQLUnionType.mock(
-        "ClassroomPet",
+        "classroomPet",
         types: [
-          GraphQLObjectType.mock("Cat"),
-          GraphQLObjectType.mock("Bird"),
-          GraphQLObjectType.mock("Rat"),
-          GraphQLObjectType.mock("PetRock")
+          GraphQLObjectType.mock("cat"),
+          GraphQLObjectType.mock("bird"),
+          GraphQLObjectType.mock("rat"),
+          GraphQLObjectType.mock("petRock")
         ]
       )
     )


### PR DESCRIPTION
This is a follow-on from #2247 to ensure we correctly case all generated Swift types.