### PR TITLE
fix: Correctly namespace schema types in operation files when a `.relative` or `.absolute` location is used

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/AllAnimalsQuery.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/AllAnimalsQuery.swift
@@ -428,11 +428,11 @@ public class AllAnimalsQuery: GraphQLQuery {
         public static var __parentType: ParentType { .Object(AnimalKingdomAPI.Dog.self) }
         public static var selections: [Selection] { [
           .field("favoriteToy", String.self),
-          .field("birthdate", AnimalKingdomAPI.CustomDate?.self),
+          .field("birthdate", CustomDate?.self),
         ] }
 
         public var favoriteToy: String { __data["favoriteToy"] }
-        public var birthdate: AnimalKingdomAPI.CustomDate? { __data["birthdate"] }
+        public var birthdate: CustomDate? { __data["birthdate"] }
         public var height: Height { __data["height"] }
         public var species: String { __data["species"] }
         public var skinCovering: GraphQLEnum<SkinCovering>? { __data["skinCovering"] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Dog+Mock.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Dog+Mock.swift
@@ -10,7 +10,7 @@ extension Dog: Mockable {
   public typealias MockValueCollectionType = Array<Mock<Dog>>
 
   public struct MockFields {
-    @Field<AnimalKingdomAPI.CustomDate>("birthdate") public var birthdate
+    @Field<CustomDate>("birthdate") public var birthdate
     @Field<Int>("bodyTemperature") public var bodyTemperature
     @Field<String>("favoriteToy") public var favoriteToy
     @Field<Height>("height") public var height
@@ -26,7 +26,7 @@ extension Dog: Mockable {
 
 public extension Mock where O == Dog {
   convenience init(
-    birthdate: AnimalKingdomAPI.CustomDate? = nil,
+    birthdate: CustomDate? = nil,
     bodyTemperature: Int? = nil,
     favoriteToy: String? = nil,
     height: Mock<Height>? = nil,

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
@@ -56,6 +56,15 @@ public class GraphQLScalarType: GraphQLNamedType {
       return true
     }    
   }
+
+  var isSwiftType: Bool {
+    switch name {
+    case "String", "Int", "Float", "Boolean":
+      return true
+    default:
+      return false
+    }
+  }
 }
 
 public class GraphQLEnumType: GraphQLNamedType {

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -25,7 +25,8 @@ struct FragmentTemplate: TemplateRenderer {
 
       \(SelectionSetTemplate(
         schema: schema,
-        mutable: isMutable
+        mutable: isMutable,
+        config: config
       ).BodyTemplate(fragment.rootField.selectionSet))
     }
     """)

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -41,7 +41,7 @@ struct InputObjectTemplate: TemplateRenderer {
   private func InitializerParametersTemplate() -> TemplateString {
     TemplateString("""
     \(graphqlInputObject.fields.map({
-      "\($1.name): \($1.renderInputValueType(includeDefault: true, inSchemaNamed: schema.name))"
+      "\($1.name): \($1.renderInputValueType(includeDefault: true, config: config))"
     }), separator: ",\n")
     """)
   }
@@ -54,7 +54,7 @@ struct InputObjectTemplate: TemplateRenderer {
 
   private func FieldPropertyTemplate(_ field: GraphQLInputField) -> String {
     """
-    public var \(field.name): \(field.renderInputValueType(inSchemaNamed: schema.name)) {
+    public var \(field.name): \(field.renderInputValueType(config: config)) {
       get { __data.\(field.name) }
       set { __data.\(field.name) = newValue }
     }

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -54,7 +54,7 @@ struct InputObjectTemplate: TemplateRenderer {
 
   private func FieldPropertyTemplate(_ field: GraphQLInputField) -> String {
     """
-    public var \(field.name): \(field.renderInputValueType(config: config)) {
+    public var \(field.name): \(field.renderInputValueType(config: config.value)) {
       get { __data.\(field.name) }
       set { __data.\(field.name) = newValue }
     }

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -41,7 +41,7 @@ struct InputObjectTemplate: TemplateRenderer {
   private func InitializerParametersTemplate() -> TemplateString {
     TemplateString("""
     \(graphqlInputObject.fields.map({
-      "\($1.name): \($1.renderInputValueType(includeDefault: true, config: config))"
+      "\($1.name): \($1.renderInputValueType(includeDefault: true, config: config.value))"
     }), separator: ",\n")
     """)
   }

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -24,7 +24,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableAccessors(operation.definition.variables))
 
-      \(SelectionSetTemplate(schema: schema, mutable: true).render(for: operation))
+      \(SelectionSetTemplate(schema: schema, mutable: true, config: config).render(for: operation))
     }
     """)
   }

--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -18,7 +18,7 @@ struct MockObjectTemplate: TemplateRenderer {
       .map {
         (
           name: $0.0,
-          type: $0.1.rendered(containedInNonNull: true, config: config),
+          type: $0.1.rendered(as: .selectionSetField(forceNonNull: true), config: config.value),
           mockType: mockTypeName(for: $0.1)
         )
       }
@@ -72,9 +72,9 @@ struct MockObjectTemplate: TemplateRenderer {
     }
 
     return type.rendered(
-      containedInNonNull: true,
+      as: .selectionSetField(forceNonNull: true),
       replacingNamedTypeWith: nameReplacement(for: type),
-      config: config
+      config: config.value
     )
   }
   

--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -18,7 +18,7 @@ struct MockObjectTemplate: TemplateRenderer {
       .map {
         (
           name: $0.0,
-          type: $0.1.rendered(containedInNonNull: true, inSchemaNamed: ir.schema.name),
+          type: $0.1.rendered(containedInNonNull: true, config: config),
           mockType: mockTypeName(for: $0.1)
         )
       }
@@ -74,7 +74,7 @@ struct MockObjectTemplate: TemplateRenderer {
     return type.rendered(
       containedInNonNull: true,
       replacingNamedTypeWith: nameReplacement(for: type),
-      inSchemaNamed: ir.schema.name
+      config: config
     )
   }
   

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -29,7 +29,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableAccessors(operation.definition.variables))
 
-      \(SelectionSetTemplate(schema: schema).render(for: operation))
+      \(SelectionSetTemplate(schema: schema, config: config).render(for: operation))
     }
     """)
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
@@ -4,10 +4,10 @@ import ApolloUtils
 extension GraphQLInputField {
   func renderInputValueType(
     includeDefault: Bool = false,
-    config: ReferenceWrapped<ApolloCodegenConfiguration>
+    config: ApolloCodegenConfiguration
   ) -> String {
     """
-    \(type.renderAsInputValue(config: config))\
+    \(type.rendered(as: .inputValue, config: config))\
     \(isSwiftOptional ? "?" : "")\
     \(includeDefault && hasSwiftNilDefault ? " = nil" : "")
     """

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
@@ -1,5 +1,4 @@
 import JavaScriptCore
-import ApolloUtils
 
 extension GraphQLInputField {
   func renderInputValueType(

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
@@ -1,9 +1,13 @@
 import JavaScriptCore
+import ApolloUtils
 
 extension GraphQLInputField {
-  func renderInputValueType(includeDefault: Bool = false, inSchemaNamed schemaName: String) -> String {
+  func renderInputValueType(
+    includeDefault: Bool = false,
+    config: ReferenceWrapped<ApolloCodegenConfiguration>
+  ) -> String {
     """
-    \(type.renderAsInputValue(inSchemaNamed: schemaName))\
+    \(type.renderAsInputValue(config: config))\
     \(isSwiftOptional ? "?" : "")\
     \(includeDefault && hasSwiftNilDefault ? " = nil" : "")
     """

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -10,12 +10,15 @@ extension GraphQLType {
     var schemaModuleName = ""
 
     switch self {
-    case let .entity(type as GraphQLNamedType),
-      let .inputObject(type as GraphQLNamedType):
+    case let .inputObject(type as GraphQLNamedType):
+      if !config.output.operations.isInModule {
+        schemaModuleName = "\(config.schemaName)."
+      }
+      fallthrough
 
+    case let .entity(type as GraphQLNamedType):
       let typeName = newTypeName ?? type.swiftName
-
-      return containedInNonNull ? typeName : "\(typeName)?"
+      return containedInNonNull ? "\(schemaModuleName)\(typeName)" : "\(schemaModuleName)\(typeName)?"
 
     case let .scalar(type):
       if !type.isSwiftType && !config.output.operations.isInModule {

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -5,6 +5,11 @@ extension GraphQLType {
     replacingNamedTypeWith newTypeName: String? = nil,
     inSchemaNamed schemaName: String?
   ) -> String {
+    var schemaModuleName = ""
+    if let schemaName = schemaName {
+      schemaModuleName = "\(schemaName)."
+    }
+
     switch self {
     case let .entity(type as GraphQLNamedType),
       let .inputObject(type as GraphQLNamedType):
@@ -15,11 +20,6 @@ extension GraphQLType {
 
     case let .scalar(type):
       let typeName = newTypeName ?? type.swiftName
-      var schemaModuleName = ""
-
-      if let schemaName = schemaName {
-        schemaModuleName = "\(schemaName)."
-      }
 
       return TemplateString(
         "\(schemaModuleName)\(typeName)\(if: !containedInNonNull, "?")"
@@ -27,7 +27,7 @@ extension GraphQLType {
 
     case let .enum(type as GraphQLNamedType):
       let typeName = newTypeName ?? type.name
-      let enumType = "GraphQLEnum<\(typeName)>"
+      let enumType = "GraphQLEnum<\(schemaModuleName)\(typeName)>"
 
       return containedInNonNull ? enumType : "\(enumType)?"
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -3,7 +3,7 @@ extension GraphQLType {
   func rendered(
     containedInNonNull: Bool = false,
     replacingNamedTypeWith newTypeName: String? = nil,
-    inSchemaNamed schemaName: String
+    inSchemaNamed schemaName: String?
   ) -> String {
     switch self {
     case let .entity(type as GraphQLNamedType),
@@ -15,9 +15,14 @@ extension GraphQLType {
 
     case let .scalar(type):
       let typeName = newTypeName ?? type.swiftName
+      var schemaModuleName = ""
+
+      if let schemaName = schemaName {
+        schemaModuleName = "\(schemaName)."
+      }
 
       return TemplateString(
-        "\(if: type.isCustomScalar, "\(schemaName).")\(typeName)\(if: !containedInNonNull, "?")"
+        "\(schemaModuleName)\(typeName)\(if: !containedInNonNull, "?")"
       ).description
 
     case let .enum(type as GraphQLNamedType):

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -1,4 +1,3 @@
-import ApolloUtils
 extension GraphQLType {
 
   enum RenderContext {

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -1,10 +1,38 @@
 import ApolloUtils
 extension GraphQLType {
 
+  enum RenderContext {
+    case selectionSetField(forceNonNull: Bool = false)
+    /// Renders the type for use as an input value.
+    ///
+    /// If the outermost type is nullable, it will be wrapped in a `GraphQLNullable` instead of
+    /// an `Optional`.
+    case inputValue
+  }
+
   func rendered(
-    containedInNonNull: Bool = false,
+    as context: RenderContext,
     replacingNamedTypeWith newTypeName: String? = nil,
-    config: ReferenceWrapped<ApolloCodegenConfiguration>
+    config: ApolloCodegenConfiguration
+  ) -> String {
+    switch context {
+    case .selectionSetField(let forceNonNull):
+      return renderedAsSelectionSetField(
+        containedInNonNull: forceNonNull,
+        replacingNamedTypeWith: newTypeName,
+        config: config
+      )
+    case .inputValue:
+      return renderAsInputValue(inNullable: true, config: config)
+    }
+  }
+
+  // MARK: Selection Set Field
+
+  private func renderedAsSelectionSetField(
+    containedInNonNull: Bool,
+    replacingNamedTypeWith newTypeName: String? = nil,
+    config: ApolloCodegenConfiguration
   ) -> String {
 
     lazy var schemaModuleName: String = {
@@ -18,7 +46,7 @@ extension GraphQLType {
 
     case let .inputObject(type as GraphQLNamedType):
       let typeName = newTypeName ?? type.swiftName
-      return containedInNonNull ? "\(schemaModuleName)\(typeName)" : "\(schemaModuleName)\(typeName)?"
+      return TemplateString("\(schemaModuleName)\(typeName)\(if: !containedInNonNull, "?")").description
 
     case let .scalar(type):
       let typeName = newTypeName ?? type.swiftName
@@ -34,10 +62,19 @@ extension GraphQLType {
       return containedInNonNull ? enumType : "\(enumType)?"
 
     case let .nonNull(ofType):
-      return ofType.rendered(containedInNonNull: true, replacingNamedTypeWith: newTypeName, config: config)
+      return ofType.renderedAsSelectionSetField(
+        containedInNonNull: true,
+        replacingNamedTypeWith: newTypeName,
+        config: config
+      )
 
     case let .list(ofType):
-      let inner = "[\(ofType.rendered(containedInNonNull: false, replacingNamedTypeWith: newTypeName, config: config))]"
+      let rendered = ofType.renderedAsSelectionSetField(
+        containedInNonNull: false,
+        replacingNamedTypeWith: newTypeName,
+        config: config
+      )
+      let inner = "[\(rendered)]"
 
       return containedInNonNull ? inner : "\(inner)?"
     }
@@ -45,31 +82,23 @@ extension GraphQLType {
 
   // MARK: Input Value
 
-  /// Renders the type for use as an input value.
-  ///
-  /// If the outermost type is nullable, it will be wrapped in a `GraphQLNullable` instead of
-  /// an `Optional`.
-  func renderAsInputValue(config: ReferenceWrapped<ApolloCodegenConfiguration>) -> String {
-    return renderAsInputValue(inNullable: true, config: config)
-  }
-
   private func renderAsInputValue(
     inNullable: Bool,
-    config: ReferenceWrapped<ApolloCodegenConfiguration>
+    config: ApolloCodegenConfiguration
   ) -> String {
     switch self {
     case .entity:
       preconditionFailure("Entities cannot be used as input values")
 
     case .enum, .scalar, .inputObject:
-      let typeName = self.rendered(containedInNonNull: true, config: config)
+      let typeName = self.renderedAsSelectionSetField(containedInNonNull: true, config: config)
       return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
 
     case let .nonNull(ofType):
       return ofType.renderAsInputValue(inNullable: false, config: config)
 
     case let .list(ofType):
-      let typeName = "[\(ofType.rendered(config: config))]"
+      let typeName = "[\(ofType.renderedAsSelectionSetField(containedInNonNull: false, config: config))]"
       return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
     }
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -18,7 +18,7 @@ extension GraphQLType {
       return containedInNonNull ? typeName : "\(typeName)?"
 
     case let .scalar(type):
-      if type.isCustomScalar && !config.output.operations.isInModule {
+      if !type.isSwiftType && !config.output.operations.isInModule {
         schemaModuleName = "\(config.schemaName)."
       }
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -1,14 +1,13 @@
+import ApolloUtils
 extension GraphQLType {
 
   func rendered(
     containedInNonNull: Bool = false,
     replacingNamedTypeWith newTypeName: String? = nil,
-    inSchemaNamed schemaName: String?
+    config: ReferenceWrapped<ApolloCodegenConfiguration>
   ) -> String {
+
     var schemaModuleName = ""
-    if let schemaName = schemaName {
-      schemaModuleName = "\(schemaName)."
-    }
 
     switch self {
     case let .entity(type as GraphQLNamedType),
@@ -19,6 +18,10 @@ extension GraphQLType {
       return containedInNonNull ? typeName : "\(typeName)?"
 
     case let .scalar(type):
+      if type.isCustomScalar && !config.output.operations.isInModule {
+        schemaModuleName = "\(config.schemaName)."
+      }
+
       let typeName = newTypeName ?? type.swiftName
 
       return TemplateString(
@@ -26,16 +29,20 @@ extension GraphQLType {
       ).description
 
     case let .enum(type as GraphQLNamedType):
+      if !config.output.operations.isInModule {
+        schemaModuleName = "\(config.schemaName)."
+      }
+
       let typeName = newTypeName ?? type.name
       let enumType = "GraphQLEnum<\(schemaModuleName)\(typeName)>"
 
       return containedInNonNull ? enumType : "\(enumType)?"
 
     case let .nonNull(ofType):
-      return ofType.rendered(containedInNonNull: true, replacingNamedTypeWith: newTypeName, inSchemaNamed: schemaName)
+      return ofType.rendered(containedInNonNull: true, replacingNamedTypeWith: newTypeName, config: config)
 
     case let .list(ofType):
-      let inner = "[\(ofType.rendered(containedInNonNull: false, replacingNamedTypeWith: newTypeName, inSchemaNamed: schemaName))]"
+      let inner = "[\(ofType.rendered(containedInNonNull: false, replacingNamedTypeWith: newTypeName, config: config))]"
 
       return containedInNonNull ? inner : "\(inner)?"
     }
@@ -47,21 +54,24 @@ extension GraphQLType {
   ///
   /// If the outermost type is nullable, it will be wrapped in a `GraphQLNullable` instead of
   /// an `Optional`.
-  func renderAsInputValue(inSchemaNamed schemaName: String) -> String {
-    return renderAsInputValue(inNullable: true, inSchemaNamed: schemaName)
+  func renderAsInputValue(config: ReferenceWrapped<ApolloCodegenConfiguration>) -> String {
+    return renderAsInputValue(inNullable: true, config: config)
   }
 
-  private func renderAsInputValue(inNullable: Bool, inSchemaNamed schemaName: String) -> String {
+  private func renderAsInputValue(
+    inNullable: Bool,
+    config: ReferenceWrapped<ApolloCodegenConfiguration>
+  ) -> String {
     switch self {
     case .entity, .enum, .scalar, .inputObject:
-      let typeName = self.rendered(containedInNonNull: true, inSchemaNamed: schemaName)
+      let typeName = self.rendered(containedInNonNull: true, config: config)
       return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
 
     case let .nonNull(ofType):
-      return ofType.renderAsInputValue(inNullable: false, inSchemaNamed: schemaName)
+      return ofType.renderAsInputValue(inNullable: false, config: config)
 
     case let .list(ofType):
-      let typeName = "[\(ofType.rendered(inSchemaNamed: schemaName))]"
+      let typeName = "[\(ofType.rendered(config: config))]"
       return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
     }
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
@@ -1,8 +1,10 @@
 import OrderedCollections
+import ApolloUtils
 
 protocol InputVariableRenderable {
   var type: GraphQLType { get }
   var defaultValue: GraphQLValue? { get }
+//  var config: ReferenceWrapped<ApolloCodegenConfiguration> { get }
 }
 
 extension CompilationResult.VariableDefinition: InputVariableRenderable {}
@@ -10,6 +12,7 @@ extension CompilationResult.VariableDefinition: InputVariableRenderable {}
 struct InputVariable: InputVariableRenderable {
   let type: GraphQLType
   let defaultValue: GraphQLValue?
+//  let config: ReferenceWrapped<ApolloCodegenConfiguration>
 }
 
 extension InputVariableRenderable {

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
@@ -10,7 +10,6 @@ extension CompilationResult.VariableDefinition: InputVariableRenderable {}
 struct InputVariable: InputVariableRenderable {
   let type: GraphQLType
   let defaultValue: GraphQLValue?
-  let config: ApolloCodegenConfiguration
 }
 
 extension InputVariableRenderable {
@@ -36,7 +35,7 @@ extension InputVariableRenderable {
         let .list(listInnerType):
         return """
         [\(list.compactMap {
-          InputVariable(type: listInnerType, defaultValue: $0, config: config).renderVariableDefaultValue(inList: true, config: config)
+          InputVariable(type: listInnerType, defaultValue: $0).renderVariableDefaultValue(inList: true, config: config)
         }, separator: ", ")]
         """
 
@@ -76,7 +75,7 @@ fileprivate extension GraphQLInputObjectType {
         preconditionFailure("Field \(entry.0) not found on input object.")
       }
 
-      let variable = InputVariable(type: field.type, defaultValue: entry.value, config: config)
+      let variable = InputVariable(type: field.type, defaultValue: entry.value)
 
       return "\(entry.0): " + variable.renderVariableDefaultValue(config: config)
     }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -33,7 +33,7 @@ extension OperationTemplateRenderer {
   ) -> TemplateString {
       """
       \(variable.name): \(variable.type.rendered(as: .inputValue, config: config.value))\
-      \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue())
+      \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue(config: config.value))
       """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -24,7 +24,7 @@ extension OperationTemplateRenderer {
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
     """
-    \(variables.map { "public var \($0.name): \($0.type.renderAsInputValue(config: config))"}, separator: "\n")
+    \(variables.map { "public var \($0.name): \($0.type.rendered(as: .inputValue, config: config.value))"}, separator: "\n")
     """
   }
 
@@ -32,7 +32,7 @@ extension OperationTemplateRenderer {
     _ variable: CompilationResult.VariableDefinition
   ) -> TemplateString {
       """
-      \(variable.name): \(variable.type.renderAsInputValue(config: config))\
+      \(variable.name): \(variable.type.rendered(as: .inputValue, config: config.value))\
       \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue())
       """
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -24,7 +24,7 @@ extension OperationTemplateRenderer {
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
     """
-    \(variables.map { "public var \($0.name): \($0.type.renderAsInputValue(inSchemaNamed: schema.name))"}, separator: "\n")
+    \(variables.map { "public var \($0.name): \($0.type.renderAsInputValue(config: config))"}, separator: "\n")
     """
   }
 
@@ -32,7 +32,7 @@ extension OperationTemplateRenderer {
     _ variable: CompilationResult.VariableDefinition
   ) -> TemplateString {
       """
-      \(variable.name): \(variable.type.renderAsInputValue(inSchemaNamed: schema.name))\
+      \(variable.name): \(variable.type.renderAsInputValue(config: config))\
       \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue())
       """
   }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -18,7 +18,7 @@ struct SelectionSetTemplate {
     self.isMutable = mutable
     self.config = config
 
-    self.nameCache = SelectionSetNameCache(schema: schema)
+    self.nameCache = SelectionSetNameCache(schema: schema, config: config)
   }
 
   // MARK: - Operation
@@ -172,14 +172,7 @@ struct SelectionSetTemplate {
     let fieldName: String
     switch field {
     case let scalarField as IR.ScalarField:
-      let schemaName: String?
-      switch (field.isScalar, field.isCustomScalar, config.output.operations.isInModule) {
-      case (true, true, false): schemaName = schema.name
-      case (false, _, false): schemaName = schema.name
-      default: schemaName = nil
-      }
-
-      fieldName = scalarField.type.rendered(inSchemaNamed: schemaName)
+      fieldName = scalarField.type.rendered(config: config)
 
     case let entityField as IR.EntityField:
       fieldName = self.nameCache.selectionSetType(for: entityField)
@@ -385,9 +378,11 @@ fileprivate class SelectionSetNameCache {
   private var generatedSelectionSetNames: [ObjectIdentifier: String] = [:]
 
   unowned let schema: IR.Schema
+  let config: ReferenceWrapped<ApolloCodegenConfiguration>
 
-  init(schema: IR.Schema) {
+  init(schema: IR.Schema, config: ReferenceWrapped<ApolloCodegenConfiguration>) {
     self.schema = schema
+    self.config = config
   }
 
   // MARK: Entity Field
@@ -401,7 +396,7 @@ fileprivate class SelectionSetNameCache {
   }
 
   func selectionSetType(for field: IR.EntityField) -> String {
-    field.type.rendered(replacingNamedTypeWith: selectionSetName(for: field), inSchemaNamed: schema.name)
+    field.type.rendered(replacingNamedTypeWith: selectionSetName(for: field), config: config)
   }
 
   // MARK: Name Computation

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -172,7 +172,7 @@ struct SelectionSetTemplate {
     let fieldName: String
     switch field {
     case let scalarField as IR.ScalarField:
-      fieldName = scalarField.type.rendered(config: config)
+      fieldName = scalarField.type.rendered(as: .selectionSetField(), config: config.value)
 
     case let entityField as IR.EntityField:
       fieldName = self.nameCache.selectionSetType(for: entityField)
@@ -394,9 +394,13 @@ fileprivate class SelectionSetNameCache {
     generatedSelectionSetNames[objectId] = name
     return name
   }
-
+  
   func selectionSetType(for field: IR.EntityField) -> String {
-    field.type.rendered(replacingNamedTypeWith: selectionSetName(for: field), config: config)
+    field.type.rendered(
+      as: .selectionSetField(),
+      replacingNamedTypeWith: selectionSetName(for: field),
+      config: config.value
+    )
   }
 
   // MARK: Name Computation

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -5,11 +5,19 @@ struct SelectionSetTemplate {
 
   let schema: IR.Schema
   let isMutable: Bool
+  let config: ReferenceWrapped<ApolloCodegenConfiguration>
+
   private let nameCache: SelectionSetNameCache
 
-  init(schema: IR.Schema, mutable: Bool = false) {
+  init(
+    schema: IR.Schema,
+    mutable: Bool = false,
+    config: ReferenceWrapped<ApolloCodegenConfiguration>
+  ) {
     self.schema = schema
     self.isMutable = mutable
+    self.config = config
+
     self.nameCache = SelectionSetNameCache(schema: schema)
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -172,7 +172,12 @@ struct SelectionSetTemplate {
     let fieldName: String
     switch field {
     case let scalarField as IR.ScalarField:
-      fieldName = scalarField.type.rendered(inSchemaNamed: schema.name)
+      var schemaName: String? = nil
+      if field.isCustomScalar && !config.output.operations.isInModule {
+        schemaName = schema.name
+      }
+
+      fieldName = scalarField.type.rendered(inSchemaNamed: schemaName)
 
     case let entityField as IR.EntityField:
       fieldName = self.nameCache.selectionSetType(for: entityField)

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -394,7 +394,7 @@ fileprivate class SelectionSetNameCache {
     generatedSelectionSetNames[objectId] = name
     return name
   }
-  
+
   func selectionSetType(for field: IR.EntityField) -> String {
     field.type.rendered(
       as: .selectionSetField(),
@@ -619,13 +619,6 @@ fileprivate extension IR.Field {
     guard let scalar = self.type.namedType as? GraphQLScalarType else { return false }
 
     return scalar.isCustomScalar
-  }
-
-  var isScalar: Bool {
-    switch self.type.namedType {
-    case is GraphQLScalarType: return true
-    default: return false
-    }
   }
 }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -172,9 +172,11 @@ struct SelectionSetTemplate {
     let fieldName: String
     switch field {
     case let scalarField as IR.ScalarField:
-      var schemaName: String? = nil
-      if field.isCustomScalar && !config.output.operations.isInModule {
-        schemaName = schema.name
+      let schemaName: String?
+      switch (field.isScalar, field.isCustomScalar, config.output.operations.isInModule) {
+      case (true, true, false): schemaName = schema.name
+      case (false, _, false): schemaName = schema.name
+      default: schemaName = nil
       }
 
       fieldName = scalarField.type.rendered(inSchemaNamed: schemaName)
@@ -618,6 +620,13 @@ fileprivate extension IR.Field {
     guard let scalar = self.type.namedType as? GraphQLScalarType else { return false }
 
     return scalar.isCustomScalar
+  }
+
+  var isScalar: Bool {
+    switch self.type.namedType {
+    case is GraphQLScalarType: return true
+    default: return false
+    }
   }
 }
 

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -148,7 +148,9 @@ private struct ImportStatementTemplate {
   }
 
   enum Operation {
-    static func template(forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>) -> TemplateString {
+    static func template(
+      forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>
+    ) -> TemplateString {
       """
       \(ImportStatementTemplate.template)
       @_exported import enum ApolloAPI.GraphQLEnum
@@ -160,7 +162,7 @@ private struct ImportStatementTemplate {
     private static func shouldImportSchemaModule(
       _ config: ReferenceWrapped<ApolloCodegenConfiguration>
     ) -> Bool {
-      config.output.operations != .inSchemaModule && config.output.schemaTypes.isInModule
+      config.output.operations != .inSchemaModule
     }
   }
 

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/UploadMultipleFilesToDifferentParametersMutation.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/UploadMultipleFilesToDifferentParametersMutation.swift
@@ -22,12 +22,12 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
       """
     ))
 
-  public var singleFile: UploadAPI.Upload
-  public var multipleFiles: [UploadAPI.Upload]
+  public var singleFile: Upload
+  public var multipleFiles: [Upload]
 
   public init(
-    singleFile: UploadAPI.Upload,
-    multipleFiles: [UploadAPI.Upload]
+    singleFile: Upload,
+    multipleFiles: [Upload]
   ) {
     self.singleFile = singleFile
     self.multipleFiles = multipleFiles

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/UploadMultipleFilesToTheSameParameterMutation.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/UploadMultipleFilesToTheSameParameterMutation.swift
@@ -22,9 +22,9 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
       """
     ))
 
