### PR TITLE
refactor: Wrap codegen output options in a struct + cleanup options

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -128,7 +128,50 @@ public struct ApolloCodegenConfiguration {
     case absolute(path: String)
   }
 
-  // MARK: General Types
+  public struct OutputOptions {
+    /// Any non-default rules for pluralization or singularization you wish to include.
+    public let additionalInflectionRules: [InflectionRule]
+    /// Formatting of the GraphQL query string literal that is included in each
+    /// generated operation object.
+    public let queryStringLiteralFormat: QueryStringLiteralFormat
+    /// How to handle properties using a custom scalar from the schema.
+    public let customScalarFormat: CustomScalarFormat
+    /// How deprecated enum cases from the schema should be handled.
+    public let deprecatedEnumCases: Composition
+    /// Whether schema documentation is added to the generated files.
+    public let schemaDocumentation: Composition
+    /// Whether the generated operations should use Automatic Persisted Queries.
+    ///
+    /// See `APQConfig` for more information on Automatic Persisted Queries.
+    public let apqs: APQConfig
+
+    /// Designated initializer.
+    ///
+    /// - Parameters:
+    ///  - additionalInflectionRules: Any non-default rules for pluralization or singularization
+    ///  you wish to include.
+    ///  - queryStringLiteralFormat: Formatting of the GraphQL query string literal that is
+    ///  included in each generated operation object.
+    ///  - customScalarFormat: How to handle properties using a custom scalar from the schema.
+    ///  - deprecatedEnumCases: How deprecated enum cases from the schema should be handled.
+    ///  - schemaDocumentation: Whether schema documentation is added to the generated files.
+    ///  - apqs: Whether the generated operations should use Automatic Persisted Queries.
+    public init(
+      additionalInflectionRules: [InflectionRule] = [],
+      queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
+      customScalarFormat: CustomScalarFormat = .defaultAsString,
+      deprecatedEnumCases: Composition = .include,
+      schemaDocumentation: Composition = .include,
+      apqs: APQConfig = .disabled
+    ) {
+      self.additionalInflectionRules = additionalInflectionRules
+      self.queryStringLiteralFormat = queryStringLiteralFormat
+      self.customScalarFormat = customScalarFormat
+      self.deprecatedEnumCases = deprecatedEnumCases
+      self.schemaDocumentation = schemaDocumentation
+      self.apqs = apqs
+    }
+  }
 
   /// Specify the formatting of the GraphQL query string literal.
   public enum QueryStringLiteralFormat {
@@ -177,6 +220,8 @@ public struct ApolloCodegenConfiguration {
     case persistedOperationsOnly
   }
 
+  // MARK: Other Types
+
   public struct ExperimentalFeatures {
     /**
      * EXPERIMENTAL: If enabled, the parser will understand and parse Client Controlled Nullability
@@ -210,22 +255,12 @@ public struct ApolloCodegenConfiguration {
   public let input: FileInput
   /// The paths and files output by code generation.
   public let output: FileOutput
-  /// Any non-default rules for pluralization or singularization you wish to include.
-  public let additionalInflectionRules: [InflectionRule]
-  /// Formatting of the GraphQL query string literal that is included in each
-  /// generated operation object.
-  public let queryStringLiteralFormat: QueryStringLiteralFormat
-  /// How to handle properties using a custom scalar from the schema.
-  public let customScalarFormat: CustomScalarFormat
-  /// How deprecated enum cases from the schema should be handled.
-  public let deprecatedEnumCases: Composition
-  /// Whether schema documentation is added to the generated files.
-  public let schemaDocumentation: Composition
-  /// Whether the generated operations should use Automatic Persisted Queries.
+  /// Rules and options to customize the generated code.
+  public let options: OutputOptions
+  /// Allows users to enable experimental features.
   ///
-  /// See `APQConfig` for more information on Automatic Persisted Queries.
-  public let apqs: APQConfig
-  /// Options to pass to the GraphQL parser. Allows users to enable experimental features.
+  /// Note: These features could change at any time and they are not guaranteed to always be
+  /// available.
   public let experimentalFeatures: ExperimentalFeatures
 
   // MARK: Initializers
@@ -235,43 +270,23 @@ public struct ApolloCodegenConfiguration {
   /// - Parameters:
   ///  - input: The input files required for code generation.
   ///  - output: The paths and files output by code generation.
-  ///  - additionalInflectionRules: Any non-default rules for pluralization or singularization you
-  ///  wish to include. Defaults to an empty array.
-  ///  - queryStringLiteralFormat: Formatting of the GraphQL query string literal that is included
-  ///  in each generated operation object. Defaults to `.multiline`.
-  ///  - customScalarFormat: How to handle properties using a custom scalar from the schema. Defaults to `.defaultAsString`.
-  ///  - deprecatedEnumCases: How deprecated enum cases from the schema should be handled. The
-  ///  default of `.include` will cause the generated code to include the deprecated enum cases.
-  ///  - schemaDocumentation: Whether schema documentation is added to the generated files.
-  ///  The default of `.include` will cause the schema documentation comments to be copied over
-  ///  into the generated schema types files.
-  ///  - apqs: Whether the generated operations should use Automatic Persisted Queries.
-  ///  Defaults to `.disabled`.
+  ///  - options: Rules and options to customize the generated code.
+  ///  - experimentalFeatures: Allows users to enable experimental features.
   public init(
     input: FileInput,
     output: FileOutput,
-    additionalInflectionRules: [InflectionRule] = [],
-    queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
-    customScalarFormat: CustomScalarFormat = .defaultAsString,
-    deprecatedEnumCases: Composition = .include,
-    schemaDocumentation: Composition = .include,
-    apqs: APQConfig = .disabled,
+    options: OutputOptions = OutputOptions(),
     experimentalFeatures: ExperimentalFeatures = ExperimentalFeatures()
   ) {
     self.input = input
     self.output = output
-    self.additionalInflectionRules = additionalInflectionRules
-    self.queryStringLiteralFormat = queryStringLiteralFormat
-    self.customScalarFormat = customScalarFormat
-    self.deprecatedEnumCases = deprecatedEnumCases
-    self.schemaDocumentation = schemaDocumentation
-    self.apqs = apqs
+    self.options = options
     self.experimentalFeatures = experimentalFeatures
   }
 
 }
 
-// MARK: Validation Extension
+// MARK: - Validation Extension
 
 extension ApolloCodegenConfiguration {
   public enum PathType {
@@ -380,7 +395,7 @@ extension ApolloCodegenConfiguration {
   }
 }
 
-// MARK: Helpers
+// MARK: - Helpers
 
 extension ApolloCodegenConfiguration.SchemaTypesFileOutput {
   /// Determine whether the schema types files are output to a module.

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -150,7 +150,6 @@ public struct ApolloCodegenConfiguration {
     ///  you wish to include.
     ///  - queryStringLiteralFormat: Formatting of the GraphQL query string literal that is
     ///  included in each generated operation object.
-    ///  - customScalarFormat: How to handle properties using a custom scalar from the schema.
     ///  - deprecatedEnumCases: How deprecated enum cases from the schema should be handled.
     ///  - schemaDocumentation: Whether schema documentation is added to the generated files.
     ///  - apqs: Whether the generated operations should use Automatic Persisted Queries.
@@ -180,16 +179,6 @@ public struct ApolloCodegenConfiguration {
   public enum Composition {
     case include
     case exclude
-  }
-
-  /// Enum to select how to handle properties using a custom scalar from the schema.
-  public enum CustomScalarFormat: Equatable {
-    /// Uses the default type of String.
-    case defaultAsString
-    /// Use your own types for custom scalars. These will be taken from the associated schema.
-    case passthrough
-    /// Use your own types for custom scalars with a prefix.
-    case passthroughWithPrefix(String)
   }
 
   /// Enum to enable using

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -134,8 +134,6 @@ public struct ApolloCodegenConfiguration {
     /// Formatting of the GraphQL query string literal that is included in each
     /// generated operation object.
     public let queryStringLiteralFormat: QueryStringLiteralFormat
-    /// How to handle properties using a custom scalar from the schema.
-    public let customScalarFormat: CustomScalarFormat
     /// How deprecated enum cases from the schema should be handled.
     public let deprecatedEnumCases: Composition
     /// Whether schema documentation is added to the generated files.
@@ -159,14 +157,12 @@ public struct ApolloCodegenConfiguration {
     public init(
       additionalInflectionRules: [InflectionRule] = [],
       queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
-      customScalarFormat: CustomScalarFormat = .defaultAsString,
       deprecatedEnumCases: Composition = .include,
       schemaDocumentation: Composition = .include,
       apqs: APQConfig = .disabled
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
-      self.customScalarFormat = customScalarFormat
       self.deprecatedEnumCases = deprecatedEnumCases
       self.schemaDocumentation = schemaDocumentation
       self.apqs = apqs

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -17,7 +17,11 @@ struct OperationDefinitionTemplate: TemplateRenderer {
     TemplateString(
     """
     \(OperationDeclaration(operation.definition))
-      \(DocumentType.render(operation.definition, fragments: operation.referencedFragments, apq: config.apqs))
+      \(DocumentType.render(
+        operation.definition,
+        fragments: operation.referencedFragments,
+        apq: config.options.apqs)
+      )
 
       \(section: VariableProperties(operation.definition.variables))
 

--- a/Sources/ApolloCodegenTestSupport/MockApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenTestSupport/MockApolloCodegenConfiguration.swift
@@ -4,23 +4,9 @@ extension ApolloCodegenConfiguration {
   public static func mock(
     input: FileInput = .init(schemaPath: "MockSchemaPath", searchPaths: []),
     output: FileOutput = .init(schemaTypes: .init(path: "MockSchemaTypes", schemaName: "MockSchemaTypes")),
-    additionalInflectionRules: [ApolloCodegenLib.InflectionRule] = [],
-    queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
-    customScalarFormat: CustomScalarFormat = .defaultAsString,
-    deprecatedEnumCases: Composition = .include,
-    schemaDocumentation: Composition = .include,
-    apqs: APQConfig = .disabled
+    options: OutputOptions = .init()
   ) -> Self {
-    .init(
-      input: input,
-      output: output,
-      additionalInflectionRules: additionalInflectionRules,
-      queryStringLiteralFormat: queryStringLiteralFormat,
-      customScalarFormat: customScalarFormat,
-      deprecatedEnumCases: deprecatedEnumCases,
-      schemaDocumentation: schemaDocumentation,
-      apqs: apqs
-    )
+    .init(input: input, output: output, options: options)
   }
 
   public static func mock(

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -83,12 +83,12 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     )
 
     // then
-    expect(config.additionalInflectionRules).to(beEmpty())
-    expect(config.queryStringLiteralFormat).to(equal(.multiline))
-    expect(config.customScalarFormat).to(equal(.defaultAsString))
-    expect(config.deprecatedEnumCases).to(equal(.include))
-    expect(config.schemaDocumentation).to(equal(.include))
-    expect(config.apqs).to(equal(.disabled))
+    expect(config.options.additionalInflectionRules).to(beEmpty())
+    expect(config.options.queryStringLiteralFormat).to(equal(.multiline))
+    expect(config.options.customScalarFormat).to(equal(.defaultAsString))
+    expect(config.options.deprecatedEnumCases).to(equal(.include))
+    expect(config.options.schemaDocumentation).to(equal(.include))
+    expect(config.options.apqs).to(equal(.disabled))
   }
 
   // MARK: Validation Tests

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -85,7 +85,6 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     // then
     expect(config.options.additionalInflectionRules).to(beEmpty())
     expect(config.options.queryStringLiteralFormat).to(equal(.multiline))
-    expect(config.options.customScalarFormat).to(equal(.defaultAsString))
     expect(config.options.deprecatedEnumCases).to(equal(.include))
     expect(config.options.schemaDocumentation).to(equal(.include))
     expect(config.options.apqs).to(equal(.disabled))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -26,7 +26,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     OperationDefinitionTemplate.DocumentType.render(
       try XCTUnwrap(definition),
       fragments: referencedFragments ?? [],
-      apq: try XCTUnwrap(config.apqs)
+      apq: try XCTUnwrap(config.options.apqs)
     ).description
   }
 
@@ -38,7 +38,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
       name
     }
     """
-    config = .mock(apqs: .disabled)
+    config = .mock(options: .init(apqs: .disabled))
 
     // when
     let actual = try renderDocumentType()
@@ -71,7 +71,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(apqs: .disabled)
+    config = .mock(options: .init(apqs: .disabled))
 
     // when
     let actual = try renderDocumentType()
@@ -113,7 +113,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(apqs: .disabled)
+    config = .mock(options: .init(apqs: .disabled))
 
     // when
     let actual = try renderDocumentType()
@@ -148,7 +148,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(apqs: .automaticallyPersist)
+    config = .mock(options: .init(apqs: .automaticallyPersist))
 
     // when
     let actual = try renderDocumentType()
@@ -179,7 +179,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(apqs: .persistedOperationsOnly)
+    config = .mock(options: .init(apqs: .persistedOperationsOnly))
 
     // when
     let actual = try renderDocumentType()


### PR DESCRIPTION
PR #1 of #2166:
* Moves the properties that affect the generated code output into another struct; `OutputOptions`. There are now groups for codegen config of:
  * `input`: All input file locations
  * `output`: All output file locations and behaviour
  * `options`: All options that affect the generated code
  * `experimentalFeatures`: All codegen output related to experimental feature sets
* Removed the `customScalarFormat` property because the behaviour of custom scalars is to always be output as a `typealias`'d `String`. The user is then free to modify the generated file and those changes will not be overwritten.