### PR TITLE
feature: Generate deprecation warnings on InputObject when fields are deprecated

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/MeasurementsInput.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Schema/InputObjects/MeasurementsInput.swift
@@ -12,6 +12,17 @@ public struct MeasurementsInput: InputObject {
 
   public init(
     height: Double,
+    weight: Double
+  ) {
+    __data = InputDict([
+      "height": height,
+      "weight": weight
+    ])
+  }
+
+  @available(*, deprecated, message: "Argument 'wingspan' is deprecated.")
+  public init(
+    height: Double,
     weight: Double,
     wingspan: GraphQLNullable<Double> = nil
   ) {
@@ -32,6 +43,7 @@ public struct MeasurementsInput: InputObject {
     set { __data.weight = newValue }
   }
 
+  @available(*, deprecated, message: "No longer valid.")
   public var wingspan: GraphQLNullable<Double> {
     get { __data.wingspan }
     set { __data.wingspan = newValue }

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
@@ -23,7 +23,7 @@ input PetAdoptionInput {
 input MeasurementsInput {
   height: Float!
   weight: Float!
-  wingspan: Float
+  wingspan: Float @deprecated(reason: "No longer valid.")
 }
 
 input PetSearchFilters {

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
@@ -80,8 +80,10 @@ public class GraphQLEnumValue: JavaScriptObject {
   lazy var deprecationReason: String? = self["deprecationReason"]
 }
 
+typealias GraphQLInputFieldDictionary = OrderedDictionary<String, GraphQLInputField>
+
 public class GraphQLInputObjectType: GraphQLNamedType {
-  lazy var fields: OrderedDictionary<String, GraphQLInputField> = try! invokeMethod("getFields")
+  lazy var fields: GraphQLInputFieldDictionary = try! invokeMethod("getFields")
 }
 
 public class GraphQLInputField: JavaScriptObject {
@@ -96,7 +98,7 @@ public class GraphQLInputField: JavaScriptObject {
     return node?["defaultValue"]
   }()
     
-  private(set) lazy var deprecationReason: String? = self["deprecationReason"]
+  lazy var deprecationReason: String? = self["deprecationReason"]
 }
 
 public class GraphQLCompositeType: GraphQLNamedType {

--- a/Sources/ApolloCodegenLib/TemplateString.swift
+++ b/Sources/ApolloCodegenLib/TemplateString.swift
@@ -144,6 +144,21 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
       }
     }
 
+    mutating func appendInterpolation(
+      if bool: Bool,
+      where whereBlock: @autoclosure @escaping () -> Bool = true,
+      _ template: @autoclosure () -> TemplateString,
+      else: @autoclosure () -> TemplateString? = nil
+    ) {
+      if bool && whereBlock() {
+        appendInterpolation(template())
+      } else if let elseTemplate = `else`() {
+        appendInterpolation(elseTemplate)
+      } else {
+        removeLineIfEmpty()
+      }
+    }
+
     /// MARK: If Let
 
     mutating func appendInterpolation<T>(

--- a/Sources/ApolloCodegenLib/TemplateString.swift
+++ b/Sources/ApolloCodegenLib/TemplateString.swift
@@ -144,21 +144,6 @@ struct TemplateString: ExpressibleByStringInterpolation, CustomStringConvertible
       }
     }
 
-    mutating func appendInterpolation(
-      if bool: Bool,
-      where whereBlock: @autoclosure @escaping () -> Bool = true,
-      _ template: @autoclosure () -> TemplateString,
-      else: @autoclosure () -> TemplateString? = nil
-    ) {
-      if bool && whereBlock() {
-        appendInterpolation(template())
-      } else if let elseTemplate = `else`() {
-        appendInterpolation(elseTemplate)
-      } else {
-        removeLineIfEmpty()
-      }
-    }
-
     /// MARK: If Let
 
     mutating func appendInterpolation<T>(

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -40,7 +40,9 @@ struct InputObjectTemplate: TemplateRenderer {
     )
   }
 
-  private func InitializerParametersTemplate() -> TemplateString {
+  private func InitializerParametersTemplate(
+    _ fields:
+  ) -> TemplateString {
     TemplateString("""
     \(graphqlInputObject.fields.map({
       "\($1.name): \($1.renderInputValueType(includeDefault: true, config: config.config))"
@@ -57,6 +59,10 @@ struct InputObjectTemplate: TemplateRenderer {
   private func FieldPropertyTemplate(_ field: GraphQLInputField) -> TemplateString {
     """
     \(documentation: field.documentation, config: config)
+    \(ifLet: field.deprecationReason,
+      where: config.options.warningsOnDeprecatedUsage == .include, {
+        "@available(*, deprecated, message: \"\($0)\")"
+      })
     public var \(field.name): \(field.renderInputValueType(config: config.config)) {
       get { __data.\(field.name) }
       set { __data.\(field.name) = newValue }

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -14,7 +14,9 @@ struct InputObjectTemplate: TemplateRenderer {
   let target: TemplateTarget = .schemaFile
 
   var template: TemplateString {
-    TemplateString(
+    let (validFields, deprecatedFields) = filterFields(graphqlInputObject.fields)
+
+    return TemplateString(
     """
     \(documentation: graphqlInputObject.documentation, config: config)
     \(embeddedAccessControlModifier)\
@@ -25,11 +27,15 @@ struct InputObjectTemplate: TemplateRenderer {
         __data = data
       }
 
+      \(if: !deprecatedFields.isEmpty,
+        where: config.options.warningsOnDeprecatedUsage == .include, """
+      @available(*, deprecated, message: "\(deprecatedMessage(for: deprecatedFields))")
+      """)
       public init(
-        \(InitializerParametersTemplate())
+        \(InitializerParametersTemplate(graphqlInputObject.fields))
       ) {
         __data = InputDict([
-          \(InputDictInitializerTemplate())
+          \(InputDictInitializerTemplate(graphqlInputObject.fields))
         ])
       }
 
@@ -40,19 +46,50 @@ struct InputObjectTemplate: TemplateRenderer {
     )
   }
 
+  private func filterFields(
+    _ fields: GraphQLInputFieldDictionary
+  ) -> (valid: GraphQLInputFieldDictionary, deprecated: GraphQLInputFieldDictionary) {
+    var valid: GraphQLInputFieldDictionary = [:]
+    var deprecated: GraphQLInputFieldDictionary = [:]
+
+    for (key, value) in fields {
+      if let _ = value.deprecationReason {
+        deprecated[key] = value
+      } else {
+        valid[key] = value
+      }
+    }
+
+    return (valid: valid, deprecated: deprecated)
+  }
+
+  private func deprecatedMessage(for fields: GraphQLInputFieldDictionary) -> String {
+    guard !fields.isEmpty else { return "" }
+
+    let names: String = fields.values.map({ $0.name }).joined(separator: ", ")
+
+    if fields.count > 1 {
+      return "Arguments '\(names)' are deprecated."
+    } else {
+      return "Argument '\(names)' is deprecated."
+    }
+  }
+
   private func InitializerParametersTemplate(
-    _ fields:
+    _ fields: GraphQLInputFieldDictionary
   ) -> TemplateString {
     TemplateString("""
-    \(graphqlInputObject.fields.map({
+    \(fields.map({
       "\($1.name): \($1.renderInputValueType(includeDefault: true, config: config.config))"
     }), separator: ",\n")
     """)
   }
 
-  private func InputDictInitializerTemplate() -> TemplateString {
+  private func InputDictInitializerTemplate(
+    _ fields: GraphQLInputFieldDictionary
+  ) -> TemplateString {
     TemplateString("""
-    \(graphqlInputObject.fields.map({ "\"\($1.name)\": \($1.name)" }), separator: ",\n")
+    \(fields.map({ "\"\($1.name)\": \($1.name)" }), separator: ",\n")
     """)
   }
 

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -27,8 +27,18 @@ struct InputObjectTemplate: TemplateRenderer {
         __data = data
       }
 
-      \(if: !deprecatedFields.isEmpty,
-        where: config.options.warningsOnDeprecatedUsage == .include, """
+      \(if: !deprecatedFields.isEmpty && !validFields.isEmpty && shouldIncludeDeprecatedWarnings, """
+      public init(
+        \(InitializerParametersTemplate(validFields))
+      ) {
+        __data = InputDict([
+          \(InputDictInitializerTemplate(validFields))
+        ])
+      }
+
+      """
+      )
+      \(if: !deprecatedFields.isEmpty && shouldIncludeDeprecatedWarnings, """
       @available(*, deprecated, message: "\(deprecatedMessage(for: deprecatedFields))")
       """)
       public init(
@@ -44,6 +54,10 @@ struct InputObjectTemplate: TemplateRenderer {
 
     """
     )
+  }
+
+  private var shouldIncludeDeprecatedWarnings: Bool {
+    config.options.warningsOnDeprecatedUsage == .include
   }
 
   private func filterFields(

--- a/Tests/ApolloCodegenInternalTestHelpers/MockGraphQLType.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockGraphQLType.swift
@@ -162,13 +162,15 @@ public extension GraphQLInputField {
     _ name: String,
     type: GraphQLType,
     defaultValue: GraphQLValue?,
-    documentation: String? = nil
+    documentation: String? = nil,
+    deprecationReason: String? = nil
   ) -> Self {
     let mock = Self.emptyMockObject()
     mock.name = name
     mock.type = type
     mock.defaultValue = defaultValue
     mock.documentation = documentation
+    mock.deprecationReason = deprecationReason
     return mock
   }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -844,6 +844,51 @@ class InputObjectTemplateTests: XCTestCase {
     expect(rendered).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
+  func test__render__givenOnlyDeprecatedFields_includeDeprecationWarnings_shouldGenerateWarning_withoutValidInitializer() throws {
+    // given
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Not used anymore!"
+        )
+      ],
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .include
+      ))
+    )
+
+    let expected = """
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      @available(*, deprecated, message: "Argument 'fieldOne' is deprecated.")
+      public init(
+        fieldOne: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne
+        ])
+      }
+
+      @available(*, deprecated, message: "Not used anymore!")
+      public var fieldOne: String {
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   func test__render__givenDeprecatedField_excludeDeprecationWarnings_shouldNotGenerateWarning() throws {
     // given
     buildSubject(

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -766,7 +766,6 @@ class InputObjectTemplateTests: XCTestCase {
 
   func test__render__givenSchemaDocumentation_exclude_hasDocumentation_shouldNotGenerateDocumentationComment() throws {
     // given
-    // given
     let documentation = "This is some great documentation!"
     buildSubject(
       fields: [
@@ -795,6 +794,190 @@ class InputObjectTemplateTests: XCTestCase {
         ])
       }
 
+      public var fieldOne: String {
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  // MARK: Deprecation Tests
+
+  func test__render__givenDeprecatedField_includeDeprecationWarnings_shouldGenerateWarning() throws {
+    // given
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Not used anymore!"
+        )
+      ],
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .include
+      ))
+    )
+
+    let expected = """
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      public init(
+        fieldOne: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne
+        ])
+      }
+
+      @available(*, deprecated, message: "Not used anymore!")
+      public var fieldOne: String {
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenDeprecatedField_excludeDeprecationWarnings_shouldNotGenerateWarning() throws {
+    // given
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Not used anymore!"
+        )
+      ],
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .exclude
+      ))
+    )
+
+    let expected = """
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      public init(
+        fieldOne: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne
+        ])
+      }
+
+      public var fieldOne: String {
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenDeprecatedField_andDocumentation_includeDeprecationWarnings_shouldGenerateWarning_afterDocumentation() throws {
+    // given
+    let documentation = "This is some great documentation!"
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          documentation: "Field Documentation!",
+          deprecationReason: "Not used anymore!"
+        )
+      ],
+      documentation: documentation,
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .include
+      ))
+    )
+
+    let expected = """
+    /// This is some great documentation!
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      public init(
+        fieldOne: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne
+        ])
+      }
+
+      /// Field Documentation!
+      @available(*, deprecated, message: "Not used anymore!")
+      public var fieldOne: String {
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenDeprecatedField_andDocumentation_excludeDeprecationWarnings_shouldNotGenerateWarning_afterDocumentation() throws {
+    // given
+    let documentation = "This is some great documentation!"
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          documentation: "Field Documentation!")
+      ],
+      documentation: documentation,
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .exclude
+      ))
+    )
+
+    let expected = """
+    /// This is some great documentation!
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      public init(
+        fieldOne: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne
+        ])
+      }
+
+      /// Field Documentation!
       public var fieldOne: String {
     """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -831,6 +831,7 @@ class InputObjectTemplateTests: XCTestCase {
         __data = data
       }
 
+      @available(*, deprecated, message: "Argument 'fieldOne' is deprecated.")
       public init(
         fieldOne: String
       ) {
@@ -922,6 +923,7 @@ class InputObjectTemplateTests: XCTestCase {
         __data = data
       }
 
+      @available(*, deprecated, message: "Argument 'fieldOne' is deprecated.")
       public init(
         fieldOne: String
       ) {
@@ -979,6 +981,151 @@ class InputObjectTemplateTests: XCTestCase {
 
       /// Field Documentation!
       public var fieldOne: String {
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenDeprecatedAndValidFields_includeDeprecationWarnings_shouldGenerateWarnings() throws {
+    // given
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Not used anymore!"
+        ),
+        GraphQLInputField.mock(
+          "fieldTwo",
+          type: .nonNull(.string()),
+          defaultValue: nil
+        ),
+        GraphQLInputField.mock(
+          "fieldThree",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Stop using this field!"
+        )
+      ],
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .include
+      ))
+    )
+
+    let expected = """
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      @available(*, deprecated, message: "Arguments 'fieldOne, fieldThree' are deprecated.")
+      public init(
+        fieldOne: String,
+        fieldTwo: String,
+        fieldThree: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne,
+          "fieldTwo": fieldTwo,
+          "fieldThree": fieldThree
+        ])
+      }
+
+      @available(*, deprecated, message: "Not used anymore!")
+      public var fieldOne: String {
+        get { __data.fieldOne }
+        set { __data.fieldOne = newValue }
+      }
+
+      public var fieldTwo: String {
+        get { __data.fieldTwo }
+        set { __data.fieldTwo = newValue }
+      }
+
+      @available(*, deprecated, message: "Stop using this field!")
+      public var fieldThree: String {
+        get { __data.fieldThree }
+        set { __data.fieldThree = newValue }
+      }
+    """
+
+    // when
+    let rendered = renderSubject()
+
+    // then
+    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__render__givenDeprecatedAndValidFields_excludeDeprecationWarnings_shouldNotGenerateWarning_afterDocumentation() throws {
+    // given
+    buildSubject(
+      fields: [
+        GraphQLInputField.mock(
+          "fieldOne",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Not used anymore!"
+        ),
+        GraphQLInputField.mock(
+          "fieldTwo",
+          type: .nonNull(.string()),
+          defaultValue: nil
+        ),
+        GraphQLInputField.mock(
+          "fieldThree",
+          type: .nonNull(.string()),
+          defaultValue: nil,
+          deprecationReason: "Stop using this field!"
+        )
+      ],
+      config: .mock(options: .init(
+        schemaDocumentation: .include,
+        warningsOnDeprecatedUsage: .exclude
+      ))
+    )
+
+    let expected = """
+    struct MockInput: InputObject {
+      public private(set) var __data: InputDict
+
+      public init(_ data: InputDict) {
+        __data = data
+      }
+
+      public init(
+        fieldOne: String,
+        fieldTwo: String,
+        fieldThree: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne,
+          "fieldTwo": fieldTwo,
+          "fieldThree": fieldThree
+        ])
+      }
+
+      public var fieldOne: String {
+        get { __data.fieldOne }
+        set { __data.fieldOne = newValue }
+      }
+
+      public var fieldTwo: String {
+        get { __data.fieldTwo }
+        set { __data.fieldTwo = newValue }
+      }
+
+      public var fieldThree: String {
+        get { __data.fieldThree }
+        set { __data.fieldThree = newValue }
+      }
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -824,13 +824,6 @@ class InputObjectTemplateTests: XCTestCase {
     )
 
     let expected = """
-    struct MockInput: InputObject {
-      public private(set) var __data: InputDict
-
-      public init(_ data: InputDict) {
-        __data = data
-      }
-
       @available(*, deprecated, message: "Argument 'fieldOne' is deprecated.")
       public init(
         fieldOne: String
@@ -848,7 +841,7 @@ class InputObjectTemplateTests: XCTestCase {
     let rendered = renderSubject()
 
     // then
-    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+    expect(rendered).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
   func test__render__givenDeprecatedField_excludeDeprecationWarnings_shouldNotGenerateWarning() throws {
@@ -869,13 +862,6 @@ class InputObjectTemplateTests: XCTestCase {
     )
 
     let expected = """
-    struct MockInput: InputObject {
-      public private(set) var __data: InputDict
-
-      public init(_ data: InputDict) {
-        __data = data
-      }
-
       public init(
         fieldOne: String
       ) {
@@ -891,7 +877,7 @@ class InputObjectTemplateTests: XCTestCase {
     let rendered = renderSubject()
 
     // then
-    expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
+    expect(rendered).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
   func test__render__givenDeprecatedField_andDocumentation_includeDeprecationWarnings_shouldGenerateWarning_afterDocumentation() throws {
@@ -990,7 +976,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test__render__givenDeprecatedAndValidFields_includeDeprecationWarnings_shouldGenerateWarnings() throws {
+  func test__render__givenDeprecatedAndValidFields_includeDeprecationWarnings_shouldGenerateWarnings_withValidInitializer() throws {
     // given
     buildSubject(
       fields: [
@@ -1007,6 +993,11 @@ class InputObjectTemplateTests: XCTestCase {
         ),
         GraphQLInputField.mock(
           "fieldThree",
+          type: .nonNull(.string()),
+          defaultValue: nil
+        ),
+        GraphQLInputField.mock(
+          "fieldFour",
           type: .nonNull(.string()),
           defaultValue: nil,
           deprecationReason: "Stop using this field!"
@@ -1026,16 +1017,28 @@ class InputObjectTemplateTests: XCTestCase {
         __data = data
       }
 
-      @available(*, deprecated, message: "Arguments 'fieldOne, fieldThree' are deprecated.")
       public init(
-        fieldOne: String,
         fieldTwo: String,
         fieldThree: String
       ) {
         __data = InputDict([
-          "fieldOne": fieldOne,
           "fieldTwo": fieldTwo,
           "fieldThree": fieldThree
+        ])
+      }
+
+      @available(*, deprecated, message: "Arguments 'fieldOne, fieldFour' are deprecated.")
+      public init(
+        fieldOne: String,
+        fieldTwo: String,
+        fieldThree: String,
+        fieldFour: String
+      ) {
+        __data = InputDict([
+          "fieldOne": fieldOne,
+          "fieldTwo": fieldTwo,
+          "fieldThree": fieldThree,
+          "fieldFour": fieldFour
         ])
       }
 
@@ -1050,10 +1053,15 @@ class InputObjectTemplateTests: XCTestCase {
         set { __data.fieldTwo = newValue }
       }
 
-      @available(*, deprecated, message: "Stop using this field!")
       public var fieldThree: String {
         get { __data.fieldThree }
         set { __data.fieldThree = newValue }
+      }
+
+      @available(*, deprecated, message: "Stop using this field!")
+      public var fieldFour: String {
+        get { __data.fieldFour }
+        set { __data.fieldFour = newValue }
       }
     """
 
@@ -1064,7 +1072,7 @@ class InputObjectTemplateTests: XCTestCase {
     expect(rendered).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test__render__givenDeprecatedAndValidFields_excludeDeprecationWarnings_shouldNotGenerateWarning_afterDocumentation() throws {
+  func test__render__givenDeprecatedAndValidFields_excludeDeprecationWarnings_shouldNotGenerateWarning_afterDocumentation_withOnlyOneInitializer() throws {
     // given
     buildSubject(
       fields: [


### PR DESCRIPTION
This PR is the final piece to adding deprecation warnings to the Swift generated code.

* Generates a second InputField initializer that doesn't contain any of the deprecated fields
* Annotates initializer with deprecated fields as deprecated using Swift's `@available` attribute
* Annotates fields as deprecated using Swift's `@available` attribute