### PR TITLE
Fix singularization of plural names for non-list fields

### DIFF
--- a/Sources/ApolloCodegenLib/IR/IR+NamedFragmentBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+NamedFragmentBuilder.swift
@@ -9,15 +9,15 @@ extension IR {
       return fragment
     }
 
-    let rootEntity = Entity(
-      rootTypePath: LinkedList(fragmentDefinition.type),
-      fieldPath: ResponsePath(fragmentDefinition.name)
-    )
-
     let rootField = CompilationResult.Field(
       name: fragmentDefinition.name,
       type: .nonNull(.entity(fragmentDefinition.type)),
       selectionSet: fragmentDefinition.selectionSet
+    )
+
+    let rootEntity = Entity(
+      rootTypePath: LinkedList(fragmentDefinition.type),
+      fieldPath: [.init(name: rootField.name, type: rootField.type)]
     )
 
     let result = RootFieldBuilder.buildRootEntityField(

--- a/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
@@ -5,12 +5,15 @@ import ApolloUtils
 extension IR {
 
   func build(operation operationDefinition: CompilationResult.OperationDefinition) -> Operation {
-    let rootEntity = buildRootEntity(for: operationDefinition)
-
     let rootField = CompilationResult.Field(
       name: operationDefinition.operationType.rawValue,
       type: .nonNull(.entity(operationDefinition.rootType)),
       selectionSet: operationDefinition.selectionSet
+    )
+
+    let rootEntity = Entity(
+      rootTypePath: LinkedList(operationDefinition.rootType),
+      fieldPath: [.init(name: rootField.name, type: rootField.type)]
     )
 
     let result = RootFieldBuilder.buildRootEntityField(
@@ -24,18 +27,6 @@ extension IR {
       rootField: result.rootField,
       referencedFragments: result.referencedFragments
     )
-  }
-
-  private func buildRootEntity(for operationDefinition: CompilationResult.OperationDefinition) -> Entity {
-    let rootFieldName = operationDefinition.operationType.rawValue
-    let rootResponsePath = ResponsePath(rootFieldName)
-
-    let rootEntity = Entity(
-      rootTypePath: LinkedList(operationDefinition.rootType),
-      fieldPath: rootResponsePath
-    )
-
-    return rootEntity
   }
 
 }

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -5,7 +5,7 @@ import ApolloUtils
 extension IR {
 
   class RootFieldEntityStorage {
-    private(set) var entitiesForFields: [ResponsePath: IR.Entity] = [:]
+    private(set) var entitiesForFields: [Entity.FieldPath: IR.Entity] = [:]
 
     init(rootEntity: Entity) {
       entitiesForFields[rootEntity.fieldPath] = rootEntity
@@ -17,7 +17,7 @@ extension IR {
     ) -> Entity {
       let fieldPath = enclosingEntity
         .fieldPath
-        .appending(field.responseKey)
+        .appending(.init(name: field.responseKey, type: field.type))
 
       var rootTypePath: LinkedList<GraphQLCompositeType> {
         guard let fieldType = field.selectionSet?.parentType else {
@@ -35,7 +35,7 @@ extension IR {
       inFragmentSpreadAtTypePath fragmentSpreadTypeInfo: SelectionSet.TypeInfo
     ) -> Entity {
       let fieldPath = fragmentSpreadTypeInfo.entity.fieldPath +
-      otherEntity.fieldPath.toArray().dropFirst()
+      otherEntity.fieldPath.dropFirst()
 
       var rootTypePath: LinkedList<GraphQLCompositeType> {
         let otherRootTypePath = otherEntity.rootTypePath.dropFirst()
@@ -47,7 +47,7 @@ extension IR {
     }
 
     private func createEntity(
-      fieldPath: ResponsePath,
+      fieldPath: Entity.FieldPath,
       rootTypePath: LinkedList<GraphQLCompositeType>
     ) -> Entity {
       let entity = Entity(rootTypePath: rootTypePath, fieldPath: fieldPath)
@@ -67,7 +67,7 @@ extension IR {
     struct Result {
       let rootField: IR.EntityField
       let referencedFragments: ReferencedFragments
-      let entities: [ResponsePath: IR.Entity]
+      let entities: [Entity.FieldPath: IR.Entity]
     }
 
     typealias ReferencedFragments = OrderedSet<NamedFragment>

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -25,13 +25,19 @@ class IR {
   /// Multiple `SelectionSet`s may select fields on the same `Entity`. All `SelectionSet`s that will
   /// be selected on the same object share the same `Entity`.
   class Entity {
+    struct FieldPathComponent: Hashable {
+      let name: String
+      let type: GraphQLType
+    }
+    typealias FieldPath = LinkedList<FieldPathComponent>
+
     /// The selections that are selected for the entity across all type scopes in the operation.
     /// Represented as a tree.
     let selectionTree: EntitySelectionTree
 
     /// A list of path components indicating the path to the field containing the `Entity` in
     /// an operation or fragment.
-    let fieldPath: ResponsePath
+    let fieldPath: FieldPath
 
     var rootTypePath: LinkedList<GraphQLCompositeType> { selectionTree.rootTypePath }
 
@@ -39,7 +45,7 @@ class IR {
 
     init(
       rootTypePath: LinkedList<GraphQLCompositeType>,
-      fieldPath: ResponsePath
+      fieldPath: FieldPath
     ) {
       self.selectionTree = EntitySelectionTree(rootTypePath: rootTypePath)
       self.fieldPath = fieldPath
@@ -104,7 +110,7 @@ class IR {
     ///
     /// - Note: The ResponsePath for an entity within a fragment will begin with a path component
     /// equal to the fragment's name.
-    let entities: [ResponsePath: IR.Entity]    
+    let entities: [IR.Entity.FieldPath: IR.Entity]
 
     var name: String { definition.name }
     var type: GraphQLCompositeType { definition.type }
@@ -113,7 +119,7 @@ class IR {
       definition: CompilationResult.FragmentDefinition,
       rootField: EntityField,
       referencedFragments: OrderedSet<NamedFragment>,
-      entities: [ResponsePath: IR.Entity]
+      entities: [IR.Entity.FieldPath: IR.Entity]
     ) {
       self.definition = definition
       self.rootField = rootField

--- a/Sources/ApolloUtils/LinkedList.swift
+++ b/Sources/ApolloUtils/LinkedList.swift
@@ -76,6 +76,7 @@ public struct LinkedList<T>: ExpressibleByArrayLiteral {
   }
 
   public init(array: [T]) {
+    precondition(!array.isEmpty, "Cannot initialize LinkedList with an empty array. LinkedList must have at least one element.")
     var segments = array
     let headNode = HeadNode(value: segments.removeFirst())
 
@@ -156,6 +157,22 @@ public struct LinkedList<T>: ExpressibleByArrayLiteral {
     return copy
   }
 
+  // MARK: - Operators
+
+  public static func +<S: Sequence>(
+    lhs: LinkedList<T>,
+    rhs: S
+  ) -> LinkedList<T> where S.Element == T {
+    return lhs.appending(rhs)
+  }
+
+  public static func +=<S: Sequence>(
+    lhs: inout LinkedList<T>,
+    rhs: S
+  ) where S.Element == T {
+    lhs.append(rhs)
+  }
+
 }
 
 extension LinkedList.Node: Equatable where T: Equatable {
@@ -196,16 +213,20 @@ extension LinkedList: Collection {
 
   public var isEmpty: Bool { false }
 
+  public func node(at position: Int) -> Node {
+    let traverseFromFront = position <= last.index / 2
+    let numberOfIndiciesToTarget = traverseFromFront ? position : last.index - position
+
+    var node = traverseFromFront ? head : last
+    for _ in 0..<numberOfIndiciesToTarget {
+      node = traverseFromFront ? node.next.unsafelyUnwrapped : node.previous.unsafelyUnwrapped
+    }
+    return node
+  }
+
   public subscript(position: Int) -> T {
     _read {
-      let traverseFromFront = position <= last.index / 2
-      let numberOfIndiciesToTarget = traverseFromFront ? position : last.index - position
-
-      var node = traverseFromFront ? head : last
-      for _ in 0..<numberOfIndiciesToTarget {
-        node = traverseFromFront ? node.next.unsafelyUnwrapped : node.previous.unsafelyUnwrapped
-      }
-      yield node.value
+      yield node(at: position).value
     }
   }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
@@ -60,12 +60,13 @@ extension IR.NamedFragment {
     _ name: String,
     type: GraphQLCompositeType = .mock("MockType")
   ) -> IR.NamedFragment {
+    let rootField = CompilationResult.Field.mock(name, type: .entity(type))
     let rootEntity = IR.Entity(
       rootTypePath: LinkedList(type),
-      fieldPath: ResponsePath(name)
+      fieldPath: [.init(name: name, type: .entity(type))]
     )
-    let rootField = IR.EntityField.init(
-      CompilationResult.Field.mock(),
+    let rootEntityField = IR.EntityField.init(
+      rootField,
       inclusionConditions: nil,
       selectionSet: .init(
         entity: rootEntity,
@@ -78,7 +79,7 @@ extension IR.NamedFragment {
 
     return IR.NamedFragment(
       definition: CompilationResult.FragmentDefinition.mock(name, type: type),
-      rootField: rootField,
+      rootField: rootEntityField,
       referencedFragments: [],
       entities: [rootEntity.fieldPath: rootEntity]
     )
@@ -95,7 +96,7 @@ extension IR.Operation {
                        selectionSet: .init(
                         entity: .init(
                           rootTypePath: [.mock()],
-                          fieldPath: []),
+                          fieldPath: [.init(name: "mock", type: .entity(.mock("name")))]),
                         scopePath: [.descriptor(
                           forType: .mock(),
                           inclusionConditions: nil,

--- a/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
@@ -83,7 +83,8 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootType).to(equal(Object_Query))
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Query)))
-    expect(self.subject.rootField.selectionSet.entity.fieldPath).to(equal(ResponsePath("query")))
+    expect(self.subject.rootField.selectionSet.entity.fieldPath)
+      .to(equal([.init(name: "query", type: .nonNull(.entity(Object_Query)))]))
   }
 
   func test__buildOperation__givenSubscription_hasRootFieldAsSubscription() throws {
@@ -126,7 +127,8 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootType).to(equal(Object_Subscription))
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Subscription)))
-    expect(self.subject.rootField.selectionSet.entity.fieldPath).to(equal(ResponsePath("subscription")))
+    expect(self.subject.rootField.selectionSet.entity.fieldPath)
+      .to(equal([.init(name: "subscription", type: .nonNull(.entity(Object_Subscription)))]))      
   }
 
   func test__buildOperation__givenMutation_hasRootFieldAsMutation() throws {
@@ -169,7 +171,8 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootType).to(equal(Object_Mutation))
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Mutation)))
-    expect(self.subject.rootField.selectionSet.entity.fieldPath).to(equal(ResponsePath("mutation")))
+    expect(self.subject.rootField.selectionSet.entity.fieldPath)
+      .to(equal([.init(name: "mutation", type: .nonNull(.entity(Object_Mutation)))]))
   }
 
   // MARK: - Operation Identifier Computation

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -45,7 +45,7 @@ class IRRootFieldBuilderTests: XCTestCase {
       ),
       onRootEntity: IR.Entity(
         rootTypePath: LinkedList(operation.rootType),
-        fieldPath: ResponsePath("query")
+        fieldPath: [.init(name: "query", type: .nonNull(.entity(operation.rootType)))]
       ),
       inIR: ir
     )

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
@@ -43,7 +43,7 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
       ),
       onRootEntity: IR.Entity(
         rootTypePath: LinkedList(operation.rootType),
-        fieldPath: ResponsePath("query")
+        fieldPath: [.init(name: "query", type: .nonNull(.entity(operation.rootType)))]
       ),
       inIR: ir
     )


### PR DESCRIPTION
Had to refactor `Entity.fieldPath` to include the type of the field as well as the response path.