### PR TITLE
Add `Codable` support to `ApolloCodegenConfiguration` and `InflectionRule`

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 		E676333427FF857D00D8B953 /* HousePet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E676333327FF857D00D8B953 /* HousePet.swift */; };
 		E68D824527A1D8A60040A46F /* ObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC227A1243A0059C021 /* ObjectTemplateTests.swift */; };
 		E68D824727A228A80040A46F /* SchemaModuleFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */; };
+		E6908E55282694630054682B /* ApolloCodegenConfigurationCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6908E54282694630054682B /* ApolloCodegenConfigurationCodableTests.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
 		E6A6866427F63AEF008A1D13 /* FileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A6866327F63AEF008A1D13 /* FileGeneratorTests.swift */; };
@@ -1301,6 +1302,7 @@
 		E676333127FF856700D8B953 /* Dog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dog.swift; sourceTree = "<group>"; };
 		E676333327FF857D00D8B953 /* HousePet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HousePet.swift; sourceTree = "<group>"; };
 		E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaModuleFileGenerator.swift; sourceTree = "<group>"; };
+		E6908E54282694630054682B /* ApolloCodegenConfigurationCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenConfigurationCodableTests.swift; sourceTree = "<group>"; };
 		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
 		E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplateTests.swift; sourceTree = "<group>"; };
 		E6A6866327F63AEF008A1D13 /* FileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileGeneratorTests.swift; sourceTree = "<group>"; };
@@ -1792,6 +1794,7 @@
 				9BAEEC16234C275600808306 /* ApolloSchemaPublicTests.swift */,
 				E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */,
 				9BAEEC18234C297800808306 /* ApolloCodegenConfigurationTests.swift */,
+				E6908E54282694630054682B /* ApolloCodegenConfigurationCodableTests.swift */,
 				9BAEEC0D234BB95B00808306 /* FileManagerExtensionsTests.swift */,
 				9B4751AC2575B5070001FB87 /* PluralizerTests.swift */,
 				9B8C3FB4248DA3E000707B13 /* URLExtensionsTests.swift */,
@@ -3785,6 +3788,7 @@
 				E64F7EBA27A085D90059C021 /* UnionTemplateTests.swift in Sources */,
 				E610D8D9278EA2560023E495 /* EnumFileGeneratorTests.swift in Sources */,
 				9FDE0731258F3AA100DC0CA5 /* SchemaLoadingTests.swift in Sources */,
