### PR TITLE
fix: Test mock extension, fields and initializers should use module namespace

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -25,11 +25,11 @@ struct MockObjectTemplate: TemplateRenderer {
 
     return """
     extension \
-    \(if: !config.output.schemaTypes.isInModule, "\(ir.schema.name.firstUppercased).")\
+    \(schemaModuleName)\
     \(objectName): Mockable {
       public static let __mockFields = MockFields()
 
-      public typealias MockValueCollectionType = Array<Mock<\(objectName)>>
+      public typealias MockValueCollectionType = Array<Mock<\(schemaModuleName)\(objectName)>>
     
       public struct MockFields {
         \(fields.map {
@@ -40,7 +40,7 @@ struct MockObjectTemplate: TemplateRenderer {
       }
     }
 
-    public extension Mock where O == \(objectName) {
+    public extension Mock where O == \(schemaModuleName)\(objectName) {
       convenience init(
         \(fields.map { "\($0.name): \($0.mockType)? = nil" }, separator: ",\n")
       ) {
@@ -49,6 +49,14 @@ struct MockObjectTemplate: TemplateRenderer {
       }
     }
     """
+  }
+
+  private var schemaModuleName: String {
+    if !config.output.schemaTypes.isInModule {
+      return "\(config.schemaName)."
+    } else {
+      return ""
+    }
   }
 
   private func mockTypeName(for type: GraphQLType) -> String {

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -155,30 +155,26 @@ private struct ImportStatementTemplate {
       \(ImportStatementTemplate.template)
       @_exported import enum ApolloAPI.GraphQLEnum
       @_exported import enum ApolloAPI.GraphQLNullable
-      \(if: shouldImportSchemaModule(config), "import \(config.schemaName.firstUppercased)")
+      \(if: config.output.operations != .inSchemaModule, "import \(config.schemaModuleName)")
       """
-    }
-
-    private static func shouldImportSchemaModule(
-      _ config: ReferenceWrapped<ApolloCodegenConfiguration>
-    ) -> Bool {
-      config.output.operations != .inSchemaModule
     }
   }
 
   enum TestMock {
     static func template(forConfig config: ReferenceWrapped<ApolloCodegenConfiguration>) -> TemplateString {
-      let schemaModuleName: String = {
-        switch config.output.schemaTypes.moduleType {
-        case let .embeddedInTarget(targetName): return targetName
-        case .swiftPackageManager, .other: return config.schemaName.firstUppercased
-        }
-      }()
-
       return """
       import ApolloTestSupport
-      import \(schemaModuleName)
+      import \(config.schemaModuleName)
       """
+    }
+  }
+}
+
+fileprivate extension ApolloCodegenConfiguration {
+  var schemaModuleName: String {
+    switch output.schemaTypes.moduleType {
+    case let .embeddedInTarget(targetName): return targetName
+    case .swiftPackageManager, .other: return schemaName.firstUppercased
     }
   }
 }

--- a/Sources/ApolloTestSupport/MockObject.swift
+++ b/Sources/ApolloTestSupport/MockObject.swift
@@ -1,4 +1,4 @@
-import ApolloAPI
+@_exported import ApolloAPI
 import Foundation
 
 @dynamicMemberLookup

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -45,9 +45,9 @@ class MockObjectTemplateTests: XCTestCase {
     expect(self.subject.target).to(equal(.testMockFile))
   }
 
-  func test_render_givenSchemaType_generatesExtension() {
+  func test_render_givenModuleType_swiftPackageManager_generatesExtension_noNamespace() {
     // given
-    buildSubject(name: "Dog")
+    buildSubject(name: "Dog", moduleType: .swiftPackageManager)
 
     let expected = """
     extension Dog: Mockable {
@@ -67,7 +67,29 @@ class MockObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenConfig_SchemaTypeOutputNone_generatesExtensionWithSchemaNamespace() {
+  func test_render_givenModuleType_other_generatesExtension_noNamespace() {
+    // given
+    buildSubject(name: "Dog", moduleType: .other)
+
+    let expected = """
+    extension Dog: Mockable {
+      public static let __mockFields = MockFields()
+
+      public typealias MockValueCollectionType = Array<Mock<Dog>>
+
+      public struct MockFields {
+      }
+    }
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_render_givenModuleType_embeddedInTarget_generatesExtension_withNamespace() {
     // given
     buildSubject(name: "Dog", moduleType: .embeddedInTarget(name: "MockApplication"))
 
@@ -75,7 +97,7 @@ class MockObjectTemplateTests: XCTestCase {
     extension TestSchema.Dog: Mockable {
       public static let __mockFields = MockFields()
 
-      public typealias MockValueCollectionType = Array<Mock<Dog>>
+      public typealias MockValueCollectionType = Array<Mock<TestSchema.Dog>>
 
       public struct MockFields {
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -130,9 +130,91 @@ class MockObjectTemplateTests: XCTestCase {
 
   // MARK: Field Accessor Tests
 
-  func test_render_givenSchemaType_generatesFieldAccessors() {
+  func test_render_givenModuleType_swiftPackageManager_generatesFieldAccessors_noNamespace() {
     // given
-    buildSubject()
+    buildSubject(moduleType: .swiftPackageManager)
+
+    let Cat: GraphQLType = .entity(.mock("Cat"))
+
+    subject.graphqlObject.fields = [
+      "string": .mock("string", type: .nonNull(.string())),
+      "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
+      "optionalString": .mock("optionalString", type: .string()),
+      "object": .mock("object", type: Cat),
+      "objectList": .mock("objectList", type: .list(.nonNull(Cat))),
+      "objectNestedList": .mock("objectNestedList", type: .list(.nonNull(.list(.nonNull(Cat))))),
+      "objectOptionalList": .mock("objectOptionalList", type: .list(Cat)),
+    ]
+
+    ir.fieldCollector.add(
+      fields: subject.graphqlObject.fields.values.map {
+        .mock($0.name, type: $0.type)
+      },
+      to: subject.graphqlObject
+    )
+
+    let expected = """
+      public struct MockFields {
+        @Field<CustomScalar>("customScalar") public var customScalar
+        @Field<Cat>("object") public var object
+        @Field<[Cat]>("objectList") public var objectList
+        @Field<[[Cat]]>("objectNestedList") public var objectNestedList
+        @Field<[Cat?]>("objectOptionalList") public var objectOptionalList
+        @Field<String>("optionalString") public var optionalString
+        @Field<String>("string") public var string
+      }
+    """
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
+  }
+
+  func test_render_givenModuleType_other_generatesFieldAccessors_noNamespace() {
+    // given
+    buildSubject(moduleType: .other)
+
+    let Cat: GraphQLType = .entity(.mock("Cat"))
+
+    subject.graphqlObject.fields = [
+      "string": .mock("string", type: .nonNull(.string())),
+      "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
+      "optionalString": .mock("optionalString", type: .string()),
+      "object": .mock("object", type: Cat),
+      "objectList": .mock("objectList", type: .list(.nonNull(Cat))),
+      "objectNestedList": .mock("objectNestedList", type: .list(.nonNull(.list(.nonNull(Cat))))),
+      "objectOptionalList": .mock("objectOptionalList", type: .list(Cat)),
+    ]
+
+    ir.fieldCollector.add(
+      fields: subject.graphqlObject.fields.values.map {
+        .mock($0.name, type: $0.type)
+      },
+      to: subject.graphqlObject
+    )
+
+    let expected = """
+      public struct MockFields {
+        @Field<CustomScalar>("customScalar") public var customScalar
+        @Field<Cat>("object") public var object
+        @Field<[Cat]>("objectList") public var objectList
+        @Field<[[Cat]]>("objectNestedList") public var objectNestedList
+        @Field<[Cat?]>("objectOptionalList") public var objectOptionalList
+        @Field<String>("optionalString") public var optionalString
+        @Field<String>("string") public var string
+      }
+    """
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
+  }
+
+  func test_render_givenModuleType_embeddedInTarget_generatesFieldAccessors_withNamespace() {
+    // given
+    buildSubject(moduleType: .embeddedInTarget(name: "MockTarget"))
 
     let Cat: GraphQLType = .entity(.mock("Cat"))
 
@@ -156,10 +238,10 @@ class MockObjectTemplateTests: XCTestCase {
     let expected = """
       public struct MockFields {
         @Field<TestSchema.CustomScalar>("customScalar") public var customScalar
-        @Field<Cat>("object") public var object
-        @Field<[Cat]>("objectList") public var objectList
-        @Field<[[Cat]]>("objectNestedList") public var objectNestedList
-        @Field<[Cat?]>("objectOptionalList") public var objectOptionalList
+        @Field<TestSchema.Cat>("object") public var object
+        @Field<[TestSchema.Cat]>("objectList") public var objectList
+        @Field<[[TestSchema.Cat]]>("objectNestedList") public var objectNestedList
+        @Field<[TestSchema.Cat?]>("objectOptionalList") public var objectOptionalList
         @Field<String>("optionalString") public var optionalString
         @Field<String>("string") public var string
       }
@@ -173,11 +255,13 @@ class MockObjectTemplateTests: XCTestCase {
 
   // MARK: Convenience Initializer Tests
 
-  func test_render_givenSchemaType_generatesConvenienceInitializer() {
+  func test_render_givenModuleType_swiftPackageManager_generatesConvenienceInitializer_noNamespace() {
     // given
-    buildSubject()
+    buildSubject(moduleType: .swiftPackageManager)
 
     let Cat: GraphQLType = .entity(GraphQLObjectType.mock("Cat"))
+    let Animal: GraphQLType = .entity(GraphQLInterfaceType.mock("Animal"))
+    let Pet: GraphQLType = .entity(GraphQLUnionType.mock("Pet"))
 
     subject.graphqlObject.fields = [
       "string": .mock("string", type: .nonNull(.string())),
@@ -187,60 +271,14 @@ class MockObjectTemplateTests: XCTestCase {
       "objectList": .mock("objectList", type: .list(.nonNull(Cat))),
       "objectNestedList": .mock("objectNestedList", type: .list(.nonNull(.list(.nonNull(Cat))))),
       "objectOptionalList": .mock("objectOptionalList", type: .list(Cat)),
-    ]
-
-    ir.fieldCollector.add(
-      fields: subject.graphqlObject.fields.values.map {
-        .mock($0.name, type: $0.type)
-      },
-      to: subject.graphqlObject
-    )
-
-    let expected = """
-    }
-
-    public extension Mock where O == Dog {
-      convenience init(
-        customScalar: TestSchema.CustomScalar? = nil,
-        object: Mock<Cat>? = nil,
-        objectList: [Mock<Cat>]? = nil,
-        objectNestedList: [[Mock<Cat>]]? = nil,
-        objectOptionalList: [Mock<Cat>?]? = nil,
-        optionalString: String? = nil,
-        string: String? = nil
-      ) {
-        self.init()
-        self.customScalar = customScalar
-        self.object = object
-        self.objectList = objectList
-        self.objectNestedList = objectNestedList
-        self.objectOptionalList = objectOptionalList
-        self.optionalString = optionalString
-        self.string = string
-      }
-    }
-    """
-    // when
-    let actual = renderSubject()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
-  }
-
-  func test_render_givenSchemaType_withInterfaceTypedFields_generatesConvenienceInitializer() {
-    // given
-    buildSubject()
-
-    let Animal: GraphQLType = .entity(GraphQLInterfaceType.mock("Animal"))
-
-    subject.graphqlObject.fields = [
-      "string": .mock("string", type: .nonNull(.string())),
-      "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
-      "optionalString": .mock("optionalString", type: .string()),
       "interface": .mock("interface", type: Animal),
       "interfaceList": .mock("interfaceList", type: .list(.nonNull(Animal))),
       "interfaceNestedList": .mock("interfaceNestedList", type: .list(.nonNull(.list(.nonNull(Animal))))),
       "interfaceOptionalList": .mock("interfaceOptionalList", type: .list(Animal)),
+      "union": .mock("union", type: Pet),
+      "unionList": .mock("unionList", type: .list(.nonNull(Pet))),
+      "unionNestedList": .mock("unionNestedList", type: .list(.nonNull(.list(.nonNull(Pet))))),
+      "unionOptionalList": .mock("unionOptionalList", type: .list(Pet)),
     ]
 
     ir.fieldCollector.add(
@@ -255,61 +293,15 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: TestSchema.CustomScalar? = nil,
+        customScalar: CustomScalar? = nil,
         interface: AnyMock? = nil,
         interfaceList: [AnyMock]? = nil,
         interfaceNestedList: [[AnyMock]]? = nil,
         interfaceOptionalList: [AnyMock?]? = nil,
-        optionalString: String? = nil,
-        string: String? = nil
-      ) {
-        self.init()
-        self.customScalar = customScalar
-        self.interface = interface
-        self.interfaceList = interfaceList
-        self.interfaceNestedList = interfaceNestedList
-        self.interfaceOptionalList = interfaceOptionalList
-        self.optionalString = optionalString
-        self.string = string
-      }
-    }
-    """
-    // when
-    let actual = renderSubject()
-
-    // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
-  }
-
-  func test_render_givenSchemaType_withUnionTypedFields_generatesConvenienceInitializer() {
-    // given
-    buildSubject()
-
-    let Animal: GraphQLType = .entity(GraphQLUnionType.mock("Animal"))
-
-    subject.graphqlObject.fields = [
-      "string": .mock("string", type: .nonNull(.string())),
-      "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
-      "optionalString": .mock("optionalString", type: .string()),
-      "union": .mock("union", type: Animal),
-      "unionList": .mock("unionList", type: .list(.nonNull(Animal))),
-      "unionNestedList": .mock("unionNestedList", type: .list(.nonNull(.list(.nonNull(Animal))))),
-      "unionOptionalList": .mock("unionOptionalList", type: .list(Animal)),
-    ]
-
-    ir.fieldCollector.add(
-      fields: subject.graphqlObject.fields.values.map {
-        .mock($0.name, type: $0.type)
-      },
-      to: subject.graphqlObject
-    )
-
-    let expected = """
-    }
-
-    public extension Mock where O == Dog {
-      convenience init(
-        customScalar: TestSchema.CustomScalar? = nil,
+        object: Mock<Cat>? = nil,
+        objectList: [Mock<Cat>]? = nil,
+        objectNestedList: [[Mock<Cat>]]? = nil,
+        objectOptionalList: [Mock<Cat>?]? = nil,
         optionalString: String? = nil,
         string: String? = nil,
         union: AnyMock? = nil,
@@ -319,6 +311,14 @@ class MockObjectTemplateTests: XCTestCase {
       ) {
         self.init()
         self.customScalar = customScalar
+        self.interface = interface
+        self.interfaceList = interfaceList
+        self.interfaceNestedList = interfaceNestedList
+        self.interfaceOptionalList = interfaceOptionalList
+        self.object = object
+        self.objectList = objectList
+        self.objectNestedList = objectNestedList
+        self.objectOptionalList = objectOptionalList
         self.optionalString = optionalString
         self.string = string
         self.union = union
@@ -332,7 +332,167 @@ class MockObjectTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 23, ignoringExtraLines: true))
+  }
+
+  func test_render_givenModuleType_other_generatesConvenienceInitializer_noNamespace() {
+    // given
+    buildSubject(moduleType: .other)
+
+    let Cat: GraphQLType = .entity(GraphQLObjectType.mock("Cat"))
+    let Animal: GraphQLType = .entity(GraphQLInterfaceType.mock("Animal"))
+    let Pet: GraphQLType = .entity(GraphQLUnionType.mock("Pet"))
+
+    subject.graphqlObject.fields = [
+      "string": .mock("string", type: .nonNull(.string())),
+      "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
+      "optionalString": .mock("optionalString", type: .string()),
+      "object": .mock("object", type: Cat),
+      "objectList": .mock("objectList", type: .list(.nonNull(Cat))),
+      "objectNestedList": .mock("objectNestedList", type: .list(.nonNull(.list(.nonNull(Cat))))),
+      "objectOptionalList": .mock("objectOptionalList", type: .list(Cat)),
+      "interface": .mock("interface", type: Animal),
+      "interfaceList": .mock("interfaceList", type: .list(.nonNull(Animal))),
+      "interfaceNestedList": .mock("interfaceNestedList", type: .list(.nonNull(.list(.nonNull(Animal))))),
+      "interfaceOptionalList": .mock("interfaceOptionalList", type: .list(Animal)),
+      "union": .mock("union", type: Pet),
+      "unionList": .mock("unionList", type: .list(.nonNull(Pet))),
+      "unionNestedList": .mock("unionNestedList", type: .list(.nonNull(.list(.nonNull(Pet))))),
+      "unionOptionalList": .mock("unionOptionalList", type: .list(Pet)),
+    ]
+
+    ir.fieldCollector.add(
+      fields: subject.graphqlObject.fields.values.map {
+        .mock($0.name, type: $0.type)
+      },
+      to: subject.graphqlObject
+    )
+
+    let expected = """
+    }
+
+    public extension Mock where O == Dog {
+      convenience init(
+        customScalar: CustomScalar? = nil,
+        interface: AnyMock? = nil,
+        interfaceList: [AnyMock]? = nil,
+        interfaceNestedList: [[AnyMock]]? = nil,
+        interfaceOptionalList: [AnyMock?]? = nil,
+        object: Mock<Cat>? = nil,
+        objectList: [Mock<Cat>]? = nil,
+        objectNestedList: [[Mock<Cat>]]? = nil,
+        objectOptionalList: [Mock<Cat>?]? = nil,
+        optionalString: String? = nil,
+        string: String? = nil,
+        union: AnyMock? = nil,
+        unionList: [AnyMock]? = nil,
+        unionNestedList: [[AnyMock]]? = nil,
+        unionOptionalList: [AnyMock?]? = nil
+      ) {
+        self.init()
+        self.customScalar = customScalar
+        self.interface = interface
+        self.interfaceList = interfaceList
+        self.interfaceNestedList = interfaceNestedList
+        self.interfaceOptionalList = interfaceOptionalList
+        self.object = object
+        self.objectList = objectList
+        self.objectNestedList = objectNestedList
+        self.objectOptionalList = objectOptionalList
+        self.optionalString = optionalString
+        self.string = string
+        self.union = union
+        self.unionList = unionList
+        self.unionNestedList = unionNestedList
+        self.unionOptionalList = unionOptionalList
+      }
+    }
+    """
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 23, ignoringExtraLines: true))
+  }
+
+  func test_render_givenModuleType_embeddedInTarget_generatesConvenienceInitializer_withNamespace() {
+    // given
+    buildSubject(moduleType: .embeddedInTarget(name: "MockTarget"))
+
+    let Cat: GraphQLType = .entity(GraphQLObjectType.mock("Cat"))
+    let Animal: GraphQLType = .entity(GraphQLInterfaceType.mock("Animal"))
+    let Pet: GraphQLType = .entity(GraphQLUnionType.mock("Pet"))
+
+    subject.graphqlObject.fields = [
+      "string": .mock("string", type: .nonNull(.string())),
+      "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
+      "optionalString": .mock("optionalString", type: .string()),
+      "object": .mock("object", type: Cat),
+      "objectList": .mock("objectList", type: .list(.nonNull(Cat))),
+      "objectNestedList": .mock("objectNestedList", type: .list(.nonNull(.list(.nonNull(Cat))))),
+      "objectOptionalList": .mock("objectOptionalList", type: .list(Cat)),
+      "interface": .mock("interface", type: Animal),
+      "interfaceList": .mock("interfaceList", type: .list(.nonNull(Animal))),
+      "interfaceNestedList": .mock("interfaceNestedList", type: .list(.nonNull(.list(.nonNull(Animal))))),
+      "interfaceOptionalList": .mock("interfaceOptionalList", type: .list(Animal)),
+      "union": .mock("union", type: Pet),
+      "unionList": .mock("unionList", type: .list(.nonNull(Pet))),
+      "unionNestedList": .mock("unionNestedList", type: .list(.nonNull(.list(.nonNull(Pet))))),
+      "unionOptionalList": .mock("unionOptionalList", type: .list(Pet)),
+    ]
+
+    ir.fieldCollector.add(
+      fields: subject.graphqlObject.fields.values.map {
+        .mock($0.name, type: $0.type)
+      },
+      to: subject.graphqlObject
+    )
+
+    let expected = """
+    }
+
+    public extension Mock where O == TestSchema.Dog {
+      convenience init(
+        customScalar: TestSchema.CustomScalar? = nil,
+        interface: AnyMock? = nil,
+        interfaceList: [AnyMock]? = nil,
+        interfaceNestedList: [[AnyMock]]? = nil,
+        interfaceOptionalList: [AnyMock?]? = nil,
+        object: Mock<TestSchema.Cat>? = nil,
+        objectList: [Mock<TestSchema.Cat>]? = nil,
+        objectNestedList: [[Mock<TestSchema.Cat>]]? = nil,
+        objectOptionalList: [Mock<TestSchema.Cat>?]? = nil,
+        optionalString: String? = nil,
+        string: String? = nil,
+        union: AnyMock? = nil,
+        unionList: [AnyMock]? = nil,
+        unionNestedList: [[AnyMock]]? = nil,
+        unionOptionalList: [AnyMock?]? = nil
+      ) {
+        self.init()
+        self.customScalar = customScalar
+        self.interface = interface
+        self.interfaceList = interfaceList
+        self.interfaceNestedList = interfaceNestedList
+        self.interfaceOptionalList = interfaceOptionalList
+        self.object = object
+        self.objectList = objectList
+        self.objectNestedList = objectNestedList
+        self.objectOptionalList = objectOptionalList
+        self.optionalString = optionalString
+        self.string = string
+        self.union = union
+        self.unionList = unionList
+        self.unionNestedList = unionNestedList
+        self.unionOptionalList = unionOptionalList
+      }
+    }
+    """
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 23, ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -78,6 +78,14 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
     """
 
+    let expectedAPIAndTarget = """
+    import ApolloAPI
+    @_exported import enum ApolloAPI.GraphQLEnum
+    @_exported import enum ApolloAPI.GraphQLNullable
+    import MockApplication
+
+    """
+
     let tests: [(
       schemaTypes: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
       operations: ApolloCodegenConfiguration.OperationsFileOutput,
@@ -116,12 +124,12 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .relative(subpath: nil),
-        expectation: expectedAPIAndSchema
+        expectation: expectedAPIAndTarget
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .absolute(path: "path"),
-        expectation: expectedAPIAndSchema
+        expectation: expectedAPIAndTarget
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),


### PR DESCRIPTION
Fixed #2332 

Test mock field types and convenience initializers were not being generated with the schema module namespace when required.