### PR TITLE
fix: Swift build phase documentation (#2256)

### DIFF
--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -189,6 +189,8 @@ This is best achieved with a Run Script Build Phase.
     ```
     # Don't run this during index builds
     if [ $ACTION = "indexbuild" ]; then exit 0; fi
+    # Don't run during SwiftUI previews
+    if [ $ENABLE_PREVIEWS = "YES" ]; then exit 0; fi
 
     cd "${SRCROOT}"/ApolloCodegen
     xcrun -sdk macosx swift run ApolloCodegen generate


### PR DESCRIPTION
Adds an environment variable check in the build phase run script so it doesn't run during SwiftUI Previews. Otherwise Xcode thinks files have been updated and the preview needs to pause.