### PR TITLE
public `write(string:completion:)` function within `ApolloWebSocket`

### DIFF
--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -302,7 +302,7 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
    - parameter string:        The string to write.
    - parameter completion: The (optional) completion handler.
    */
-  func write(string: String, completion: (() -> ())? = nil) {
+  public func write(string: String, completion: (() -> ())? = nil) {
     guard isConnected else { return }
     dequeueWrite(string.data(using: String.Encoding.utf8)!, code: .textFrame, writeCompletion: completion)
   }


### PR DESCRIPTION
While toying around with a web3 API, noticed that I _really_ needed a completion block on this function. I saw that it was already fully implemented and documented, but not made public. 