### PR TITLE
Expose GraphQLResultError Path String

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		DED46035261CEA660086EF63 /* ApolloTestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F8A95781EC0FC1200304A2D /* ApolloTestSupport.framework */; };
 		DED46042261CEA8A0086EF63 /* TestServerURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED45C172615308E0086EF63 /* TestServerURLs.swift */; };
 		DED46051261CEAD20086EF63 /* StarWarsAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FCE2CFA1E6C213D00E34457 /* StarWarsAPI.framework */; };
+		E6057F8B287D7E24007D84EC /* ResponsePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6057F8A287D7E24007D84EC /* ResponsePathTests.swift */; };
 		E616B6D126C3335600DB049E /* ExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616B6D026C3335600DB049E /* ExecutionTests.swift */; };
 		E61DD76526D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */; };
 		E63C03DF27BDDC3D00D675C6 /* SubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C03DD27BDDC3400D675C6 /* SubscriptionTests.swift */; };
@@ -846,6 +847,7 @@
 		DED45FB1261CDE7D0086EF63 /* Apollo-PerformanceTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Apollo-PerformanceTestPlan.xctestplan"; sourceTree = "<group>"; };
 		DED45FB2261CDE980086EF63 /* Apollo-CITestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Apollo-CITestPlan.xctestplan"; sourceTree = "<group>"; };
 		DED45FB3261CDEC60086EF63 /* Apollo-CodegenTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Apollo-CodegenTestPlan.xctestplan"; sourceTree = "<group>"; };
+		E6057F8A287D7E24007D84EC /* ResponsePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsePathTests.swift; sourceTree = "<group>"; };
 		E616B6D026C3335600DB049E /* ExecutionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionTests.swift; sourceTree = "<group>"; };
 		E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDotSwiftDatabaseBehaviorTests.swift; sourceTree = "<group>"; };
 		E63C03D327BDB55900D675C6 /* subscription.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = subscription.graphql; sourceTree = "<group>"; };
@@ -1578,6 +1580,7 @@
 				E61DD76426D60C1800C41614 /* SQLiteDotSwiftDatabaseBehaviorTests.swift */,
 				9B9BBB1A24DB75E60021C30F /* UploadRequestTests.swift */,
 				5BB2C0222380836100774170 /* VersionNumberTests.swift */,
+				E6057F8A287D7E24007D84EC /* ResponsePathTests.swift */,
 			);
 			path = ApolloTests;
 			sourceTree = "<group>";
@@ -2810,6 +2813,7 @@
 				9B64F6762354D219002D1BB5 /* URL+QueryDict.swift in Sources */,
 				9B2B66F42513FAFE00B53ABF /* CancellationHandlingInterceptor.swift in Sources */,
 				9BC139A624EDCAD900876D29 /* BlindRetryingTestInterceptor.swift in Sources */,
+				E6057F8B287D7E24007D84EC /* ResponsePathTests.swift in Sources */,
 				9B96500A24BE62B7003C29C0 /* RequestChainTests.swift in Sources */,
 				DED45DEA261B96B70086EF63 /* WatchQueryTests.swift in Sources */,
 				DED45E30261B972C0086EF63 /* CachePersistenceTests.swift in Sources */,

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -36,6 +36,8 @@ struct GraphQLResolveInfo {
 public struct GraphQLResultError: Error, LocalizedError {
   let path: ResponsePath
 
+  public var pathString: String { path.description }
+
   /// The error that occurred during parsing.
   public let underlying: Error
 

--- a/Tests/ApolloTests/ResponsePathTests.swift
+++ b/Tests/ApolloTests/ResponsePathTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Apollo
+import Nimble
+
+class ResponsePathTests: XCTestCase {
+
+  func test__initializer__givenArray_shouldRespectKeyCasing() {
+    let subject: ResponsePath = ["first", "Second", "Third"]
+
+    expect(subject.joined).to(equal("first.Second.Third"))
+  }
+
+  func test__joined__givenArray_shouldReturnJoinedKeysInOrder() {
+    let subject: ResponsePath = ["first", "second", "third"]
+
+    expect(subject.joined).to(equal("first.second.third"))
+  }
+
+  func test__joined__whenAppendKey_shouldIncludeAppendedKeyLast() {
+    var subject: ResponsePath = ["first", "second", "third"]
+    subject.append("fourth")
+
+    expect(subject.joined).to(equal("first.second.third.fourth"))
+  }
+
+  func test__joined__whenAddKey_shouldIncludeAddedKeyLast() {
+    let paths: ResponsePath = ["first", "second"]
+    let subject = paths + "third"
+
+    expect(subject.joined).to(equal("first.second.third"))
+  }
+
+  func test__description__givenArray_shouldEqualJoined() {
+    let subject: ResponsePath = ["first", "second", "third"]
+
+    expect(subject.description).to(equal(subject.joined))
+  }
+}


### PR DESCRIPTION
# Summary
Adds a new publicly available computed property to `GraphQLResultError` which just exposes the `path` description.

# Motivation
My team uses apollo-ios SDK for most of our networking needs, however, we also include crash and error reporting within our project. While using Apollo, if there are errors thrown and my team has identified it's something we care about reporting, we log those to our reporting tools.

I go into more detail in the [community post I made](https://community.apollographql.com/t/apollo-ios-remove-potential-pii-from-graphqlresulterror-jsondecodingerror-couldnotconvert/3714), but the problem we have is when the thrown errors contain PII (Personally Identifiable Information). In this specific instance, we saw this with the `JSONDecodingError.couldNotConvert` error when combined with the `GraphQLResultError`. You could have a situation like the following:
> Error at path “accountHolder.birthDate)”: couldNotConvert(value: 2000-01-01T00:00:00.000Z, to: Foundation.Date)

For this, we decided we needed to map the errors we cared about reporting into new errors - removing the parts that could be considered PII. We could regenerate the `JSONDecodingError.couldNotConvert` error without a problem, but the `GraphQLResultError` type couldn't be re-created as the underlying `ResponsePath` type is not public and therefore neither is the `path` property.

# Solution
Considering the above, we had a couple of options we could take:
- Parse the `errorDescription` String to take what we needed?
  - Fragile - what if the string format changed between versions?
- Only recreate the `JSONDecodingError.couldNotConvert` error?
  - This would work, but we'd lose the information for which json key had the issue.
- Fork the repo and make an adjustment?
  - Likely the best outcome to maintain error fidelity in our logs while ensuring no PII is logged.

We opted to fork the repo and only add in a `pathString` computed property to the `GraphQLResultError` type so we could map to new errors while still including the json key which had the issue.