### PR TITLE
Make SelectionSet Hashable with JSON conversion to AnyHashable

### DIFF
--- a/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -10,7 +10,7 @@ final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLRes
          let .customScalar(decodable as JSONDecodable.Type):
       // This will convert a JSON value to the expected value type,
       // which could be a custom scalar or an enum.
-      return try decodable.init(jsonValue: scalar)
+      return try (decodable.init(jsonValue: scalar) as! JSONValue)
     default:
       preconditionFailure()
     }

--- a/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -10,7 +10,7 @@ final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLRes
          let .customScalar(decodable as JSONDecodable.Type):
       // This will convert a JSON value to the expected value type,
       // which could be a custom scalar or an enum.
-      return try (decodable.init(jsonValue: scalar) as! JSONValue)
+      return try (decodable.init(jsonValue: scalar) as! JSONValue?)
     default:
       preconditionFailure()
     }

--- a/Sources/Apollo/InputValue+Evaluation.swift
+++ b/Sources/Apollo/InputValue+Evaluation.swift
@@ -41,7 +41,7 @@ extension InputValue {
       return value.jsonEncodableValue?.jsonValue
 
     case let .scalar(value):
-      return value
+      return value.jsonValue
 
     case let .list(array):
       return try InputValue.evaluate(array, with: variables)

--- a/Sources/Apollo/InputValue+Evaluation.swift
+++ b/Sources/Apollo/InputValue+Evaluation.swift
@@ -22,10 +22,12 @@ extension Selection.Field {
         return "[\($0.key):\(orderIndependentKey(for: object))]"
       case let array as [JSONObject]:
         return "\($0.key):[\(array.map { orderIndependentKey(for: $0) }.joined(separator: ","))]"
+      case let array as [AnyHashable]:
+        return "\($0.key):[\(array.map { String(describing: $0.base) }.joined(separator: ", "))]"
       case is NSNull:
         return "\($0.key):null"
       default:
-        return "\($0.key):\($0.value)"
+        return "\($0.key):\($0.value.base)"
       }
     }.joined(separator: ",")
   }

