### PR TITLE
Update build phases example to propagate errors to Xcode

### DIFF
--- a/docs/source/swift-scripting.md
+++ b/docs/source/swift-scripting.md
@@ -192,6 +192,10 @@ This is best achieved with a Run Script Build Phase.
 
     cd "${SRCROOT}"/ApolloCodegen
     xcrun -sdk macosx swift run ApolloCodegen generate
+    
+    # propagate the xcrun call's return code to Xcode
+    exit $? 
+    
     ```
 
     >**Note**: If your package ever seems to have problems with caching, run `swift package clean` before `swift run` for a totally clean build. Do not do this by default, because it substantially increases build time.


### PR DESCRIPTION
Without the explicit propagation I wasn't seeing errors in Xcode.

Build phase shell env: `/bin/sh`
Xcode version: `Version 13.2.1 (13C100)`