### PR TITLE
1.0/introspection json output

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.resolved
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Apollo",
+        "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "12505179e122df9eb2fecb0c5fcff93334460373",
+          "version": "1.0.0-alpha.7"
+        }
+      },
+      {
+        "package": "InflectorKit",
+        "repositoryURL": "https://github.com/mattt/InflectorKit",
+        "state": {
+          "branch": null,
+          "revision": "d8cbcc04972690aaa5fc760a2b9ddb3e9f0decd7",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "SQLite.swift",
+        "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "4d543d811ee644fa4cc4bfa0be996b4dd6ba0f54",
+          "version": "0.13.3"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
Closes #2159

This doesn't have any tests, because the Schema Downloader tests seem to be all in the integration tests which are not currently running. Those tests are pretty bare bones and need to be improved in the future as well, but this should work as intended.