### PR TITLE
feat: Prepare apollo-ios-cli for Homebrew formula submission

### DIFF
--- a/CodegenCLI/Package.resolved
+++ b/CodegenCLI/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "state" : {
+        "branch" : "release/1.0",
+        "revision" : "12505179e122df9eb2fecb0c5fcff93334460373"
+      }
+    },
+    {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",

--- a/CodegenCLI/Package.swift
+++ b/CodegenCLI/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .macOS(.v10_15)
   ],
   dependencies: [
-    .package(name: "Apollo", path: ".."),
+    .package(url: "https://github.com/apollographql/apollo-ios.git", branch: "release/1.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.1.2")),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0")),
   ],
@@ -17,7 +17,7 @@ let package = Package(
     .executableTarget(
       name: "apollo-ios-cli",
       dependencies: [
-        .product(name: "ApolloCodegenLib", package: "Apollo"),
+        .product(name: "ApolloCodegenLib", package: "apollo-ios"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "./Sources"

--- a/CodegenCLI/Sources/main.swift
+++ b/CodegenCLI/Sources/main.swift
@@ -5,7 +5,7 @@ struct CodegenCLI: ParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "apollo-ios-cli",
     abstract: "A command line utility for Apollo iOS code generation.",
-    version: "1.0.0",
+    version: "1.0.0-alpha.8",
     subcommands: [
       Initialize.self,
       Validate.self,


### PR DESCRIPTION
_Related to #2305 but that issue probably won't get closed out until the forumla is submitted to homebrew-core._

This PR updates the CLI package to prepare for submission to [homebrew-core](https://github.com/Homebrew/homebrew-core).
* Changes the apollo-ios dependency from a relative path to target a branch. This is needed so we can archive just the CodegenCLI folder and make it available for download to support the Homebrew `--build-from-source` command. An example of the archive is attached to the [1.0.0-alpha.7 release](https://github.com/apollographql/apollo-ios/releases/tag/1.0.0-alpha.7); _see Assets at the bottom of the release notes._
* Updates the version to match the next release (`1.0.0-alpha.8`) when we would submit the formula to homebrew-core for approval.

There is a chance that our submission to homebrew-core will be rejected given that we're still in alpha releases but I think there is a good chance it will be accepted because there is no stable version yet; _we could try a Cask if it were rejected._

Below is one of the [common reasons for rejecting a Cask](https://docs.brew.sh/Acceptable-Casks#rejected-casks) which is why we'll try homebrew-core first:
> The app is both open-source and CLI-only (i.e. it only uses the binary artifact). In that case, and [in the spirit of deduplication](https://github.com/Homebrew/homebrew-cask/issues/15603), submit it first to [Homebrew/core](https://github.com/Homebrew/homebrew-core) as a formula that builds from source. If it is rejected, you may then try again as a cask (link us to the issue so we can see the discussion and reasoning for rejection).

Below is the formula that will be submitted for approval - _in the submitted formula the `url` and `sha256` will change_.
```ruby
class ApolloIosCli < Formula
  desc "Generate Swift code for your GraphQL client"
  homepage "https://github.com/apollographql/apollo-ios/tree/release/1.0/CodegenCLI"
  url "https://github.com/apollographql/apollo-ios/releases/download/1.0.0-alpha.7/apollo-ios-cli_1.0.0-homebrew_test_source.tar.gz"
  sha256 "e6e555bd51700d72d4236a487abeacbb3369137289c5d2a379c328f23524a05f"
  license "MIT"

  depends_on xcode: ["13.3", :build, :test]

  uses_from_macos "swift"

  def install
    system "swift", "build", "--disable-sandbox", "--configuration", "release"
    bin.install ".build/release/apollo-ios-cli"
  end

  test do
    assert_match "New configuration output to ./apollo-codegen-config.json.",
      shell_output("#{bin}/apollo-ios-cli init").strip

    assert_predicate testpath/"apollo-codegen-config.json", :exist?
    (testpath/"schema.graphqls").write ""

    assert_match "The configuration is valid.",
      shell_output("#{bin}/apollo-ios-cli validate").strip
  end
end
```

If you wanted to test this yourself you will need to:
1. Save the above formula into the following path; `opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/apollo-ios-cli.rb`
2. At the command line execute `brew install --build-from-source apollo-ios-cli`
3. Voila! You should now have an apollo-ios-cli executable installed via Homebrew. 🎉 