### PR TITLE
refactor: ApolloSchemaDownloadConfiguration

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
@@ -24,23 +24,22 @@ public struct ApolloSchemaDownloadConfiguration {
       /// - Parameters:
       ///   - apiKey: The API key to use when retrieving your schema.
       ///   - graphID: The identifier of the graph to fetch. Can be found in Apollo Studio.
-      ///   - variant: The variant of the graph to fetch. Defaults to "current", which will return whatever is set to the current variant.
-      public init(apiKey: String,
-                  graphID: String,
-                  variant: String = "current") {
+      ///   - variant: The variant of the graph to fetch. Defaults to "current", which will return
+      ///   whatever is set to the current variant.
+      public init(apiKey: String, graphID: String, variant: String = "current") {
         self.apiKey = apiKey
         self.graphID = graphID
         self.variant = variant
       }
     }
 
-    /// The HTTP request method. This is an option on Introspection schema downloads only. Apollo Registry downloads are always
-    /// POST requests.
+    /// The HTTP request method. This is an option on Introspection schema downloads only.
+    /// Apollo Registry downloads are always POST requests.
     public enum HTTPMethod: Equatable, CustomStringConvertible {
       /// Use POST for HTTP requests. This is the default for GraphQL.
       case POST
-      /// Use GET for HTTP requests with the GraphQL query being sent in the query string parameter named in
-      /// `queryParameterName`.
+      /// Use GET for HTTP requests with the GraphQL query being sent in the query string
+      /// parameter named in `queryParameterName`.
       case GET(queryParameterName: String)
 
       public var description: String {
@@ -55,9 +54,9 @@ public struct ApolloSchemaDownloadConfiguration {
     
     public static func == (lhs: DownloadMethod, rhs: DownloadMethod) -> Bool {
       switch (lhs, rhs) {
-      case (.introspection(let lhsURL, let lhsHTTPMethod), .introspection(let rhsURL, let rhsHTTPMethod)):
+      case let (.introspection(lhsURL, lhsHTTPMethod), .introspection(rhsURL, rhsHTTPMethod)):
         return lhsURL == rhsURL && lhsHTTPMethod == rhsHTTPMethod
-      case (.apolloRegistry(let lhsSettings), .apolloRegistry(let rhsSettings)):
+      case let (.apolloRegistry(lhsSettings), .apolloRegistry(rhsSettings)):
         return lhsSettings == rhsSettings
       default:
         return false
@@ -82,28 +81,31 @@ public struct ApolloSchemaDownloadConfiguration {
 
   /// How to download your schema. Supports the Apollo Registry and GraphQL Introspection methods.
   public let downloadMethod: DownloadMethod
-  /// The maximum time to wait before indicating that the download timed out, in seconds. Defaults to 30 seconds.
+  /// The maximum time (in seconds) to wait before indicating that the download timed out.
+  /// Defaults to 30 seconds.
   public let downloadTimeout: Double
   /// Any additional headers to include when retrieving your schema. Defaults to nil.
   public let headers: [HTTPHeader]
-  /// The URL where the downloaded schema should be written to.
-  public let outputURL: URL
+  /// The local path where the downloaded schema should be written to.
+  public let outputPath: String
 
   /// Designated Initializer
   ///
   /// - Parameters:
   ///   - downloadMethod: How to download your schema.
-  ///   - downloadTimeout: The maximum time to wait before indicating that the download timed out, in seconds. Defaults to 30 seconds.
-  ///   - headers: [optional] Any additional headers to include when retrieving your schema. Defaults to nil
-  ///   - outputURL: The URL where the downloaded schema should be written to.
+  ///   - downloadTimeout: The maximum time (in seconds) to wait before indicating that the
+  ///   download timed out. Defaults to 30 seconds.
+  ///   - headers: [optional] Any additional headers to include when retrieving your schema.
+  ///   Defaults to nil
+  ///   - outputPath: The local path where the downloaded schema should be written to.
   public init(using downloadMethod: DownloadMethod,
               timeout downloadTimeout: Double = 30.0,
               headers: [HTTPHeader] = [],
-              outputURL: URL) {
+              outputPath: String) {
     self.downloadMethod = downloadMethod
     self.downloadTimeout = downloadTimeout
     self.headers = headers
-    self.outputURL = outputURL
+    self.outputPath = outputPath
   }
 }
 
@@ -113,7 +115,7 @@ extension ApolloSchemaDownloadConfiguration: CustomDebugStringConvertible {
       downloadMethod: \(self.downloadMethod)
       downloadTimeout: \(self.downloadTimeout)
       headers: \(self.headers)
-      outputURL: \(self.outputURL)
+      outputPath: \(self.outputPath)
       """
   }
 }

--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -43,24 +43,36 @@ public struct ApolloSchemaDownloader {
   /// Downloads your schema using the specified configuration object.
   ///
   /// - Parameters:
-  ///   - configuration: The `ApolloSchemaDownloadConfiguration` object to use to download the schema.
-  /// - Returns: Output from a successful run
-  public static func fetch(with configuration: ApolloSchemaDownloadConfiguration) throws {
-    try FileManager.default.apollo.createContainingDirectoryIfNeeded(forPath: configuration.outputURL.path)
+  ///   - configuration: The `ApolloSchemaDownloadConfiguration` used to download the schema.
+  /// - Returns: Output from a successful fetch or throws an error.
+  /// - Throws: Any error which occurs during the fetch.
+  public static func fetch(configuration: ApolloSchemaDownloadConfiguration) throws {
+    try FileManager.default.apollo.createContainingDirectoryIfNeeded(
+      forPath: configuration.outputPath
+    )
 
     switch configuration.downloadMethod {
     case .introspection(let endpointURL, let httpMethod):
-      try self.downloadViaIntrospection(from: endpointURL, httpMethod: httpMethod, configuration: configuration)
+      try self.downloadFrom(
+        introspection: endpointURL,
+        httpMethod: httpMethod,
+        configuration: configuration
+      )
+
     case .apolloRegistry(let settings):
-      try self.downloadFromRegistry(with: settings, configuration: configuration)
+      try self.downloadFrom(
+        registry: settings,
+        configuration: configuration
+      )
     }
   }
 
-  private static func request(url: URL,
-                              httpMethod: ApolloSchemaDownloadConfiguration.DownloadMethod.HTTPMethod,
-                              headers: [ApolloSchemaDownloadConfiguration.HTTPHeader],
-                              bodyData: Data? = nil) -> URLRequest {
-
+  private static func request(
+    url: URL,
+    httpMethod: ApolloSchemaDownloadConfiguration.DownloadMethod.HTTPMethod,
+    headers: [ApolloSchemaDownloadConfiguration.HTTPHeader],
+    bodyData: Data? = nil
+  ) -> URLRequest {
     var request = URLRequest(url: url)
 
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -91,51 +103,70 @@ public struct ApolloSchemaDownloader {
             }
           }
       """
-    
-  
-  static func downloadFromRegistry(with settings: ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings,
-                                   configuration: ApolloSchemaDownloadConfiguration) throws {
 
+  static func downloadFrom(
+    registry: ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings,
+    configuration: ApolloSchemaDownloadConfiguration
+  ) throws {
     CodegenLogger.log("Downloading schema from registry", logLevel: .debug)
 
-    let urlRequest = try registryRequest(with: settings, headers: configuration.headers)
-    let jsonOutputURL = configuration.outputURL.apollo.parentFolderURL().appendingPathComponent("registry_response.json")
+    let urlRequest = try registryRequest(with: registry, headers: configuration.headers)
+    let jsonOutputURL = URL(fileURLWithPath: configuration.outputPath)
+      .apollo
+      .parentFolderURL()
+      .appendingPathComponent("registry_response.json")
 
-    try URLDownloader().downloadSynchronously(with: urlRequest,
-                                              to: jsonOutputURL,
-                                              timeout: configuration.downloadTimeout)
-    
-    try self.convertFromRegistryJSONToSDLFile(jsonFileURL: jsonOutputURL, configuration: configuration)
-    
+    try URLDownloader().downloadSynchronously(
+      urlRequest,
+      to: jsonOutputURL,
+      timeout: configuration.downloadTimeout
+    )
+
+    try self.convertFromRegistryJSONToSDLFile(
+      jsonFileURL: jsonOutputURL,
+      configuration: configuration
+    )
+
     CodegenLogger.log("Successfully downloaded schema from registry", logLevel: .debug)
   }
 
-  static func registryRequest(with settings: ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings,
-                              headers: [ApolloSchemaDownloadConfiguration.HTTPHeader]) throws -> URLRequest {
-
+  static func registryRequest(
+    with settings: ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings,
+    headers: [ApolloSchemaDownloadConfiguration.HTTPHeader]
+  ) throws -> URLRequest {
     var variables = [String: String]()
     variables["graphID"] = settings.graphID
     if let variant = settings.variant {
       variables["variant"] = variant
     }
 
-    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: self.RegistryDownloadQuery,
-                                                                   variables: variables,
-                                                                   operationName: "DownloadSchema")
+    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(
+      for: self.RegistryDownloadQuery,
+      variables: variables,
+      operationName: "DownloadSchema"
+    )
     let bodyData = try JSONSerialization.data(withJSONObject: requestBody, options: [.sortedKeys])
 
     var allHeaders = headers
-    allHeaders.append(ApolloSchemaDownloadConfiguration.HTTPHeader(key: "x-api-key", value: settings.apiKey))
+    allHeaders.append(ApolloSchemaDownloadConfiguration.HTTPHeader(
+      key: "x-api-key",
+      value: settings.apiKey
+    ))
 
-    let urlRequest = request(url: self.RegistryEndpoint,
-                             httpMethod: .POST,
-                             headers: allHeaders,
-                             bodyData: bodyData)
+    let urlRequest = request(
+      url: self.RegistryEndpoint,
+      httpMethod: .POST,
+      headers: allHeaders,
+      bodyData: bodyData
+    )
 
     return urlRequest
   }
 
-  static func convertFromRegistryJSONToSDLFile(jsonFileURL: URL, configuration: ApolloSchemaDownloadConfiguration) throws {
+  static func convertFromRegistryJSONToSDLFile(
+    jsonFileURL: URL,
+    configuration: ApolloSchemaDownloadConfiguration
+  ) throws {
     let jsonData: Data
 
     do {
@@ -161,15 +192,17 @@ public struct ApolloSchemaDownloader {
       let variant = service["variant"] as? [String: Any],
       let asp = variant["activeSchemaPublish"] as? [String: Any],
       let schemaDict = asp["schema"] as? [String: Any],
-      let sdlSchema = schemaDict["document"] as? String else {
-        throw SchemaDownloadError.couldNotExtractSDLFromRegistryJSON
+      let sdlSchema = schemaDict["document"] as? String
+    else {
+      throw SchemaDownloadError.couldNotExtractSDLFromRegistryJSON
     }
 
     guard let sdlData = sdlSchema.data(using: .utf8) else {
       throw SchemaDownloadError.couldNotCreateSDLDataToWrite(schema: sdlSchema)
     }
 
-    try sdlData.write(to: configuration.outputURL)
+    let outputURL = URL(fileURLWithPath: configuration.outputPath)
+    try sdlData.write(to: outputURL)
   }
 
   // MARK: - Schema Introspection
@@ -266,22 +299,34 @@ public struct ApolloSchemaDownloader {
     """
   
   
-  static func downloadViaIntrospection(
-    from endpointURL: URL,
+  static func downloadFrom(
+    introspection endpoint: URL,
     httpMethod: ApolloSchemaDownloadConfiguration.DownloadMethod.HTTPMethod,
     configuration: ApolloSchemaDownloadConfiguration
   ) throws {
 
-    CodegenLogger.log("Downloading schema via introspection from \(endpointURL)", logLevel: .debug)
+    CodegenLogger.log("Downloading schema via introspection from \(endpoint)", logLevel: .debug)
 
-    let urlRequest = try introspectionRequest(from: endpointURL, httpMethod: httpMethod, headers: configuration.headers)
-    let jsonOutputURL = configuration.outputURL.apollo.parentFolderURL().appendingPathComponent("introspection_response.json")
+    let urlRequest = try introspectionRequest(
+      from: endpoint,
+      httpMethod: httpMethod,
+      headers: configuration.headers
+    )
+    let jsonOutputURL = URL(fileURLWithPath: configuration.outputPath)
+      .apollo
+      .parentFolderURL()
+      .appendingPathComponent("introspection_response.json")
     
-    try URLDownloader().downloadSynchronously(with: urlRequest,
-                                              to: jsonOutputURL,
-                                              timeout: configuration.downloadTimeout)
+    try URLDownloader().downloadSynchronously(
+      urlRequest,
+      to: jsonOutputURL,
+      timeout: configuration.downloadTimeout
+    )
 
-    try convertFromIntrospectionJSONToSDLFile(jsonFileURL: jsonOutputURL, configuration: configuration)
+    try convertFromIntrospectionJSONToSDLFile(
+      jsonFileURL: jsonOutputURL,
+      configuration: configuration
+    )
     
     CodegenLogger.log("Successfully downloaded schema via introspection", logLevel: .debug)
   }
@@ -295,16 +340,23 @@ public struct ApolloSchemaDownloader {
 
     switch httpMethod {
     case .POST:
-      let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: self.IntrospectionQuery,
-                                                              variables: nil,
-                                                              operationName: "IntrospectionQuery")
-      let bodyData = try JSONSerialization.data(withJSONObject: requestBody, options: [.sortedKeys])
-      urlRequest = request(url: endpointURL,
-                           httpMethod: httpMethod,
-                           headers: headers,
-                           bodyData: bodyData)
+      let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(
+        for: self.IntrospectionQuery,
+        variables: nil,
+        operationName: "IntrospectionQuery"
+      )
+      let bodyData = try JSONSerialization.data(
+        withJSONObject: requestBody,
+        options: [.sortedKeys]
+      )
+      urlRequest = request(
+        url: endpointURL,
+        httpMethod: httpMethod,
+        headers: headers,
+        bodyData: bodyData
+      )
 
-    case .GET(let queryParameterName):
+    case let .GET(queryParameterName):
       guard var components = URLComponents(url: endpointURL, resolvingAgainstBaseURL: true) else {
         throw SchemaDownloadError.couldNotCreateURLComponentsFromEndpointURL(url: endpointURL)
       }
@@ -323,9 +375,14 @@ public struct ApolloSchemaDownloader {
     jsonFileURL: URL,
     configuration: ApolloSchemaDownloadConfiguration
   ) throws {
-    defer { try? FileManager.default.removeItem(at: jsonFileURL) }
+
+    defer {
+      try? FileManager.default.removeItem(at: jsonFileURL)
+    }
+
     let frontend = try GraphQLJSFrontend()
     let schema: GraphQLSchema
+
     do {
       schema = try frontend.loadSchema(from: jsonFileURL)
     } catch {
@@ -333,15 +390,19 @@ public struct ApolloSchemaDownloader {
     }
     
     let sdlSchema: String
+
     do {
       sdlSchema = try frontend.printSchemaAsSDL(schema: schema)
     } catch {
       throw SchemaDownloadError.couldNotConvertIntrospectionJSONToSDL(underlying: error)
     }
-    
-    try sdlSchema.write(to: configuration.outputURL,
-                        atomically: true,
-                        encoding: .utf8)
+
+    let outputURL = URL(fileURLWithPath: configuration.outputPath)
+    try sdlSchema.write(
+      to: outputURL,
+      atomically: true,
+      encoding: .utf8
+    )
   }
 }
 #endif

--- a/Sources/ApolloCodegenLib/URLDownloader.swift
+++ b/Sources/ApolloCodegenLib/URLDownloader.swift
@@ -6,14 +6,22 @@ protocol NetworkSession {
   /// Load data via the abstracted network provider
   ///
   /// - Parameters:
-  ///   - urlRequest: A URL request object that provides the URL, cache policy, request type, body data or body stream, and so on.
+  ///   - urlRequest: A URL request object that provides the URL, cache policy, request type,
+  ///   body data or body stream, and so on.
   ///   - completionHandler: The completion handler to call when the load request is complete.
-  /// - Returns: The new session data task. This task will already have been started with a call to `resume`.
-  @discardableResult func loadData(with urlRequest: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask?
+  /// - Returns: The new session data task. This task will already have been started with a call
+  /// to `resume`.
+  @discardableResult func loadData(
+    with urlRequest: URLRequest,
+    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+  ) -> URLSessionDataTask?
 }
 
 extension URLSession: NetworkSession {
-  func loadData(with urlRequest: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask? {
+  func loadData(
+    with urlRequest: URLRequest,
+    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+  ) -> URLSessionDataTask? {
     let task = dataTask(with: urlRequest) { (data, response, error) in
       completionHandler(data, response, error)
     }
@@ -53,63 +61,73 @@ class URLDownloader {
   /// Designated initializer.
   ///
   /// - Parameters:
-  ///   - session: The NetworkSession conforming instance used for downloads, defaults to the shared URLSession singleton object.
+  ///   - session: The NetworkSession conforming instance used for downloads, defaults to the
+  ///   shared URLSession singleton object.
   init(session: NetworkSession = URLSession.shared) {
     self.session = session
   }
   
   /// Downloads the contents of a given URL synchronously to the given output URL
   /// - Parameters:
-  ///   - urlRequest: A URL request object that provides the URL, cache policy, request type, body data or body stream, and so on.
+  ///   - urlRequest: A URL request object that provides the URL, cache policy, request type,
+  ///   body data or body stream, and so on.
   ///   - outputURL: The file URL where the result will be written to.
   ///   - timeout: The timeout value for the download request duration.
   /// - Throws: Any error which occurs during the download.
-  func downloadSynchronously(with urlRequest: URLRequest, to outputURL: URL, timeout: Double) throws {
+  func downloadSynchronously(
+    _ request: URLRequest,
+    to outputURL: URL,
+    timeout: Double
+  ) throws {
     let semaphore = DispatchSemaphore(value: 0)
     var errorToThrow: Error? = DownloadError.downloadTimedOut(after: timeout)
 
-    session.loadData(with: urlRequest) { data, response, error in
-      func finished(with finalError: Error?) {
-        errorToThrow = finalError
+    session.loadData(with: request) { data, response, error in
+      func finished(_ error: Error? = nil) {
+        errorToThrow = error
         semaphore.signal()
       }
         
       if let error = error {
-        finished(with: error)
+        finished(error)
         return
       }
       
       guard let httpResponse = response as? HTTPURLResponse else {
-        finished(with: DownloadError.responseNotHTTPResponse)
+        finished(DownloadError.responseNotHTTPResponse)
         return
       }
       
       guard httpResponse.statusCode == 200 else {
         let dataAsString = String(bytes: data ?? Data(), encoding: .utf8)
-        finished(with: DownloadError.badResponse(code: httpResponse.statusCode, response: dataAsString))
+        finished(DownloadError.badResponse(
+          code: httpResponse.statusCode,
+          response: dataAsString)
+        )
         return
       }
       
       guard let data = data else {
-        finished(with: DownloadError.noDataReceived)
+        finished(DownloadError.noDataReceived)
         return
       }
       
       guard !data.isEmpty else {
-        finished(with: DownloadError.emptyDataReceived)
+        finished(DownloadError.emptyDataReceived)
         return
       }
       
       do {
         try FileManager.default.apollo.createContainingDirectoryIfNeeded(forPath: outputURL.path)
         try data.write(to: outputURL)
+
       } catch (let writeError) {
-        finished(with: writeError)
+        finished(writeError)
         return
       }
       
       // If we got here, it all worked and it's good to go!
-      finished(with: nil)
+      finished()
     }
     
     _ = semaphore.wait(timeout: .now() + timeout)

--- a/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
@@ -13,14 +13,14 @@ class ApolloSchemaInternalTests: XCTestCase {
     try FileManager.default.apollo.createDirectoryIfNeeded(atPath: CodegenTestHelper.outputFolderURL().path)
     let configuration = ApolloSchemaDownloadConfiguration(
       using: .introspection(endpointURL: TestURL.mockPort8080.url),
-      outputURL: CodegenTestHelper.schemaOutputURL()
+      outputPath: CodegenTestHelper.schemaOutputURL().path
     )
 
     try ApolloSchemaDownloader.convertFromIntrospectionJSONToSDLFile(jsonFileURL: jsonURL, configuration: configuration)
-    XCTAssertTrue(FileManager.default.apollo.doesFileExist(atPath: configuration.outputURL.path))
+    XCTAssertTrue(FileManager.default.apollo.doesFileExist(atPath: configuration.outputPath))
 
     let frontend = try GraphQLJSFrontend()
-    let source = try frontend.makeSource(from: configuration.outputURL)
+    let source = try frontend.makeSource(from: URL(fileURLWithPath: configuration.outputPath))
     let schema = try frontend.loadSchemaFromSDL(source)
 
     let authorType = try schema.getType(named: "Author")

--- a/Tests/ApolloCodegenTests/ApolloSchemaPublicTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaPublicTests.swift
@@ -8,11 +8,11 @@ class ApolloSchemaPublicTests: XCTestCase {
   func testCreatingSchemaDownloadConfiguration_forIntrospectionDownload_usingDefaultParameters() throws {
     let configuration = ApolloSchemaDownloadConfiguration(
       using: .introspection(endpointURL: TestURL.mockPort8080.url),
-      outputURL: CodegenTestHelper.schemaOutputURL()
+      outputPath: CodegenTestHelper.schemaOutputURL().path
     )
 
     XCTAssertEqual(configuration.downloadMethod, .introspection(endpointURL: TestURL.mockPort8080.url))
-    XCTAssertEqual(configuration.outputURL, CodegenTestHelper.schemaOutputURL())
+    XCTAssertEqual(configuration.outputPath, CodegenTestHelper.schemaOutputURL().path)
     XCTAssertTrue(configuration.headers.isEmpty)
   }
 
@@ -24,21 +24,29 @@ class ApolloSchemaPublicTests: XCTestCase {
     
     let configuration = ApolloSchemaDownloadConfiguration(
       using: .apolloRegistry(settings),
-      outputURL: CodegenTestHelper.schemaOutputURL()
+      outputPath: CodegenTestHelper.schemaOutputURL().path
     )
 
     XCTAssertEqual(configuration.downloadMethod, .apolloRegistry(settings))
-    XCTAssertEqual(configuration.outputURL, CodegenTestHelper.schemaOutputURL())
+    XCTAssertEqual(configuration.outputPath, CodegenTestHelper.schemaOutputURL().path)
     XCTAssertTrue(configuration.headers.isEmpty)
   }
 
   func testCreatingSchemaDownloadConfiguration_forRegistryDownload_usingAllParameters() throws {
-    let settings = ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings(apiKey: "Fake_API_Key",
-                                                                                           graphID: "Fake_Graph_ID",
-                                                                                           variant: "Fake_Variant")
+    let settings = ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings(
+      apiKey: "Fake_API_Key",
+      graphID: "Fake_Graph_ID",
+      variant: "Fake_Variant"
+    )
     let headers = [
-      ApolloSchemaDownloadConfiguration.HTTPHeader(key: "Authorization", value: "Bearer tokenGoesHere"),
-      ApolloSchemaDownloadConfiguration.HTTPHeader(key: "Custom-Header",  value: "Custom_Customer")
+      ApolloSchemaDownloadConfiguration.HTTPHeader(
+        key: "Authorization",
+        value: "Bearer tokenGoesHere"
+      ),
+      ApolloSchemaDownloadConfiguration.HTTPHeader(
+        key: "Custom-Header",
+        value: "Custom_Customer"
+      )
     ]
 
     let schemaFileName = "different_name"
@@ -47,13 +55,12 @@ class ApolloSchemaPublicTests: XCTestCase {
     let configuration = ApolloSchemaDownloadConfiguration(
       using: .apolloRegistry(settings),
       headers: headers,
-      outputURL: outputURL
+      outputPath: outputURL.path
     )
 
     XCTAssertEqual(configuration.downloadMethod, .apolloRegistry(settings))
     XCTAssertEqual(configuration.headers, headers)
-
-    XCTAssertEqual(configuration.outputURL, outputURL)
+    XCTAssertEqual(configuration.outputPath, outputURL.path)
   }
   
 }

--- a/Tests/ApolloCodegenTests/URLDownloaderTests.swift
+++ b/Tests/ApolloCodegenTests/URLDownloaderTests.swift
@@ -41,7 +41,7 @@ class URLDownloaderTests: XCTestCase {
     setRequestHandler(statusCode: statusCode, error: error)
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch (let error as NSError) {
       XCTAssertEqual(error.domain, domain)
       XCTAssertEqual(error.code, NSURLErrorNotConnectedToInternet)
@@ -55,7 +55,7 @@ class URLDownloaderTests: XCTestCase {
     setRequestHandler(statusCode: statusCode, data: responseString.data(using: .utf8))
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch URLDownloader.DownloadError.badResponse(let code, let response) {
       XCTAssertEqual(code, statusCode)
       XCTAssertEqual(response, responseString)
@@ -68,7 +68,7 @@ class URLDownloaderTests: XCTestCase {
     setRequestHandler(statusCode: 200, data: Data())
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch URLDownloader.DownloadError.emptyDataReceived {
       // Expected response
     } catch {
@@ -80,7 +80,7 @@ class URLDownloaderTests: XCTestCase {
     setRequestHandler(statusCode: 200)
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch URLDownloader.DownloadError.noDataReceived {
       // Expected response
     } catch {
@@ -92,7 +92,7 @@ class URLDownloaderTests: XCTestCase {
     setRequestHandler(statusCode: 200, abandon: true)
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch URLDownloader.DownloadError.downloadTimedOut(let timeout) {
       XCTAssertEqual(timeout, defaultTimeout)
     } catch {
@@ -112,7 +112,7 @@ class URLDownloaderTests: XCTestCase {
     let downloader = URLDownloader(session: CustomNetworkSession())
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch URLDownloader.DownloadError.responseNotHTTPResponse {
       // Expected response
     } catch {
@@ -128,7 +128,7 @@ class URLDownloaderTests: XCTestCase {
     setRequestHandler(statusCode: statusCode, data: responseString.data(using: .utf8))
 
     do {
-      try downloader.downloadSynchronously(with: urlRequest, to: downloadURL, timeout: defaultTimeout)
+      try downloader.downloadSynchronously(urlRequest, to: downloadURL, timeout: defaultTimeout)
     } catch {
       XCTFail("Unexpected error received: \(error)")
     }


### PR DESCRIPTION
Closes #2012 

Minor changes:
- changes from URL to String type for local paths
- reformats lines to the column limit
- renames and drops some parameter names