### PR TITLE
feature: Support deprecation warnings with the Swift `@available` attribute

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -289,6 +289,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///
     /// See `APQConfig` for more information on Automatic Persisted Queries.
     public let apqs: APQConfig
+    /// Annotate generated Swift code with the Swift `available` attribute and `deprecated`
+    /// argument for parts of the GraphQL schema annotated with the built-in `@deprecated`
+    /// directive.
+    ///
+    /// This is currently limited to enum values.
+    public let warningsOnDeprecatedUsage: Composition
 
     /// Designated initializer.
     ///
@@ -305,13 +311,15 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
       deprecatedEnumCases: Composition = .include,
       schemaDocumentation: Composition = .include,
-      apqs: APQConfig = .disabled
+      apqs: APQConfig = .disabled,
+      warningsOnDeprecatedUsage: Composition = .include
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
       self.deprecatedEnumCases = deprecatedEnumCases
       self.schemaDocumentation = schemaDocumentation
       self.apqs = apqs
+      self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
     }
   }
 

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -25,9 +25,22 @@ struct EnumTemplate: TemplateRenderer {
   }
 
   private func evaluateDeprecation(graphqlEnumValue: GraphQLEnumValue) -> String? {
-    switch (config.options.deprecatedEnumCases, graphqlEnumValue.deprecationReason) {
-    case (.exclude, .some): return nil
-    default: return "case \(graphqlEnumValue.name)"
+    switch (
+      config.options.deprecatedEnumCases,
+      graphqlEnumValue.deprecationReason,
+      config.options.warningsOnDeprecatedUsage
+    ) {
+    case (.exclude, .some, _):
+      return nil
+
+    case let (.include, .some(reason), .include):
+      return TemplateString("""
+        @available(*, deprecated, message: \"\(reason)\")
+        case \(graphqlEnumValue.name)
+        """).description
+
+    default:
+      return "case \(graphqlEnumValue.name)"
     }
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -32,7 +32,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           queryStringLiteralFormat: .multiline,
           deprecatedEnumCases: .exclude,
           schemaDocumentation: .include,
-          apqs: .disabled
+          apqs: .disabled,
+          warningsOnDeprecatedUsage: .include
         ),
         experimentalFeatures: .init(
           clientControlledNullability: true,
@@ -42,7 +43,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     }
 
     static var encoded: String {
-      "{\"schemaName\":\"SerializedSchema\",\"options\":{\"schemaDocumentation\":\"include\",\"deprecatedEnumCases\":\"exclude\",\"apqs\":\"disabled\",\"additionalInflectionRules\":[{\"pluralization\":{\"singularRegex\":\"animal\",\"replacementRegex\":\"animals\"}}],\"queryStringLiteralFormat\":\"multiline\"},\"input\":{\"operationSearchPaths\":[\"\\/search\\/path\\/**\\/*.graphql\"],\"schemaSearchPaths\":[\"\\/path\\/to\\/schema.graphqls\"]},\"output\":{\"testMocks\":{\"swiftPackage\":{\"targetName\":\"SchemaTestMocks\"}},\"schemaTypes\":{\"path\":\"\\/output\\/path\",\"moduleType\":{\"swiftPackageManager\":{}}},\"operations\":{\"relative\":{\"subpath\":\"\\/relative\\/subpath\"}}},\"experimentalFeatures\":{\"clientControlledNullability\":true,\"legacySafelistingCompatibleOperations\":true}}"
+      "{\"schemaName\":\"SerializedSchema\",\"options\":{\"schemaDocumentation\":\"include\",\"warningsOnDeprecatedUsage\":\"include\",\"deprecatedEnumCases\":\"exclude\",\"apqs\":\"disabled\",\"additionalInflectionRules\":[{\"pluralization\":{\"singularRegex\":\"animal\",\"replacementRegex\":\"animals\"}}],\"queryStringLiteralFormat\":\"multiline\"},\"input\":{\"operationSearchPaths\":[\"\\/search\\/path\\/**\\/*.graphql\"],\"schemaSearchPaths\":[\"\\/path\\/to\\/schema.graphqls\"]},\"output\":{\"testMocks\":{\"swiftPackage\":{\"targetName\":\"SchemaTestMocks\"}},\"schemaTypes\":{\"path\":\"\\/output\\/path\",\"moduleType\":{\"swiftPackageManager\":{}}},\"operations\":{\"relative\":{\"subpath\":\"\\/relative\\/subpath\"}}},\"experimentalFeatures\":{\"clientControlledNullability\":true,\"legacySafelistingCompatibleOperations\":true}}"
     }
   }
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -131,7 +131,7 @@ class EnumTemplateTests: XCTestCase {
 
   // MARK: Deprecation Tests
 
-  func test__render__givenOption_deprecatedEnumCasesIncluded_whenEnumValueIsDeprecated_shouldGenerateEnumCase() throws {
+  func test__render__givenOption_deprecatedInclude_warningsExclude_whenDeprecation_shouldGenerateEnumCase_noAvailableAttribute() throws {
     // given / when
     buildSubject(
       values: [
@@ -139,7 +139,10 @@ class EnumTemplateTests: XCTestCase {
         ("TWO", "Deprecated for tests"),
         ("THREE", nil)
       ],
-      config: ApolloCodegenConfiguration.mock(options: .init(deprecatedEnumCases: .include))
+      config: ApolloCodegenConfiguration.mock(options: .init(
+        deprecatedEnumCases: .include,
+        warningsOnDeprecatedUsage: .exclude
+      ))
     )
 
     let expected = """
@@ -157,7 +160,37 @@ class EnumTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test__render__givenOption_deprecatedEnumCasesExcluded_whenEnumValueIsDeprecated_shouldNotGenerateEnumCase() throws {
+  func test__render__givenOption_deprecatedInclude_warningsInclude_whenDeprecation_shouldGenerateEnumCase_withAvailableAttribute() throws {
+    // given / when
+    buildSubject(
+      values: [
+        ("ONE", nil),
+        ("TWO", "Deprecated for tests"),
+        ("THREE", nil)
+      ],
+      config: ApolloCodegenConfiguration.mock(options: .init(
+        deprecatedEnumCases: .include,
+        warningsOnDeprecatedUsage: .include
+      ))
+    )
+
+    let expected = """
+    enum TestEnum: String, EnumType {
+      case ONE
+      @available(*, deprecated, message: "Deprecated for tests")
+      case TWO
+      case THREE
+    }
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render__givenOption_deprecatedExclude_warningsInclude_whenDeprecation_shouldNotGenerateEnumCase() throws {
     // given / when
     buildSubject(
       values: [
@@ -165,7 +198,37 @@ class EnumTemplateTests: XCTestCase {
         ("TWO", nil),
         ("THREE", "Deprecated for tests")
       ],
-      config: ApolloCodegenConfiguration.mock(options: .init(deprecatedEnumCases: .exclude))
+      config: ApolloCodegenConfiguration.mock(options: .init(
+        deprecatedEnumCases: .exclude,
+        warningsOnDeprecatedUsage: .include
+      ))
+    )
+
+    let expected = """
+    enum TestEnum: String, EnumType {
+      case TWO
+    }
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render__givenOption_deprecatedExclude_warningsExclude_whenDeprecation_shouldNotGenerateEnumCase() throws {
+    // given / when
+    buildSubject(
+      values: [
+        ("ONE", "Deprecated for tests"),
+        ("TWO", nil),
+        ("THREE", "Deprecated for tests")
+      ],
+      config: ApolloCodegenConfiguration.mock(options: .init(
+        deprecatedEnumCases: .exclude,
+        warningsOnDeprecatedUsage: .exclude
+      ))
     )
 
     let expected = """


### PR DESCRIPTION
_This PR is layered on top of #2339 to avoid conflicts with the additional configuration options added in that PR._

Adds a configuration option that supports annotating deprecated enum cases with the Swift `@available` attribute. The default is to include the attribute.