-  public var files: [UploadAPI.Upload]
+  public var files: [Upload]
 
-  public init(files: [UploadAPI.Upload]) {
+  public init(files: [Upload]) {
     self.files = files
   }
 

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/UploadOneFileMutation.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/UploadOneFileMutation.swift
@@ -22,9 +22,9 @@ public class UploadOneFileMutation: GraphQLMutation {
       """
     ))
 
-  public var file: UploadAPI.Upload
+  public var file: Upload
 
-  public init(file: UploadAPI.Upload) {
+  public init(file: Upload) {
     self.file = file
   }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -39,7 +39,7 @@ extension ApolloCodegenConfiguration {
 extension ApolloCodegenConfiguration.FileOutput {
   public static func mock(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .embeddedInTarget(name: "MockApplication"),
-    operations: ApolloCodegenConfiguration.OperationsFileOutput,
+    operations: ApolloCodegenConfiguration.OperationsFileOutput = .relative(subpath: nil),
     testMocks: ApolloCodegenConfiguration.TestMockFileOutput = .none,
     path: String = ""
   ) -> Self {

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -2,7 +2,7 @@
 
 extension ApolloCodegenConfiguration {
   public static func mock(
-    schemaName: String = "MockSchemaTypes",
+    schemaName: String = "TestSchema",
     input: FileInput = .init(
       schemaPath: "MockSchemaPath",
       searchPaths: []
@@ -20,7 +20,7 @@ extension ApolloCodegenConfiguration {
 
   public static func mock(
     _ moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
-    schemaName: String = "MockSchemaTypes",
+    schemaName: String = "TestSchema",
     to path: String = "MockModulePath"
   ) -> Self {
     .init(

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -365,7 +365,7 @@ class FragmentTemplateTests: XCTestCase {
 
       public static var __parentType: ParentType { .Object(TestSchema.Query.self) }
       public static var selections: [Selection] { [
-        .field("allAnimals", [AllAnimal]?.self),
+        .field("allAnimals", [MockSchemaTypes.AllAnimal]?.self),
       ] }
 
       public var allAnimals: [AllAnimal]? {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -365,7 +365,7 @@ class FragmentTemplateTests: XCTestCase {
 
       public static var __parentType: ParentType { .Object(TestSchema.Query.self) }
       public static var selections: [Selection] { [
-        .field("allAnimals", [MockSchemaTypes.AllAnimal]?.self),
+        .field("allAnimals", [AllAnimal]?.self),
       ] }
 
       public var allAnimals: [AllAnimal]? {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -6,10 +6,6 @@ import ApolloUtils
 class InputObjectTemplateTests: XCTestCase {
   var subject: InputObjectTemplate!
 
-  override func setUp() {
-    super.setUp()
-  }
-
   override func tearDown() {
     subject = nil
     super.tearDown()
@@ -226,7 +222,7 @@ class InputObjectTemplateTests: XCTestCase {
         type: .list(.scalar(.string())),
         defaultValue: nil
       )
-    ])
+    ], config: .mock(schemaName: "TestSchema"))
 
     let expected = """
       public init(
@@ -234,8 +230,8 @@ class InputObjectTemplateTests: XCTestCase {
         intField: GraphQLNullable<Int> = nil,
         boolField: GraphQLNullable<Bool> = nil,
         floatField: GraphQLNullable<Double> = nil,
-        enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>> = nil,
-        inputField: GraphQLNullable<MockSchemaTypes.InnerInputObject> = nil,
+        enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> = nil,
+        inputField: GraphQLNullable<TestSchema.InnerInputObject> = nil,
         listField: GraphQLNullable<[String?]> = nil
       ) {
         __data = InputDict([
@@ -269,12 +265,12 @@ class InputObjectTemplateTests: XCTestCase {
         set { __data.floatField = newValue }
       }
 
-      public var enumField: GraphQLNullable<GraphQLEnum<EnumValue>> {
+      public var enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> {
         get { __data.enumField }
         set { __data.enumField = newValue }
       }
 
-      public var inputField: GraphQLNullable<InnerInputObject> {
+      public var inputField: GraphQLNullable<TestSchema.InnerInputObject> {
         get { __data.inputField }
         set { __data.inputField = newValue }
       }
@@ -612,14 +608,14 @@ class InputObjectTemplateTests: XCTestCase {
 
     let expected = """
       public init(
-        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<MockSchemaTypes.EnumValue>?]> = nil
+        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TestSchema.EnumValue>?]> = nil
       ) {
         __data = InputDict([
           "nullableListNullableItem": nullableListNullableItem
         ])
       }
 
-      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<MockSchemaTypes.EnumValue>?]> {
+      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TestSchema.EnumValue>?]> {
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -234,7 +234,7 @@ class InputObjectTemplateTests: XCTestCase {
         intField: GraphQLNullable<Int> = nil,
         boolField: GraphQLNullable<Bool> = nil,
         floatField: GraphQLNullable<Double> = nil,
-        enumField: GraphQLNullable<GraphQLEnum<EnumValue>> = nil,
+        enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>> = nil,
         inputField: GraphQLNullable<InnerInputObject> = nil,
         listField: GraphQLNullable<[String?]> = nil
       ) {
@@ -612,14 +612,14 @@ class InputObjectTemplateTests: XCTestCase {
 
     let expected = """
       public init(
-        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<EnumValue>?]> = nil
+        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<MockSchemaTypes.EnumValue>?]> = nil
       ) {
         __data = InputDict([
           "nullableListNullableItem": nullableListNullableItem
         ])
       }
 
-      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<EnumValue>?]> {
+      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<MockSchemaTypes.EnumValue>?]> {
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Nimble
 @testable import ApolloCodegenLib
 import ApolloUtils
+import Apollo
 
 class InputObjectTemplateTests: XCTestCase {
   var subject: InputObjectTemplate!
@@ -286,6 +287,94 @@ class InputObjectTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__render__givenSchemaModuleInputFieldTypes__generatesCorrectParametersAndInitializer_withNamespaceWhenRequired() throws {
+    // given
+    let fields: [GraphQLInputField] = [
+      GraphQLInputField.mock(
+        "enumField",
+        type: .enum(.mock(name: "EnumValue")),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "inputField",
+        type: .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            GraphQLInputField.mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        )),
+        defaultValue: nil
+      )
+    ]
+
+    let expectedNoNamespace = """
+      public init(
+        enumField: GraphQLNullable<GraphQLEnum<EnumValue>> = nil,
+        inputField: GraphQLNullable<InnerInputObject> = nil
+      ) {
+        __data = InputDict([
+          "enumField": enumField,
+          "inputField": inputField
+        ])
+      }
+
+      public var enumField: GraphQLNullable<GraphQLEnum<EnumValue>> {
+        get { __data.enumField }
+        set { __data.enumField = newValue }
+      }
+
+      public var inputField: GraphQLNullable<InnerInputObject> {
+        get { __data.inputField }
+        set { __data.inputField = newValue }
+      }
+    """
+
+    let expectedWithNamespace = """
+      public init(
+        enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> = nil,
+        inputField: GraphQLNullable<TestSchema.InnerInputObject> = nil
+      ) {
+        __data = InputDict([
+          "enumField": enumField,
+          "inputField": inputField
+        ])
+      }
+
+      public var enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> {
+        get { __data.enumField }
+        set { __data.enumField = newValue }
+      }
+
+      public var inputField: GraphQLNullable<TestSchema.InnerInputObject> {
+        get { __data.inputField }
+        set { __data.inputField = newValue }
+      }
+    """
+
+    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
+      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    ]
+
+    for test in tests {
+      // given
+      buildSubject(fields: fields, config: .mock(output: test.config))
+
+      // when
+      let actual = renderSubject()
+
+      // then
+      expect(actual).to(equalLineByLine(test.expected, atLine: 8, ignoringExtraLines: true))
+    }
   }
 
   // MARK: Nullable Field Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -235,7 +235,7 @@ class InputObjectTemplateTests: XCTestCase {
         boolField: GraphQLNullable<Bool> = nil,
         floatField: GraphQLNullable<Double> = nil,
         enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>> = nil,
-        inputField: GraphQLNullable<InnerInputObject> = nil,
+        inputField: GraphQLNullable<MockSchemaTypes.InnerInputObject> = nil,
         listField: GraphQLNullable<[String?]> = nil
       ) {
         __data = InputDict([

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -134,10 +134,10 @@ class MockObjectTemplateTests: XCTestCase {
     let expected = """
       public struct MockFields {
         @Field<MockSchemaTypes.CustomScalar>("customScalar") public var customScalar
-        @Field<Cat>("object") public var object
-        @Field<[Cat]>("objectList") public var objectList
-        @Field<[[Cat]]>("objectNestedList") public var objectNestedList
-        @Field<[Cat?]>("objectOptionalList") public var objectOptionalList
+        @Field<MockSchemaTypes.Cat>("object") public var object
+        @Field<[MockSchemaTypes.Cat]>("objectList") public var objectList
+        @Field<[[MockSchemaTypes.Cat]]>("objectNestedList") public var objectNestedList
+        @Field<[MockSchemaTypes.Cat?]>("objectOptionalList") public var objectOptionalList
         @Field<String>("optionalString") public var optionalString
         @Field<String>("string") public var string
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -133,11 +133,11 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expected = """
       public struct MockFields {
-        @Field<MockSchemaTypes.CustomScalar>("customScalar") public var customScalar
-        @Field<MockSchemaTypes.Cat>("object") public var object
-        @Field<[MockSchemaTypes.Cat]>("objectList") public var objectList
-        @Field<[[MockSchemaTypes.Cat]]>("objectNestedList") public var objectNestedList
-        @Field<[MockSchemaTypes.Cat?]>("objectOptionalList") public var objectOptionalList
+        @Field<TestSchema.CustomScalar>("customScalar") public var customScalar
+        @Field<Cat>("object") public var object
+        @Field<[Cat]>("objectList") public var objectList
+        @Field<[[Cat]]>("objectNestedList") public var objectNestedList
+        @Field<[Cat?]>("objectOptionalList") public var objectOptionalList
         @Field<String>("optionalString") public var optionalString
         @Field<String>("string") public var string
       }
@@ -179,7 +179,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: MockSchemaTypes.CustomScalar? = nil,
+        customScalar: TestSchema.CustomScalar? = nil,
         object: Mock<Cat>? = nil,
         objectList: [Mock<Cat>]? = nil,
         objectNestedList: [[Mock<Cat>]]? = nil,
@@ -233,7 +233,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: MockSchemaTypes.CustomScalar? = nil,
+        customScalar: TestSchema.CustomScalar? = nil,
         interface: AnyMock? = nil,
         interfaceList: [AnyMock]? = nil,
         interfaceNestedList: [[AnyMock]]? = nil,
@@ -287,7 +287,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: MockSchemaTypes.CustomScalar? = nil,
+        customScalar: TestSchema.CustomScalar? = nil,
         optionalString: String? = nil,
         string: String? = nil,
         union: AnyMock? = nil,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -133,7 +133,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expected = """
       public struct MockFields {
-        @Field<TestSchema.CustomScalar>("customScalar") public var customScalar
+        @Field<MockSchemaTypes.CustomScalar>("customScalar") public var customScalar
         @Field<Cat>("object") public var object
         @Field<[Cat]>("objectList") public var objectList
         @Field<[[Cat]]>("objectNestedList") public var objectNestedList
@@ -179,7 +179,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: TestSchema.CustomScalar? = nil,
+        customScalar: MockSchemaTypes.CustomScalar? = nil,
         object: Mock<Cat>? = nil,
         objectList: [Mock<Cat>]? = nil,
         objectNestedList: [[Mock<Cat>]]? = nil,
@@ -233,7 +233,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: TestSchema.CustomScalar? = nil,
+        customScalar: MockSchemaTypes.CustomScalar? = nil,
         interface: AnyMock? = nil,
         interfaceList: [AnyMock]? = nil,
         interfaceNestedList: [[AnyMock]]? = nil,
@@ -287,7 +287,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: TestSchema.CustomScalar? = nil,
+        customScalar: MockSchemaTypes.CustomScalar? = nil,
         optionalString: String? = nil,
         string: String? = nil,
         union: AnyMock? = nil,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -80,7 +80,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           type: .enum(.mock(name: "EnumValue")),
           defaultValue: nil
         ),
-        "enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>>"
+        "enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>>"
       ),
       (
         .mock(
@@ -93,7 +93,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           )),
           defaultValue: nil
         ),
-        "inputField: GraphQLNullable<MockSchemaTypes.InnerInputObject>"
+        "inputField: GraphQLNullable<TestSchema.InnerInputObject>"
       ),
       (
         .mock(
@@ -171,7 +171,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           type: .enum(.mock(name: "EnumValue")),
           defaultValue: .enum("CaseONE")
         ),
-        "enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>> = .init(.CaseONE)"
+        "enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> = .init(.CaseONE)"
       ),
       (
         .mock(
@@ -179,7 +179,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           type: .nonNull(.enum(.mock(name: "EnumValue"))),
           defaultValue: .enum("CaseONE")
         ),
-        "enumField: GraphQLEnum<MockSchemaTypes.EnumValue> = .init(.CaseONE)"
+        "enumField: GraphQLEnum<TestSchema.EnumValue> = .init(.CaseONE)"
       ),
       (
         .mock(
@@ -203,8 +203,8 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           defaultValue: .object(["innerStringField": .string("Value")])
         ),
         """
-        inputField: GraphQLNullable<MockSchemaTypes.InnerInputObject> = .init(
-          InnerInputObject(innerStringField: "Value")
+        inputField: GraphQLNullable<TestSchema.InnerInputObject> = .init(
+          TestSchema.InnerInputObject(innerStringField: "Value")
         )
         """
       ),
@@ -261,8 +261,8 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
     )
 
     let expected = """
-    inputField: GraphQLNullable<MockSchemaTypes.InputObject> = .init(
-      InputObject(
+    inputField: GraphQLNullable<TestSchema.InputObject> = .init(
+      TestSchema.InputObject(
         innerStringField: "ABCD",
         innerIntField: 123,
         innerFloatField: 12.3456,
@@ -270,7 +270,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
         innerListField: ["A", "B"],
         innerEnumField: .init(.CaseONE),
         innerInputObject: .init(
-          InnerInputObject(
+          TestSchema.InnerInputObject(
             innerStringField: "EFGH",
             innerListField: [.init(.CaseTwo), .init(.CaseThree)]
           )
@@ -328,14 +328,14 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
     )
 
     let expected = """
-    inputField: MockSchemaTypes.InputObject = InputObject(
+    inputField: TestSchema.InputObject = TestSchema.InputObject(
       innerStringField: "ABCD",
       innerIntField: 123,
       innerFloatField: 12.3456,
       innerBoolField: true,
       innerListField: ["A", "B"],
       innerEnumField: .init(.CaseONE),
-      innerInputObject: InnerInputObject(
+      innerInputObject: TestSchema.InnerInputObject(
         innerStringField: "EFGH",
         innerListField: [.init(.CaseTwo), .init(.CaseThree)]
       )
@@ -538,7 +538,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
                     type: .list(.enum(.mock(name: "EnumValue"))),
                     defaultValue: nil)
 
-    let expected = "nullableListNullableItem: GraphQLNullable<[GraphQLEnum<MockSchemaTypes.EnumValue>?]>"
+    let expected = "nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TestSchema.EnumValue>?]>"
 
     // when
     let actual = template.VariableParameter(subject).description

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -80,7 +80,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           type: .enum(.mock(name: "EnumValue")),
           defaultValue: nil
         ),
-        "enumField: GraphQLNullable<GraphQLEnum<EnumValue>>"
+        "enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>>"
       ),
       (
         .mock(
@@ -171,7 +171,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           type: .enum(.mock(name: "EnumValue")),
           defaultValue: .enum("CaseONE")
         ),
-        "enumField: GraphQLNullable<GraphQLEnum<EnumValue>> = .init(.CaseONE)"
+        "enumField: GraphQLNullable<GraphQLEnum<MockSchemaTypes.EnumValue>> = .init(.CaseONE)"
       ),
       (
         .mock(
@@ -179,7 +179,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           type: .nonNull(.enum(.mock(name: "EnumValue"))),
           defaultValue: .enum("CaseONE")
         ),
-        "enumField: GraphQLEnum<EnumValue> = .init(.CaseONE)"
+        "enumField: GraphQLEnum<MockSchemaTypes.EnumValue> = .init(.CaseONE)"
       ),
       (
         .mock(
@@ -538,7 +538,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
                     type: .list(.enum(.mock(name: "EnumValue"))),
                     defaultValue: nil)
 
-    let expected = "nullableListNullableItem: GraphQLNullable<[GraphQLEnum<EnumValue>?]>"
+    let expected = "nullableListNullableItem: GraphQLNullable<[GraphQLEnum<MockSchemaTypes.EnumValue>?]>"
 
     // when
     let actual = template.VariableParameter(subject).description

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -93,7 +93,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           )),
           defaultValue: nil
         ),
-        "inputField: GraphQLNullable<InnerInputObject>"
+        "inputField: GraphQLNullable<MockSchemaTypes.InnerInputObject>"
       ),
       (
         .mock(
@@ -203,7 +203,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
           defaultValue: .object(["innerStringField": .string("Value")])
         ),
         """
-        inputField: GraphQLNullable<InnerInputObject> = .init(
+        inputField: GraphQLNullable<MockSchemaTypes.InnerInputObject> = .init(
           InnerInputObject(innerStringField: "Value")
         )
         """
@@ -261,7 +261,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
     )
 
     let expected = """
-    inputField: GraphQLNullable<InputObject> = .init(
+    inputField: GraphQLNullable<MockSchemaTypes.InputObject> = .init(
       InputObject(
         innerStringField: "ABCD",
         innerIntField: 123,
@@ -328,7 +328,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
     )
 
     let expected = """
-    inputField: InputObject = InputObject(
+    inputField: MockSchemaTypes.InputObject = InputObject(
       innerStringField: "ABCD",
       innerIntField: 123,
       innerFloatField: 12.3456,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -148,70 +148,6 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 
-//  func test__render() throws {
-//    // given
-//    schemaSDL = """
-//    type Query {
-//      pets(filters: PetSearchFilters!): [Pet!]!
-//    }
-//
-//    input MeasurementsInput {
-//      height: Float!
-//      weight: Float!
-//      wingspan: Float
-//    }
-//
-//    input PetSearchFilters {
-//      species: [String!]!
-//      size: RelativeSize
-//      measurements: MeasurementsInput
-//    }
-//
-//    interface Pet {
-//      id: ID!
-//      humanName: String
-//      favoriteToy: String!
-//    }
-//
-//    enum RelativeSize {
-//      LARGE
-//      AVERAGE
-//      SMALL
-//    }
-//    """
-//
-//    document = """
-//    query PetSearch($filters: PetSearchFilters = {
-//      species: ["Dog", "Cat"],
-//      size: SMALL,
-//      measurements: {
-//        height: 10.5,
-//        weight: 5.0
-//        }
-//      }
-//    ) {
-//      pets(filters: $filters) {
-//        id
-//        humanName
-//      }
-//    }
-//    """
-//
-//    let expected = """
-//    """
-//
-//    // when
-//    ir = try .mock(schema: schemaSDL, document: document)
-//    let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: "PetSearch"])
-//    let operation = ir.build(operation: operationDefinition)
-//    let template = OperationDefinitionTemplate(operation: operation, schema: ir.schema, config: ReferenceWrapped(value: .mock()))
-//
-//    let actual = template.render()
-//
-//    // then
-//    expect(actual).to(equalLineByLine(expected))
-//  }
-
   func test__render_parentType__givenParentTypeAs_Union_rendersParentType() throws {
     // given
     schemaSDL = """
@@ -386,10 +322,10 @@ class SelectionSetTemplateTests: XCTestCase {
         .field("float_optional", Double?.self),
         .field("boolean", Bool.self),
         .field("boolean_optional", Bool?.self),
-        .field("custom", MockSchemaTypes.Custom.self),
-        .field("custom_optional", MockSchemaTypes.Custom?.self),
-        .field("custom_required_list", [MockSchemaTypes.Custom].self),
-        .field("custom_optional_list", [MockSchemaTypes.Custom]?.self),
+        .field("custom", TestSchema.Custom.self),
+        .field("custom_optional", TestSchema.Custom?.self),
+        .field("custom_required_list", [TestSchema.Custom].self),
+        .field("custom_optional_list", [TestSchema.Custom]?.self),
         .field("list_required_required", [String].self),
         .field("list_optional_required", [String]?.self),
         .field("list_required_optional", [String?].self),
@@ -445,12 +381,12 @@ class SelectionSetTemplateTests: XCTestCase {
     }
     """
 
-    let expectedNamespaced = """
+    let expectedWithNamespace = """
       public static var selections: [Selection] { [
-        .field("custom", MockSchemaTypes.Custom.self),
-        .field("custom_optional", MockSchemaTypes.Custom?.self),
-        .field("custom_required_list", [MockSchemaTypes.Custom].self),
-        .field("custom_optional_list", [MockSchemaTypes.Custom]?.self),
+        .field("custom", TestSchema.Custom.self),
+        .field("custom_optional", TestSchema.Custom?.self),
+        .field("custom_required_list", [TestSchema.Custom].self),
+        .field("custom_optional_list", [TestSchema.Custom]?.self),
       ] }
     """
 
@@ -464,14 +400,14 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
     ]
 
@@ -489,7 +425,7 @@ class SelectionSetTemplateTests: XCTestCase {
     }
   }
 
-  func test__render_selections__givenEnumField_rendersFieldSelections() throws {
+  func test__render_selections__givenEnumField_rendersFieldSelections_withNamespaceWhenRequired() throws {
     // given
     schemaSDL = """
     type Query {
@@ -526,22 +462,22 @@ class SelectionSetTemplateTests: XCTestCase {
       ] }
     """
 
-    let expectedNamespaced = """
+    let expectedWithNamespace = """
       public static var selections: [Selection] { [
-        .field("testEnum", GraphQLEnum<MockSchemaTypes.TestEnum>.self),
-        .field("testEnumOptional", GraphQLEnum<MockSchemaTypes.TestEnumOptional>?.self),
+        .field("testEnum", GraphQLEnum<TestSchema.TestEnum>.self),
+        .field("testEnumOptional", GraphQLEnum<TestSchema.TestEnumOptional>?.self),
       ] }
     """
 
     let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
     ]
 
@@ -660,7 +596,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var selections: [Selection] { [
-        .field("predator", MockSchemaTypes.Predator.self),
+        .field("predator", Predator.self),
       ] }
     """
 
@@ -1440,6 +1376,74 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 34, ignoringExtraLines: true))
   }
 
+  func test__render_fieldAccessors__givenCustomScalarFields_rendersFieldAccessors_withNamespaceWhenRequired() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      custom: Custom!
+      custom_optional: Custom
+      custom_required_list: [Custom!]!
+      custom_optional_list: [Custom!]
+    }
+
+    scalar Custom
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        custom
+        custom_optional
+        custom_required_list
+        custom_optional_list
+      }
+    }
+    """
+
+    let expectedWithNamespace = """
+      public var custom: TestSchema.Custom { __data["custom"] }
+      public var custom_optional: TestSchema.Custom? { __data["custom_optional"] }
+      public var custom_required_list: [TestSchema.Custom] { __data["custom_required_list"] }
+      public var custom_optional_list: [TestSchema.Custom]? { __data["custom_optional_list"] }
+    """
+
+    let expectedNoNamespace = """
+      public var custom: Custom { __data["custom"] }
+      public var custom_optional: Custom? { __data["custom_optional"] }
+      public var custom_required_list: [Custom] { __data["custom_required_list"] }
+      public var custom_optional_list: [Custom]? { __data["custom_optional_list"] }
+    """
+
+    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
+      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    ]
+
+    for test in tests {
+      // when
+      try buildSubjectAndOperation(configOutput: test.config)
+      let allAnimals = try XCTUnwrap(
+        operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+      )
+
+      let actual = subject.render(field: allAnimals)
+
+      // then
+      expect(actual).to(equalLineByLine(test.expected, atLine: 14, ignoringExtraLines: true))
+    }
+  }
+
   func test__render_fieldAccessors__givenEnumField_rendersFieldAccessors_namespacedWhenRequired() throws {
     // given
     schemaSDL = """
@@ -1470,30 +1474,25 @@ class SelectionSetTemplateTests: XCTestCase {
     }
     """
 
-    let expectedNamespaced = """
+    let expectedWithNamespace = """
       public var testEnum: GraphQLEnum<TestSchema.TestEnum> { __data["testEnum"] }
       public var testEnumOptional: GraphQLEnum<TestSchema.TestEnumOptional>? { __data["testEnumOptional"] }
     """
 
-    // when
-    try buildSubjectAndOperation()
-    let allAnimals = try XCTUnwrap(
-      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
-    )
     let expectedNoNamespace = """
-      public var testEnum: GraphQLEnum<TestEnum> { data["testEnum"] }
-      public var testEnumOptional: GraphQLEnum<TestEnumOptional>? { data["testEnumOptional"] }
+      public var testEnum: GraphQLEnum<TestEnum> { __data["testEnum"] }
+      public var testEnumOptional: GraphQLEnum<TestEnumOptional>? { __data["testEnumOptional"] }
     """
 
     let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedNamespaced),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedNamespaced),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
+      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
       (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
     ]
 
@@ -3704,14 +3703,14 @@ class SelectionSetTemplateTests: XCTestCase {
       public var predator: Predator { __data["predator"] }
 
       /// AllAnimal.Predator
-      public struct Predator: MockSchemaTypes..SelectionSet {
+      public struct Predator: TestSchema.SelectionSet {
     """
 
     let allAnimals_predator_expected = """
-      public var asWarmBlooded: MockSchemaTypes.AsWarmBlooded? { _asInlineFragment() }
+      public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
 
       /// AllAnimal.Predator.AsWarmBlooded
-      public struct AsWarmBlooded: MockSchemaTypes..InlineFragment {
+      public struct AsWarmBlooded: TestSchema.InlineFragment {
     """
 
     let allAnimals_predator_asWarmBlooded_expected = """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -34,7 +34,7 @@ class SelectionSetTemplateTests: XCTestCase {
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
-    let config = ApolloCodegenConfiguration.mock(output: configOutput)
+    let config = ApolloCodegenConfiguration.mock(schemaName: "TestSchema", output: configOutput)
     subject = SelectionSetTemplate(schema: ir.schema, config: ReferenceWrapped(value: config))
   }
 
@@ -147,6 +147,70 @@ class SelectionSetTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
+
+//  func test__render() throws {
+//    // given
+//    schemaSDL = """
+//    type Query {
+//      pets(filters: PetSearchFilters!): [Pet!]!
+//    }
+//
+//    input MeasurementsInput {
+//      height: Float!
+//      weight: Float!
+//      wingspan: Float
+//    }
+//
+//    input PetSearchFilters {
+//      species: [String!]!
+//      size: RelativeSize
+//      measurements: MeasurementsInput
+//    }
+//
+//    interface Pet {
+//      id: ID!
+//      humanName: String
+//      favoriteToy: String!
+//    }
+//
+//    enum RelativeSize {
+//      LARGE
+//      AVERAGE
+//      SMALL
+//    }
+//    """
+//
+//    document = """
+//    query PetSearch($filters: PetSearchFilters = {
+//      species: ["Dog", "Cat"],
+//      size: SMALL,
+//      measurements: {
+//        height: 10.5,
+//        weight: 5.0
+//        }
+//      }
+//    ) {
+//      pets(filters: $filters) {
+//        id
+//        humanName
+//      }
+//    }
+//    """
+//
+//    let expected = """
+//    """
+//
+//    // when
+//    ir = try .mock(schema: schemaSDL, document: document)
+//    let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: "PetSearch"])
+//    let operation = ir.build(operation: operationDefinition)
+//    let template = OperationDefinitionTemplate(operation: operation, schema: ir.schema, config: ReferenceWrapped(value: .mock()))
+//
+//    let actual = template.render()
+//
+//    // then
+//    expect(actual).to(equalLineByLine(expected))
+//  }
 
   func test__render_parentType__givenParentTypeAs_Union_rendersParentType() throws {
     // given
@@ -596,7 +660,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var selections: [Selection] { [
-        .field("predator", Predator.self),
+        .field("predator", MockSchemaTypes.Predator.self),
       ] }
     """
 
@@ -3640,14 +3704,14 @@ class SelectionSetTemplateTests: XCTestCase {
       public var predator: Predator { __data["predator"] }
 
       /// AllAnimal.Predator
-      public struct Predator: TestSchema.SelectionSet {
+      public struct Predator: MockSchemaTypes..SelectionSet {
     """
 
     let allAnimals_predator_expected = """
-      public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
+      public var asWarmBlooded: MockSchemaTypes.AsWarmBlooded? { _asInlineFragment() }
 
       /// AllAnimal.Predator.AsWarmBlooded
-      public struct AsWarmBlooded: TestSchema.InlineFragment {
+      public struct AsWarmBlooded: MockSchemaTypes..InlineFragment {
     """
 
     let allAnimals_predator_asWarmBlooded_expected = """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -322,10 +322,10 @@ class SelectionSetTemplateTests: XCTestCase {
         .field("float_optional", Double?.self),
         .field("boolean", Bool.self),
         .field("boolean_optional", Bool?.self),
-        .field("custom", TestSchema.Custom.self),
-        .field("custom_optional", TestSchema.Custom?.self),
-        .field("custom_required_list", [TestSchema.Custom].self),
-        .field("custom_optional_list", [TestSchema.Custom]?.self),
+        .field("custom", MockSchemaTypes.Custom.self),
+        .field("custom_optional", MockSchemaTypes.Custom?.self),
+        .field("custom_required_list", [MockSchemaTypes.Custom].self),
+        .field("custom_optional_list", [MockSchemaTypes.Custom]?.self),
         .field("list_required_required", [String].self),
         .field("list_optional_required", [String]?.self),
         .field("list_required_optional", [String?].self),
@@ -383,10 +383,10 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expectedNamespaced = """
       public static var selections: [Selection] { [
-        .field("custom", TestSchema.Custom.self),
-        .field("custom_optional", TestSchema.Custom?.self),
-        .field("custom_required_list", [TestSchema.Custom].self),
-        .field("custom_optional_list", [TestSchema.Custom]?.self),
+        .field("custom", MockSchemaTypes.Custom.self),
+        .field("custom_optional", MockSchemaTypes.Custom?.self),
+        .field("custom_required_list", [MockSchemaTypes.Custom].self),
+        .field("custom_optional_list", [MockSchemaTypes.Custom]?.self),
       ] }
     """
 
@@ -464,8 +464,8 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expectedNamespaced = """
       public static var selections: [Selection] { [
-        .field("testEnum", GraphQLEnum<TestSchema.TestEnum>.self),
-        .field("testEnumOptional", GraphQLEnum<TestSchema.TestEnumOptional>?.self),
+        .field("testEnum", GraphQLEnum<MockSchemaTypes.TestEnum>.self),
+        .field("testEnumOptional", GraphQLEnum<MockSchemaTypes.TestEnumOptional>?.self),
       ] }
     """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -27,18 +27,14 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
 
   // MARK: - Helpers
 
-  func buildSubjectAndOperation(
-    named operationName: String = "TestOperation",
-    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager
-  ) throws {
+  func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
-    let config = ApolloCodegenConfiguration.mock(moduleType)
     subject = SelectionSetTemplate(
       schema: ir.schema,
       mutable: true,
-      config: ReferenceWrapped(value: config)
+      config: ReferenceWrapped(value: .mock())
     )
   }
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Nimble
 @testable import ApolloCodegenLib
 import ApolloCodegenInternalTestHelpers
+import ApolloUtils
 
 class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
 
@@ -26,11 +27,19 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
 
   // MARK: - Helpers
 
-  func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
+  func buildSubjectAndOperation(
+    named operationName: String = "TestOperation",
+    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager
+  ) throws {
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
-    subject = SelectionSetTemplate(schema: ir.schema, mutable: true)
+    let config = ApolloCodegenConfiguration.mock(moduleType)
+    subject = SelectionSetTemplate(
+      schema: ir.schema,
+      mutable: true,
+      config: ReferenceWrapped(value: config)
+    )
   }
 
   // MARK: - Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Nimble
 @testable import ApolloCodegenLib
 import ApolloCodegenInternalTestHelpers
+import ApolloUtils
 
 class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
 
@@ -26,11 +27,15 @@ class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
 
   // MARK: - Helpers
 
-  func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
+  func buildSubjectAndOperation(
+    named operationName: String = "TestOperation",
+    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager
+  ) throws {
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
-    subject = SelectionSetTemplate(schema: ir.schema)
+    let config = ApolloCodegenConfiguration.mock(moduleType)
+    subject = SelectionSetTemplate(schema: ir.schema, config: ReferenceWrapped(value: config))
   }
 
   // MARK: - Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
@@ -27,15 +27,11 @@ class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
 
   // MARK: - Helpers
 
-  func buildSubjectAndOperation(
-    named operationName: String = "TestOperation",
-    moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager
-  ) throws {
+  func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
-    let config = ApolloCodegenConfiguration.mock(moduleType)
-    subject = SelectionSetTemplate(schema: ir.schema, config: ReferenceWrapped(value: config))
+    subject = SelectionSetTemplate(schema: ir.schema, config: ReferenceWrapped(value: .mock()))
   }
 
   // MARK: - Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -116,12 +116,12 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .relative(subpath: nil),
-        expectation: expectedAPI
+        expectation: expectedAPIAndSchema
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .absolute(path: "path"),
-        expectation: expectedAPI
+        expectation: expectedAPIAndSchema
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
@@ -204,13 +204,13 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .relative(subpath: nil),
         expectation: expectedNoNamespace,
-        atLine: 8
+        atLine: 9
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .absolute(path: "path"),
         expectation: expectedNoNamespace,
-        atLine: 8
+        atLine: 9
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),


### PR DESCRIPTION
Fixes #2301 
Fixes #2302 

This PR updates the way schema module types are used in operation files when they are located with a `.relative` or `.absolute` placing them outside the schema module. Prior to this change the operation files would reference types that were inaccessible resulting in build errors.