### PR TITLE
API for Local Cache Mutations

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		DE5FD609276956C70033EE23 /* SchemaTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */; };
 		DE5FD60B276970FC0033EE23 /* FragmentTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60A276970FC0033EE23 /* FragmentTemplate.swift */; };
 		DE64C1F7284033BA00F64B9D /* LocalCacheMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE64C1F6284033BA00F64B9D /* LocalCacheMutation.swift */; };
+		DE64C1FA284037C500F64B9D /* MockLocalCacheMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE64C1F8284037B700F64B9D /* MockLocalCacheMutation.swift */; };
 		DE674D9D261CEEE4000E8FC8 /* c.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9B2061172591B3550020D1E0 /* c.txt */; };
 		DE674D9E261CEEE4000E8FC8 /* b.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9B2061182591B3550020D1E0 /* b.txt */; };
 		DE674D9F261CEEE4000E8FC8 /* a.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9B2061192591B3550020D1E0 /* a.txt */; };
@@ -1112,6 +1113,7 @@
 		DE5FD60A276970FC0033EE23 /* FragmentTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FragmentTemplate.swift; sourceTree = "<group>"; };
 		DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FragmentTemplateTests.swift; sourceTree = "<group>"; };
 		DE64C1F6284033BA00F64B9D /* LocalCacheMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheMutation.swift; sourceTree = "<group>"; };
+		DE64C1F8284037B700F64B9D /* MockLocalCacheMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocalCacheMutation.swift; sourceTree = "<group>"; };
 		DE664ED326602AF60054DB4F /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		DE6B15AC26152BE10068D642 /* ApolloServerIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApolloServerIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE6B15AE26152BE10068D642 /* DefaultInterceptorProviderIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultInterceptorProviderIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1899,6 +1901,7 @@
 				DE4766E726F92F30004622E0 /* MockSchemaConfiguration.swift */,
 				DE5EB9C126EFCBD40004176A /* MockApolloStore.swift */,
 				DE5EB9CA26EFE5510004176A /* MockOperation.swift */,
+				DE64C1F8284037B700F64B9D /* MockLocalCacheMutation.swift */,
 				DE5EB9BF26EFCB010004176A /* TestObserver.swift */,
 				9B7BDA8723FDE92900ACD198 /* MockWebSocket.swift */,
 				E608A5222808E59A001BE656 /* MockWebSocketDelegate.swift */,
@@ -3974,6 +3977,7 @@
 				DE12B2D7273B204B003371CC /* TestError.swift in Sources */,
 				9FBE0D4025407B64002ED0B1 /* AsyncResultObserver.swift in Sources */,
 				9F3910272549741400AF54A6 /* MockGraphQLServer.swift in Sources */,
+				DE64C1FA284037C500F64B9D /* MockLocalCacheMutation.swift in Sources */,
 				DED45E6B261B9EAC0086EF63 /* SQLiteTestCacheProvider.swift in Sources */,
 				DE5EB9C226EFCBD40004176A /* MockApolloStore.swift in Sources */,
 				9BEEDC2B24E61995001D1294 /* TestURLs.swift in Sources */,

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		DE5FD607276950CC0033EE23 /* IR+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD606276950CC0033EE23 /* IR+Schema.swift */; };
 		DE5FD609276956C70033EE23 /* SchemaTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */; };
 		DE5FD60B276970FC0033EE23 /* FragmentTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5FD60A276970FC0033EE23 /* FragmentTemplate.swift */; };
+		DE64C1F7284033BA00F64B9D /* LocalCacheMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE64C1F6284033BA00F64B9D /* LocalCacheMutation.swift */; };
 		DE674D9D261CEEE4000E8FC8 /* c.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9B2061172591B3550020D1E0 /* c.txt */; };
 		DE674D9E261CEEE4000E8FC8 /* b.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9B2061182591B3550020D1E0 /* b.txt */; };
 		DE674D9F261CEEE4000E8FC8 /* a.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9B2061192591B3550020D1E0 /* a.txt */; };
@@ -1110,6 +1111,7 @@
 		DE5FD608276956C70033EE23 /* SchemaTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaTemplateTests.swift; sourceTree = "<group>"; };
 		DE5FD60A276970FC0033EE23 /* FragmentTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FragmentTemplate.swift; sourceTree = "<group>"; };
 		DE5FD60C2769711E0033EE23 /* FragmentTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FragmentTemplateTests.swift; sourceTree = "<group>"; };
+		DE64C1F6284033BA00F64B9D /* LocalCacheMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalCacheMutation.swift; sourceTree = "<group>"; };
 		DE664ED326602AF60054DB4F /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		DE6B15AC26152BE10068D642 /* ApolloServerIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApolloServerIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE6B15AE26152BE10068D642 /* DefaultInterceptorProviderIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultInterceptorProviderIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2241,6 +2243,7 @@
 				DE90FDB927FE405F0084CC79 /* Selection+Conditions.swift */,
 				DECD53CE26EC0EE50059A639 /* OutputTypeConvertible.swift */,
 				9FC750601D2A59C300458D91 /* GraphQLOperation.swift */,
+				DE64C1F6284033BA00F64B9D /* LocalCacheMutation.swift */,
 				DE05862426697A8C00265760 /* Info.plist */,
 			);
 			name = ApolloAPI;
@@ -4195,6 +4198,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE058609266978A100265760 /* Selection.swift in Sources */,
+				DE64C1F7284033BA00F64B9D /* LocalCacheMutation.swift in Sources */,
 				DE05860B266978A100265760 /* SelectionSet.swift in Sources */,
 				DE9C04AC26EAAE4400EC35E7 /* JSON.swift in Sources */,
 				DE2FCF1D26E806710057EA67 /* SchemaConfiguration.swift in Sources */,

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -257,8 +257,6 @@ public class ApolloStore {
         variables: cacheMutation.variables,
         body
       )
-//      try body(&data)
-//      try write(data: data, forQuery: query)
     }
 
     public func updateObject<SelectionSet: ApolloAPI.MutableRootSelectionSet>(

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -50,9 +50,11 @@ public class ApolloStore {
   public func clearCache(callbackQueue: DispatchQueue = .main, completion: ((Result<Void, Error>) -> Void)? = nil) {
     queue.async(flags: .barrier) {
       let result = Result { try self.cache.clear() }
-      DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                     action: completion,
-                                                     result: result)
+      DispatchQueue.apollo.returnResultAsyncIfNeeded(
+        on: callbackQueue,
+        action: completion,
+        result: result
+      )
     }
   }
 
@@ -68,13 +70,17 @@ public class ApolloStore {
       do {
         let changedKeys = try self.cache.merge(records: records)
         self.didChangeKeys(changedKeys, identifier: identifier)
-        DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                       action: completion,
-                                                       result: .success(()))
+        DispatchQueue.apollo.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .success(())
+        )
       } catch {
-        DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                       action: completion,
-                                                       result: .failure(error))
+        DispatchQueue.apollo.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .failure(error)
+        )
       }
     }
   }
@@ -104,13 +110,17 @@ public class ApolloStore {
       do {
         let returnValue = try body(ReadTransaction(store: self))
         
-        DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                       action: completion,
-                                                       result: .success(returnValue))
+        DispatchQueue.apollo.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .success(returnValue)
+        )
       } catch {
-        DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                       action: completion,
-                                                       result: .failure(error))
+        DispatchQueue.apollo.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .failure(error)
+        )
       }
     }
   }
@@ -128,13 +138,17 @@ public class ApolloStore {
       do {
         let returnValue = try body(ReadWriteTransaction(store: self))
         
-        DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                       action: completion,
-                                                       result: .success(returnValue))
+        DispatchQueue.apollo.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .success(returnValue)
+        )
       } catch {
-        DispatchQueue.apollo.returnResultAsyncIfNeeded(on: callbackQueue,
-                                                       action: completion,
-                                                       result: .failure(error))
+        DispatchQueue.apollo.returnResultAsyncIfNeeded(
+          on: callbackQueue,
+          action: completion,
+          result: .failure(error)
+        )
       }
     }
   }
@@ -154,11 +168,13 @@ public class ApolloStore {
                          GraphQLDependencyTracker())
       )
       
-      return GraphQLResult(data: data,
-                           extensions: nil,
-                           errors: nil,
-                           source:.cache,
-                           dependentKeys: dependentKeys)
+      return GraphQLResult(
+        data: data,
+        extensions: nil,
+        errors: nil,
+        source:.cache,
+        dependentKeys: dependentKeys
+      )
     }, callbackQueue: callbackQueue, completion: resultHandler)
   }
 
