### PR TITLE
Update CircleCI tool versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,16 @@ version: 2.1
 parameters:
   xcode_version:
     type: string
-    default: "13.3.1"
+    default: "13.4.1"
   ios_current_version:
     type: string
-    default: "15.4"
+    default: "15.5"
   ios_previous_version:
     type: string
     default: "14.5"
   ios_sdk:
     type: string
-    default: "iphonesimulator15.4"
+    default: "iphonesimulator15.5"
   macos_version: # The user-facing version string for macOS builds
     type: string
     default: "12.3.1"

--- a/scripts/install-node-v12.sh
+++ b/scripts/install-node-v12.sh
@@ -5,4 +5,4 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 echo nvm install v12.22.10 >> $BASH_ENV
-echo nvm use v16.14.2 >> $BASH_ENV
+echo nvm use v16.15.1 >> $BASH_ENV


### PR DESCRIPTION
This updates the tooling to use:
- Xcode 13.4.1
- iOS 15.5
- tvOS 15.5
- Node v16.15.1