### PR TITLE
refactor: Various uses of `ApolloCodegenConfiguration`

### DIFF
--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -27,7 +27,7 @@ extension FileGenerator {
     let filePath = URL(fileURLWithPath: directoryPath)
       .appendingPathComponent(fileName.firstUppercased).path
 
-    let rendered: String = template.render(forConfig: config)
+    let rendered: String = template.render()
 
     try fileManager.apollo.createFile(
       atPath: filePath,

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -21,12 +21,16 @@ struct SchemaModuleFileGenerator {
       filePath = pathURL.appendingPathComponent("Package.swift").path
       rendered = SwiftPackageManagerModuleTemplate(
         moduleName: config.schemaName,
-        testMockConfig: config.output.testMocks
+        testMockConfig: config.output.testMocks,
+        config: config
       ).render(forConfig: config)
 
     case .embeddedInTarget:
       filePath = pathURL.appendingPathComponent("\(config.schemaName).swift").path
-      rendered = SchemaModuleNamespaceTemplate(namespace: config.schemaName).render(forConfig: config)
+      rendered = SchemaModuleNamespaceTemplate(
+        namespace: config.schemaName,
+        config: config
+        ).render(forConfig: config)
 
     case .other:
       // no-op - the implementation is import statements in the generated operation files

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -23,14 +23,14 @@ struct SchemaModuleFileGenerator {
         moduleName: config.schemaName,
         testMockConfig: config.output.testMocks,
         config: config
-      ).render(forConfig: config)
+      ).render()
 
     case .embeddedInTarget:
       filePath = pathURL.appendingPathComponent("\(config.schemaName).swift").path
       rendered = SchemaModuleNamespaceTemplate(
         namespace: config.schemaName,
         config: config
-        ).render(forConfig: config)
+        ).render()
 
     case .other:
       // no-op - the implementation is import statements in the generated operation files

--- a/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
@@ -6,7 +6,7 @@ import ApolloUtils
 struct CustomScalarTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Custom Scalar](https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars).
   let graphqlScalar: GraphQLScalarType
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget { .schemaFile }

--- a/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
@@ -27,7 +27,7 @@ struct CustomScalarTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     typealias \(graphqlScalar.name.firstUppercased) = String
     """
     )

--- a/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/CustomScalarTemplate.swift
@@ -9,7 +9,7 @@ struct CustomScalarTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget { .schemaFile }
+  let target: TemplateTarget = .schemaFile
 
   var headerTemplate: TemplateString? {
     TemplateString(

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -17,17 +17,14 @@ struct EnumTemplate: TemplateRenderer {
     \(embeddedAccessControlModifier)\
     enum \(graphqlEnum.name.firstUppercased): String, EnumType {
       \(graphqlEnum.values.compactMap({
-        evaluateDeprecation(graphqlEnumValue: $0, config: config)
+        evaluateDeprecation(graphqlEnumValue: $0)
       }), separator: "\n")
     }
     """
     )
   }
 