@@ -177,9 +193,11 @@ public class ApolloStore {
     }
 
     public func read<Query: GraphQLQuery>(query: Query) throws -> Query.Data {
-      return try readObject(ofType: Query.Data.self,
-                            withKey: CacheReference.rootCacheReference(for: query).key,
-                            variables: query.variables)
+      return try readObject(
+        ofType: Query.Data.self,
+        withKey: CacheReference.rootCacheReference(for: query).key,
+        variables: query.variables
+      )
     }
 
     public func readObject<SelectionSet: RootSelectionSet>(
@@ -187,10 +205,12 @@ public class ApolloStore {
       withKey key: CacheKey,
       variables: GraphQLOperation.Variables? = nil
     ) throws -> SelectionSet {
-      return try self.readObject(ofType: type,
-                                 withKey: key,
-                                 variables: variables,
-                                 accumulator: GraphQLSelectionSetMapper<SelectionSet>())
+      return try self.readObject(
+        ofType: type,
+        withKey: key,
+        variables: variables,
+        accumulator: GraphQLSelectionSetMapper<SelectionSet>()
+      )
     }
 
     func readObject<SelectionSet: RootSelectionSet, Accumulator: GraphQLResultAccumulator>(
@@ -201,11 +221,13 @@ public class ApolloStore {
     ) throws -> Accumulator.FinalResult {
       let object = try loadObject(forKey: key).get()
 
-      return try executor.execute(selectionSet: type,
-                                  on: object,
-                                  withRootCacheReference: CacheReference(key),
-                                  variables: variables,
-                                  accumulator: accumulator)
+      return try executor.execute(
+        selectionSet: type,
+        on: object,
+        withRootCacheReference: CacheReference(key),
+        variables: variables,
+        accumulator: accumulator
+      )
     }
     
     private final func loadObject(forKey key: CacheKey) -> PossiblyDeferred<JSONObject> {
@@ -229,24 +251,56 @@ public class ApolloStore {
       _ cacheMutation: CacheMutation,
       _ body: (inout CacheMutation.Data) throws -> Void
     ) throws {
-      fatalError("TODO: Write Transactions not yet working!")
-//      var data = try read(query: query)
+      try updateObject(
+        ofType: CacheMutation.Data.self,
+        withKey: CacheReference.RootQuery.key,
+        variables: cacheMutation.variables,
+        body
+      )
 //      try body(&data)
 //      try write(data: data, forQuery: query)
     }
 
-    public func updateObject<SelectionSet: ApolloAPI.MutableSelectionSet>(
+    public func updateObject<SelectionSet: ApolloAPI.MutableRootSelectionSet>(
       ofType type: SelectionSet.Type,
       withKey key: CacheKey,
       variables: GraphQLOperation.Variables? = nil,
       _ body: (inout SelectionSet) throws -> Void
     ) throws {
-      fatalError("TODO: Write Transactions not yet working!")
-//      var object = try readObject(ofType: type,
-//                                  withKey: key,
-//                                  variables: variables)
-//      try body(&object)
-//      try write(object: object, withKey: key, variables: variables)
+      var object = try readObject(ofType: type,
+                                  withKey: key,
+                                  variables: variables)
+      try body(&object)
+      try write(selectionSet: object, withKey: key, variables: variables)
+    }
+
+    public func write<SelectionSet: MutableRootSelectionSet>(
+      selectionSet: SelectionSet,
+      withKey key: CacheKey,
+      variables: GraphQLOperation.Variables? = nil
+    ) throws {
+      let normalizer = GraphQLResultNormalizer()
+      let executor = GraphQLExecutor { object, info in
+        return object[info.responseKeyForField]
+      }
+
+      let records = try executor.execute(
+        selectionSet: SelectionSet.self,
+        on: selectionSet.data._data,
+        withRootCacheReference: CacheReference(key),
+        variables: variables,
+        accumulator: normalizer
+      )
+
+      let changedKeys = try self.cache.merge(records: records)
+
+      // Remove cached records, so subsequent reads
+      // within the same transaction will reload the updated value.
+      loader.removeAll()
+
+      if let didChangeKeysFunc = self.updateChangedKeysFunc {
+        didChangeKeysFunc(changedKeys, nil)
+      }
     }
     
     /// Removes the object for the specified cache key. Does not cascade
@@ -286,42 +340,5 @@ public class ApolloStore {
 //                variables: query.variables)
     }
 
-    public func write<SelectionSet: MutableSelectionSet>(
-      object: SelectionSet,
-      withKey key: CacheKey,
-      variables: GraphQLOperation.Variables? = nil
-    ) throws {
-      fatalError("TODO: Write Transactions not yet working!")
-//      try write(object: object.jsonObject,
-//                forSelections: type(of: object).selections,
-//                withKey: key, variables: variables)
-    }
-//
-//    private func write(object: JSONObject,
-//                       forSelections selections: [GraphQLSelection],
-//                       withKey key: CacheKey,
-//                       variables: GraphQLMap?) throws {
-//      let normalizer = GraphQLResultNormalizer()
-//      let executor = GraphQLExecutor { object, info in
-//        return object[info.responseKeyForField]
-//      }
-//
-//      executor.cacheKeyForObject = self.cacheKeyForObject
-//
-//      let records = try executor.execute(selections: selections,
-//                                         on: object,
-//                                         withKey: key,
-//                                         variables: variables,
-//                                         accumulator: normalizer)
-//      let changedKeys = try self.cache.merge(records: records)
-//
-//      // Remove cached records, so subsequent reads
-//      // within the same transaction will reload the updated value.
-//      loader.removeAll()
-//
-//      if let didChangeKeysFunc = self.updateChangedKeysFunc {
-//        didChangeKeysFunc(changedKeys, nil)
-//      }
-//    }
   }
 }

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -274,6 +274,15 @@ public class ApolloStore {
       try write(selectionSet: object, withKey: key, variables: variables)
     }
 
+    public func write<CacheMutation: LocalCacheMutation>(
+      data: CacheMutation.Data,
+      for cacheMutation: CacheMutation
+    ) throws {
+      try write(selectionSet: data,
+                withKey: CacheReference.RootQuery.key,
+                variables: cacheMutation.variables)
+    }
+
     public func write<SelectionSet: MutableRootSelectionSet>(
       selectionSet: SelectionSet,
       withKey key: CacheKey,
@@ -328,16 +337,6 @@ public class ApolloStore {
     ///   - pattern: The pattern that will be applied to find matching keys.
     public func removeObjects(matching pattern: CacheKey) throws {
       try self.cache.removeRecords(matching: pattern)
-    }
-
-    public func write<CacheMutation: LocalCacheMutation>(
-      data: CacheMutation.Data,
-      for cacheMutation: CacheMutation
-    ) throws {
-      fatalError("TODO: Write Transactions not yet working!")
-//      try write(object: data,
-//                withKey: rootCacheKey(for: query),
-//                variables: query.variables)
     }
 
   }

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -225,9 +225,9 @@ public class ApolloStore {
       super.init(store: store)
     }
 
-    public func update<Query: GraphQLQuery>(
-      query: Query,
-      _ body: (inout Query.Data) throws -> Void
+    public func update<CacheMutation: LocalCacheMutation>(
+      _ cacheMutation: CacheMutation,
+      _ body: (inout CacheMutation.Data) throws -> Void
     ) throws {
       fatalError("TODO: Write Transactions not yet working!")
 //      var data = try read(query: query)
@@ -235,10 +235,10 @@ public class ApolloStore {
 //      try write(data: data, forQuery: query)
     }
 
-    public func updateObject<SelectionSet: ApolloAPI.SelectionSet>(
+    public func updateObject<SelectionSet: ApolloAPI.MutableSelectionSet>(
       ofType type: SelectionSet.Type,
       withKey key: CacheKey,
-      variables: [String: InputValue]? = nil,
+      variables: GraphQLOperation.Variables? = nil,
       _ body: (inout SelectionSet) throws -> Void
     ) throws {
       fatalError("TODO: Write Transactions not yet working!")
@@ -276,19 +276,26 @@ public class ApolloStore {
       try self.cache.removeRecords(matching: pattern)
     }
 
-//    public func write<Query: GraphQLQuery>(data: Query.Data, forQuery query: Query) throws {
+    public func write<CacheMutation: LocalCacheMutation>(
+      data: CacheMutation.Data,
+      for cacheMutation: CacheMutation
+    ) throws {
+      fatalError("TODO: Write Transactions not yet working!")
 //      try write(object: data,
 //                withKey: rootCacheKey(for: query),
 //                variables: query.variables)
-//    }
-//
-//    public func write(object: GraphQLSelectionSet,
-//                      withKey key: CacheKey,
-//                      variables: GraphQLMap? = nil) throws {
+    }
+
+    public func write<SelectionSet: MutableSelectionSet>(
+      object: SelectionSet,
+      withKey key: CacheKey,
+      variables: GraphQLOperation.Variables? = nil
+    ) throws {
+      fatalError("TODO: Write Transactions not yet working!")
 //      try write(object: object.jsonObject,
 //                forSelections: type(of: object).selections,
 //                withKey: key, variables: variables)
-//    }
+    }
 //
 //    private func write(object: JSONObject,
 //                       forSelections selections: [GraphQLSelection],

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -127,8 +127,8 @@ fileprivate struct FieldSelectionGrouping: Sequence {
   }
 }
 
-/// An error which has occurred in processing a GraphQLResult
-public struct GraphQLResultError: Error, LocalizedError {
+/// An error which has occurred during GraphQL execution.
+public struct GraphQLExecutionError: Error, LocalizedError {
   let path: ResponsePath
 
   /// The error that occurred during parsing.
@@ -318,8 +318,8 @@ final class GraphQLExecutor {
     }.map {
       try accumulator.accept(fieldEntry: $0, info: fieldInfo)
     }.mapError { error in
-      if !(error is GraphQLResultError) {
-        return GraphQLResultError(path: fieldInfo.responsePath, underlying: error)
+      if !(error is GraphQLExecutionError) {
+        return GraphQLExecutionError(path: fieldInfo.responsePath, underlying: error)
       } else {
         return error
       }
@@ -386,8 +386,8 @@ final class GraphQLExecutor {
                       asType: innerType,
                       accumulator: accumulator)
             .mapError { error in
-              if !(error is GraphQLResultError) {
-                return GraphQLResultError(path: elementFieldInfo.responsePath, underlying: error)
+              if !(error is GraphQLExecutionError) {
+                return GraphQLExecutionError(path: elementFieldInfo.responsePath, underlying: error)
               } else {
                 return error
               }

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -153,8 +153,8 @@ final class GraphQLExecutor {
 
   var shouldComputeCachePath = true
 
-  /// Creates a GraphQLExecutor that resolves field values by calling the provided resolver. If provided, it will also resolve references by calling
-  /// the reference resolver.
+  /// Creates a GraphQLExecutor that resolves field values by calling the provided resolver.
+  /// If provided, it will also resolve references by calling the reference resolver.
   init(
     resolver: @escaping GraphQLFieldResolver,
     resolveReference: ReferenceResolver? = nil

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -15,11 +15,21 @@ public struct DataDict: Hashable {
   @inlinable public subscript<T: AnyScalarType & Hashable>(_ key: String) -> T {
     get { _data[key] as! T }
     set { _data[key] = newValue }
+    _modify {
+      var value = _data[key] as! T
+      defer { _data[key] = value }
+      yield &value
+    }
   }
   
   @inlinable public subscript<T: SelectionSetEntityValue>(_ key: String) -> T {
     get { T.init(fieldData: _data[key], variables: _variables) }
     set { _data[key] = newValue._fieldData }
+    _modify {
+      var value = T.init(fieldData: _data[key], variables: _variables)
+      defer { _data[key] = value._fieldData }
+      yield &value
+    }
   }
 
   @inlinable public func hash(into hasher: inout Hasher) {

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -1,7 +1,7 @@
 /// A structure that wraps the underlying data dictionary used by `SelectionSet`s.
 public struct DataDict: Hashable {
 
-  public let _data: JSONObject
+  public var _data: JSONObject
   public let _variables: GraphQLOperation.Variables?
 
   @inlinable public init(
@@ -12,20 +12,22 @@ public struct DataDict: Hashable {
     self._variables = variables
   }
 
-  @inlinable public subscript<T: AnyScalarType>(_ key: String) -> T {
-    _data[key] as! T
+  @inlinable public subscript<T: AnyScalarType & Hashable>(_ key: String) -> T {
+    get { _data[key] as! T }
+    set { _data[key] = newValue }
   }
   
   @inlinable public subscript<T: SelectionSetEntityValue>(_ key: String) -> T {
-    T.init(fieldData: _data[key], variables: _variables)
+    get { T.init(fieldData: _data[key], variables: _variables) }
+    set { _data[key] = newValue._fieldData }
   }
 
-  public func hash(into hasher: inout Hasher) {
+  @inlinable public func hash(into hasher: inout Hasher) {
     hasher.combine(_data)
     hasher.combine(_variables?.jsonEncodableValue?.jsonValue)
   }
 
-  public static func == (lhs: DataDict, rhs: DataDict) -> Bool {
+  @inlinable public static func ==(lhs: DataDict, rhs: DataDict) -> Bool {
     lhs._data == rhs._data &&
     lhs._variables?.jsonEncodableValue?.jsonValue == rhs._variables?.jsonEncodableValue?.jsonValue
   }
@@ -33,6 +35,7 @@ public struct DataDict: Hashable {
 
 public protocol SelectionSetEntityValue {
   init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?)
+  var _fieldData: AnyHashable { get }
 }
 
 extension AnySelectionSet {
@@ -42,6 +45,8 @@ extension AnySelectionSet {
     }
     self.init(data: DataDict(fieldData, variables: variables))
   }
+
+  @inlinable public var _fieldData: AnyHashable { data._data }
 }
 
 extension Optional: SelectionSetEntityValue where Wrapped: SelectionSetEntityValue {
@@ -52,6 +57,8 @@ extension Optional: SelectionSetEntityValue where Wrapped: SelectionSetEntityVal
     }
     self = .some(Wrapped.init(fieldData: fieldData, variables: variables))
   }
+
+  @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }
 }
 
 extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue {
@@ -61,4 +68,6 @@ extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue 
     }
     self = fieldData.map { Element.init(fieldData:$0, variables: variables) }
   }
+
+  @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }
 }

--- a/Sources/ApolloAPI/JSONDecodingError.swift
+++ b/Sources/ApolloAPI/JSONDecodingError.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public enum JSONDecodingError: Error, LocalizedError {
+public enum JSONDecodingError: Error, LocalizedError, Equatable {
   case missingValue
   case nullValue
   case wrongType
-  case couldNotConvert(value: Any, to: Any.Type)
+  case couldNotConvert(value: AnyHashable, to: Any.Type)
 
   public var errorDescription: String? {
     switch self {
@@ -16,6 +16,22 @@ public enum JSONDecodingError: Error, LocalizedError {
       return "Wrong type"
     case .couldNotConvert(let value, let expectedType):
       return "Could not convert \"\(value)\" to \(expectedType)"
+    }
+  }
+
+  public static func == (lhs: JSONDecodingError, rhs: JSONDecodingError) -> Bool {
+    switch (lhs, rhs) {
+    case (.missingValue, .missingValue),
+      (.nullValue, .nullValue),
+      (.wrongType, .wrongType):
+      return true
+
+    case let (.couldNotConvert(value: lhsValue, to: lhsType),
+              .couldNotConvert(value: rhsValue, to: rhsType)):
+      return lhsValue == rhsValue && lhsType == rhsType
+
+    default:
+      return false
     }
   }
 }

--- a/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -18,4 +18,15 @@ public extension LocalCacheMutation {
 
 public protocol MutableSelectionSet: AnySelectionSet {}
 
-public protocol MutableRootSelectionSet: RootSelectionSet, MutableSelectionSet {}
+public protocol MutableRootSelectionSet: RootSelectionSet, MutableSelectionSet {
+  var data: DataDict { get set }
+}
+
+extension MutableRootSelectionSet {
+
+  @inlinable public var __typename: String {
+    get { data["__typename"] }
+    set { data["__typename"] = newValue }
+  }
+
+}

--- a/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public protocol LocalCacheMutation: AnyObject, Hashable {
+  var variables: GraphQLOperation.Variables? { get }
+
+  associatedtype Data: MutableRootSelectionSet
+}
+
+public extension LocalCacheMutation {
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.variables?.jsonEncodableValue?.jsonValue == rhs.variables?.jsonEncodableValue?.jsonValue
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(variables?.jsonEncodableValue?.jsonValue)
+  }
+}
+
+public protocol MutableSelectionSet: AnySelectionSet {}
+
+public protocol MutableRootSelectionSet: RootSelectionSet, MutableSelectionSet {}

--- a/Sources/ApolloAPI/ScalarTypes.swift
+++ b/Sources/ApolloAPI/ScalarTypes.swift
@@ -1,4 +1,4 @@
-public protocol AnyScalarType: JSONEncodable {}
+public protocol AnyScalarType: JSONEncodable, AnyHashableConvertible {}
 
 public protocol ScalarType:
   AnyScalarType,

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -9,3 +9,10 @@ open class MockLocalCacheMutation<SelectionSet: MutableRootSelectionSet>: LocalC
   public init() {}
 
 }
+
+public protocol MockMutableRootSelectionSet: MutableRootSelectionSet {}
+
+public extension MockMutableRootSelectionSet {
+  static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
+  static var __parentType: ParentType { .Object(Object.self) }
+}

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -1,0 +1,13 @@
+import Foundation
+import ApolloAPI
+
+open class MockMutableSelectionSet: AbstractMockSelectionSet, MutableRootSelectionSet { }
+
+open class MockLocalCacheMutation<SelectionSet: MutableRootSelectionSet>: LocalCacheMutation {
+  public typealias Data = SelectionSet
+
+  open var variables: GraphQLOperation.Variables?
+
+  public init() {}
+
+}

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -1,7 +1,28 @@
 import Foundation
 import ApolloAPI
 
-open class MockMutableSelectionSet: AbstractMockSelectionSet, MutableRootSelectionSet { }
+@dynamicMemberLookup
+open class MockMutableSelectionSet: MutableRootSelectionSet {
+  open class var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
+  open class var selections: [Selection] { [] }
+  open class var __parentType: ParentType { .Object(Object.self) }
+
+  public var data: DataDict = DataDict([:], variables: nil)
+
+  public required init(data: DataDict) {
+    self.data = data
+  }
+
+  public subscript<T: AnyScalarType & Hashable>(dynamicMember key: String) -> T? {
+    get { data[key] }
+    set { data[key] = newValue }
+  }
+
+  public subscript<T: MockMutableSelectionSet>(dynamicMember key: String) -> T? {
+    get { data[key] }
+    set { data[key] = newValue }
+  }
+}
 
 open class MockLocalCacheMutation<SelectionSet: MutableRootSelectionSet>: LocalCacheMutation {
   public typealias Data = SelectionSet

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -1,29 +1,6 @@
 import Foundation
 import ApolloAPI
 
-@dynamicMemberLookup
-open class MockMutableSelectionSet: MutableRootSelectionSet {
-  open class var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
-  open class var selections: [Selection] { [] }
-  open class var __parentType: ParentType { .Object(Object.self) }
-
-  public var data: DataDict = DataDict([:], variables: nil)
-
-  public required init(data: DataDict) {
-    self.data = data
-  }
-
-  public subscript<T: AnyScalarType & Hashable>(dynamicMember key: String) -> T? {
-    get { data[key] }
-    set { data[key] = newValue }
-  }
-
-  public subscript<T: MockMutableSelectionSet>(dynamicMember key: String) -> T? {
-    get { data[key] }
-    set { data[key] = newValue }
-  }
-}
-
 open class MockLocalCacheMutation<SelectionSet: MutableRootSelectionSet>: LocalCacheMutation {
   public typealias Data = SelectionSet
 

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -55,7 +55,7 @@ open class AbstractMockSelectionSet: AnySelectionSet {
     self.data = data
   }
 
-  public subscript<T: AnyScalarType>(dynamicMember key: String) -> T? {
+  public subscript<T: AnyScalarType & Hashable>(dynamicMember key: String) -> T? {
     data[key]
   }
 
@@ -64,7 +64,15 @@ open class AbstractMockSelectionSet: AnySelectionSet {
   }
 }
 
-open class MockSelectionSet: AbstractMockSelectionSet, RootSelectionSet { }
+open class MockSelectionSet: AbstractMockSelectionSet, RootSelectionSet, Hashable {
+  public static func == (lhs: MockSelectionSet, rhs: MockSelectionSet) -> Bool {
+    lhs.data == rhs.data
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(data)
+  }
+}
 
 open class MockFragment: AbstractMockSelectionSet, RootSelectionSet, Fragment {
   open class var fragmentDefinition: StaticString { "" }

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -62,6 +62,7 @@ open class AbstractMockSelectionSet: AnySelectionSet {
   public subscript<T: MockSelectionSet>(dynamicMember key: String) -> T? {
     data[key]
   }
+  
 }
 
 open class MockSelectionSet: AbstractMockSelectionSet, RootSelectionSet, Hashable {

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -127,7 +127,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     loadFromStore(query: query) { result in
       // then
       XCTAssertThrowsError(try result.get()) { error in
-        if let error = error as? GraphQLResultError {
+        if let error = error as? GraphQLExecutionError {
           XCTAssertEqual(error.path, ["hero", "name"])
           XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
         } else {
@@ -163,7 +163,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     loadFromStore(query: query) { result in
       // then
       XCTAssertThrowsError(try result.get()) { error in
-        if let error = error as? GraphQLResultError {
+        if let error = error as? GraphQLExecutionError {
           XCTAssertEqual(error.path, ["hero", "name"])
           XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
         } else {
@@ -379,7 +379,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     loadFromStore(query: query) { result in
       // then
       XCTAssertThrowsError(try result.get()) { error in
-        if let error = error as? GraphQLResultError {
+        if let error = error as? GraphQLExecutionError {
           XCTAssertEqual(error.path, ["hero", "friends"])
           XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
         } else {
@@ -438,7 +438,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     loadFromStore(query: query) { result in
       XCTAssertThrowsError(try result.get()) { error in
         // then
-        if let error = error as? GraphQLResultError,
+        if let error = error as? GraphQLExecutionError,
            case JSONDecodingError.couldNotConvert(_, let expectedType) = error.underlying {
           XCTAssertEqual(error.path, ["hero", "friends", "0", "name"])
           XCTAssertTrue(expectedType == String.self)

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -192,18 +192,41 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func testUpdateHeroNameQuery() throws {
     // given
-    class GivenSelectionSet: MockMutableSelectionSet {
-      override class var selections: [Selection] { [
+    struct GivenSelectionSet: MutableRootSelectionSet {
+      static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
+      static var __parentType: ParentType { .Object(Object.self) }
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      public init(data: DataDict) {
+        self.data = data
+      }
+
+      static var selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
-//      var hero: Hero? { get { self[dynamicMember: "hero"] }
-//        set { self[dynamicMember: "hero"] = newValue } }
+      var hero: Hero? {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
 
-      class Hero: MockMutableSelectionSet {
-        override class var selections: [Selection] { [
+      struct Hero: MutableRootSelectionSet {
+        static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
+        static var __parentType: ParentType { .Object(Object.self) }
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        public init(data: DataDict) {
+          self.data = data
+        }
+        
+        static var selections: [Selection] { [
           .field("name", String.self)
         ]}
+
+        var name: String? {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
       }
     }
 
@@ -220,8 +243,6 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       store.withinReadWriteTransaction({ transaction in
         try transaction.update(cacheMutation) { data in
           data.hero?.name = "Artoo"
-//          hero?.name = "Artoo"
-//          data.hero = hero
         }
       }, completion: { result in
         defer { updateCompletedExpectation.fulfill() }

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -190,48 +190,60 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   // MARK: - Write Local Cache Mutation Tests
 
-//  func testUpdateHeroNameQuery() throws {
-//    // given
-//    class GivenSelectionSet: MockMutableSelectionSet {
-//      override class var selections: [Selection] { [
-//        .field("name", String.self)
-//      ]}
-//    }
-//
-//    let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
-//
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("QUERY_ROOT.hero")],
-//      "QUERY_ROOT.hero": ["__typename": "Droid", "name": "R2-D2"]
-//    ])
-//
-//
-//    runActivity("update mutation") { _ in
-//      let updateCompletedExpectation = expectation(description: "Update completed")
-//
-//      store.withinReadWriteTransaction({ transaction in
-//        try transaction.update(cacheMutation: cacheMutation) { data in
-//          data.hero?.name = "Artoo"
-//        }
-//      }, completion: { result in
-//        defer { updateCompletedExpectation.fulfill() }
-//        XCTAssertSuccessResult(result)
-//      })
-//
-//      self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//
-//    loadFromStore(query: query) { result in
-//      try XCTAssertSuccessResult(result) { graphQLResult in
-//        XCTAssertEqual(graphQLResult.source, .cache)
-//        XCTAssertNil(graphQLResult.errors)
-//
-//        let data = try XCTUnwrap(graphQLResult.data)
-//        XCTAssertEqual(data.hero?.name, "Artoo")
-//      }
-//    }
-//  }
-//
+  func testUpdateHeroNameQuery() throws {
+    // given
+    class GivenSelectionSet: MockMutableSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+//      var hero: Hero? { get { self[dynamicMember: "hero"] }
+//        set { self[dynamicMember: "hero"] = newValue } }
+
+      class Hero: MockMutableSelectionSet {
+        override class var selections: [Selection] { [
+          .field("name", String.self)
+        ]}
+      }
+    }
+
+    let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("QUERY_ROOT.hero")],
+      "QUERY_ROOT.hero": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+
+    runActivity("update mutation") { _ in
+      let updateCompletedExpectation = expectation(description: "Update completed")
+
+      store.withinReadWriteTransaction({ transaction in
+        try transaction.update(cacheMutation) { data in
+          data.hero?.name = "Artoo"
+//          hero?.name = "Artoo"
+//          data.hero = hero
+        }
+      }, completion: { result in
+        defer { updateCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      })
+
+      self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    let query = MockQuery<GivenSelectionSet>()
+
+    loadFromStore(query: query) { result in
+      try XCTAssertSuccessResult(result) { graphQLResult in
+        XCTAssertEqual(graphQLResult.source, .cache)
+        XCTAssertNil(graphQLResult.errors)
+
+        let data = try XCTUnwrap(graphQLResult.data)
+        XCTAssertEqual(data.hero?.name, "Artoo")
+      }
+    }
+  }
+
 //  func testWriteHeroNameQueryWhenErrorIsThrown() throws {
 //    let writeCompletedExpectation = expectation(description: "Write completed")
 //

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -368,123 +368,120 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [writeCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
-//  func test_writeDataForCacheMutation_givenDeleteRecordReferencedByOtherRecord_thenReadQueryReferencingRemovedRecord_throwsError() throws {
-//    /// given
-//    struct GivenSelectionSet: MockMutableRootSelectionSet {
-//      public var data: DataDict = DataDict([:], variables: nil)
-//
-//      public init(data: DataDict) {
-//        self.data = data
-//      }
-//
-//      static var selections: [Selection] { [
-//        .field("hero", Hero.self)
-//      ]}
-//
-//      var hero: Hero? {
-//        get { data["hero"] }
-//        set { data["hero"] = newValue }
-//      }
-//
-//      struct Hero: MockMutableRootSelectionSet {
-//        public var data: DataDict = DataDict([:], variables: nil)
-//
-//        public init(data: DataDict) {
-//          self.data = data
-//        }
-//
-//        static var selections: [Selection] { [
-//          .field("id", String.self),
-//          .field("name", String.self),
-//        ]}
-//
-//        var name: String? {
-//          get { data["name"] }
-//          set { data["name"] = newValue }
-//        }
-//
-//        struct Friend: MockMutableRootSelectionSet {
-//          public var data: DataDict = DataDict([:], variables: nil)
-//
-//          public init(data: DataDict) {
-//            self.data = data
-//          }
-//
-//          static var selections: [Selection] { [
-//            .field("id", String.self),
-//            .field("name", String.self),
-//          ]}
-//
-//          var name: String? {
-//            get { data["name"] }
-//            set { data["name"] = newValue }
-//          }
-//        }
-//      }
-//    }
-//
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": [
-//          CacheReference("1000"),
-//          CacheReference("1002"),
-//          CacheReference("1003")
-//        ]
-//      ],
-//      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
-//      "1002": ["__typename": "Human", "name": "Han Solo"],
-//      "1003": ["__typename": "Human", "name": "Leia Organa"],
-//    ])
-//
-//    let query = HeroAndFriendsNamesQuery()
-//
-//    let readWriteCompletedExpectation = expectation(description: "ReadWrite completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//      XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-//
-//      try transaction.removeObject(for: "1003")
-//    }, completion: { result in
-//      defer { readWriteCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readWriteCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      _ = try transaction.read(query: query)
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertFailureResult(result) { readError in
-//        guard let error = readError as? GraphQLResultError else {
-//          XCTFail("Unexpected error for reading removed record: \(readError)")
-//          return
-//        }
-//
-//        /// The error should occur when trying to load all the hero's friend references, since one has been deleted
-//        XCTAssertEqual(error.path, ["hero", "friends"])
-//
-//        switch error.underlying {
-//        case JSONDecodingError.missingValue:
-//          // This is what we want
-//          return
-//        default:
-//          XCTFail("Unexpected error for reading removed record: \(error.underlying)")
-//        }
-//      }
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
+  func test_writeDataForCacheMutation_givenDeleteRecordReferencedByOtherRecord_thenReadQueryReferencingRemovedRecord_throwsError() throws {
+    /// given
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      public init(data: DataDict) {
+        self.data = data
+      }
+
+      static var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero? {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        public init(data: DataDict) {
+          self.data = data
+        }
+
+        static var selections: [Selection] { [
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self),
+        ]}
+
+        var name: String? {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+
+        var friends: [Friend]? {
+          get { data["friend"] }
+          set { data["friend"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          public init(data: DataDict) {
+            self.data = data
+          }
+
+          static var selections: [Selection] { [
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+
+          var name: String? {
+            get { data["name"] }
+            set { data["name"] = newValue }
+          }
+        }
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("2001")],
+      "2001": [
+        "name": "R2-D2",
+        "id": "2001",
+        "__typename": "Droid",
+        "friends": [
+          CacheReference("1000"),
+          CacheReference("1002"),
+          CacheReference("1003")
+        ]
+      ],
+      "1000": ["__typename": "Human", "name": "Luke Skywalker", "id": "1000"],
+      "1002": ["__typename": "Human", "name": "Han Solo", "id": "1002"],
+      "1003": ["__typename": "Human", "name": "Leia Organa", "id": "1003"],
+    ])
+
+    runActivity("delete record for Leia Organa") { _ in
+      let readWriteCompletedExpectation = expectation(description: "ReadWrite completed")
+
+      store.withinReadWriteTransaction({ transaction in
+        try transaction.removeObject(for: "1003")
+      }, completion: { result in
+        defer { readWriteCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      })
+
+      self.wait(for: [readWriteCompletedExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Read query with deleted record reference") { _ in
+      let query = MockQuery<GivenSelectionSet>()
+      let readCompletedExpectation = expectation(description: "Read completed")
+
+      store.withinReadTransaction({ transaction in
+        _ = try transaction.read(query: query)
+      }, completion: { result in
+        defer { readCompletedExpectation.fulfill() }
+        XCTAssertFailureResult(result) { readError in
+          guard let error = readError as? GraphQLExecutionError else {
+            XCTFail("Unexpected error for reading removed record: \(readError)")
+            return
+          }
+          
+          /// The error should occur when trying to load all the hero's friend references, since one has been deleted
+          XCTAssertEqual(error.path, ["hero", "friends", "2"])
+          expect(error.underlying as? JSONDecodingError).to(equal(JSONDecodingError.missingValue))
+        }
+      })
+
+      self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
 //
 //  func testUpdateHeroAndFriendsNamesQuery() throws {
 //    mergeRecordsIntoCache([

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -5,7 +5,6 @@ import ApolloUtils
 import ApolloAPI
 import ApolloInternalTestHelpers
 
-#warning("TODO fix these after refactoring cache transactions")
 class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   var cacheType: TestCacheProvider.Type {
@@ -235,7 +234,6 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       "1003": ["__typename": "Human", "name": "Leia Organa", "id": "1003"],
     ])
 
-
     let readCompletedExpectation = expectation(description: "Read completed")
 
     store.withinReadTransaction({ transaction in
@@ -244,6 +242,116 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       XCTAssertEqual(data.hero.name, "R2-D2")
       let friendsNames: [String] = data.hero.friends.compactMap { $0.name }
       XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  func test_readObject_givenFragmentWithTypeSpecificProperty() throws {
+    // given
+    class Droid: Object {}
+    MockSchemaConfiguration.stub_objectTypeForTypeName = { typename in
+      switch typename {
+      case "Droid": return Droid.self
+      default: return nil
+      }
+    }
+
+    class GivenSelectionSet: MockFragment, SelectionSet {
+      typealias Schema = MockSchemaConfiguration
+
+      override class var selections: [Selection] { [
+        .field("__typename", String.self),
+        .field("name", String.self),
+        .inlineFragment(AsDroid.self),
+      ]}
+
+      var asDroid: AsDroid? { _asInlineFragment() }
+
+      class AsDroid: MockTypeCase, SelectionSet {
+        typealias Schema = MockSchemaConfiguration
+        override class var __parentType: ParentType { .Object(Droid.self) }
+
+        override class var selections: [Selection] { [
+          .field("primaryFunction", String.self),
+        ]}
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "2001": ["name": "R2-D2", "__typename": "Droid", "primaryFunction": "Protocol"]
+    ])
+
+    let readCompletedExpectation = expectation(description: "Read completed")
+
+    store.withinReadTransaction({ transaction in
+      let r2d2 = try transaction.readObject(
+        ofType: GivenSelectionSet.self,
+        withKey: "2001"
+      )
+
+      XCTAssertEqual(r2d2.name, "R2-D2")
+      XCTAssertEqual(r2d2.asDroid?.primaryFunction, "Protocol")
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  func test_readObject_givenFragmentWithMissingTypeSpecificProperty() throws {
+    // given
+    class Droid: Object {}
+    MockSchemaConfiguration.stub_objectTypeForTypeName = { typename in
+      switch typename {
+      case "Droid": return Droid.self
+      default: return nil
+      }
+    }
+
+    class GivenSelectionSet: MockFragment, SelectionSet {
+      typealias Schema = MockSchemaConfiguration
+
+      override class var selections: [Selection] { [
+        .field("__typename", String.self),
+        .field("name", String.self),
+        .inlineFragment(AsDroid.self),
+      ]}
+
+      var asDroid: AsDroid? { _asInlineFragment() }
+
+      class AsDroid: MockTypeCase, SelectionSet {
+        typealias Schema = MockSchemaConfiguration
+        override class var __parentType: ParentType { .Object(Droid.self) }
+
+        override class var selections: [Selection] { [
+          .field("primaryFunction", String.self),
+        ]}
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "2001": ["name": "R2-D2", "__typename": "Droid"]
+    ])
+
+    let readCompletedExpectation = expectation(description: "Read completed")
+
+    store.withinReadTransaction({ transaction in
+      XCTAssertThrowsError(try transaction.readObject(
+        ofType: GivenSelectionSet.self,
+        withKey: "2001")
+      ) { error in
+        if case let error as GraphQLExecutionError = error {
+          XCTAssertEqual(error.path, ["primaryFunction"])
+          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
+        } else {
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
     }, completion: { result in
       defer { readCompletedExpectation.fulfill() }
       XCTAssertSuccessResult(result)
@@ -314,6 +422,102 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         let data = try XCTUnwrap(graphQLResult.data)
         XCTAssertEqual(data.hero.name, "Artoo")
       }
+    }
+  }
+
+  func test_updateCacheMutation_givenQueryWithVariables_updateNestedField_updatesObjectsOnlyForQueryWithMatchingVariables() throws {
+    // given
+    enum Episode: String, EnumType {
+      case JEDI
+      case PHANTOM_MENACE
+    }
+
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] { [
+          .field("name", String.self)
+        ]}
+
+        var name: String {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": [
+        "hero(episode:JEDI)": CacheReference("hero(episode:JEDI)"),
+        "hero(episode:PHANTOM_MENACE)": CacheReference("hero(episode:PHANTOM_MENACE)")
+      ],
+      "hero(episode:JEDI)": ["__typename": "Droid", "name": "R2-D2"],
+      "hero(episode:PHANTOM_MENACE)": ["__typename": "Human", "name": "Qui-Gon Jinn"]
+    ])
+
+    runActivity("update mutation") { _ in
+      let updateCompletedExpectation = expectation(description: "Update completed")
+      let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
+      cacheMutation.variables = ["episode": Episode.JEDI]
+
+      store.withinReadWriteTransaction({ transaction in
+        try transaction.update(cacheMutation) { data in
+          data.hero.name = "Artoo"
+        }
+      }, completion: { result in
+        defer { updateCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      })
+
+      self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("read queries") { _ in
+      let readCompletedExpectation = expectation(description: "Read completed")
+      readCompletedExpectation.expectedFulfillmentCount = 2
+
+      let query = MockQuery<GivenSelectionSet>()
+      query.variables = ["episode": Episode.JEDI]
+
+      loadFromStore(query: query) { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .cache)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero.name, "Artoo")
+
+          readCompletedExpectation.fulfill()
+        }
+      }
+
+      query.variables = ["episode": Episode.PHANTOM_MENACE]
+
+      loadFromStore(query: query) { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .cache)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero.name, "Qui-Gon Jinn")
+
+          readCompletedExpectation.fulfill()
+        }
+      }
+
+      self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
     }
   }
 
@@ -482,6 +686,182 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [writeCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
+  func test_updateObjectWithKey_readAfterUpdateWithinSameTransaction_hasUpdatedValue() throws {
+    // given
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] { [
+          .field("name", String.self)
+        ]}
+
+        var name: String {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("QUERY_ROOT.hero")],
+      "QUERY_ROOT.hero": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+
+    // then
+    let readAfterUpdateCompletedExpectation = expectation(description: "Read after update completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      try transaction.updateObject(
+        ofType: GivenSelectionSet.self,
+        withKey: "QUERY_ROOT", { data in
+          data.hero.name = "Artoo"
+        })
+
+      let data = try transaction.readObject(
+        ofType: GivenSelectionSet.self,
+        withKey: "QUERY_ROOT"
+      )
+
+      XCTAssertEqual(data.hero.name, "Artoo")
+
+    }, completion: { result in
+      defer { readAfterUpdateCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [readAfterUpdateCompletedExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  func testUpdateObjectWithKey_givenFragment_updatesObject() throws {
+    /// given
+    struct GivenFragment: MockMutableRootSelectionSet, Fragment {
+      static var fragmentDefinition: StaticString { "" }
+
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] { [
+        .field("id", String.self),
+        .field("friends", [Friend].self),
+      ]}
+
+      var friends: [Friend] {
+        get { data["friends"] }
+        set { data["friends"] = newValue }
+      }
+
+      struct Friend: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] { [
+          .field("id", String.self),
+          .field("name", String.self),
+        ]}
+
+        var id: String {
+          get { data["id"] }
+          set { data["id"] = newValue }
+        }
+
+        var name: String {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("2001")],
+      "2001": [
+        "name": "R2-D2",
+        "id": "2001",
+        "__typename": "Droid",
+        "friends": [
+          CacheReference("1000"),
+          CacheReference("1002"),
+          CacheReference("1003")
+        ]
+      ],
+      "1000": ["__typename": "Human", "name": "Luke Skywalker", "id": "1000"],
+      "1002": ["__typename": "Human", "name": "Han Solo", "id": "1002"],
+      "1003": ["__typename": "Human", "name": "Leia Organa", "id": "1003"],
+    ])
+
+    let updateCompletedExpectation = expectation(description: "Update completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      try transaction.updateObject(
+        ofType: GivenFragment.self,
+        withKey: "2001"
+      ) { friendsNamesFragment in
+        var c3po = GivenFragment.Friend()
+        c3po.__typename = "Droid"
+        c3po.id = "1004"
+        c3po.name = "C-3PO"
+
+        friendsNamesFragment.friends.append(c3po)
+      }
+    }, completion: { result in
+      defer { updateCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
+
+    class HeroFriendsSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero { data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self)
+        ]}
+
+        var friends: [Friend] { data["friends"] }
+
+        class Friend: MockSelectionSet {
+          override class var selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+        }
+      }
+    }
+
+    let query = MockQuery<HeroFriendsSelectionSet>()
+    loadFromStore(query: query) { result in
+      try XCTAssertSuccessResult(result) { graphQLResult in
+        XCTAssertEqual(graphQLResult.source, .cache)
+        XCTAssertNil(graphQLResult.errors)
+
+        let data = try XCTUnwrap(graphQLResult.data)
+        XCTAssertEqual(data.hero.name, "R2-D2")
+        let friendsNames: [String] = data.hero.friends.compactMap { $0.name }
+        XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
+      }
+    }
+  }
+
+  // MARK: - Remove Object
+
   func test_removeObject_givenReferencedByOtherRecord_thenReadQueryReferencingRemovedRecord_throwsError() throws {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
@@ -510,9 +890,9 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           set { data["name"] = newValue }
         }
 
-        var friends: [Friend]? {
-          get { data["friend"] }
-          set { data["friend"] = newValue }
+        var friends: [Friend] {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
         }
 
         struct Friend: MockMutableRootSelectionSet {
@@ -523,7 +903,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
             .field("name", String.self),
           ]}
 
-          var name: String? {
+          var name: String {
             get { data["name"] }
             set { data["name"] = newValue }
           }
@@ -574,7 +954,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
             XCTFail("Unexpected error for reading removed record: \(readError)")
             return
           }
-          
+
           /// The error should occur when trying to load all the hero's friend references, since one has been deleted
           XCTAssertEqual(error.path, ["hero", "friends", "2"])
           expect(error.underlying as? JSONDecodingError).to(equal(JSONDecodingError.missingValue))
@@ -585,452 +965,224 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
   }
 
-//
-//  func testUpdateHeroAndFriendsNamesQueryWithVariable() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero(episode:NEWHOPE)": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": [
-//          CacheReference("1000"),
-//          CacheReference("1002"),
-//          CacheReference("1003")
-//        ]
-//      ],
-//      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
-//      "1002": ["__typename": "Human", "name": "Han Solo"],
-//      "1003": ["__typename": "Human", "name": "Leia Organa"],
-//    ])
-//
-//    let query = HeroAndFriendsNamesQuery(episode: Episode.newhope)
-//
-//    let updateCompletedExpectation = expectation(description: "Update completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.update(query: query) { data in
-//        data.hero?.friends?.append(.makeDroid(name: "C-3PO"))
-//      }
-//    }, completion: { result in
-//      defer { updateCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    loadFromStore(query: query) { result in
-//      try XCTAssertSuccessResult(result) { graphQLResult in
-//        XCTAssertEqual(graphQLResult.source, .cache)
-//        XCTAssertNil(graphQLResult.errors)
-//
-//        let data = try XCTUnwrap(graphQLResult.data)
-//        XCTAssertEqual(data.hero?.name, "R2-D2")
-//        let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//        XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
-//      }
-//    }
-//  }
-//
-//  func testReadAfterUpdateWithinSameTransaction() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": [
-//          CacheReference("1000"),
-//          CacheReference("1002"),
-//          CacheReference("1003")
-//        ]
-//      ],
-//      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
-//      "1002": ["__typename": "Human", "name": "Han Solo"],
-//      "1003": ["__typename": "Human", "name": "Leia Organa"],
-//    ])
-//
-//    let query = HeroAndFriendsNamesQuery()
-//
-//    let readAfterUpdateCompletedExpectation = expectation(description: "Read after update completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.update(query: query) { data in
-//        data.hero?.name = "Artoo"
-//        data.hero?.friends?.append(.makeDroid(name: "C-3PO"))
-//      }
-//
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.name, "Artoo")
-//      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//      XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
-//    }, completion: { result in
-//      defer { readAfterUpdateCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readAfterUpdateCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testReadHeroDetailsFragmentWithTypeSpecificProperty() throws {
-//    mergeRecordsIntoCache([
-//      "2001": ["name": "R2-D2", "__typename": "Droid", "primaryFunction": "Protocol"]
-//    ])
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      let r2d2 = try transaction.readObject(ofType: HeroDetails.self, withKey: "2001")
-//
-//      XCTAssertEqual(r2d2.name, "R2-D2")
-//      XCTAssertEqual(r2d2.asDroid?.primaryFunction, "Protocol")
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testReadHeroDetailsFragmentWithMissingTypeSpecificProperty() throws {
-//    mergeRecordsIntoCache([
-//      "2001": ["name": "R2-D2", "__typename": "Droid"]
-//    ])
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      XCTAssertThrowsError(try transaction.readObject(ofType: HeroDetails.self, withKey: "2001")) { error in
-//        if case let error as GraphQLResultError = error {
-//          XCTAssertEqual(error.path, ["primaryFunction"])
-//          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-//        } else {
-//          XCTFail("Unexpected error: \(error)")
-//        }
-//      }
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testReadFriendsNamesFragment() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": [
-//          CacheReference("1000"),
-//          CacheReference("1002"),
-//          CacheReference("1003")
-//        ]
-//      ],
-//      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
-//      "1002": ["__typename": "Human", "name": "Han Solo"],
-//      "1003": ["__typename": "Human", "name": "Leia Organa"],
-//    ])
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      let friendsNamesFragment = try transaction.readObject(ofType: FriendsNames.self, withKey: "2001")
-//
-//      let friendsNames = friendsNamesFragment.friends?.compactMap { $0?.name }
-//      XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testUpdateFriendsNamesFragment() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": [
-//          CacheReference("1000"),
-//          CacheReference("1002"),
-//          CacheReference("1003")
-//        ]
-//      ],
-//      "1000": ["__typename": "Human", "name": "Luke Skywalker"],
-//      "1002": ["__typename": "Human", "name": "Han Solo"],
-//      "1003": ["__typename": "Human", "name": "Leia Organa"],
-//    ])
-//
-//    let updateCompletedExpectation = expectation(description: "Update completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.updateObject(ofType: FriendsNames.self, withKey: "2001") { friendsNames in
-//        friendsNames.friends?.append(.makeDroid(name: "C-3PO"))
-//      }
-//    }, completion: { result in
-//      defer { updateCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    loadFromStore(query: HeroAndFriendsNamesQuery()) { result in
-//      try XCTAssertSuccessResult(result) { graphQLResult in
-//        XCTAssertEqual(graphQLResult.source, .cache)
-//        XCTAssertNil(graphQLResult.errors)
-//
-//        let data = try XCTUnwrap(graphQLResult.data)
-//        XCTAssertEqual(data.hero?.name, "R2-D2")
-//        let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//        XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa", "C-3PO"])
-//      }
-//    }
-//  }
-//
-//  func test_removeObjectsMatchingPattern_givenPatternNotMatchingKeyCase_deletesCaseInsensitiveMatchingRecords() throws {
-//    let heroKey = "hero"
-//
-//    //
-//    // 1. Merge all required records into the cache with lowercase key
-//    //
-//
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["\(heroKey.lowercased())": CacheReference("QUERY_ROOT.\(heroKey.lowercased())")],
-//      "QUERY_ROOT.\(heroKey.lowercased())": ["__typename": "Droid", "name": "R2-D2"]
-//    ])
-//
-//    //
-//    // 2. Attempt to successfully read out the record
-//    //
-//
-//    let query = HeroNameQuery()
-//    let readCompletedExpectation = expectation(description: "Read hero object from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//      XCTAssertEqual(data.hero?.__typename, "Droid")
-//
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    waitForExpectations(timeout: Self.defaultWaitTimeout)
-//
-//    //
-//    // 3. Remove object matching case insensitive (uppercase) key
-//    // - This should remove `QUERY_ROOT.hero` using pattern `QUERY_ROOT.HERO`
-//    //
-//
-//    let removeRecordsCompletedExpectation = expectation(description: "Remove cache record by key pattern")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.removeObjects(matching: "\(heroKey.uppercased())")
-//    }, completion: { result in
-//      defer { removeRecordsCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    waitForExpectations(timeout: Self.defaultWaitTimeout)
-//
-//    //
-//    // 4. Attempt to read records after pattern removal - expected FAIL
-//    //
-//
-//    let readAfterRemoveCompletedExpectation = expectation(description: "Read from cache after removal by pattern")
-//
-//    store.withinReadTransaction({ transaction in
-//      _ = try transaction.read(query: query)
-//
-//    }, completion: { result in
-//      defer { readAfterRemoveCompletedExpectation.fulfill() }
-//
-//      XCTAssertFailureResult(result) { error in
-//        if let error = error as? GraphQLResultError {
-//          XCTAssertEqual(error.path, ["hero"])
-//          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-//        } else {
-//          XCTFail("Unexpected error: \(error)")
-//        }
-//      }
-//    })
-//
-//    waitForExpectations(timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func test_removeObjectsMatchingPattern_givenKeyMatchingSubrangePattern_deletesMultipleRecords() throws {
-//
-//    //
-//    // 1. Merge all required records into the cache
-//    //
-//
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": [
-//        "hero(episode:NEWHOPE)": CacheReference("1002"),
-//        "hero(episode:JEDI)": CacheReference("1101"),
-//        "hero(episode:EMPIRE)": CacheReference("2001")
-//      ],
-//      "2001": [
-//        "id": "2001",
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": [
-//          CacheReference("1101"),
-//          CacheReference("1003")
-//        ]
-//      ],
-//      "1101": ["__typename": "Human", "name": "Luke Skywalker", "id": "1101", "friends": []],
-//      "1002": ["__typename": "Human", "name": "Han Solo", "id": "1002", "friends": []],
-//      "1003": ["__typename": "Human", "name": "Leia Organa", "id": "1003", "friends": []],
-//    ])
-//
-//    //
-//    // 2. Attempt to successfully read out the three queries
-//    //
-//
-//    let readHeroNewHopeCompletedExpectation = expectation(description: "Read hero object for .newhope episode from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let query = HeroAndFriendsNamesWithIDsQuery(episode: .newhope)
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Human")
-//      XCTAssertEqual(data.hero?.name, "Han Solo")
-//
-//      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//      XCTAssertEqual(friendsNames, [])
-//
-//    }, completion: { newHopeResult in
-//      defer { readHeroNewHopeCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(newHopeResult)
-//    })
-//
-//    let readHeroJediCompletedExpectation = expectation(description: "Read hero object for .jedi episode from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let query = HeroAndFriendsNamesWithIDsQuery(episode: .jedi)
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Human")
-//      XCTAssertEqual(data.hero?.name, "Luke Skywalker")
-//
-//      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//      XCTAssertEqual(friendsNames, [])
-//
-//    }, completion: { jediResult in
-//      defer { readHeroJediCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(jediResult)
-//    })
-//
-//    let readHeroEmpireCompletedExpectation = expectation(description: "Read hero object for .empire episode from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let query = HeroAndFriendsNamesWithIDsQuery(episode: .empire)
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Droid")
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//
-//      let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//      XCTAssertEqual(friendsNames, ["Luke Skywalker", "Leia Organa"])
-//
-//    }, completion: { empireResult in
-//      defer { readHeroEmpireCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(empireResult)
-//    })
-//
-//    waitForExpectations(timeout: Self.defaultWaitTimeout)
-//
-//    //
-//    // 3. Remove all objects matching the pattern `100`
-//    // - This will remove `1002` (Han Solo, hero for the .newhope episode)
-//    // - This will remove `1003` (Leia Organa, friend of the hero in .empire episode)
-//    //
-//
-//    let removeFromCacheCompletedExpectation = expectation(description: "Hero objects removed from cache by pattern")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.removeObjects(matching: "100")
-//    }, completion: { result in
-//      defer { removeFromCacheCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    waitForExpectations(timeout: Self.defaultWaitTimeout)
-//
-//    //
-//    // 4. Attempt to read records after pattern removal
-//    // - .newhope episode query expected to FAIL on the `hero` path
-//    // - .jedi episdoe query expected to SUCCEED
-//    // - .empire episode query expected to FAIL on the `hero.friends` path
-//    //
-//
-//    let readHeroNewHopeAfterRemoveCompletedExpectation = expectation(description: "Read removed hero object for .newhope episode from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let query = HeroAndFriendsNamesWithIDsQuery(episode: .newhope)
-//      _ = try transaction.read(query: query)
-//
-//    }, completion: { newHopeResult in
-//      defer { readHeroNewHopeAfterRemoveCompletedExpectation.fulfill() }
-//
-//      XCTAssertFailureResult(newHopeResult) { error in
-//        if let error = error as? GraphQLResultError {
-//          XCTAssertEqual(error.path, ["hero"])
-//          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-//        } else {
-//          XCTFail("Unexpected error: \(error)")
-//        }
-//      }
-//    })
-//
-//    let readHeroJediAfterRemoveCompletedExpectation = expectation(description: "Read removed hero object for .jedi episode from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let query = HeroAndFriendsNamesWithIDsQuery(episode: .jedi)
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Human")
-//      XCTAssertEqual(data.hero?.name, "Luke Skywalker")
-//
-//    }, completion: { jediResult in
-//      defer { readHeroJediAfterRemoveCompletedExpectation.fulfill() }
-//
-//      XCTAssertSuccessResult(jediResult)
-//    })
-//
-//    let readHeroEmpireAfterRemoveCompletedExpectation = expectation(description: "Read removed hero object for .empire episode from cache")
-//
-//    store.withinReadTransaction({ transaction in
-//      let query = HeroAndFriendsNamesWithIDsQuery(episode: .empire)
-//      _ = try transaction.read(query: query)
-//
-//    }, completion: { empireResult in
-//      defer { readHeroEmpireAfterRemoveCompletedExpectation.fulfill() }
-//
-//      XCTAssertFailureResult(empireResult) { error in
-//        if let error = error as? GraphQLResultError {
-//          XCTAssertEqual(error.path, ["hero.friends"])
-//          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-//        } else {
-//          XCTFail("Unexpected error: \(error)")
-//        }
-//      }
-//    })
-//
-//    waitForExpectations(timeout: Self.defaultWaitTimeout)
-//  }
+  func test_removeObjectsMatchingPattern_givenPatternNotMatchingKeyCase_deletesCaseInsensitiveMatchingRecords() throws {
+    // given
+    class HeroNameSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      class Hero: MockSelectionSet {
+        override class var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("name", String.self)
+        ]}
+      }
+    }
+
+    let query = MockQuery<HeroNameSelectionSet>()
+
+    // then
+    let heroKey = "hero"
+
+    //
+    // 1. Merge all required records into the cache with lowercase key
+    //
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["\(heroKey.lowercased())": CacheReference("QUERY_ROOT.\(heroKey.lowercased())")],
+      "QUERY_ROOT.\(heroKey.lowercased())": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+
+    //
+    // 2. Remove object matching case insensitive (uppercase) key
+    // - This should remove `QUERY_ROOT.hero` using pattern `QUERY_ROOT.HERO`
+    //
+
+    let removeRecordsCompletedExpectation = expectation(description: "Remove cache record by key pattern")
+
+    store.withinReadWriteTransaction({ transaction in
+      try transaction.removeObjects(matching: "\(heroKey.uppercased())")
+    }, completion: { result in
+      defer { removeRecordsCompletedExpectation.fulfill() }
+
+      XCTAssertSuccessResult(result)
+    })
+
+    waitForExpectations(timeout: Self.defaultWaitTimeout)
+
+    //
+    // 3. Attempt to read records after pattern removal - expected FAIL
+    //
+
+    let readAfterRemoveCompletedExpectation = expectation(description: "Read from cache after removal by pattern")
+
+    store.withinReadTransaction({ transaction in
+      _ = try transaction.read(query: query)
+
+    }, completion: { result in
+      defer { readAfterRemoveCompletedExpectation.fulfill() }
+
+      XCTAssertFailureResult(result) { error in
+        if let error = error as? GraphQLExecutionError {
+          XCTAssertEqual(error.path, ["hero"])
+          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
+        } else {
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+    })
+
+    waitForExpectations(timeout: Self.defaultWaitTimeout)
+  }
+
+  func test_removeObjectsMatchingPattern_givenKeyMatchingSubrangePattern_deletesMultipleRecords() throws {
+    // given
+    enum Episode: String, EnumType {
+      case NEWHOPE
+      case JEDI
+      case EMPIRE
+    }
+
+    class HeroFriendsSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
+      ]}
+
+      var hero: Hero { data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self)
+        ]}
+
+        var friends: [Friend] { data["friends"] }
+
+        class Friend: MockSelectionSet {
+          override class var selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+        }
+      }
+    }
+
+    //
+    // 1. Merge all required records into the cache
+    //
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": [
+        "hero(episode:NEWHOPE)": CacheReference("1002"),
+        "hero(episode:JEDI)": CacheReference("1101"),
+        "hero(episode:EMPIRE)": CacheReference("2001")
+      ],
+      "2001": [
+        "id": "2001",
+        "name": "R2-D2",
+        "__typename": "Droid",
+        "friends": [
+          CacheReference("1101"),
+          CacheReference("1003")
+        ]
+      ],
+      "1101": [
+        "__typename": "Human", "name": "Luke Skywalker", "id": "1101", "friends": []
+      ],
+      "1002": [
+        "__typename": "Human", "name": "Han Solo", "id": "1002", "friends": []
+      ],
+      "1003": [
+        "__typename": "Human", "name": "Leia Organa", "id": "1003", "friends": []
+      ],
+    ])
+
+    //
+    // 2. Remove all objects matching the pattern `100`
+    // - This will remove `1002` (Han Solo, hero for the .newhope episode)
+    // - This will remove `1003` (Leia Organa, friend of the hero in .empire episode)
+    //
+
+    let removeFromCacheCompletedExpectation = expectation(description: "Hero objects removed from cache by pattern")
+
+    store.withinReadWriteTransaction({ transaction in
+      try transaction.removeObjects(matching: "100")
+    }, completion: { result in
+      defer { removeFromCacheCompletedExpectation.fulfill() }
+
+      XCTAssertSuccessResult(result)
+    })
+
+    waitForExpectations(timeout: Self.defaultWaitTimeout)
+
+    //
+    // 3. Attempt to read records after pattern removal
+    // - .newhope episode query expected to FAIL on the `hero` path
+    // - .jedi episdoe query expected to SUCCEED
+    // - .empire episode query expected to FAIL on the `hero.friends` path
+    //
+
+    let readHeroNewHopeAfterRemoveCompletedExpectation = expectation(description: "Read removed hero object for .newhope episode from cache")
+
+    store.withinReadTransaction({ transaction in
+      let query = MockQuery<HeroFriendsSelectionSet>()
+      query.variables = ["episode": "NEWHOPE"]
+      _ = try transaction.read(query: query)
+
+    }, completion: { newHopeResult in
+      defer { readHeroNewHopeAfterRemoveCompletedExpectation.fulfill() }
+
+      XCTAssertFailureResult(newHopeResult) { error in
+        if let error = error as? GraphQLExecutionError {
+          XCTAssertEqual(error.path, ["hero"])
+          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
+        } else {
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+    })
+
+    let readHeroJediAfterRemoveCompletedExpectation = expectation(description: "Read removed hero object for .jedi episode from cache")
+
+    store.withinReadTransaction({ transaction in
+      let query = MockQuery<HeroFriendsSelectionSet>()
+      query.variables = ["episode": "JEDI"]
+      let data = try transaction.read(query: query)
+
+      XCTAssertEqual(data.hero.__typename, "Human")
+      XCTAssertEqual(data.hero.name, "Luke Skywalker")
+
+    }, completion: { jediResult in
+      defer { readHeroJediAfterRemoveCompletedExpectation.fulfill() }
+
+      XCTAssertSuccessResult(jediResult)
+    })
+
+    let readHeroEmpireAfterRemoveCompletedExpectation = expectation(description: "Read removed hero object for .empire episode from cache")
+
+    store.withinReadTransaction({ transaction in
+      let query = MockQuery<HeroFriendsSelectionSet>()
+      query.variables = ["episode": "EMPIRE"]
+      _ = try transaction.read(query: query)
+
+    }, completion: { empireResult in
+      defer { readHeroEmpireAfterRemoveCompletedExpectation.fulfill() }
+
+      XCTAssertFailureResult(empireResult) { error in
+        if let error = error as? GraphQLExecutionError {
+          XCTAssertEqual(error.path, ["hero.friends.1"])
+          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
+        } else {
+          XCTFail("Unexpected error: \(error)")
+        }
+      }
+    })
+
+    waitForExpectations(timeout: Self.defaultWaitTimeout)
+  }
 }
 
 // MARK: Helpers

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -1192,21 +1192,23 @@ fileprivate func expectJSONMissingValueError(
   atPath path: ResponsePath,
   file: FileString = #file, line: UInt = #line
 ) {
-  guard case let .failure(readError) = result,
-          let error = readError as? GraphQLExecutionError else {
+  guard case let .failure(readError) = result else {
     fail("Expected JSON Missing Value Error: \(result)",
          file: file, line: line)
     return
   }
 
-  expect(file: file, line: line, error.path).to(equal(path))
-
-  switch error.underlying {
-  case JSONDecodingError.missingValue:
-    // This is correct.
-    break
-  default:
-    fail("Expected JSON Missing Value Error: \(result)",
-         file: file, line: line)
+  if let error = readError as? GraphQLExecutionError {
+    expect(file: file, line: line, error.path).to(equal(path))
+    switch error.underlying {
+    case JSONDecodingError.missingValue:
+      // This is correct.
+      break
+    default:
+      fail("Expected JSON Missing Value Error: \(result)",
+           file: file, line: line)
+    }
+  } else {
+    expect(readError as? JSONDecodingError).to(equal(.missingValue))
   }
 }

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -256,14 +256,8 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func test_updateObject_updateNestedField_updatesObjects() throws {
     // given
-    struct GivenSelectionSet: MutableRootSelectionSet {
-      static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
-      static var __parentType: ParentType { .Object(Object.self) }
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var data: DataDict = DataDict([:], variables: nil)
-
-      public init(data: DataDict) {
-        self.data = data
-      }
 
       static var selections: [Selection] { [
         .field("hero", Hero.self)
@@ -274,14 +268,8 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         set { data["hero"] = newValue }
       }
 
-      struct Hero: MutableRootSelectionSet {
-        static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
-        static var __parentType: ParentType { .Object(Object.self) }
+      struct Hero: MockMutableRootSelectionSet {
         public var data: DataDict = DataDict([:], variables: nil)
-
-        public init(data: DataDict) {
-          self.data = data
-        }
         
         static var selections: [Selection] { [
           .field("name", String.self)
@@ -329,16 +317,10 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
   }
 
-  func test_writeDataForCacheMutation_givenInvalidData_errorIsThrown() throws {
+  func test_writeDataForCacheMutation_givenInvalidData_throwsError() throws {
     // given
-    struct GivenSelectionSet: MutableRootSelectionSet {
-      static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
-      static var __parentType: ParentType { .Object(Object.self) }
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var data: DataDict = DataDict([:], variables: nil)
-
-      public init(data: DataDict) {
-        self.data = data
-      }
 
       static var selections: [Selection] { [
         .field("hero", Hero.self)
@@ -349,14 +331,8 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         set { data["hero"] = newValue }
       }
 
-      struct Hero: MutableRootSelectionSet {
-        static var schema: SchemaConfiguration.Type { MockSchemaConfiguration.self }
-        static var __parentType: ParentType { .Object(Object.self) }
+      struct Hero: MockMutableRootSelectionSet {
         public var data: DataDict = DataDict([:], variables: nil)
-
-        public init(data: DataDict) {
-          self.data = data
-        }
 
         static var selections: [Selection] { [
           .field("name", String.self)
@@ -392,8 +368,61 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [writeCompletedExpectation], timeout: Self.defaultWaitTimeout)
   }
 
+//  func test_writeDataForCacheMutation_givenDeleteRecordReferencedByOtherRecord_thenReadQueryReferencingRemovedRecord_throwsError() throws {
+//    /// given
+//    struct GivenSelectionSet: MockMutableRootSelectionSet {
+//      public var data: DataDict = DataDict([:], variables: nil)
 //
-//  func testReadHeroAndFriendsNamesQueryFailsAfterRemovingFriendRecord() throws {
+//      public init(data: DataDict) {
+//        self.data = data
+//      }
+//
+//      static var selections: [Selection] { [
+//        .field("hero", Hero.self)
+//      ]}
+//
+//      var hero: Hero? {
+//        get { data["hero"] }
+//        set { data["hero"] = newValue }
+//      }
+//
+//      struct Hero: MockMutableRootSelectionSet {
+//        public var data: DataDict = DataDict([:], variables: nil)
+//
+//        public init(data: DataDict) {
+//          self.data = data
+//        }
+//
+//        static var selections: [Selection] { [
+//          .field("id", String.self),
+//          .field("name", String.self),
+//        ]}
+//
+//        var name: String? {
+//          get { data["name"] }
+//          set { data["name"] = newValue }
+//        }
+//
+//        struct Friend: MockMutableRootSelectionSet {
+//          public var data: DataDict = DataDict([:], variables: nil)
+//
+//          public init(data: DataDict) {
+//            self.data = data
+//          }
+//
+//          static var selections: [Selection] { [
+//            .field("id", String.self),
+//            .field("name", String.self),
+//          ]}
+//
+//          var name: String? {
+//            get { data["name"] }
+//            set { data["name"] = newValue }
+//          }
+//        }
+//      }
+//    }
+//
 //    mergeRecordsIntoCache([
 //      "QUERY_ROOT": ["hero": CacheReference("2001")],
 //      "2001": [

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -1,235 +1,225 @@
 import XCTest
+import Nimble
 @testable import Apollo
+import ApolloUtils
 import ApolloAPI
 import ApolloInternalTestHelpers
-import StarWarsAPI
 
 #warning("TODO fix these after refactoring cache transactions")
-//class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
-//
-//  var cacheType: TestCacheProvider.Type {
-//    InMemoryTestCacheProvider.self
-//  }
-//
-//  static let defaultWaitTimeout: TimeInterval = 5.0
-//
-//  var cache: NormalizedCache!
-//  var store: ApolloStore!
-//
-//  override func setUpWithError() throws {
-//    try super.setUpWithError()
-//
-//    cache = try makeNormalizedCache()
-//    store = ApolloStore(cache: cache)
-//  }
-//
-//  override func tearDownWithError() throws {
-//    cache = nil
-//    store = nil
-//
-//    try super.tearDownWithError()
-//  }
-//
-//  func testReadHeroNameQuery() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("hero")],
-//      "hero": ["__typename": "Droid", "name": "R2-D2"]
-//    ])
-//
-//    let query = HeroNameQuery()
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Droid")
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testReadHeroNameQueryAfterRemovingRecord() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("hero")],
-//      "hero": ["__typename": "Droid", "name": "R2-D2"]
-//    ])
-//
-//    let query = HeroNameQuery()
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Droid")
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    let removeCompletedExpectation = expectation(description: "Remove completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.removeObject(for: "hero")
-//    }, completion: { result in
-//      defer { removeCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [removeCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    let refetchExpectation = expectation(description: "Refetch completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      _ = try transaction.read(query: query)
-//    }, completion: { result in
-//      defer { refetchExpectation.fulfill() }
-//      XCTAssertFailureResult(result) { refetchError in
-//        guard let error = refetchError as? GraphQLResultError else {
-//          XCTFail("Unexpected error trying to load a removed record: \(refetchError)")
-//          return
-//        }
-//
-//        XCTAssertEqual(error.path, ["hero"])
-//
-//        switch error.underlying {
-//        case JSONDecodingError.missingValue:
-//          // This is correct.
-//          break
-//        default:
-//          XCTFail("Unexpected error trying to load a removed record: \(refetchError)")
-//        }
-//      }
-//    })
-//
-//    self.wait(for: [refetchExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testHeroNameQueryStillLoadsAfterAttemptingToDeleteFieldKey() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("hero")],
-//      "hero": ["__typename": "Droid", "name": "R2-D2"]
-//    ])
-//
-//    let query = HeroNameQuery()
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Droid")
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    let removeCompletedExpectation = expectation(description: "Remove completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.removeObject(for: "hero.name")
-//    }, completion: { result in
-//      defer { removeCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [removeCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//
-//    let refetchExpectation = expectation(description: "Refetch completed")
-//
-//    store.withinReadWriteTransaction({ transaction in
-//      _ = try transaction.read(query: query)
-//    }, completion: { result in
-//      defer { refetchExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [refetchExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testReadHeroNameQueryWithVariable() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
-//      "hero(episode:JEDI)": ["__typename": "Droid", "name": "R2-D2"]
-//    ])
-//
-//    let query = HeroNameQuery(episode: .jedi)
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//
-//      XCTAssertEqual(data.hero?.__typename, "Droid")
-//      XCTAssertEqual(data.hero?.name, "R2-D2")
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
-//  func testReadHeroNameQueryWithMissingName() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("hero")],
-//      "hero": ["__typename": "Droid"]
-//    ])
-//
-//    let query = HeroNameQuery()
-//
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//
-//    store.withinReadTransaction({ transaction in
-//      XCTAssertThrowsError(try transaction.read(query: query)) { error in
-//        if case let error as GraphQLResultError = error {
-//          XCTAssertEqual(error.path, ["hero", "name"])
-//          XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
-//        } else {
-//          XCTFail("Unexpected error: \(error)")
-//        }
-//      }
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//
-//    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
-//  }
-//
+class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
+
+  var cacheType: TestCacheProvider.Type {
+    InMemoryTestCacheProvider.self
+  }
+
+  static let defaultWaitTimeout: TimeInterval = 5.0
+
+  var cache: NormalizedCache!
+  var store: ApolloStore!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+
+    cache = try makeNormalizedCache()
+    store = ApolloStore(cache: cache)
+  }
+
+  override func tearDownWithError() throws {
+    cache = nil
+    store = nil
+
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Read Query Tests
+
+  func test_readQuery_givenQueryDataInCache_returnsData() throws {
+    class HeroNameSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      class Hero: MockSelectionSet {
+        override class var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("name", String.self)
+        ]}
+      }
+    }
+
+    let query = MockQuery<HeroNameSelectionSet>()
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("hero")],
+      "hero": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+
+    let readCompletedExpectation = expectation(description: "Read completed")
+
+    store.withinReadTransaction({ transaction in
+      let data = try transaction.read(query: query)
+
+      expect(data.hero?.__typename).to(equal("Droid"))
+      expect(data.hero?.name).to(equal("R2-D2"))
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  func test_readQuery_givenQueryDataDoesNotExist_throwsMissingValueError() throws {
+    // given
+    class GivenSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("name", String.self)
+      ]}
+    }
+
+    let query = MockQuery<GivenSelectionSet>()
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": [:],
+    ])
+
+    // when
+    let readCompletedExpectation = expectation(description: "Read completed")
+
+    store.withinReadWriteTransaction({ transaction in
+      _ = try transaction.read(query: query)
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+
+      // then
+      expectJSONMissingValueError(result, atPath: ["name"])
+    })
+
+    self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+  }
+
+  func test_readQuery_givenQueryDataWithVariableInCache_readsQuery() throws {
+    // given
+    enum Episode: String, EnumType {
+      case JEDI
+    }
+
+    class HeroNameSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
+      ]}
+
+      class Hero: MockSelectionSet {
+        override class var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("name", String.self)
+        ]}
+      }
+    }
+
+    let query = MockQuery<HeroNameSelectionSet>()
+    query.variables = ["episode": Episode.JEDI]
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
+      "hero(episode:JEDI)": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+
+    // when
+    runActivity("read query") { _ in
+      let readCompletedExpectation = expectation(description: "Read completed")
+      store.withinReadTransaction({ transaction in
+        let data = try transaction.read(query: query)
+
+        // then
+        expect(data.hero?.__typename).to(equal("Droid"))
+        expect(data.hero?.name).to(equal("R2-D2"))
+
+      }, completion: { result in
+        defer { readCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      })
+
+      self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
+
+  func test_readQuery_givenQueryDataWithOtherVariableValueInCache_throwsMissingValueError() throws {
+    // given
+    enum Episode: String, EnumType {
+      case JEDI
+      case PHANTOM_MENACE
+    }
+
+    class HeroNameSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [
+        .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
+      ]}
+
+      class Hero: MockSelectionSet {
+        override class var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("name", String.self)
+        ]}
+      }
+    }
+
+    let query = MockQuery<HeroNameSelectionSet>()
+    query.variables = ["episode": Episode.PHANTOM_MENACE]
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
+      "hero(episode:JEDI)": ["__typename": "Droid", "name": "R2-D2"]
+    ])
+
+    // when
+    runActivity("read query") { _ in
+      let readCompletedExpectation = expectation(description: "Read completed")
+      store.withinReadTransaction({ transaction in
+        _ = try transaction.read(query: query)
+      }, completion: { result in
+        defer { readCompletedExpectation.fulfill() }
+
+        // then
+        expectJSONMissingValueError(result, atPath: ["hero"])
+      })
+
+      self.wait(for: [readCompletedExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
+
+  // MARK: - Write Local Cache Mutation Tests
+
 //  func testUpdateHeroNameQuery() throws {
+//    // given
+//    class GivenSelectionSet: MockMutableSelectionSet {
+//      override class var selections: [Selection] { [
+//        .field("name", String.self)
+//      ]}
+//    }
+//
+//    let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
+//
 //    mergeRecordsIntoCache([
 //      "QUERY_ROOT": ["hero": CacheReference("QUERY_ROOT.hero")],
 //      "QUERY_ROOT.hero": ["__typename": "Droid", "name": "R2-D2"]
 //    ])
 //
-//    let query = HeroNameQuery()
 //
-//    let updateCompletedExpectation = expectation(description: "Update completed")
+//    runActivity("update mutation") { _ in
+//      let updateCompletedExpectation = expectation(description: "Update completed")
 //
-//    store.withinReadWriteTransaction({ transaction in
-//      try transaction.update(query: query) { data in
-//        data.hero?.name = "Artoo"
-//      }
-//    }, completion: { result in
-//      defer { updateCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
+//      store.withinReadWriteTransaction({ transaction in
+//        try transaction.update(cacheMutation: cacheMutation) { data in
+//          data.hero?.name = "Artoo"
+//        }
+//      }, completion: { result in
+//        defer { updateCompletedExpectation.fulfill() }
+//        XCTAssertSuccessResult(result)
+//      })
 //
-//    self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
+//      self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
+//    }
 //
 //    loadFromStore(query: query) { result in
 //      try XCTAssertSuccessResult(result) { graphQLResult in
@@ -853,4 +843,30 @@ import StarWarsAPI
 //
 //    waitForExpectations(timeout: Self.defaultWaitTimeout)
 //  }
-//}
+}
+
+// MARK: Helpers
+
+fileprivate func expectJSONMissingValueError(
+  _ result: Result<(), Error>,
+  atPath path: ResponsePath,
+  file: FileString = #file, line: UInt = #line
+) {
+  guard case let .failure(readError) = result,
+          let error = readError as? GraphQLExecutionError else {
+    fail("Expected JSON Missing Value Error: \(result)",
+         file: file, line: line)
+    return
+  }
+
+  expect(file: file, line: line, error.path).to(equal(path))
+
+  switch error.underlying {
+  case JSONDecodingError.missingValue:
+    // This is correct.
+    break
+  default:
+    fail("Expected JSON Missing Value Error: \(result)",
+         file: file, line: line)
+  }
+}

--- a/Tests/ApolloTests/Cache/SQLite/SQLiteCacheTests.swift
+++ b/Tests/ApolloTests/Cache/SQLite/SQLiteCacheTests.swift
@@ -15,12 +15,11 @@ class SQLiteLoadQueryFromStoreTests: LoadQueryFromStoreTests {
   }
 }
 
-#warning("TODO fix these after refactoring cache transactions")
-//class SQLiteReadWriteFromStoreTests: ReadWriteFromStoreTests {
-//  override var cacheType: TestCacheProvider.Type {
-//    SQLiteTestCacheProvider.self
-//  }
-//}
+class SQLiteReadWriteFromStoreTests: ReadWriteFromStoreTests {
+  override var cacheType: TestCacheProvider.Type {
+    SQLiteTestCacheProvider.self
+  }
+}
 
 class SQLiteWatchQueryTests: WatchQueryTests {
   override var cacheType: TestCacheProvider.Type {

--- a/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
+++ b/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
@@ -139,112 +139,246 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
     self.wait(for: [allReadsCompletedExpectation], timeout: defaultWaitTimeout)
   }
 
-  #warning("TODO: Fix these tests when mutable cache is implemented.")
-//  func testConcurrentUpdatesInitiatedFromMainThread() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": []
-//      ]
-//    ])
-//    
-//    let query = MockQuery<GivenSelectionSet>()
-//    
-//    let numberOfUpdates = 200
-//    
-//    let allUpdatesCompletedExpectation = XCTestExpectation(description: "All store updates completed")
-//    allUpdatesCompletedExpectation.expectedFulfillmentCount = numberOfUpdates
-//    
-//    for i in 0..<numberOfUpdates {
-//      store.withinReadWriteTransaction({ transaction in
-//        try transaction.update(query: query) { data in
-//          data.hero?.name = "Artoo"
-//          data.hero?.friends?.append(.makeDroid(name: "Droid #\(i)"))
-//        }
-//        
-//        let data = try transaction.read(query: query)
-//        
-//        XCTAssertEqual(data.hero?.name, "Artoo")
-//        XCTAssertEqual(data.hero?.friends?.last??.name, "Droid #\(i)")
-//      }, completion: { result in
-//        defer { allUpdatesCompletedExpectation.fulfill() }
-//        XCTAssertSuccessResult(result)
-//      })
-//    }
-//    
-//    self.wait(for: [allUpdatesCompletedExpectation], timeout: defaultWaitTimeout)
-//    
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//    
-//    store.withinReadTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//      
-//      XCTAssertEqual(data.hero?.name, "Artoo")
-//      
-//      let friendsNames = try XCTUnwrap(data.hero?.friends?.compactMap { $0?.name })
-//      let expectedFriendsNames = (0..<numberOfUpdates).map { i in "Droid #\(i)" }
-//      XCTAssertEqualUnordered(friendsNames, expectedFriendsNames)
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//    
-//    self.wait(for: [readCompletedExpectation], timeout: 5)
-//  }
-//  
-//  func testConcurrentUpdatesInitiatedFromBackgroundThreads() throws {
-//    mergeRecordsIntoCache([
-//      "QUERY_ROOT": ["hero": CacheReference("2001")],
-//      "2001": [
-//        "name": "R2-D2",
-//        "__typename": "Droid",
-//        "friends": []
-//      ]
-//    ])
-//    
-//    let query = MockQuery<GivenSelectionSet>()
-//    
-//    let numberOfUpdates = 200
-//    
-//    let allUpdatesCompletedExpectation = XCTestExpectation(description: "All store updates completed")
-//    allUpdatesCompletedExpectation.expectedFulfillmentCount = numberOfUpdates
-//    
-//    DispatchQueue.concurrentPerform(iterations: numberOfUpdates) { i in      
-//      store.withinReadWriteTransaction({ transaction in
-//        try transaction.update(query: query) { data in
-//          data.hero?.name = "Artoo"
-//          data.hero?.friends?.append(.makeDroid(name: "Droid #\(i)"))
-//        }
-//        
-//        let data = try transaction.read(query: query)
-//        
-//        XCTAssertEqual(data.hero?.name, "Artoo")
-//        XCTAssertEqual(data.hero?.friends?.last??.name, "Droid #\(i)")
-//      }, completion: { result in
-//        defer { allUpdatesCompletedExpectation.fulfill() }
-//        XCTAssertSuccessResult(result)
-//      })
-//    }
-//    
-//    self.wait(for: [allUpdatesCompletedExpectation], timeout: defaultWaitTimeout)
-//    
-//    let readCompletedExpectation = expectation(description: "Read completed")
-//    
-//    store.withinReadTransaction({ transaction in
-//      let data = try transaction.read(query: query)
-//      
-//      XCTAssertEqual(data.hero?.name, "Artoo")
-//      
-//      let friendsNames = try XCTUnwrap(data.hero?.friends?.compactMap { $0?.name })
-//      let expectedFriendsNames = (0..<numberOfUpdates).map { i in "Droid #\(i)" }
-//      XCTAssertEqualUnordered(friendsNames, expectedFriendsNames)
-//    }, completion: { result in
-//      defer { readCompletedExpectation.fulfill() }
-//      XCTAssertSuccessResult(result)
-//    })
-//    
-//    self.wait(for: [readCompletedExpectation], timeout: 5)
-//  }
+  func testConcurrentUpdatesInitiatedFromMainThread() throws {
+    /// given
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] { [
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self),
+        ]}
+
+        var id: String {
+          get { data["id"] }
+          set { data["id"] = newValue }
+        }
+
+        var name: String? {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+
+        var friends: [Friend] {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          static var selections: [Selection] { [
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+
+          var id: String {
+            get { data["id"] }
+            set { data["id"] = newValue }
+          }
+
+          var name: String {
+            get { data["name"] }
+            set { data["name"] = newValue }
+          }
+        }
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("2001")],
+      "2001": [
+        "name": "R2-D2",
+        "id": "2001",
+        "__typename": "Droid",
+        "friends": []
+      ]
+    ])
+
+    let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
+    let query = MockQuery<GivenSelectionSet>()
+
+    let numberOfUpdates = 100
+
+    let allUpdatesCompletedExpectation = XCTestExpectation(description: "All store updates completed")
+    allUpdatesCompletedExpectation.expectedFulfillmentCount = numberOfUpdates
+
+    for i in 0..<numberOfUpdates {
+      store.withinReadWriteTransaction({ transaction in
+        try transaction.update(cacheMutation) { data in
+          data.hero.name = "Artoo"
+
+          var newDroid = GivenSelectionSet.Hero.Friend()
+          newDroid.__typename = "Droid"
+          newDroid.id = "\(i)"
+          newDroid.name = "Droid #\(i)"
+          data.hero.friends.append(newDroid)
+        }
+
+        let data = try transaction.read(query: query)
+
+        XCTAssertEqual(data.hero.name, "Artoo")
+        XCTAssertEqual(data.hero.friends.last?.name, "Droid #\(i)")
+      }, completion: { result in
+        defer { allUpdatesCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      })
+    }
+
+    self.wait(for: [allUpdatesCompletedExpectation], timeout: defaultWaitTimeout)
+
+    let readCompletedExpectation = expectation(description: "Read completed")
+
+    store.withinReadTransaction({ transaction in
+      let data = try transaction.read(query: query)
+
+      XCTAssertEqual(data.hero.name, "Artoo")
+
+      let friendsNames: [String] = try XCTUnwrap(
+        data.hero.friends.compactMap { $0.name }
+      )
+      let expectedFriendsNames = (0..<numberOfUpdates).map { "Droid #\($0)" }
+      XCTAssertEqualUnordered(friendsNames, expectedFriendsNames)
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [readCompletedExpectation], timeout: 5)
+  }
+
+  func testConcurrentUpdatesInitiatedFromBackgroundThreads() throws {
+    /// given
+    struct GivenSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] { [
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] { [
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self),
+        ]}
+
+        var id: String {
+          get { data["id"] }
+          set { data["id"] = newValue }
+        }
+
+        var name: String? {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+
+        var friends: [Friend] {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          static var selections: [Selection] { [
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+
+          var id: String {
+            get { data["id"] }
+            set { data["id"] = newValue }
+          }
+
+          var name: String {
+            get { data["name"] }
+            set { data["name"] = newValue }
+          }
+        }
+      }
+    }
+
+    mergeRecordsIntoCache([
+      "QUERY_ROOT": ["hero": CacheReference("2001")],
+      "2001": [
+        "name": "R2-D2",
+        "id": "2001",
+        "__typename": "Droid",
+        "friends": []
+      ]
+    ])
+
+    let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
+    let query = MockQuery<GivenSelectionSet>()
+
+    let numberOfUpdates = 100
+
+    let allUpdatesCompletedExpectation = XCTestExpectation(description: "All store updates completed")
+    allUpdatesCompletedExpectation.expectedFulfillmentCount = numberOfUpdates
+
+    DispatchQueue.concurrentPerform(iterations: numberOfUpdates) { i in
+      store.withinReadWriteTransaction({ transaction in
+        try transaction.update(cacheMutation) { data in
+          data.hero.name = "Artoo"
+
+          var newDroid = GivenSelectionSet.Hero.Friend()
+          newDroid.__typename = "Droid"
+          newDroid.id = "\(i)"
+          newDroid.name = "Droid #\(i)"
+          data.hero.friends.append(newDroid)
+        }
+
+        let data = try transaction.read(query: query)
+
+        XCTAssertEqual(data.hero.name, "Artoo")
+        XCTAssertEqual(data.hero.friends.last?.name, "Droid #\(i)")
+      }, completion: { result in
+        defer { allUpdatesCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      })
+    }
+
+    self.wait(for: [allUpdatesCompletedExpectation], timeout: defaultWaitTimeout)
+
+    let readCompletedExpectation = expectation(description: "Read completed")
+
+    store.withinReadTransaction({ transaction in
+      let data = try transaction.read(query: query)
+
+      XCTAssertEqual(data.hero.name, "Artoo")
+
+      let friendsNames: [String] = try XCTUnwrap(
+        data.hero.friends.compactMap { $0.name }
+      )
+
+      let expectedFriendsNames = (0..<numberOfUpdates).map { "Droid #\($0)" }
+      XCTAssertEqualUnordered(friendsNames, expectedFriendsNames)
+    }, completion: { result in
+      defer { readCompletedExpectation.fulfill() }
+      XCTAssertSuccessResult(result)
+    })
+
+    self.wait(for: [readCompletedExpectation], timeout: 5)
+  }
 }

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -354,7 +354,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     
     runActivity("Fetch same query from server with different argument but returning same object with changed data") { _ in
       let serverRequestExpectation = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        expect(request.operation.variables?["episode"] as? String).to(equal("JEDI"))        
+        expect(request.operation.variables?["episode"] as? String).to(equal("JEDI"))
         return [
           "data": [
             "hero": [
@@ -826,194 +826,328 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
   }
 
-  #warning("Fix this test after mutable cache is implemented.")
-//  func testWatchedQueryGetsUpdatedWhenObjectIsChangedByDirectStoreUpdate() throws {
-//    class HeroAndFriendsNamesSelectionSet: MockSelectionSet {
-//      override class var selections: [Selection] {[
-//        .field("hero", Hero?.self)
-//      ]}
-//
-//      var hero: Hero? { data["hero"] }
-//
-//      class Hero: MockSelectionSet {
-//        override class var selections: [Selection] {[
-//          .field("__typename", String.self),
-//          .field("name", String.self),
-//          .field("friends", [Friend]?.self),
-//        ]}
-//
-//        var friends: [Friend]? { data["friends"] }
-//
-//        class Friend: MockSelectionSet {
-//          override class var selections: [Selection] {[
-//            .field("__typename", String.self),
-//            .field("name", String.self),
-//          ]}
-//
-//          var name: String { data["name"] }
-//        }
-//      }
-//    }
-//    let watchedQuery = MockQuery<HeroAndFriendsNamesSelectionSet>()
-//    
-//    let resultObserver = makeResultObserver(for: watchedQuery)
-//    
-//    let watcher = GraphQLQueryWatcher(client: client,
-//                                      query: watchedQuery,
-//                                      resultHandler: resultObserver.handler)
-//    addTeardownBlock { watcher.cancel() }
-//    
-//    runActivity("Initial fetch from server") { _ in
-//      let serverRequestExpectation =
-//        server.expect(MockQuery<HeroAndFriendsNamesSelectionSet>.self) { request in
-//        [
-//          "data": [
-//            "hero": [
-//              "name": "R2-D2",
-//              "__typename": "Droid",
-//              "friends": [
-//                ["__typename": "Human", "name": "Luke Skywalker"],
-//                ["__typename": "Human", "name": "Han Solo"],
-//                ["__typename": "Human", "name": "Leia Organa"],
-//              ]
-//            ]
-//          ]
-//        ]
-//      }
-//      
-//      let initialWatcherResultExpectation = resultObserver.expectation(
-//        description: "Watcher received initial result from server"
-//      ) { result in
-//        try XCTAssertSuccessResult(result) { graphQLResult in
-//          XCTAssertEqual(graphQLResult.source, .server)
-//          XCTAssertNil(graphQLResult.errors)
-//          
-//          let data = try XCTUnwrap(graphQLResult.data)
-//          XCTAssertEqual(data.hero?.name, "R2-D2")
-//          let friendsNames = data.hero?.friends?.compactMap { $0.name }
-//          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-//        }
-//      }
-//      
-//      watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
-//      
-//      wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//    
-//    runActivity("Update object directly in store") { _ in
-//      let updatedWatcherResultExpectation = resultObserver.expectation(
-//        description: "Watcher received updated result from cache"
-//      ) { result in
-//        try XCTAssertSuccessResult(result) { graphQLResult in
-//          XCTAssertEqual(graphQLResult.source, .cache)
-//          XCTAssertNil(graphQLResult.errors)
-//          
-//          let data = try XCTUnwrap(graphQLResult.data)
-//          XCTAssertEqual(data.hero?.name, "Artoo")
-//          
-//          let friendsNames = data.hero?.friends?.compactMap { $0.name }
-//          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-//        }
-//      }
-//      
-//      client.store.withinReadWriteTransaction({ transaction in
-//        try transaction.update(query: HeroNameQuery()) { data in
-//          data.hero?.name = "Artoo"
-//        }
-//      })
-//      
-//      wait(for: [updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//  }
+  func testWatchedQueryGetsUpdatedWhenObjectIsChangedByDirectStoreUpdate() throws {
+    struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
 
-  #warning("Fix this test after mutable cache is implemented.")
-//  func testWatchedQuery_givenCachePolicyReturnCacheDataDontFetch_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
-//    client.store.cacheKeyForObject = { $0["id"] }
-//
-//    let watchedQuery = HeroAndFriendsNamesWithIDsQuery()
-//
-//    let resultObserver = makeResultObserver(for: watchedQuery)
-//
-//    let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
-//    addTeardownBlock { watcher.cancel() }
-//
-//    runActivity("Write data to cache") { _ in
-//      let writeToStoreExpectation = expectation(description: "Initial Data written to store")
-//
-//      client.store.withinReadWriteTransaction({ transaction in
-//        let data = HeroAndFriendsNamesWithIDsQuery.Data(
-//          unsafeResultMap: [
-//            "hero": [
-//              "id": "2001",
-//              "name": "R2-D2",
-//              "__typename": "Droid",
-//              "friends": [
-//                ["__typename": "Human", "id": "1000", "name": "Luke Skywalker"],
-//                ["__typename": "Human", "id": "1002", "name": "Han Solo"],
-//                ["__typename": "Human", "id": "1003", "name": "Leia Organa"],
-//              ]
-//            ]
-//          ])
-//
-//        try transaction.write(data: data, forQuery: HeroAndFriendsNamesWithIDsQuery())
-//      }) { result in
-//        XCTAssertSuccessResult(result)
-//        writeToStoreExpectation.fulfill()
-//      }
-//
-//      wait(for: [writeToStoreExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//
-//    runActivity("Initial fetch from cache") { _ in
-//      let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from cache") { result in
-//        try XCTAssertSuccessResult(result) { graphQLResult in
-//          XCTAssertEqual(graphQLResult.source, .cache)
-//          XCTAssertNil(graphQLResult.errors)
-//
-//          let data = try XCTUnwrap(graphQLResult.data)
-//          XCTAssertEqual(data.hero?.name, "R2-D2")
-//          let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
-//        }
-//      }
-//
-//      watcher.fetch(cachePolicy: .returnCacheDataDontFetch)
-//
-//      wait(for: [initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//
-//    runActivity("Fetch other query with list of updated keys from server") { _ in
-//      let serverRequestExpectation = server.expect(HeroAndFriendsIDsQuery.self) { request in
-//        [
-//          "data": [
-//            "hero": [
-//              "id": "2001",
-//              "name": "Artoo",
-//              "__typename": "Droid",
-//              "friends": [
-//                ["__typename": "Human", "id": "1003"],
-//                ["__typename": "Human", "id": "1004"],
-//                ["__typename": "Human", "id": "1000"],
-//              ]
-//            ]
-//          ]
-//        ]
-//      }
-//
-//      let noRefetchExpectation = resultObserver.expectation(description: "Initial query shouldn't trigger refetch") { _ in }
-//      noRefetchExpectation.isInverted = true
-//
-//      let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
-//
-//      client.fetch(query: HeroAndFriendsIDsQuery(), cachePolicy: .fetchIgnoringCacheData) { result in
-//        defer { otherFetchCompletedExpectation.fulfill() }
-//        XCTAssertSuccessResult(result)
-//      }
-//
-//      wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, noRefetchExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//  }
-  
+      static var selections: [Selection] {[
+        .field("hero", Hero?.self)
+      ]}
+
+      var hero: Hero? {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend]?.self),
+        ]}
+
+        var name: String {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+
+        var friends: [Friend]? {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          static var selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("name", String.self),
+          ]}
+
+          var name: String {
+            get { data["name"] }
+            set { data["name"] = newValue }
+          }
+        }
+      }
+    }
+
+    let watchedQuery = MockQuery<HeroAndFriendsNamesSelectionSet>()
+
+    let resultObserver = makeResultObserver(for: watchedQuery)
+
+    let watcher = GraphQLQueryWatcher(client: client,
+                                      query: watchedQuery,
+                                      resultHandler: resultObserver.handler)
+    addTeardownBlock { watcher.cancel() }
+
+    runActivity("Initial fetch from server") { _ in
+      let serverRequestExpectation =
+        server.expect(MockQuery<HeroAndFriendsNamesSelectionSet>.self) { request in
+        [
+          "data": [
+            "hero": [
+              "name": "R2-D2",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "name": "Luke Skywalker"],
+                ["__typename": "Human", "name": "Han Solo"],
+                ["__typename": "Human", "name": "Leia Organa"],
+              ]
+            ]
+          ]
+        ]
+      }
+
+      let initialWatcherResultExpectation = resultObserver.expectation(
+        description: "Watcher received initial result from server"
+      ) { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .server)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero?.name, "R2-D2")
+          let friendsNames: [String] = try XCTUnwrap(
+            data.hero?.friends?.compactMap { $0.name }
+          )
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+        }
+      }
+
+      watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
+
+      wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Update object directly in store") { _ in
+      let updatedWatcherResultExpectation = resultObserver.expectation(
+        description: "Watcher received updated result from cache"
+      ) { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .cache)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero?.name, "Artoo")
+
+          let friendsNames = data.hero?.friends?.compactMap { $0.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+        }
+      }
+
+      client.store.withinReadWriteTransaction({ transaction in
+        let cacheMutation = MockLocalCacheMutation<HeroAndFriendsNamesSelectionSet>()
+        try transaction.update(cacheMutation) { data in
+          data.hero?.name = "Artoo"
+        }
+      })
+
+      wait(for: [updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
+
+  func testWatchedQuery_givenCachePolicyReturnCacheDataDontFetch_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
+    // given
+    struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] {[
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self),
+        ]}
+
+        var id: String {
+          get { data["id"] }
+          set { data["id"] = newValue }
+        }
+
+        var name: String {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+
+        var friends: [Friend] {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          static var selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+
+          var id: String {
+            get { data["id"] }
+            set { data["id"] = newValue }
+          }
+
+          var name: String {
+            get { data["name"] }
+            set { data["name"] = newValue }
+          }
+        }
+      }
+    }
+
+    struct HeroAndFriendsIDsOnlySelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] {[
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("friends", [Friend].self),
+        ]}
+
+        var id: String {
+          get { data["id"] }
+          set { data["id"] = newValue }
+        }
+
+        var friends: [Friend] {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          static var selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+          ]}
+
+          var id: String {
+            get { data["id"] }
+            set { data["id"] = newValue }
+          }
+        }
+      }
+    }
+
+    MockSchemaConfiguration.stub_cacheKeyProviderForUnknownType = { _, _ in IDCacheKeyProvider.self }
+
+    let watchedQuery = MockQuery<HeroAndFriendsNamesSelectionSet>()
+
+    let resultObserver = makeResultObserver(for: watchedQuery)
+
+    let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
+    addTeardownBlock { watcher.cancel() }
+
+    runActivity("Write data to cache") { _ in
+      let writeToStoreExpectation = expectation(description: "Initial Data written to store")
+
+      client.store.withinReadWriteTransaction({ transaction in
+        let data = HeroAndFriendsNamesSelectionSet(
+          data: DataDict(
+            [
+              "hero": [
+                "id": "2001",
+                "name": "R2-D2",
+                "__typename": "Droid",
+                "friends": [
+                  ["__typename": "Human", "id": "1000", "name": "Luke Skywalker"],
+                  ["__typename": "Human", "id": "1002", "name": "Han Solo"],
+                  ["__typename": "Human", "id": "1003", "name": "Leia Organa"],
+                ]
+              ]
+            ],
+            variables: nil
+          ))
+
+        let cacheMutation = MockLocalCacheMutation<HeroAndFriendsNamesSelectionSet>()
+        try transaction.write(data: data, for: cacheMutation)
+      }) { result in
+        XCTAssertSuccessResult(result)
+        writeToStoreExpectation.fulfill()
+      }
+
+      wait(for: [writeToStoreExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Initial fetch from cache") { _ in
+      let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from cache") { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .cache)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+          XCTAssertEqual(data.hero.name, "R2-D2")
+          let friendsNames = data.hero.friends.compactMap { $0.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo", "Leia Organa"])
+        }
+      }
+
+      watcher.fetch(cachePolicy: .returnCacheDataDontFetch)
+
+      wait(for: [initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Fetch other query with list of updated keys from server") { _ in
+      let serverRequestExpectation = server.expect(MockQuery<HeroAndFriendsIDsOnlySelectionSet>.self) { request in
+        [
+          "data": [
+            "hero": [
+              "id": "2001",
+              "name": "Artoo",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "id": "1003"],
+                ["__typename": "Human", "id": "1004"],
+                ["__typename": "Human", "id": "1000"],
+              ]
+            ]
+          ]
+        ]
+      }
+
+      let noRefetchExpectation = resultObserver.expectation(description: "Initial query shouldn't trigger refetch") { _ in }
+      noRefetchExpectation.isInverted = true
+
+      let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
+
+      let query = MockQuery<HeroAndFriendsIDsOnlySelectionSet>()
+      client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { result in
+        defer { otherFetchCompletedExpectation.fulfill() }
+        XCTAssertSuccessResult(result)
+      }
+
+      wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, noRefetchExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
+
   func testWatchedQueryIsOnlyUpdatedOnceIfConcurrentFetchesAllReturnTheSameResult() throws {
     class HeroNameSelectionSet: MockSelectionSet {
       override class var selections: [Selection] { [
@@ -1029,12 +1163,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     let watchedQuery = MockQuery<HeroNameSelectionSet>()
-    
+
     let resultObserver = makeResultObserver(for: watchedQuery)
-    
+
     let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
     addTeardownBlock { watcher.cancel() }
-    
+
     runActivity("Initial fetch from server") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<HeroNameSelectionSet>.self) { request in
@@ -1047,24 +1181,24 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           ]
         ]
       }
-      
+
       let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from server") { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
           XCTAssertEqual(graphQLResult.source, .server)
           XCTAssertNil(graphQLResult.errors)
-          
+
           let data = try XCTUnwrap(graphQLResult.data)
           XCTAssertEqual(data.hero?.name, "R2-D2")
         }
       }
-      
+
       watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
-      
+
       wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
-    
+
     let numberOfFetches = 10
-    
+
     runActivity("Fetch same query concurrently \(numberOfFetches) times") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<HeroNameSelectionSet>.self) { request in
@@ -1077,41 +1211,41 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           ]
         ]
       }
-      
+
       serverRequestExpectation.expectedFulfillmentCount = numberOfFetches
-      
+
       let updatedWatcherResultExpectation = resultObserver.expectation(
         description: "Watcher received updated result from cache"
       ) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
           XCTAssertEqual(graphQLResult.source, .cache)
           XCTAssertNil(graphQLResult.errors)
-          
+
           let data = try XCTUnwrap(graphQLResult.data)
           XCTAssertEqual(data.hero?.name, "Artoo")
         }
       }
-      
+
       let otherFetchesCompletedExpectation = expectation(description: "Other fetches completed")
       otherFetchesCompletedExpectation.expectedFulfillmentCount = numberOfFetches
-      
+
       DispatchQueue.concurrentPerform(iterations: numberOfFetches) { _ in
         client.fetch(query: MockQuery<HeroNameSelectionSet>(),
                      cachePolicy: .fetchIgnoringCacheData) { [weak self] result in
           otherFetchesCompletedExpectation.fulfill()
-          
+
           if let self = self, case .failure(let error) = result {
             self.record(error)
           }
         }
       }
-      
+
       wait(for: [serverRequestExpectation, otherFetchesCompletedExpectation, updatedWatcherResultExpectation], timeout: 3)
-      
+
       XCTAssertEqual(updatedWatcherResultExpectation.apollo.numberOfFulfillments, 1)
     }
   }
-  
+
   func testWatchedQueryIsUpdatedMultipleTimesIfConcurrentFetchesReturnChangedData() throws {
     class HeroNameSelectionSet: MockSelectionSet {
       override class var selections: [Selection] { [
@@ -1131,14 +1265,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     let watchedQuery = MockQuery<HeroNameSelectionSet>()
-    
+
     let resultObserver = makeResultObserver(for: watchedQuery)
-    
+
     let watcher = GraphQLQueryWatcher(client: client,
                                       query: watchedQuery,
                                       resultHandler: resultObserver.handler)
     addTeardownBlock { watcher.cancel() }
-    
+
     runActivity("Initial fetch from server") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<HeroNameSelectionSet>.self) { request in
@@ -1151,26 +1285,26 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           ]
         ]
       }
-      
+
       let initialWatcherResultExpectation = resultObserver.expectation(
         description: "Watcher received initial result from server"
       ) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
           XCTAssertEqual(graphQLResult.source, .server)
           XCTAssertNil(graphQLResult.errors)
-          
+
           let data = try XCTUnwrap(graphQLResult.data)
           XCTAssertEqual(data.hero.name, "R2-D2")
         }
       }
-      
+
       watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
-      
+
       wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
-    
+
     let numberOfFetches = 10
-    
+
     runActivity("Fetch same query concurrently \(numberOfFetches) times") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<HeroNameSelectionSet>.self) { request in
@@ -1183,143 +1317,208 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           ]
         ]
       }
-      
+
       serverRequestExpectation.expectedFulfillmentCount = numberOfFetches
-      
+
       let updatedWatcherResultExpectation = resultObserver.expectation(
         description: "Watcher received updated result from cache"
       ) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
           XCTAssertEqual(graphQLResult.source, .cache)
           XCTAssertNil(graphQLResult.errors)
-          
+
           let data = try XCTUnwrap(graphQLResult.data)
           XCTAssertTrue(try XCTUnwrap(data.hero.name).hasPrefix("Artoo"))
         }
       }
-      
+
       updatedWatcherResultExpectation.expectedFulfillmentCount = numberOfFetches
-      
+
       let otherFetchesCompletedExpectation = expectation(description: "Other fetches completed")
       otherFetchesCompletedExpectation.expectedFulfillmentCount = numberOfFetches
-      
+
       DispatchQueue.concurrentPerform(iterations: numberOfFetches) { _ in
         client.fetch(query: MockQuery<HeroNameSelectionSet>(),
                      cachePolicy: .fetchIgnoringCacheData) { [weak self] result in
           otherFetchesCompletedExpectation.fulfill()
-          
+
           if let self = self, case .failure(let error) = result {
             self.record(error)
           }
         }
       }
-      
+
       wait(for: [serverRequestExpectation, otherFetchesCompletedExpectation, updatedWatcherResultExpectation], timeout: 3)
-      
+
       XCTAssertEqual(updatedWatcherResultExpectation.apollo.numberOfFulfillments, numberOfFetches)
     }
   }
 
-  #warning("Fix this test after mutable cache is implemented.")
-//  func testWatchedQueryDependentKeysAreUpdatedAfterDirectStoreUpdate() {
-//    client.store.cacheKeyForObject = { $0["id"] }
-//
-//    let watchedQuery = HeroAndFriendsNamesWithIDsQuery()
-//
-//    let resultObserver = makeResultObserver(for: watchedQuery)
-//
-//    let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
-//    addTeardownBlock { watcher.cancel() }
-//
-//    runActivity("Initial fetch from server") { _ in
-//      let serverRequestExpectation = server.expect(HeroAndFriendsNamesWithIDsQuery.self) { request in
-//        [
-//          "data": [
-//            "hero": [
-//              "id": "2001",
-//              "name": "R2-D2",
-//              "__typename": "Droid",
-//              "friends": [
-//                ["__typename": "Human", "id": "1000", "name": "Luke Skywalker"],
-//              ]
-//            ]
-//          ]
-//        ]
-//      }
-//
-//      let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from server") { result in
-//        try XCTAssertSuccessResult(result) { graphQLResult in
-//          XCTAssertEqual(graphQLResult.source, .server)
-//          XCTAssertNil(graphQLResult.errors)
-//
-//          let data = try XCTUnwrap(graphQLResult.data)
-//
-//          XCTAssertEqual(data.hero?.name, "R2-D2")
-//
-//          let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//          XCTAssertEqual(friendsNames, ["Luke Skywalker"])
-//
-//          let expectedDependentKeys: Set = [
-//            "2001.__typename",
-//            "2001.friends",
-//            "2001.id",
-//            "2001.name",
-//            "1000.__typename",
-//            "1000.id",
-//            "1000.name",
-//            "QUERY_ROOT.hero",
-//          ]
-//          let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
-//          XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
-//        }
-//      }
-//
-//      watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
-//
-//      wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//
-//    runActivity("Update same query directly in store") { _ in
-//      let updatedWatcherResultExpectation = resultObserver.expectation(description: "Watcher received updated result from cache") { result in
-//        try XCTAssertSuccessResult(result) { graphQLResult in
-//          XCTAssertEqual(graphQLResult.source, .cache)
-//          XCTAssertNil(graphQLResult.errors)
-//
-//          let data = try XCTUnwrap(graphQLResult.data)
-//
-//          XCTAssertEqual(data.hero?.name, "R2-D2")
-//
-//          let friendsNames = data.hero?.friends?.compactMap { $0?.name }
-//          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo"])
-//
-//          let expectedDependentKeys: Set = [
-//            "2001.__typename",
-//            "2001.friends",
-//            "2001.id",
-//            "2001.name",
-//            "1000.__typename",
-//            "1000.id",
-//            "1000.name",
-//            "1002.__typename",
-//            "1002.id",
-//            "1002.name",
-//            "QUERY_ROOT.hero",
-//          ]
-//          let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
-//          XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
-//        }
-//      }
-//
-//      client.store.withinReadWriteTransaction({ transaction in
-//        try transaction.update(query: HeroAndFriendsNamesWithIDsQuery()) { data in
-//          data.hero?.friends?.append(.makeHuman(id: "1002", name: "Han Solo"))
-//        }
-//      })
-//
-//      wait(for: [updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
-//    }
-//  }
-  
+  func testWatchedQueryDependentKeysAreUpdatedAfterDirectStoreUpdate() {
+    // given
+    struct HeroAndFriendsNamesWithIDsSelectionSet: MockMutableRootSelectionSet {
+      public var data: DataDict = DataDict([:], variables: nil)
+
+      static var selections: [Selection] {[
+        .field("hero", Hero.self)
+      ]}
+
+      var hero: Hero {
+        get { data["hero"] }
+        set { data["hero"] = newValue }
+      }
+
+      struct Hero: MockMutableRootSelectionSet {
+        public var data: DataDict = DataDict([:], variables: nil)
+
+        static var selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friends", [Friend].self),
+        ]}
+
+        var id: String {
+          get { data["id"] }
+          set { data["id"] = newValue }
+        }
+
+        var name: String {
+          get { data["name"] }
+          set { data["name"] = newValue }
+        }
+
+        var friends: [Friend] {
+          get { data["friends"] }
+          set { data["friends"] = newValue }
+        }
+
+        struct Friend: MockMutableRootSelectionSet {
+          public var data: DataDict = DataDict([:], variables: nil)
+
+          static var selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("id", String.self),
+            .field("name", String.self),
+          ]}
+
+          var id: String {
+            get { data["id"] }
+            set { data["id"] = newValue }
+          }
+
+          var name: String {
+            get { data["name"] }
+            set { data["name"] = newValue }
+          }
+        }
+      }
+    }
+
+    MockSchemaConfiguration.stub_cacheKeyProviderForUnknownType = { _, _ in IDCacheKeyProvider.self }
+
+    typealias HeroAndFriendsNamesWithIDsQuery = MockQuery<HeroAndFriendsNamesWithIDsSelectionSet>
+    let watchedQuery = HeroAndFriendsNamesWithIDsQuery()
+
+    let resultObserver = makeResultObserver(for: watchedQuery)
+
+    let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
+    addTeardownBlock { watcher.cancel() }
+
+    runActivity("Initial fetch from server") { _ in
+      let serverRequestExpectation = server.expect(HeroAndFriendsNamesWithIDsQuery.self) { request in
+        [
+          "data": [
+            "hero": [
+              "id": "2001",
+              "name": "R2-D2",
+              "__typename": "Droid",
+              "friends": [
+                ["__typename": "Human", "id": "1000", "name": "Luke Skywalker"],
+              ]
+            ]
+          ]
+        ]
+      }
+
+      let initialWatcherResultExpectation = resultObserver.expectation(description: "Watcher received initial result from server") { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .server)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+
+          XCTAssertEqual(data.hero.name, "R2-D2")
+
+          let friendsNames = data.hero.friends.compactMap { $0.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker"])
+
+          let expectedDependentKeys: Set = [
+            "Droid:2001.__typename",
+            "Droid:2001.friends",
+            "Droid:2001.id",
+            "Droid:2001.name",
+            "Human:1000.__typename",
+            "Human:1000.id",
+            "Human:1000.name",
+            "QUERY_ROOT.hero",
+          ]
+          let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+          expect(actualDependentKeys).to(equal(expectedDependentKeys))
+        }
+      }
+
+      watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
+
+      wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+
+    runActivity("Update same query directly in store") { _ in
+      let updatedWatcherResultExpectation = resultObserver.expectation(description: "Watcher received updated result from cache") { result in
+        try XCTAssertSuccessResult(result) { graphQLResult in
+          XCTAssertEqual(graphQLResult.source, .cache)
+          XCTAssertNil(graphQLResult.errors)
+
+          let data = try XCTUnwrap(graphQLResult.data)
+
+          XCTAssertEqual(data.hero.name, "R2-D2")
+
+          let friendsNames = data.hero.friends.compactMap { $0.name }
+          XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo"])
+
+          let expectedDependentKeys: Set = [
+            "Droid:2001.__typename",
+            "Droid:2001.friends",
+            "Droid:2001.id",
+            "Droid:2001.name",
+            "Human:1000.__typename",
+            "Human:1000.id",
+            "Human:1000.name",
+            "Human:1002.__typename",
+            "Human:1002.id",
+            "Human:1002.name",
+            "QUERY_ROOT.hero",
+          ]
+          let actualDependentKeys = try XCTUnwrap(graphQLResult.dependentKeys)
+          expect(actualDependentKeys).to(equal(expectedDependentKeys))
+        }
+      }
+
+      let cacheMutation = MockLocalCacheMutation<HeroAndFriendsNamesWithIDsSelectionSet>()
+      client.store.withinReadWriteTransaction({ transaction in
+        try transaction.update(cacheMutation) { data in
+          var human = HeroAndFriendsNamesWithIDsSelectionSet.Hero.Friend()
+          human.__typename = "Human"
+          human.id = "1002"
+          human.name = "Han Solo"
+          data.hero.friends.append(human)
+        }
+      })
+
+      wait(for: [updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
+    }
+  }
+
   func testWatchedQueryDependentKeysAreUpdatedAfterOtherFetchReturnsChangedData() {
     class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
       override class var selections: [Selection] {[
@@ -1350,14 +1549,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
     }
     MockSchemaConfiguration.stub_cacheKeyProviderForUnknownType = { _, _ in IDCacheKeyProvider.self }
-    
+
     let watchedQuery = MockQuery<HeroAndFriendsNameWithIDsSelectionSet>()
-    
+
     let resultObserver = makeResultObserver(for: watchedQuery)
-    
+
     let watcher = GraphQLQueryWatcher(client: client, query: watchedQuery, resultHandler: resultObserver.handler)
     addTeardownBlock { watcher.cancel() }
-    
+
     runActivity("Initial fetch from server") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<HeroAndFriendsNameWithIDsSelectionSet>.self) { request in
@@ -1374,21 +1573,21 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           ]
         ]
       }
-      
+
       let initialWatcherResultExpectation = resultObserver.expectation(
         description: "Watcher received initial result from server"
       ) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
           XCTAssertEqual(graphQLResult.source, .server)
           XCTAssertNil(graphQLResult.errors)
-          
+
           let data = try XCTUnwrap(graphQLResult.data)
-          
+
           XCTAssertEqual(data.hero?.name, "R2-D2")
-          
+
           let friendsNames = data.hero?.friends?.compactMap { $0.name }
           XCTAssertEqual(friendsNames, ["Luke Skywalker"])
-          
+
           let expectedDependentKeys: Set = [
             "Droid:2001.__typename",
             "Droid:2001.friends",
@@ -1403,12 +1602,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
         }
       }
-      
+
       watcher.fetch(cachePolicy: .fetchIgnoringCacheData)
-      
+
       wait(for: [serverRequestExpectation, initialWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
-    
+
     runActivity("Fetch other query from server") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<HeroAndFriendsNameWithIDsSelectionSet>.self) { request in
@@ -1426,19 +1625,19 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           ]
         ]
       }
-      
+
       let updatedWatcherResultExpectation = resultObserver.expectation(description: "Watcher received updated result from cache") { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
           XCTAssertEqual(graphQLResult.source, .cache)
           XCTAssertNil(graphQLResult.errors)
-          
+
           let data = try XCTUnwrap(graphQLResult.data)
-          
+
           XCTAssertEqual(data.hero?.name, "R2-D2")
-          
+
           let friendsNames = data.hero?.friends?.compactMap { $0.name }
           XCTAssertEqual(friendsNames, ["Luke Skywalker", "Han Solo"])
-          
+
           let expectedDependentKeys: Set = [
             "Droid:2001.__typename",
             "Droid:2001.friends",
@@ -1456,15 +1655,15 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           XCTAssertEqual(actualDependentKeys, expectedDependentKeys)
         }
       }
-      
+
       let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
-      
+
       client.fetch(query: MockQuery<HeroAndFriendsNameWithIDsSelectionSet>(),
                    cachePolicy: .fetchIgnoringCacheData) { result in
         defer { otherFetchCompletedExpectation.fulfill() }
         XCTAssertSuccessResult(result)
       }
-      
+
       wait(for: [serverRequestExpectation, otherFetchCompletedExpectation, updatedWatcherResultExpectation], timeout: Self.defaultWaitTimeout)
     }
   }

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -58,7 +58,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["name"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -77,7 +77,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["name"])
         XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
       } else {
@@ -110,7 +110,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
+      if let error = error as? GraphQLExecutionError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["name"])
         XCTAssertEqual(value as? Double, 10.0)
         XCTAssertTrue(expectedType == String.self)
@@ -146,7 +146,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["name"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -193,7 +193,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
+      if let error = error as? GraphQLExecutionError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["name"])
         XCTAssertEqual(value as? Double, 10.0)
         XCTAssertTrue(expectedType == String.self)
@@ -249,7 +249,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["size"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -270,7 +270,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["size"])
         XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
       } else {
@@ -289,7 +289,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
+      if let error = error as? GraphQLExecutionError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["size"])
         XCTAssertEqual(value as? Int, 10)
         XCTAssertTrue(expectedType == String.self)
@@ -309,7 +309,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
+      if let error = error as? GraphQLExecutionError, case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["size"])
         XCTAssertEqual(value as? Double, 10.0)
         XCTAssertTrue(expectedType == String.self)
@@ -359,7 +359,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["favorites"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -378,7 +378,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["favorites"])
         XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
       } else {
@@ -430,7 +430,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError,
+      if let error = error as? GraphQLExecutionError,
          case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["favorites", "0"])
         XCTAssertEqual(value as? Double, 10.0)
@@ -481,7 +481,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["favorites"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -528,7 +528,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError,
+      if let error = error as? GraphQLExecutionError,
          case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["favorites", "0"])
         XCTAssertEqual(value as? Double, 4.0)
@@ -579,7 +579,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["favorites"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -598,7 +598,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["favorites"])
         XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
       } else {
@@ -664,7 +664,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if let error = error as? GraphQLResultError,
+      if let error = error as? GraphQLExecutionError,
          case JSONDecodingError.couldNotConvert(let value, let expectedType) = error.underlying {
         XCTAssertEqual(error.path, ["favorites", "0"])
         XCTAssertEqual(value as? Int, 10)
@@ -723,7 +723,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["child", "name"])
         XCTAssertMatch(error.underlying, JSONDecodingError.missingValue)
       } else {
@@ -755,7 +755,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     // when
     XCTAssertThrowsError(try readValues(GivenSelectionSet.self, from: object)) { (error) in
       // then
-      if case let error as GraphQLResultError = error {
+      if case let error as GraphQLExecutionError = error {
         XCTAssertEqual(error.path, ["child", "name"])
         XCTAssertMatch(error.underlying, JSONDecodingError.nullValue)
       } else {

--- a/Tests/TestPlans/Apollo-UnitTestPlan.xctestplan
+++ b/Tests/TestPlans/Apollo-UnitTestPlan.xctestplan
@@ -13,6 +13,11 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "GraphQLFileTests",
+        "MultipartFormDataTests",
+        "StoreConcurrencyTests"
+      ],
       "target" : {
         "containerPath" : "container:Apollo.xcodeproj",
         "identifier" : "9FC7504D1D2A532D00458D91",


### PR DESCRIPTION
This defines `LocalCacheMutation` and refactors the `ApolloStore` to handle read/write transactions using them.
It also makes `DataDict` mutable to be used in `LocalCacheMutation`.

Next PRs:
[] Supporting local cache mutations for `mutation`, `subscription`, and `fragment`. (Currently only supports queries).
[] Generating the local cache mutations 
