### PR TITLE
feature: Implement correct `queryStringLiteralFormat` output formatting

### DIFF
--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -29,11 +29,12 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
       try XCTUnwrap(definition),
       identifier: operationIdentifier,
       fragments: referencedFragments ?? [],
-      apq: try XCTUnwrap(config.options.apqs)
+      apq: try XCTUnwrap(config.options.apqs),
+      queryStringLiteralFormat: try XCTUnwrap(config.options.queryStringLiteralFormat)
     ).description
   }
 
-  func test__generate__generatesWithOperationDefinition() throws {
+  func test__generate__givenMultilineFormat_generatesWithOperationDefinition_asMultiline() throws {
     // given
     definition.source =
     """
@@ -41,7 +42,10 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
       name
     }
     """
-    config = .mock(options: .init(apqs: .disabled))
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .multiline,
+      apqs: .disabled
+    ))
 
     // when
     let actual = try renderDocumentType()
@@ -61,7 +65,34 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test__generate__givenIncludesFragment_generatesWithOperationDefinitionAndFragment() throws {
+  func test__generate__givenSingleLineFormat_generatesWithOperationDefinition_asSingleLine() throws {
+    // given
+    definition.source =
+    """
+    query NameQuery {
+      name
+    }
+    """
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .singleLine,
+      apqs: .disabled
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: DocumentType = .notPersisted(
+      definition: .init(
+        "query NameQuery {  name}"
+      ))
+    """
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__generate__givenIncludesFragment_formatMultiline_generatesWithOperationDefinitionAndFragment_asMultiline() throws {
     // given
     referencedFragments = [
       .mock("NameFragment"),
@@ -74,7 +105,10 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(options: .init(apqs: .disabled))
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .multiline,
+      apqs: .disabled
+    ))
 
     // when
     let actual = try renderDocumentType()
@@ -95,7 +129,40 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test__generate__givenIncludesManyFragments_generatesWithOperationDefinitionAndFragment() throws {
+  func test__generate__givenIncludesFragment_formatSingleLine_generatesWithOperationDefinitionAndFragment_asSingleLine() throws {
+    // given
+    referencedFragments = [
+      .mock("NameFragment"),
+    ]
+
+    definition.source =
+    """
+    query NameQuery {
+      ...NameFragment
+    }
+    """
+
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .singleLine,
+      apqs: .disabled
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: DocumentType = .notPersisted(
+      definition: .init(
+        "query NameQuery {  ...NameFragment}",
+        fragments: [NameFragment.self]
+      ))
+    """
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__generate__givenIncludesManyFragments_formatMultiline_generatesWithOperationDefinitionAndFragment_asMultiline() throws {
     // given
     referencedFragments = [
       .mock("Fragment1"),
@@ -116,7 +183,10 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(options: .init(apqs: .disabled))
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .multiline,
+      apqs: .disabled
+    ))
 
     // when
     let actual = try renderDocumentType()
@@ -141,6 +211,47 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
+  func test__generate__givenIncludesManyFragments_formatSingleLine_generatesWithOperationDefinitionAndFragment_asSingleLine() throws {
+    // given
+    referencedFragments = [
+      .mock("Fragment1"),
+      .mock("Fragment2"),
+      .mock("Fragment3"),
+      .mock("Fragment4"),
+      .mock("FragmentWithLongName1234123412341234123412341234"),
+    ]
+
+    definition.source =
+    """
+    query NameQuery {
+      ...Fragment1
+      ...Fragment2
+      ...Fragment3
+      ...Fragment4
+      ...FragmentWithLongName1234123412341234123412341234
+    }
+    """
+
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .singleLine,
+      apqs: .disabled
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: DocumentType = .notPersisted(
+      definition: .init(
+        "query NameQuery {  ...Fragment1  ...Fragment2  ...Fragment3  ...Fragment4  ...FragmentWithLongName1234123412341234123412341234}",
+        fragments: [Fragment1.self, Fragment2.self, Fragment3.self, Fragment4.self, FragmentWithLongName1234123412341234123412341234.self]
+      ))
+    """
+    expect(actual).to(equalLineByLine(expected))
+  }
+
   func test__generate__givenAPQ_automaticallyPersist_generatesWithOperationDefinitionAndIdentifier() throws {
     // given
     operationIdentifier = "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5"
@@ -151,7 +262,10 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(options: .init(apqs: .automaticallyPersist))
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .multiline,
+      apqs: .automaticallyPersist
+    ))
 
     // when
     let actual = try renderDocumentType()
@@ -172,7 +286,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test__generate__givenAPQ_persistedOperationsOnly_generatesWithOperationDefinitionAndIdentifier() throws {
+  func test__generate__givenAPQ_persistedOperationsOnly_generatesWithIdentifierOnly() throws {
     // given
     operationIdentifier = "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5"
     definition.source =
@@ -182,7 +296,10 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     }
     """
 
-    config = .mock(options: .init(apqs: .persistedOperationsOnly))
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .multiline,
+      apqs: .persistedOperationsOnly
+    ))
 
     // when
     let actual = try renderDocumentType()


### PR DESCRIPTION
_Related to #2101_ 

This one is pretty simple; either multiline or single line output.