### PR TITLE
Fix: Update Index Links 

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -6,20 +6,8 @@ description: A strongly-typed, caching GraphQL client for iOS, written in Swift
 
 **Apollo iOS** is an [open-source](https://github.com/apollographql/apollo-ios) GraphQL client for native iOS apps, written in Swift. It enables you to execute queries and mutations against a GraphQL server and returns results as operation-specific Swift types.
 
-<p>
-  <ButtonLink
-    colorScheme="indigo"
-    href="./tutorial/tutorial-introduction/"
-    mr="4"
-  >
-    Start the tutorial
-  </ButtonLink>
-  <ButtonLink
-    href="./installation/"
-  >
-    Installation
-  </ButtonLink>
-</p>
+[Start the tutorial](./tutorial/tutorial-introduction/)
+[Installation](./installation)
 
 ## Benefits
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -7,6 +7,7 @@ description: A strongly-typed, caching GraphQL client for iOS, written in Swift
 **Apollo iOS** is an [open-source](https://github.com/apollographql/apollo-ios) GraphQL client for native iOS apps, written in Swift. It enables you to execute queries and mutations against a GraphQL server and returns results as operation-specific Swift types.
 
 [Start the tutorial](./tutorial/tutorial-introduction/)
+
 [Installation](./installation)
 
 ## Benefits


### PR DESCRIPTION
The current links aren't working on the docs, so this replaces them with standard MD links to become functional. 