--- a/Sources/Apollo/InputValue+Evaluation.swift
+++ b/Sources/Apollo/InputValue+Evaluation.swift
@@ -22,7 +22,7 @@ extension Selection.Field {
         return "[\($0.key):\(orderIndependentKey(for: object))]"
       case let array as [JSONObject]:
         return "\($0.key):[\(array.map { orderIndependentKey(for: $0) }.joined(separator: ","))]"
-      case let array as [AnyHashable]:
+      case let array as [JSONValue]:
         return "\($0.key):[\(array.map { String(describing: $0.base) }.joined(separator: ", "))]"
       case is NSNull:
         return "\($0.key):null"

--- a/Sources/Apollo/JSONSerializationFormat.swift
+++ b/Sources/Apollo/JSONSerializationFormat.swift
@@ -3,7 +3,7 @@ import Foundation
 import ApolloAPI
 #endif
 
-public typealias JSONValue = Any
+public typealias JSONValue = AnyHashable
 public typealias JSONObject = [String: JSONValue]
 
 public final class JSONSerializationFormat {
@@ -16,6 +16,6 @@ public final class JSONSerializationFormat {
   }
 
   public class func deserialize(data: Data) throws -> JSONValue {
-    return try JSONSerialization.jsonObject(with: data, options: [])
+    return try JSONSerialization.jsonObject(with: data, options: []) as! AnyHashable
   }
 }

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol NormalizedCache {
+public protocol NormalizedCache: AnyObject {
   
   /// Loads records corresponding to the given keys.
   ///

--- a/Sources/Apollo/Record.swift
+++ b/Sources/Apollo/Record.swift
@@ -5,7 +5,7 @@ public typealias CacheKey = String
 public struct Record {
   public let key: CacheKey
 
-  public typealias Value = Any
+  public typealias Value = AnyHashable
   public typealias Fields = [CacheKey: Value]
   public private(set) var fields: Fields
 

--- a/Sources/Apollo/RecordSet.swift
+++ b/Sources/Apollo/RecordSet.swift
@@ -1,7 +1,3 @@
-#if !COCOAPODS
-import struct ApolloAPI.JSONValueMatcher
-#endif
-
 /// A set of cache records.
 public struct RecordSet {
   public private(set) var storage: [CacheKey: Record] = [:]
@@ -63,7 +59,7 @@ public struct RecordSet {
       var changedKeys: Set<CacheKey> = Set()
 
       for (key, value) in record.fields {
-        if let oldValue = oldRecord.fields[key], JSONValueMatcher.equals(oldValue, value) {
+        if let oldValue = oldRecord.fields[key], oldValue == value {
           continue
         }
         oldRecord[key] = value

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -43,6 +43,6 @@ public struct DataDict: Hashable {
 
   public static func == (lhs: DataDict, rhs: DataDict) -> Bool {
     lhs._data == rhs._data &&
-    lhs._variables?.jsonEncodableValue.jsonValue == rhs._variables?.jsonEncodableValue.jsonValue
+    lhs._variables?.jsonEncodableValue?.jsonValue == rhs._variables?.jsonEncodableValue?.jsonValue
   }
 }

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -1,5 +1,10 @@
 /// A structure that wraps the underlying data dictionary used by `SelectionSet`s.
 public struct DataDict {
+//  public static func == (lhs: DataDict, rhs: DataDict) -> Bool {
+//    lhs._data == rhs._data &&
+//    lhs._variables.jsonValue == rhs._variables.jsonValue
+//  }
+
 
   public let _data: JSONObject
   public let _variables: GraphQLOperation.Variables?

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -1,10 +1,5 @@
 /// A structure that wraps the underlying data dictionary used by `SelectionSet`s.
-public struct DataDict {
-//  public static func == (lhs: DataDict, rhs: DataDict) -> Bool {
-//    lhs._data == rhs._data &&
-//    lhs._variables.jsonValue == rhs._variables.jsonValue
-//  }
-
+public struct DataDict: Hashable {
 
   public let _data: JSONObject
   public let _variables: GraphQLOperation.Variables?
@@ -39,5 +34,15 @@ public struct DataDict {
   @inlinable public subscript<T: AnySelectionSet>(_ key: String) -> [T]? {
     guard let objectData = _data[key] as? [JSONObject] else { return nil }
     return objectData.map { T.init(data: DataDict($0, variables: _variables)) }
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_data)
+    hasher.combine(_variables?.jsonEncodableValue?.jsonValue)
+  }
+
+  public static func == (lhs: DataDict, rhs: DataDict) -> Bool {
+    lhs._data == rhs._data &&
+    lhs._variables?.jsonEncodableValue.jsonValue == rhs._variables?.jsonEncodableValue.jsonValue
   }
 }

--- a/Sources/ApolloAPI/GraphQLEnum.swift
+++ b/Sources/ApolloAPI/GraphQLEnum.swift
@@ -69,7 +69,7 @@ extension GraphQLEnum: CustomScalarType {
     self.init(rawValue: stringData)
   }
 
-  @inlinable public var jsonValue: Any { rawValue }
+  @inlinable public var jsonValue: AnyHashable { rawValue }
 }
 
 // MARK: Equatable

--- a/Sources/ApolloAPI/GraphQLEnum.swift
+++ b/Sources/ApolloAPI/GraphQLEnum.swift
@@ -12,7 +12,7 @@ where RawValue == String {}
 /// `GraphQLEnum` provides an `__unknown` case that is used when the response returns a value that
 /// is not recognized as a valid enum case. This is usually caused by future cases added to the enum
 /// on the schema after code generation.
-public enum GraphQLEnum<T: EnumType>: CaseIterable, Equatable, RawRepresentable {
+public enum GraphQLEnum<T: EnumType>: CaseIterable, Hashable, RawRepresentable {
   public typealias RawValue = String
 
   /// A recognized case of the wrapped enum.

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -99,17 +99,17 @@ public extension GraphQLOperation {
 
 public protocol GraphQLQuery: GraphQLOperation {}
 public extension GraphQLQuery {
-  var operationType: GraphQLOperationType { return .query }
+  @inlinable var operationType: GraphQLOperationType { return .query }
 }
 
 public protocol GraphQLMutation: GraphQLOperation {}
 public extension GraphQLMutation {
-  var operationType: GraphQLOperationType { return .mutation }
+  @inlinable var operationType: GraphQLOperationType { return .mutation }
 }
 
 public protocol GraphQLSubscription: GraphQLOperation {}
 public extension GraphQLSubscription {
-  var operationType: GraphQLOperationType { return .subscription }
+  @inlinable var operationType: GraphQLOperationType { return .subscription }
 }
 
 // MARK: - GraphQLOperationVariableValue
@@ -121,14 +121,14 @@ public protocol GraphQLOperationVariableValue {
 extension Array: GraphQLOperationVariableValue where Element: GraphQLOperationVariableValue {}
 
 extension Dictionary: GraphQLOperationVariableValue where Key == String, Value == GraphQLOperationVariableValue {
-  public var jsonEncodableValue: JSONEncodable? { jsonEncodableObject }
-  public var jsonEncodableObject: JSONEncodableDictionary {
+  @inlinable public var jsonEncodableValue: JSONEncodable? { jsonEncodableObject }
+  @inlinable public var jsonEncodableObject: JSONEncodableDictionary {
     compactMapValues { $0.jsonEncodableValue }
   }
 }
 
 extension GraphQLNullable: GraphQLOperationVariableValue where Wrapped: GraphQLOperationVariableValue {
-  public var jsonEncodableValue: JSONEncodable? {
+  @inlinable public var jsonEncodableValue: JSONEncodable? {
     switch self {
     case .none: return nil
     case .null: return NSNull()
@@ -138,7 +138,7 @@ extension GraphQLNullable: GraphQLOperationVariableValue where Wrapped: GraphQLO
 }
 
 extension Optional: GraphQLOperationVariableValue where Wrapped: GraphQLOperationVariableValue {
-  public var jsonEncodableValue: JSONEncodable? {
+  @inlinable public var jsonEncodableValue: JSONEncodable? {
     switch self {
     case .none: return nil    
     case let .some(value): return value.jsonEncodableValue
@@ -147,5 +147,5 @@ extension Optional: GraphQLOperationVariableValue where Wrapped: GraphQLOperatio
 }
 
 extension JSONEncodable where Self: GraphQLOperationVariableValue {
-  public var jsonEncodableValue: JSONEncodable? { self }
+  @inlinable public var jsonEncodableValue: JSONEncodable? { self }
 }

--- a/Sources/ApolloAPI/JSON.swift
+++ b/Sources/ApolloAPI/JSON.swift
@@ -11,22 +11,3 @@ public protocol JSONDecodable {
 public protocol JSONEncodable {
   var jsonValue: JSONValue { get }
 }
-
-// MARK: Helpers
-
-public struct JSONValueMatcher {
-
-  public static func equals(_ lhs: Any, _ rhs: Any) -> Bool {
-    if let lhs = lhs as? CacheReference, let rhs = rhs as? CacheReference {
-      return lhs == rhs
-    }
-
-    if let lhs = lhs as? Array<CacheReference>, let rhs = rhs as? Array<CacheReference> {
-      return lhs == rhs
-    }
-
-    let lhs = lhs as AnyObject, rhs = rhs as AnyObject
-    return lhs.isEqual(rhs)
-  }
-
-}

--- a/Sources/ApolloAPI/JSON.swift
+++ b/Sources/ApolloAPI/JSON.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public typealias JSONValue = Any
+public typealias JSONValue = AnyHashable
 public typealias JSONObject = [String: JSONValue]
 public typealias JSONEncodableDictionary = [String: JSONEncodable]
 

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -100,17 +100,11 @@ extension Optional where Wrapped: JSONDecodable {
   }
 }
 
-// Once [conditional conformances](https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md) have been implemented, we should be able to replace these runtime type checks with proper static typing
-
-extension Optional: JSONEncodable {
+extension Optional: JSONEncodable where Wrapped: JSONEncodable {
   @inlinable public var jsonValue: JSONValue {
     switch self {
-    case .none:
-      return NSNull()
-    case .some(let wrapped as JSONEncodable):
-      return wrapped.jsonValue
-    default:
-      fatalError("Optional is only JSONEncodable if Wrapped is")
+    case .none: return NSNull()
+    case let .some(value): return value.jsonValue
     }
   }
 }
@@ -130,6 +124,8 @@ extension JSONEncodableDictionary: JSONEncodable {
     mapValues(\.jsonValue)
   }
 }
+
+// Once [conditional conformances](https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md) have been implemented, we should be able to replace these runtime type checks with proper static typing
 
 extension Dictionary: JSONDecodable {
   @inlinable public init(jsonValue value: JSONValue) throws {

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension String: JSONDecodable, JSONEncodable {
   @inlinable public init(jsonValue value: JSONValue) throws {
-    switch value {
+    switch value.base {
     case let string as String:
         self = string
     case let int as Int:

--- a/Sources/ApolloAPI/ScalarTypes.swift
+++ b/Sources/ApolloAPI/ScalarTypes.swift
@@ -17,7 +17,7 @@ public protocol CustomScalarType:
   OutputTypeConvertible,
   GraphQLOperationVariableValue
 {
-  var jsonValue: Any { get }
+  var jsonValue: AnyHashable { get }
 }
 
 extension CustomScalarType {

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -49,7 +49,7 @@ public protocol RootSelectionSet: AnySelectionSet, OutputTypeConvertible { }
 public protocol InlineFragment: AnySelectionSet { }
 
 // MARK: - SelectionSet
-public protocol SelectionSet: AnySelectionSet {
+public protocol SelectionSet: AnySelectionSet, Hashable {
   associatedtype Schema: SchemaConfiguration
 
   /// A type representing all of the fragments the `SelectionSet` can be converted to.
@@ -99,6 +99,14 @@ extension SelectionSet {
     if condition: Selection.Condition
   ) -> T? where T.Schema == Schema {
     _asInlineFragment(if: Selection.Conditions(condition))
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(data)
+  }
+
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs.data == rhs.data
   }
 }
 

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -105,7 +105,7 @@ extension SelectionSet {
     hasher.combine(data)
   }
 
-  static func ==(lhs: Self, rhs: Self) -> Bool {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
     return lhs.data == rhs.data
   }
 }

--- a/Tests/ApolloInternalTestHelpers/MockApolloStore.swift
+++ b/Tests/ApolloInternalTestHelpers/MockApolloStore.swift
@@ -11,7 +11,7 @@ extension ApolloStore {
 
 /// A `NormalizedCache` that does not cache any data. Used for tests that don't require testing
 /// caching behavior.
-public struct NoCache: NormalizedCache {
+public class NoCache: NormalizedCache {
 
   public init() { }
 

--- a/Tests/ApolloTests/Cache/FetchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/FetchQueryTests.swift
@@ -409,7 +409,7 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
     queue.setSpecific(key: key, value: ())
     
     let query = MockQuery.mock()
-    
+
     let serverRequestExpectation = server.expect(MockQuery<MockSelectionSet>.self) { request in
       ["data": [:]]
     }

--- a/Tests/ApolloTests/CacheKeyForFieldTests.swift
+++ b/Tests/ApolloTests/CacheKeyForFieldTests.swift
@@ -63,13 +63,15 @@ class CacheKeyForFieldTests: XCTestCase {
   }
   
   func testFieldWithDictionaryArgument() throws {
-    let field = Selection.Field("hero", type: .scalar(String.self), arguments: ["nested": ["foo": 1, "bar": 2]])
+    let field = Selection.Field("hero",
+                                type: .scalar(String.self),
+                                arguments: ["nested": ["foo": 1, "bar": "2"]])
     XCTAssertEqual(field.test_cacheKey, "hero([nested:bar:2,foo:1])")
   }
   
   func testFieldWithDictionaryArgumentWithVariables() throws {
     let field = Selection.Field("hero", type: .scalar(String.self), arguments: ["nested": ["foo": InputValue.variable("a"), "bar": InputValue.variable("b")]])
-    let variables = ["a": 1, "b": 2]
+    let variables: GraphQLOperation.Variables = ["a": 1, "b": "2"]
     XCTAssertEqual(try field.cacheKey(with: variables), "hero([nested:bar:2,foo:1])")
   }
   

--- a/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
@@ -148,8 +148,8 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
           ]}
         }
       }
-    }
-    
+    }    
+
     let object: JSONObject = [
       "hero": [
         "__typename": "Droid",

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -64,7 +64,7 @@ class JSONTests: XCTestCase {
     let json = try JSONSerializationFormat.deserialize(data: data)
     XCTAssertNotNil(json)
     
-    let dict = try Dictionary<String, Any>(jsonValue: json)
+    let dict = try Dictionary<String, AnyHashable>(jsonValue: json)
     XCTAssertNotNil(dict)
     
     let reserialized = try JSONSerializationFormat.serialize(value: dict)

--- a/Tests/ApolloTests/JSONValueMatcher.swift
+++ b/Tests/ApolloTests/JSONValueMatcher.swift
@@ -2,29 +2,12 @@ import Nimble
 import Apollo
 import ApolloAPI
 
-public func equalJSONValue(_ expectedValue: Any?) -> Predicate<Any> {
-  return Predicate { actual in
-    let msg = ExpectationMessage.expectedActualValueTo("equal <\(stringify(expectedValue))>")
-    if let actualValue = try actual.evaluate(), let expectedValue = expectedValue {
-        return PredicateResult(
-          bool: JSONValueMatcher.equals(actualValue, expectedValue),
-          message: msg
-        )
-    } else {
-      return PredicateResult(
-        status: .fail,
-        message: msg.appendedBeNilHint()
-      )
-    }
-  }
-}
-
 public func equalJSONValue(_ expectedValue: JSONEncodable?) -> Predicate<JSONEncodable> {
   return Predicate { actual in
     let msg = ExpectationMessage.expectedActualValueTo("equal <\(stringify(expectedValue))>")
     if let actualValue = try actual.evaluate(), let expectedValue = expectedValue {
         return PredicateResult(
-          bool: JSONValueMatcher.equals(actualValue.jsonValue, expectedValue.jsonValue),
+          bool: actualValue.jsonValue == expectedValue.jsonValue,
           message: msg
         )
     } else {
@@ -36,19 +19,14 @@ public func equalJSONValue(_ expectedValue: JSONEncodable?) -> Predicate<JSONEnc
   }
 }
 
-public func equal(_ expectedValue: JSONEncodableDictionary?) -> Predicate<JSONEncodableDictionary> {
-  return Predicate { actual in
-    let msg = ExpectationMessage.expectedActualValueTo("equal <\(stringify(expectedValue))>")
-    if let actualValue = try actual.evaluate(), let expectedValue = expectedValue {
-        return PredicateResult(
-          bool: JSONValueMatcher.equals(actualValue.jsonValue, expectedValue.jsonValue),
-          message: msg
-        )
-    } else {
-      return PredicateResult(
-        status: .fail,
-        message: msg.appendedBeNilHint()
-      )
-    }
+extension AnyHashable: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (AnyHashable, AnyHashable)...) {
+    self.init(Dictionary(elements))
+  }
+}
+
+extension AnyHashable: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: AnyHashable...) {
+    self.init(elements)
   }
 }


### PR DESCRIPTION
Fixes #1956 

By making `JSONValue == AnyHashable` instead of `Any`, we can add `Hashable` and `Equatable` conformance to all `SelectionSet` objects, having them just match their `DataDict`s.