### PR TITLE
fix: Render schema SelectionSet and InlineFragment definitions outside of any namespace with a typealias

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -164,7 +164,7 @@ public class ApolloCodegen {
       }
     }
 
-    try SchemaFileGenerator(schema: ir.schema)
+    try SchemaFileGenerator(schema: ir.schema, config: config)
       .generate(forConfig: config, fileManager: fileManager)
 
     try SchemaModuleFileGenerator.generate(config, fileManager: fileManager)

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaFileGenerator.swift
@@ -1,12 +1,15 @@
 import Foundation
 import OrderedCollections
+import ApolloUtils
 
 /// Generates a file containing schema metadata used by the GraphQL executor at runtime.
 struct SchemaFileGenerator: FileGenerator {
   /// Source IR schema.
   let schema: IR.Schema
+  /// Shared codegen configuration
+  let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var template: TemplateRenderer { SchemaTemplate(schema: schema) }
+  var template: TemplateRenderer { SchemaTemplate(schema: schema, config: config) }
   var target: FileTarget { .schema }
   var fileName: String { "Schema.swift" }
 }

--- a/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ApolloUtils
 
 /// Provides the format to define a schema in Swift code. The schema represents metadata used by
 /// the GraphQL executor at runtime to convert response data into corresponding Swift types.
@@ -6,30 +7,64 @@ struct SchemaTemplate: TemplateRenderer {
   // IR representation of source GraphQL schema.
   let schema: IR.Schema
 
+  /// Shared codegen configuration.
+  let config: ReferenceWrapped<ApolloCodegenConfiguration>
+
+  let schemaName: String
+
   var target: TemplateTarget = .schemaFile
 
-  var template: TemplateString {
+  var template: TemplateString { embeddableTemplate }
+
+  /// Swift code that can be embedded within a namespace.
+  var embeddableTemplate: TemplateString {
     TemplateString(
     """
     public typealias ID = String
 
-    public protocol SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
-    where Schema == \(schema.name.firstUppercased).Schema {}
-    
-    public protocol InlineFragment: ApolloAPI.SelectionSet & ApolloAPI.InlineFragment
-    where Schema == \(schema.name.firstUppercased).Schema {}
+    \(if: !config.output.schemaTypes.isInModule,
+      TemplateString("""
+      public typealias SelectionSet = \(schemaName)_SelectionSet
+
+      public typealias InlineFragment = \(schemaName)_InlineFragment
+      """),
+    else: protocolDefinition(prefix: nil, schemaName: schemaName))
 
     public enum Schema: SchemaConfiguration {
       public static func objectType(forTypename __typename: String) -> Object.Type? {
         switch __typename {
         \(schema.referencedTypes.objects.map {
-          "case \"\($0.name.firstUppercased)\": return \(schema.name.firstUppercased).\($0.name.firstUppercased).self"
+          "case \"\($0.name.firstUppercased)\": return \(schemaName).\($0.name.firstUppercased).self"
         }, separator: "\n")
         default: return nil
         }
       }
     }
     """
+    )
+  }
+
+  /// Swift code that must be rendered outside of any namespace.
+  var detachedTemplate: TemplateString? {
+    guard !config.output.schemaTypes.isInModule else { return nil }
+
+    return protocolDefinition(prefix: "\(schemaName)_", schemaName: schemaName)
+  }
+
+  init(schema: IR.Schema, config: ReferenceWrapped<ApolloCodegenConfiguration>) {
+    self.schema = schema
+    self.schemaName = schema.name.firstUppercased
+    self.config = config
+  }
+
+  private func protocolDefinition(prefix: String?, schemaName: String) -> TemplateString {
+    TemplateString("""
+      public protocol \(prefix ?? "")SelectionSet: ApolloAPI.SelectionSet & ApolloAPI.RootSelectionSet
+      where Schema == \(schemaName).Schema {}
+
+      public protocol \(prefix ?? "")InlineFragment: ApolloAPI.SelectionSet & ApolloAPI.InlineFragment
+      where Schema == \(schemaName).Schema {}
+      """
     )
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -26,7 +26,10 @@ protocol TemplateRenderer {
   /// The template for the header to render.
   var headerTemplate: TemplateString? { get }
 
-  /// The swift code format.
+  /// A template that must be rendered outside of any namespace wrapping.
+  var detachedTemplate: TemplateString? { get }
+
+  /// A template that can be rendered within any namespace wrapping.
   var template: TemplateString { get }
 }
 
@@ -34,10 +37,14 @@ protocol TemplateRenderer {
 
 extension TemplateRenderer {
 
-  var headerTemplate: TemplateString? { TemplateString(HeaderCommentTemplate.template.description) }
+  var headerTemplate: TemplateString? {
+    TemplateString(HeaderCommentTemplate.template.description)
+  }
 
-  /// Renders the template converting all input values and generating a final String representation
-  /// of the template.
+  var detachedTemplate: TemplateString? { nil }
+
+  /// Renders the template converting all input values and generating a final String
+  /// representation of the template.
   ///
   /// - Parameter config: Shared codegen configuration.
   /// - Returns: Swift code derived from the template format.
@@ -58,6 +65,7 @@ extension TemplateRenderer {
     \(ifLet: headerTemplate, { "\($0)\n" })
     \(ImportStatementTemplate.SchemaType.template)
 
+    \(ifLet: detachedTemplate, { "\($0)\n" })
     \(if: config.output.schemaTypes.isInModule, template,
     else: template.wrappedInNamespace(config.schemaName))
     """

--- a/Tests/ApolloCodegenInternalTestHelpers/MockFileTemplate.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockFileTemplate.swift
@@ -14,6 +14,16 @@ public struct MockFileTemplate: TemplateRenderer {
     )
   }
 
+  public var detachedTemplate: TemplateString? {
+    TemplateString(
+    """
+    detached {
+      nested
+    }
+    """
+    )
+  }
+
   public static func mock(target: TemplateTarget) -> Self {
     MockFileTemplate(target: target)
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaFileGeneratorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Nimble
 @testable import ApolloCodegenLib
+import ApolloUtils
 
 class SchemaFileGeneratorTests: XCTestCase {
   let irSchema = IR.Schema(name: "MockSchema", referencedTypes: .init([]))
@@ -14,7 +15,10 @@ class SchemaFileGeneratorTests: XCTestCase {
   // MARK: Test Helpers
 
   private func buildSubject() {
-    subject = SchemaFileGenerator(schema: irSchema)
+    subject = SchemaFileGenerator(
+      schema: irSchema,
+      config: ReferenceWrapped(value: ApolloCodegenConfiguration.mock())
+    )
   }
 
   // MARK: Property Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
@@ -133,12 +133,20 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
   func test__renderTargetSchemaFile__givenAllSchemaTypesOperationsCombinations_conditionallyWrapInNamespace() {
     // given
     let expectedNoNamespace = """
+    detached {
+      nested
+    }
+
     root {
       nested
     }
     """
 
     let expectedNamespace = """
+    detached {
+      nested
+    }
+
     public extension TestSchema {
       root {
         nested


### PR DESCRIPTION
Fixes #2293 

The `SelectionSet` and `InlineFragment` protocols included in the schema file were incorrectly being generated within the `enum` namespace when the module type was `. embeddedInTarget`.

These protocols are now generated outside of any namespace and a typealias created for local reference to them.