+				E6908E55282694630054682B /* ApolloCodegenConfigurationCodableTests.swift in Sources */,
 				DE223C3327221144004A0148 /* IRMatchers.swift in Sources */,
 				E64F7EBF27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift in Sources */,
 				DE79642F2769A1EB00978A03 /* IROperationBuilderTests.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// A configuration object that defines behavior for code generation.
-public struct ApolloCodegenConfiguration {
+public struct ApolloCodegenConfiguration: Codable, Equatable {
 
   // MARK: Input Types
 
   /// The input paths and files required for code generation.
-  public struct FileInput {
+  public struct FileInput: Codable, Equatable {
     /// Local path to the GraphQL schema file. Can be in JSON or SDL format.
     public let schemaPath: String
     /// An array of path matching pattern strings used to find files, such as GraphQL operations
@@ -44,7 +44,7 @@ public struct ApolloCodegenConfiguration {
   // MARK: Output Types
 
   /// The paths and files output by code generation.
-  public struct FileOutput {
+  public struct FileOutput: Codable, Equatable {
     /// The local path structure for the generated schema types files.
     public let schemaTypes: SchemaTypesFileOutput
     /// The local path structure for the generated operation object files.
@@ -80,7 +80,7 @@ public struct ApolloCodegenConfiguration {
   }
 
   /// The local path structure for the generated schema types files.
-  public struct SchemaTypesFileOutput {
+  public struct SchemaTypesFileOutput: Codable, Equatable {
     /// Local path where the generated schema types files should be stored.
     public let path: String
     /// Automation to ease the integration of the generated schema types file with compatible
@@ -101,7 +101,7 @@ public struct ApolloCodegenConfiguration {
     }
 
     /// Compatible dependency manager automation.
-    public enum ModuleType: Equatable {
+    public enum ModuleType: Codable, Equatable {
       /// Generated schema types will be manually embedded in a target with the specified `name`.
       /// No module will be created for the generated schema types.
       ///
@@ -125,7 +125,7 @@ public struct ApolloCodegenConfiguration {
   }
 
   /// The local path structure for the generated operation object files.
-  public enum OperationsFileOutput: Equatable {
+  public enum OperationsFileOutput: Codable, Equatable {
     /// All operation object files will be located in the module with the schema types.
     case inSchemaModule
     /// Operation object files will be co-located relative to the defining operation `.graphql`
@@ -138,7 +138,7 @@ public struct ApolloCodegenConfiguration {
   }
 
   /// The local path structure for the generated test mock object files.
-  public enum TestMockFileOutput: Equatable {
+  public enum TestMockFileOutput: Codable, Equatable {
     /// Test mocks will not be generated. This is the default value.
     case none
     /// Generated test mock files will be located in the specified path.
@@ -162,7 +162,7 @@ public struct ApolloCodegenConfiguration {
   }
 
   // MARK: - Output Options
-  public struct OutputOptions {
+  public struct OutputOptions: Codable, Equatable {
     /// Any non-default rules for pluralization or singularization you wish to include.
     public let additionalInflectionRules: [InflectionRule]
     /// Formatting of the GraphQL query string literal that is included in each
@@ -203,14 +203,15 @@ public struct ApolloCodegenConfiguration {
   }
 
   /// Specify the formatting of the GraphQL query string literal.
-  public enum QueryStringLiteralFormat {
+  public enum QueryStringLiteralFormat: String, Codable, Equatable {
     /// The query string will be copied into the operation object with all line break formatting removed.
     case singleLine
     /// The query string will be copied with original formatting into the operation object.
     case multiline
   }
 
-  public enum Composition {
+  #warning("Needs documentation!")
+  public enum Composition: String, Codable, Equatable {
     case include
     case exclude
   }
@@ -221,7 +222,7 @@ public struct ApolloCodegenConfiguration {
   ///
   /// APQs are an Apollo Server feature. When using Apollo iOS to connect to any other GraphQL server,
   /// `APQConfig` should be set to `.disabled`
-  public enum APQConfig {
+  public enum APQConfig: String, Codable, Equatable {
     /// The default value. Disables APQs.
     /// The operation document is sent to the server with each operation request.
     case disabled
@@ -241,7 +242,7 @@ public struct ApolloCodegenConfiguration {
 
   // MARK: - Other Types
 
-  public struct ExperimentalFeatures {
+  public struct ExperimentalFeatures: Codable, Equatable {
     /**
      * EXPERIMENTAL: If enabled, the parser will understand and parse Client Controlled Nullability
      * Designators contained in Fields. They'll be represented in the

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -210,7 +210,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     case multiline
   }
 
-  #warning("Needs documentation!")
+  /// Composition is used as a substitute for a boolean where context is better placed in the value
+  /// instead of the parameter name, e.g.: `includeDeprecatedEnumCases = true` vs.
+  /// `deprecatedEnumCases = .include`.
   public enum Composition: String, Codable, Equatable {
     case include
     case exclude

--- a/Sources/ApolloCodegenLib/Pluralizer.swift
+++ b/Sources/ApolloCodegenLib/Pluralizer.swift
@@ -2,7 +2,7 @@ import Foundation
 import InflectorKit
 
 /// The types of inflection rules that can be used to customize pluralization. 
-public enum InflectionRule {
+public enum InflectionRule: Codable, Equatable {
 
   /// A pluralization rule that allows taking a singular word and pluralizing it.
   /// - singularRegex: A regular expression representing the single version of the word

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -1,0 +1,291 @@
+import XCTest
+import Nimble
+import ApolloCodegenLib
+
+class ApolloCodegenConfigurationCodableTests: XCTestCase {
+
+  // MARK: - ApolloCodegenConfiguration Tests
+
+  enum MockApolloCodegenConfiguration {
+    static var decoded: ApolloCodegenConfiguration {
+      .init(
+        schemaName: "SerializedSchema",
+        input: .init(
+          schemaPath: "/path/to/schema.graphqls",
+          searchPaths: [
+            "/search/path/**/*.graphql"
+          ]
+        ),
+        output: .init(
+          schemaTypes: .init(
+            path: "/output/path",
+            moduleType: .swiftPackageManager
+          ),
+          operations: .relative(subpath: "/relative/subpath"),
+          testMocks: .swiftPackage(targetName: "SchemaTestMocks"),
+          operationIdentifiersPath: nil
+        ),
+        options: .init(
+          additionalInflectionRules: [
+            .pluralization(singularRegex: "animal", replacementRegex: "animals")
+          ],
+          queryStringLiteralFormat: .multiline,
+          deprecatedEnumCases: .exclude,
+          schemaDocumentation: .include,
+          apqs: .disabled
+        ),
+        experimentalFeatures: .init(
+          clientControlledNullability: true
+        )
+      )
+    }
+
+    static var encoded: String {
+      "{\"schemaName\":\"SerializedSchema\",\"options\":{\"schemaDocumentation\":\"include\",\"deprecatedEnumCases\":\"exclude\",\"apqs\":\"disabled\",\"additionalInflectionRules\":[{\"pluralization\":{\"singularRegex\":\"animal\",\"replacementRegex\":\"animals\"}}],\"queryStringLiteralFormat\":\"multiline\"},\"input\":{\"searchPaths\":[\"\\/search\\/path\\/**\\/*.graphql\"],\"schemaPath\":\"\\/path\\/to\\/schema.graphqls\"},\"output\":{\"testMocks\":{\"swiftPackage\":{\"targetName\":\"SchemaTestMocks\"}},\"schemaTypes\":{\"path\":\"\\/output\\/path\",\"moduleType\":{\"swiftPackageManager\":{}}},\"operations\":{\"relative\":{\"subpath\":\"\\/relative\\/subpath\"}}},\"experimentalFeatures\":{\"clientControlledNullability\":true}}"
+    }
+  }
+
+  func test__encodeApolloCodegenConfiguration__givenAllParameters_shouldReturnJSON() throws {
+    // given
+    let subject = MockApolloCodegenConfiguration.decoded
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(MockApolloCodegenConfiguration.encoded))
+  }
+
+  func test__decodeApolloCodegenConfiguration__givenAllParameters_shouldReturnStruct() throws {
+    // given
+    let subject = MockApolloCodegenConfiguration.encoded.asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
+
+    // then
+    expect(actual).to(equal(MockApolloCodegenConfiguration.decoded))
+  }
+
+  // MARK: - QueryStringLiteralFormat Tests
+
+  func encodedValue(_ case: ApolloCodegenConfiguration.QueryStringLiteralFormat) -> String {
+    switch `case` {
+    case .singleLine: return "\"singleLine\""
+    case .multiline: return "\"multiline\""
+    }
+  }
+
+  func test__encodeQueryStringLiteralFormat__givenSingleLine_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.QueryStringLiteralFormat.singleLine
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.singleLine)))
+  }
+
+  func test__encodeQueryStringLiteralFormat__givenMultiline_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.QueryStringLiteralFormat.multiline
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.multiline)))
+  }
+
+  func test__decodeQueryStringLiteralFormat__givenSingleLine_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.singleLine).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.QueryStringLiteralFormat.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.singleLine))
+  }
+
+  func test__decodeQueryStringLiteralFormat__givenMultiline_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.multiline).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.QueryStringLiteralFormat.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.multiline))
+  }
+
+  func test__decodeQueryStringLiteralFormat__givenUnknown_shouldReturnEnum() throws {
+    // given
+    let subject = "\"unknown\"".asData
+
+    // then
+    expect(
+      try JSONDecoder().decode(ApolloCodegenConfiguration.QueryStringLiteralFormat.self, from: subject)
+    ).to(throwError())
+  }
+
+  // MARK: - Composition Tests
+
+  func encodedValue(_ case: ApolloCodegenConfiguration.Composition) -> String {
+    switch `case` {
+    case .include: return "\"include\""
+    case .exclude: return "\"exclude\""
+    }
+  }
+
+  func test__encodeComposition__givenInclude_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.Composition.include
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.include)))
+  }
+
+  func test__encodeComposition__givenExclude_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.Composition.exclude
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.exclude)))
+  }
+
+  func test__decodeComposition__givenInclude_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.include).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.Composition.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.include))
+  }
+
+  func test__decodeComposition__givenExclude_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.exclude).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.Composition.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.exclude))
+  }
+
+  func test__decodeComposition__givenUnknown_shouldReturnEnum() throws {
+    // given
+    let subject = "\"unknown\"".asData
+
+    // then
+    expect(
+      try JSONDecoder().decode(ApolloCodegenConfiguration.Composition.self, from: subject)
+    ).to(throwError())
+  }
+
+  // MARK: - APQConfig Tests
+
+  func encodedValue(_ case: ApolloCodegenConfiguration.APQConfig) -> String {
+    switch `case` {
+    case .disabled: return "\"disabled\""
+    case .automaticallyPersist: return "\"automaticallyPersist\""
+    case .persistedOperationsOnly: return "\"persistedOperationsOnly\""
+    }
+  }
+
+  func test__encodeAPQConfig__givenDisabled_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.APQConfig.disabled
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.disabled)))
+  }
+
+  func test__encodeAPQConfig__givenAutomaticallyPersist_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.APQConfig.automaticallyPersist
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.automaticallyPersist)))
+  }
+
+  func test__encodeAPQConfig__givenPersistedOperationsOnly_shouldReturnString() throws {
+    // given
+    let subject = ApolloCodegenConfiguration.APQConfig.persistedOperationsOnly
+
+    // when
+    let actual = try JSONEncoder().encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.persistedOperationsOnly)))
+  }
+
+  func test__decodeAPQConfig__givenDisabled_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.disabled).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.APQConfig.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.disabled))
+  }
+
+  func test__decodeAPQConfig__givenAutomaticallyPersist_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.automaticallyPersist).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.APQConfig.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.automaticallyPersist))
+  }
+
+  func test__decodeAPQConfig__givenPersistedOperationsOnly_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.persistedOperationsOnly).asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.APQConfig.self, from: subject)
+
+    // then
+    expect(actual).to(equal(.persistedOperationsOnly))
+  }
+
+  func test__decodeAPQConfig__givenUnknown_shouldReturnEnum() throws {
+    // given
+    let subject = "\"unknown\"".asData
+
+    // then
+    expect(
+      try JSONDecoder().decode(ApolloCodegenConfiguration.APQConfig.self, from: subject)
+    ).to(throwError())
+  }
+}
+
+// MARK: - Test Helpers
+
+fileprivate extension String {
+  var asData: Data { self.data(using: .utf8)! }
+}
+
+fileprivate extension Data {
+  var asString: String { String(data: self, encoding: .utf8)! }
+}


### PR DESCRIPTION
This work modifies `ApolloCodegenConfiguration` and `InflectionRule` to conform to `Codable` and changed a couple of the enums to use a raw type of `String`, so they are serialized as strings instead of JSON objects themselves; see `QueryStringLiteralFormat` as an example.

The added tests are limited to only the enums that were specifically changed to be serialized differently, e.g.: `QueryStringLiteralFormat` was given a raw type of `String` so that it is serialized as a string and not an embedded JSON object.