-  private func evaluateDeprecation(
-    graphqlEnumValue: GraphQLEnumValue,
-    config: ReferenceWrapped<ApolloCodegenConfiguration>
-  ) -> String? {
+  private func evaluateDeprecation(graphqlEnumValue: GraphQLEnumValue) -> String? {
     switch (config.options.deprecatedEnumCases, graphqlEnumValue.deprecationReason) {
     case (.exclude, .some): return nil
     default: return "case \(graphqlEnumValue.name)"

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -9,7 +9,7 @@ struct EnumTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget { .schemaFile }
+  let target: TemplateTarget = .schemaFile
 
   var template: TemplateString {
     TemplateString(

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -6,7 +6,7 @@ import ApolloUtils
 struct EnumTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Enum](https://spec.graphql.org/draft/#sec-Enums).
   let graphqlEnum: GraphQLEnumType
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget { .schemaFile }

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -14,7 +14,7 @@ struct EnumTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     enum \(graphqlEnum.name.firstUppercased): String, EnumType {
       \(graphqlEnum.values.compactMap({
         evaluateDeprecation(graphqlEnumValue: $0, config: config)

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -11,7 +11,7 @@ struct FragmentTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget { .operationFile }
+  let target: TemplateTarget = .operationFile
 
   var template: TemplateString {
     TemplateString(

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -16,7 +16,7 @@ struct FragmentTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     struct \(fragment.name.firstUppercased): \(schema.name)\
     .\(if: isMutable, "Mutable")SelectionSet, Fragment {
       public static var fragmentDefinition: StaticString { ""\"

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -8,7 +8,7 @@ struct FragmentTemplate: TemplateRenderer {
   let fragment: IR.NamedFragment
   /// IR representation of source GraphQL schema.
   let schema: IR.Schema
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget { .operationFile }

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -16,7 +16,7 @@ struct InputObjectTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     struct \(graphqlInputObject.name.firstUppercased): InputObject {
       public private(set) var data: InputDict
     

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -11,7 +11,7 @@ struct InputObjectTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget = .schemaFile
+  let target: TemplateTarget = .schemaFile
 
   var template: TemplateString {
     TemplateString(

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -8,7 +8,7 @@ struct InputObjectTemplate: TemplateRenderer {
   let graphqlInputObject: GraphQLInputObjectType
   /// IR representation of a GraphQL schema.
   let schema: IR.Schema
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget = .schemaFile

--- a/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
@@ -6,7 +6,7 @@ import ApolloUtils
 struct InterfaceTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Interface](https://spec.graphql.org/draft/#sec-Interfaces).
   let graphqlInterface: GraphQLInterfaceType
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget = .schemaFile

--- a/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
@@ -9,7 +9,7 @@ struct InterfaceTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget = .schemaFile
+  let target: TemplateTarget = .schemaFile
 
   var template: TemplateString {
     TemplateString(

--- a/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InterfaceTemplate.swift
@@ -14,7 +14,7 @@ struct InterfaceTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     final class \(graphqlInterface.name.firstUppercased): Interface { }
     """
     )

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -14,7 +14,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     class \(operation.definition.nameWithSuffix.firstUppercased): LocalCacheMutation {
       public static let operationType: GraphQLOperationType = .\(operation.definition.operationType.rawValue)
 

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -6,7 +6,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
   let operation: IR.Operation
   /// IR representation of source GraphQL schema.
   let schema: IR.Schema
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   let target: TemplateTarget = .operationFile

--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -5,7 +5,6 @@ struct MockObjectTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Object](https://spec.graphql.org/draft/#sec-Objects).
   let graphqlObject: GraphQLObjectType
 
-  /// Shared codegen configuration.
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   let ir: IR

--- a/Sources/ApolloCodegenLib/Templates/MockUnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockUnionTemplate.swift
@@ -5,7 +5,6 @@ struct MockUnionTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Union](https://spec.graphql.org/draft/#sec-Unions).
   let graphqlUnion: GraphQLUnionType
 
-  /// Shared codegen configuration.
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   let ir: IR

--- a/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
@@ -6,7 +6,7 @@ import ApolloUtils
 struct ObjectTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Object](https://spec.graphql.org/draft/#sec-Objects).
   let graphqlObject: GraphQLObjectType
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   let target: TemplateTarget = .schemaFile

--- a/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
@@ -14,7 +14,7 @@ struct ObjectTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     final class \(graphqlObject.name.firstUppercased): Object {
       override public class var __typename: StaticString { \"\(graphqlObject.name.firstUppercased)\" }
 

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -8,7 +8,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
   let operation: IR.Operation
   /// IR representation of source GraphQL schema.
   let schema: IR.Schema
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   let target: TemplateTarget = .operationFile

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -36,7 +36,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
   private func OperationDeclaration(_ operation: CompilationResult.OperationDefinition) -> TemplateString {
     return """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     class \(operation.nameWithSuffix.firstUppercased): \(operation.operationType.renderedProtocolName) {
       public static let operationName: String = "\(operation.name)"
     """

--- a/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
@@ -9,7 +9,7 @@ struct SchemaModuleNamespaceTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget { .moduleFile }
+  let target: TemplateTarget = .moduleFile
 
   var template: TemplateString {
     TemplateString("""

--- a/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
@@ -1,10 +1,13 @@
 import Foundation
+import ApolloUtils
 
 /// Provides the format to define a namespace that is used to wrap other templates to prevent
 /// naming collisions in Swift code.
 struct SchemaModuleNamespaceTemplate: TemplateRenderer {
   /// Module namespace.
   let namespace: String
+
+  let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget { .moduleFile }
 

--- a/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
@@ -19,26 +19,26 @@ struct SchemaTemplate: TemplateRenderer {
   var embeddableTemplate: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     typealias ID = String
 
     \(if: !config.output.schemaTypes.isInModule,
       TemplateString("""
-      \(embeddedAccessControlModifier(config: config))\
+      \(embeddedAccessControlModifier)\
       typealias SelectionSet = \(schemaName)_SelectionSet
 
-      \(embeddedAccessControlModifier(config: config))\
+      \(embeddedAccessControlModifier)\
       typealias InlineFragment = \(schemaName)_InlineFragment
 
-      \(embeddedAccessControlModifier(config: config))\
+      \(embeddedAccessControlModifier)\
       typealias MutableSelectionSet = \(schemaName)_MutableSelectionSet
 
-      \(embeddedAccessControlModifier(config: config))\
+      \(embeddedAccessControlModifier)\
       typealias MutableInlineFragment = \(schemaName)_MutableInlineFragment
       """),
     else: protocolDefinition(prefix: nil, schemaName: schemaName))
 
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     enum Schema: SchemaConfiguration {
       public static func objectType(forTypename __typename: String) -> Object.Type? {
         switch __typename {

--- a/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
@@ -11,7 +11,7 @@ struct SchemaTemplate: TemplateRenderer {
 
   let schemaName: String
 
-  var target: TemplateTarget = .schemaFile
+  let target: TemplateTarget = .schemaFile
 
   var template: TemplateString { embeddableTemplate }
 

--- a/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaTemplate.swift
@@ -6,11 +6,13 @@ import ApolloUtils
 struct SchemaTemplate: TemplateRenderer {
   // IR representation of source GraphQL schema.
   let schema: IR.Schema
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   let schemaName: String
+
   var target: TemplateTarget = .schemaFile
+
   var template: TemplateString { embeddableTemplate }
 
   /// Swift code that can be embedded within a namespace.

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ApolloUtils
 
 /// Provides the format to define a Swift Package Manager module in Swift code. The output must
 /// conform to the [configuration definition of a Swift package](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#).
@@ -11,6 +12,8 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
   let target: TemplateTarget = .moduleFile
 
   let headerTemplate: TemplateString? = nil
+
+  let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var template: TemplateString {
     let casedModuleName = moduleName.firstUppercased

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -47,18 +47,16 @@ extension TemplateRenderer {
   ///
   /// - Parameter config: Shared codegen configuration.
   /// - Returns: Swift code derived from the template format.
-  func render(forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>) -> String {
+  func render() -> String {
     switch target {
-    case .schemaFile: return renderSchemaFile(forConfig: config)
-    case .operationFile: return renderOperationFile(forConfig: config)
-    case .moduleFile: return renderModuleFile(forConfig: config)
-    case .testMockFile: return renderTestMockFile(forConfig: config)
+    case .schemaFile: return renderSchemaFile()
+    case .operationFile: return renderOperationFile()
+    case .moduleFile: return renderModuleFile()
+    case .testMockFile: return renderTestMockFile()
     }
   }
 
-  private func renderSchemaFile(
-    forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>
-  ) -> String {
+  private func renderSchemaFile() -> String {
     TemplateString(
     """
     \(ifLet: headerTemplate, { "\($0)\n" })
@@ -71,9 +69,7 @@ extension TemplateRenderer {
     ).description
   }
 
-  private func renderOperationFile(
-    forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>
-  ) -> String {
+  private func renderOperationFile() -> String {
     TemplateString(
     """
     \(ifLet: headerTemplate, { "\($0)\n" })
@@ -87,9 +83,7 @@ extension TemplateRenderer {
     ).description
   }
 
-  private func renderModuleFile(
-    forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>
-  ) -> String {
+  private func renderModuleFile() -> String {
     TemplateString(
     """
     \(ifLet: headerTemplate, { "\($0)\n" })
@@ -98,9 +92,7 @@ extension TemplateRenderer {
     ).description
   }
 
-  private func renderTestMockFile(
-    forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>
-  ) -> String {
+  private func renderTestMockFile() -> String {
     TemplateString(
     """
     \(ifLet: headerTemplate, { "\($0)\n" })

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -111,9 +111,7 @@ extension TemplateRenderer {
     ).description
   }
 
-  func embeddedAccessControlModifier(
-    config: ReferenceWrapped<ApolloCodegenConfiguration>
-  ) -> String {
+  var embeddedAccessControlModifier: String {
     guard config.output.schemaTypes.isInModule else { return "" }
 
     return "public "

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -22,15 +22,14 @@ enum TemplateTarget {
 protocol TemplateRenderer {
   /// File target of the template.
   var target: TemplateTarget { get }
-
   /// The template for the header to render.
   var headerTemplate: TemplateString? { get }
-
   /// A template that must be rendered outside of any namespace wrapping.
   var detachedTemplate: TemplateString? { get }
-
   /// A template that can be rendered within any namespace wrapping.
   var template: TemplateString { get }
+  /// Shared codegen configuration.
+  var config: ReferenceWrapped<ApolloCodegenConfiguration> { get }
 }
 
 // MARK: Extensions

--- a/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -8,7 +8,7 @@ struct UnionTemplate: TemplateRenderer {
   let moduleName: String
   /// IR representation of source [GraphQL Union](https://spec.graphql.org/draft/#sec-Unions).
   let graphqlUnion: GraphQLUnionType
-  /// Shared codegen configuration.
+
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   var target: TemplateTarget = .schemaFile

--- a/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -11,7 +11,7 @@ struct UnionTemplate: TemplateRenderer {
 
   let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  var target: TemplateTarget = .schemaFile
+  let target: TemplateTarget = .schemaFile
 
   var template: TemplateString {
     TemplateString(

--- a/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -16,7 +16,7 @@ struct UnionTemplate: TemplateRenderer {
   var template: TemplateString {
     TemplateString(
     """
-    \(embeddedAccessControlModifier(config: config))\
+    \(embeddedAccessControlModifier)\
     enum \(graphqlUnion.name.firstUppercased): Union {
       public static let possibleTypes: [Object.Type] = [
         \(graphqlUnion.types.map({ type in

--- a/Tests/ApolloCodegenInternalTestHelpers/MockFileGenerator.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockFileGenerator.swift
@@ -2,11 +2,15 @@ import Foundation
 @testable import ApolloCodegenLib
 
 public struct MockFileGenerator: FileGenerator {
-  public var template: TemplateRenderer = MockFileTemplate(target: .schemaFile)
+  public var template: TemplateRenderer
   public var target: FileTarget
   public var fileName: String
 
-  public static func mock(target: FileTarget, filename: String) -> Self {
-    MockFileGenerator(target: target, fileName: filename)
+  public static func mock(
+    template: TemplateRenderer,
+    target: FileTarget,
+    filename: String
+  ) -> Self {
+    MockFileGenerator(template: template, target: target, fileName: filename)
   }
 }

--- a/Tests/ApolloCodegenInternalTestHelpers/MockFileTemplate.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockFileTemplate.swift
@@ -1,8 +1,10 @@
 import Foundation
 @testable import ApolloCodegenLib
+import ApolloUtils
 
 public struct MockFileTemplate: TemplateRenderer {
   public var target: TemplateTarget
+  public var config: ReferenceWrapped<ApolloCodegenConfiguration>
 
   public var template: TemplateString {
     TemplateString(
@@ -24,7 +26,10 @@ public struct MockFileTemplate: TemplateRenderer {
     )
   }
 
-  public static func mock(target: TemplateTarget) -> Self {
-    MockFileTemplate(target: target)
+  public static func mock(
+    target: TemplateTarget,
+    config: ApolloCodegenConfiguration = .mock()
+  ) -> Self {
+    MockFileTemplate(target: target, config: .init(value: config))
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FileGeneratorTests.swift
@@ -95,7 +95,7 @@ class FileGeneratorTests: XCTestCase {
     buildConfig()
     buildSubject()
 
-    let expectedData = template.render(forConfig: config).data(using: .utf8)
+    let expectedData = template.render().data(using: .utf8)
 
     fileManager.mock(closure: .createFile({ path, data, attributes in
       // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FileGeneratorTests.swift
@@ -35,9 +35,13 @@ class FileGeneratorTests: XCTestCase {
   }
 
   private func buildSubject() {
-    template = MockFileTemplate(target: .schemaFile)
+    template = MockFileTemplate.mock(target: .schemaFile)
     fileTarget = .object
-    subject = .init(template: template, target: fileTarget, fileName: "lowercasedType.swift")
+    subject = MockFileGenerator.mock(
+      template: template,
+      target: fileTarget,
+      filename: "lowercasedType.swift"
+    )
   }
 
   // MARK: - Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
@@ -14,7 +14,10 @@ class SchemaModuleNamespaceTemplateTests: XCTestCase {
     """
 
     // when
-    let subject = SchemaModuleNamespaceTemplate(namespace: "namespacedModule")
+    let subject = SchemaModuleNamespaceTemplate(
+      namespace: "namespacedModule",
+      config: .init(value: .mock())
+    )
     let actual = subject.template.description
 
     // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -12,7 +12,17 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   // MARK: Helpers
 
-#warning("use a buildSubject() function here to cut down on repetition.")
+  private func buildSubject(
+    moduleName: String = "testModule",
+    testMockConfig: ApolloCodegenConfiguration.TestMockFileOutput = .none,
+    config: ApolloCodegenConfiguration = .mock()
+  ) {
+    subject = .init(
+      moduleName: moduleName,
+      testMockConfig: testMockConfig,
+      config: .init(value: config)
+    )
+  }
 
   private func renderSubject() -> String {
     subject.template.description
@@ -22,7 +32,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__boilerplate__generatesCorrectSwiftToolsVersion() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
     // swift-tools-version:5.3
@@ -37,7 +47,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__boilerplate__generatesRequiredImports() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
     import PackageDescription
@@ -54,7 +64,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesPackageDefinition() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
     let package = Package(
@@ -70,7 +80,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesPlatforms() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
       platforms: [
@@ -90,7 +100,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesProducts() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
       products: [
@@ -107,7 +117,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesNoDependencies() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
       dependencies: [
@@ -123,7 +133,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_none_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
+    buildSubject()
 
     let expected = """
       targets: [
@@ -146,7 +156,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_absolute_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .absolute(path: "path"), config: .init(value: .mock()))
+    buildSubject(testMockConfig: .absolute(path: "path"))
 
     let expected = """
       targets: [
@@ -169,7 +179,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_swiftPackage_noTargetName_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .swiftPackage(), config: .init(value: .mock()))
+    buildSubject(testMockConfig: .swiftPackage())
 
     let expected = """
       targets: [
@@ -200,7 +210,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_swiftPackage_withTargetName_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .swiftPackage(targetName: "CustomMocks"), config: .init(value: .mock()))
+    buildSubject(testMockConfig: .swiftPackage(targetName: "CustomMocks"))
 
     let expected = """
       targets: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -12,6 +12,8 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   // MARK: Helpers
 
+#warning("use a buildSubject() function here to cut down on repetition.")
+
   private func renderSubject() -> String {
     subject.template.description
   }
@@ -20,7 +22,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__boilerplate__generatesCorrectSwiftToolsVersion() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
     // swift-tools-version:5.3
@@ -35,7 +37,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__boilerplate__generatesRequiredImports() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
     import PackageDescription
@@ -52,7 +54,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesPackageDefinition() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
     let package = Package(
@@ -68,7 +70,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesPlatforms() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
       platforms: [
@@ -88,7 +90,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesProducts() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
       products: [
@@ -105,7 +107,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__generatesNoDependencies() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
       dependencies: [
@@ -121,7 +123,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_none_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .none)
+    subject = .init(moduleName: "testModule", testMockConfig: .none, config: .init(value: .mock()))
 
     let expected = """
       targets: [
@@ -144,7 +146,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_absolute_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .absolute(path: "path"))
+    subject = .init(moduleName: "testModule", testMockConfig: .absolute(path: "path"), config: .init(value: .mock()))
 
     let expected = """
       targets: [
@@ -167,7 +169,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_swiftPackage_noTargetName_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .swiftPackage())
+    subject = .init(moduleName: "testModule", testMockConfig: .swiftPackage(), config: .init(value: .mock()))
 
     let expected = """
       targets: [
@@ -198,7 +200,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfig_swiftPackage_withTargetName_generatesTargets() {
     // given
-    subject = .init(moduleName: "testModule", testMockConfig: .swiftPackage(targetName: "CustomMocks"))
+    subject = .init(moduleName: "testModule", testMockConfig: .swiftPackage(targetName: "CustomMocks"), config: .init(value: .mock()))
 
     let expected = """
       targets: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -5,14 +5,6 @@ import ApolloUtils
 import Nimble
 
 class TemplateRenderer_OperationFile_Tests: XCTestCase {
-  private var config: ReferenceWrapped<ApolloCodegenConfiguration>!
-  private var subject: MockFileTemplate = .mock(target: .operationFile)
-
-  override func tearDown() {
-    config = nil
-
-    super.tearDown()
-  }
 
   // MARK: Helpers
 
@@ -20,18 +12,16 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
     schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput
-  ) {
-    config = ReferenceWrapped(
-      value: ApolloCodegenConfiguration.mock(
-        schemaName: schemaName,
-        input: .init(schemaPath: "MockInputPath", searchPaths: []),
-        output: .mock(moduleType: moduleType, operations: operations)
-      )
+  ) -> ApolloCodegenConfiguration {
+    ApolloCodegenConfiguration.mock(
+      schemaName: schemaName,
+      input: .init(schemaPath: "MockInputPath", searchPaths: []),
+      output: .mock(moduleType: moduleType, operations: operations)
     )
   }
 
-  private func renderSubject() -> String {
-    subject.render(forConfig: config)
+  private func buildSubject(config: ApolloCodegenConfiguration = .mock()) -> MockFileTemplate {
+    MockFileTemplate(target: .operationFile, config: ReferenceWrapped(value: config))
   }
 
   // MARK: Render Target .operationFile Tests
@@ -60,10 +50,11 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
@@ -140,10 +131,11 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(test.expectation, atLine: 4, ignoringExtraLines: true))
@@ -229,10 +221,11 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(test.expectation, atLine: test.atLine))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
@@ -5,14 +5,6 @@ import ApolloUtils
 import Nimble
 
 class TemplateRenderer_SchemaFile_Tests: XCTestCase {
-  private var config: ReferenceWrapped<ApolloCodegenConfiguration>!
-  private var subject: MockFileTemplate = .mock(target: .schemaFile)
-
-  override func tearDown() {
-    config = nil
-
-    super.tearDown()
-  }
 
   // MARK: Helpers
 
@@ -20,18 +12,16 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
     schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput
-  ) {
-    config = ReferenceWrapped(
-      value: ApolloCodegenConfiguration.mock(
-        schemaName: schemaName,
-        input: .init(schemaPath: "MockInputPath", searchPaths: []),
-        output: .mock(moduleType: moduleType, operations: operations)
-      )
+  ) -> ApolloCodegenConfiguration {
+    ApolloCodegenConfiguration.mock(
+      schemaName: schemaName,
+      input: .init(schemaPath: "MockInputPath", searchPaths: []),
+      output: .mock(moduleType: moduleType, operations: operations)
     )
   }
 
-  private func renderSubject() -> String {
-    subject.render(forConfig: config)
+  private func buildSubject(config: ApolloCodegenConfiguration = .mock()) -> MockFileTemplate {
+    MockFileTemplate(target: .schemaFile, config: ReferenceWrapped(value: config))
   }
 
   // MARK: Render Target .schemaFile Tests
@@ -60,10 +50,11 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
@@ -120,10 +111,11 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))
@@ -217,10 +209,11 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(test.expectation, atLine: test.atLine))

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
@@ -5,14 +5,6 @@ import ApolloUtils
 import Nimble
 
 class TemplateRenderer_TestMockFile_Tests: XCTestCase {
-  private var config: ReferenceWrapped<ApolloCodegenConfiguration>!
-  private var subject: MockFileTemplate = .mock(target: .testMockFile)
-
-  override func tearDown() {
-    config = nil
-
-    super.tearDown()
-  }
 
   // MARK: Helpers
 
@@ -20,18 +12,16 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
     schemaName: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput
-  ) {
-    config = ReferenceWrapped(
-      value: ApolloCodegenConfiguration.mock(
-        schemaName: schemaName,
-        input: .init(schemaPath: "MockInputPath", searchPaths: []),
-        output: .mock(moduleType: moduleType, operations: operations)
-      )
+  ) -> ApolloCodegenConfiguration {
+    ApolloCodegenConfiguration.mock(
+      schemaName: schemaName,
+      input: .init(schemaPath: "MockInputPath", searchPaths: []),
+      output: .mock(moduleType: moduleType, operations: operations)
     )
   }
 
-  private func renderSubject() -> String {
-    subject.render(forConfig: config)
+  private func buildSubject(config: ApolloCodegenConfiguration = .mock()) -> MockFileTemplate {
+    MockFileTemplate(target: .testMockFile, config: ReferenceWrapped(value: config))
   }
 
   // MARK: Render Target .schemaFile Tests
@@ -60,10 +50,11 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
     ]
 
     for test in tests {
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
@@ -130,10 +121,11 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
       import \(test.importModuleName)
 
       """
-      buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let config = buildConfig(moduleType: test.schemaTypes, operations: test.operations)
+      let subject = buildSubject(config: config)
 
       // when
-      let actual = renderSubject()
+      let actual = subject.render()
 
       // then
       expect(actual).to(equalLineByLine(expected, atLine: 4, ignoringExtraLines: true))


### PR DESCRIPTION
This PR cleans up the usage of the shared configuration property in the templates and tests.
* Moves the `config` property into the protocol so it's available in the protocol extension
* Removes the need to pass `config` into various functions since it's now available on the protocol
* Refactors some test repetition
* Enforces consistency of template properties