### PR TITLE
fix: Update apollo-ios-cli tests for ApolloCodegenConfiguration updates

### DIFF
--- a/CodegenCLI/Tests/Commands/InitializeTests.swift
+++ b/CodegenCLI/Tests/Commands/InitializeTests.swift
@@ -155,10 +155,12 @@ class InitializeTests: XCTestCase {
       "queryStringLiteralFormat" : "multiline"
     },
     "input" : {
-      "searchPaths" : [
+      "operationSearchPaths" : [
         "**\\/*.graphql"
       ],
-      "schemaPath" : "schema.graphqls"
+      "schemaSearchPaths" : [
+        "schema.graphqls"
+      ]
     },
     "output" : {
       "testMocks" : {
@@ -211,7 +213,7 @@ class InitializeTests: XCTestCase {
       let expectedPath = URL(fileURLWithPath: outputPath).standardizedFileURL.path
 
       expect(actualPath).to(equal(expectedPath))
-      expect(data).to(equal(self.expectedJSON.data(using: .utf8)!))
+      expect(data?.asString).to(equal(self.expectedJSON))
 
       return true
     }))
@@ -277,7 +279,7 @@ class InitializeTests: XCTestCase {
       let expectedPath = URL(fileURLWithPath: outputPath).standardizedFileURL.path
 
       expect(actualPath).to(equal(expectedPath))
-      expect(data).to(equal(self.expectedJSON.data(using: .utf8)!))
+      expect(data?.asString).to(equal(self.expectedJSON))
 
       return true
     }))
@@ -307,13 +309,12 @@ class InitializeTests: XCTestCase {
     subject.waitUntilExit()
 
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: .utf8)
 
     // Printing to STDOUT appends a newline
     let expected = expectedJSON + "\n"
 
     // then
-    expect(output).to(equal(expected))
+    expect(data.asString).to(equal(expected))
   }
 
   func test__output__givenParameters_bothPathAndPrint_shouldPrintToStandardOutput() throws {
@@ -336,12 +337,17 @@ class InitializeTests: XCTestCase {
     subject.waitUntilExit()
 
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: .utf8)
 
     // Printing to STDOUT appends a newline
     let expected = expectedJSON + "\n"
 
     // then
-    expect(output).to(equal(expected))
+    expect(data.asString).to(equal(expected))
+  }
+}
+
+extension Data {
+  fileprivate var asString: String {
+    String(data: self, encoding: .utf8)!
   }
 }


### PR DESCRIPTION
* operationSearchPaths and schemaSearchPaths were not in the expected test text.