### PR TITLE
fix: Enable all targets in SwiftScripts

### DIFF
--- a/SwiftScripts/README.md
+++ b/SwiftScripts/README.md
@@ -1,3 +1,46 @@
-# Codegen
+# Internal Tooling
 
-A description of this package.
+```
+OVERVIEW: A Swift package that provides functionality for internal tooling and testing.
+
+USAGE: Swift run <subcommand>
+
+SUBCOMMANDS:
+  Codegen                 Generate Swift code for the specified targets and package.
+  DocumentationGenerator  Generate API reference documentation for apollo-ios.
+  SchemaDownload          Download the GraphQL schema from all targets in SDL format.
+``` 
+
+## Code Generator
+
+```
+OVERVIEW: Generate Swift code for the specified targets and package.
+
+USAGE: codegen [--target <target> ...] --package-type <package-type>
+
+OPTIONS:
+  -t, --target <target>   The target to generate code for.
+  -p, --package-type <package-type>
+                          The package manager for the generated module - Required.
+  -h, --help              Show help information.
+```
+
+## Documentation Generator
+
+```
+OVERVIEW: Generate API reference documentation for apollo-ios.
+
+USAGE: DocumentationGenerator
+
+OPTIONS: None
+```
+
+## Schema Download
+
+```
+OVERVIEW: Download the GraphQL schema from all targets in SDL format.
+
+USAGE: SchemaDownload
+
+OPTIONS: None
+```

--- a/SwiftScripts/Sources/SchemaDownload/main.swift
+++ b/SwiftScripts/Sources/SchemaDownload/main.swift
@@ -39,14 +39,9 @@ extension Target {
 
   var serverEndpoint: URL? {
     switch self {
-    case .upload:
-      return URL(string: "http://localhost:4000/")!
-    case .starWars:
-      return URL(string: "http://localhost:8080/graphql")!
-//    case .gitHub:
-//      return nil
-    case .animalKingdom:
-      return nil
+    case .upload: return URL(string: "http://localhost:4000/")!
+    case .starWars, .subscription: return URL(string: "http://localhost:8080/graphql")!
+    default: return nil
     }
   }
 

--- a/SwiftScripts/Sources/SchemaDownload/main.swift
+++ b/SwiftScripts/Sources/SchemaDownload/main.swift
@@ -22,7 +22,7 @@ for target in Target.allCases {
 
   // Introspection download:
   let configuration = ApolloSchemaDownloadConfiguration(
-    using: .introspection(endpointURL: endpoint),
+    using: .introspection(endpointURL: endpoint, outputFormat: .SDL),
     outputPath: outputURL.path
   )
 

--- a/SwiftScripts/Sources/SchemaDownload/main.swift
+++ b/SwiftScripts/Sources/SchemaDownload/main.swift
@@ -23,14 +23,8 @@ for target in Target.allCases {
   // Introspection download:
   let configuration = ApolloSchemaDownloadConfiguration(
     using: .introspection(endpointURL: endpoint),
-    outputPath: outputURL.path)
-
-  // Registry download:
-  //let registrySettings = ApolloSchemaDownloadConfiguration.DownloadMethod.RegistrySettings(apiKey: <#Replace Me For Testing#>,
-  //                                                                                         graphID: "Apollo-Fullstack-8zo5jl")
-  //
-  //let configuration = ApolloSchemaDownloadConfiguration(using: .registry(registrySettings),
-  //                                                      outputFolderURL: output)
+    outputPath: outputURL.path
+  )
 
   do {
     try ApolloSchemaDownloader.fetch(configuration: configuration)

--- a/SwiftScripts/Sources/SchemaDownload/main.swift
+++ b/SwiftScripts/Sources/SchemaDownload/main.swift
@@ -39,8 +39,9 @@ extension Target {
 
   var serverEndpoint: URL? {
     switch self {
-    case .upload: return URL(string: "http://localhost:4000/")!
-    case .starWars, .subscription: return URL(string: "http://localhost:8080/graphql")!
+    case .upload: return URL(string: "http://localhost:4001/")!
+    case .starWars: return URL(string: "http://localhost:8080/graphql")!
+    case .subscription: return URL(string: "http://localhost:4000/graphql")!
     default: return nil
     }
   }

--- a/SwiftScripts/Sources/TargetConfig/Target.swift
+++ b/SwiftScripts/Sources/TargetConfig/Target.swift
@@ -3,32 +3,26 @@ import ApolloCodegenLib
 
 public enum Target: CaseIterable {
   case starWars
-//  case gitHub
+  case gitHub
   case upload
   case animalKingdom
   case subscription
 
   public init(name: String) throws {
     switch name {
-    case "StarWars":
-      self = .starWars
-//    case "GitHub":
-//      self = .gitHub
-    case "Upload":
-      self = .upload
-    case "AnimalKingdom":
-      self = .animalKingdom
-    case "Subscription":
-      self = .subscription
-    default:
-      throw ArgumentError.invalidTargetName(name: name)
+    case "StarWars": self = .starWars
+    case "GitHub": self = .gitHub
+    case "Upload": self = .upload
+    case "AnimalKingdom": self = .animalKingdom
+    case "Subscription": self = .subscription
+    default: throw ArgumentError.invalidTargetName(name: name)
     }
   }
 
   public var moduleName: String {
     switch self {
     case .starWars: return "StarWarsAPI"
-//    case .gitHub: return "GitHubAPI"
+    case .gitHub: return "GitHubAPI"
     case .upload: return "UploadAPI"
     case .animalKingdom: return "AnimalKingdomAPI"
     case .subscription: return "SubscriptionAPI"
@@ -36,58 +30,30 @@ public enum Target: CaseIterable {
   }
 
   public func targetRootURL(fromSourceRoot sourceRootURL: Foundation.URL) -> Foundation.URL {
-    switch self {
-//    case .gitHub:
-//      return sourceRootURL
-//        .apollo.childFolderURL(folderName: "Sources")
-//        .apollo.childFolderURL(folderName: moduleName)
-    case .starWars:
-      return sourceRootURL
-        .apollo.childFolderURL(folderName: "Sources")
-        .apollo.childFolderURL(folderName: moduleName)
-    case .upload:
-      return sourceRootURL
-        .apollo.childFolderURL(folderName: "Sources")
-        .apollo.childFolderURL(folderName: moduleName)
-    case .animalKingdom:
-      return sourceRootURL
-        .apollo.childFolderURL(folderName: "Sources")
-        .apollo.childFolderURL(folderName: moduleName)
-    case .subscription:
-      return sourceRootURL
-        .apollo.childFolderURL(folderName: "Sources")
-        .apollo.childFolderURL(folderName: moduleName)
-    }
+    return sourceRootURL
+      .apollo.childFolderURL(folderName: "Sources")
+      .apollo.childFolderURL(folderName: moduleName)
   }
 
-  public func inputConfig(fromSourceRoot sourceRootURL: Foundation.URL) -> ApolloCodegenConfiguration.FileInput {
+  public func inputConfig(
+    fromSourceRoot sourceRootURL: Foundation.URL
+  ) -> ApolloCodegenConfiguration.FileInput {
     let targetRootURL = self.targetRootURL(fromSourceRoot: sourceRootURL)
     let graphQLFolder = graphQLFolder(fromTargetRoot: targetRootURL)
 
     switch self {
-    case .upload, .starWars, .subscription:
-      return ApolloCodegenConfiguration.FileInput(
-        schemaPath: schemaURL(fromTargetRoot: targetRootURL).path,
-        operationSearchPaths: [graphQLFolder.appendingPathComponent("**/*.graphql").path]
-      )
-      
-//    case .gitHub:
-//      let outputFileURL = try!  targetRootURL.apollo.childFileURL(fileName: "API.swift")
-//
-//      let schema = try! graphQLFolderURL.apollo.childFileURL(fileName: "schema.docs.graphql")
-//      let operationIDsURL = try! graphQLFolderURL.apollo.childFileURL(fileName: "operationIDs.json")
-//      return ApolloCodegenOptions(includes: "graphql/Queries/**/*.graphql",
-//                                  mergeInFieldsFromFragmentSpreads: true,
-//                                  operationIDsURL: operationIDsURL,
-//                                  outputFormat: .singleFile(atFileURL: outputFileURL),
-//                                  suppressSwiftMultilineStringLiterals: true,
-//                                  urlToSchemaFile: schema)
     case .animalKingdom:
       return ApolloCodegenConfiguration.FileInput(
         schemaPath: graphQLFolder.appendingPathComponent("AnimalSchema.graphqls").path,
-        // There is a subdirectory that contains CCN enabled operations in the same `graphQLFolder` as
-        //   the .animalKingdom target. We want to include those operations when we generate for
-        //   .animalKingdom.
+        // There is a subdirectory that contains CCN enabled operations in the same `graphQLFolder`
+        // as the .animalKingdom target. We want to include those operations when we generate for
+        // .animalKingdom.
+        operationSearchPaths: [graphQLFolder.appendingPathComponent("**/*.graphql").path]
+      )
+
+    default:
+      return ApolloCodegenConfiguration.FileInput(
+        schemaPath: schemaURL(fromTargetRoot: targetRootURL).path,
         operationSearchPaths: [graphQLFolder.appendingPathComponent("**/*.graphql").path]
       )
     }
@@ -97,8 +63,10 @@ public enum Target: CaseIterable {
     switch self {
     case .starWars:
       return targetRootURL.apollo.childFolderURL(folderName: "starwars-graphql")
+
     case .animalKingdom:
       return targetRootURL.apollo.childFolderURL(folderName: "animalkingdom-graphql")
+
     default:
       return targetRootURL.apollo.childFolderURL(folderName: "graphql")
     }
@@ -108,14 +76,14 @@ public enum Target: CaseIterable {
     let graphQLFolder = graphQLFolder(fromTargetRoot: targetRootURL)
 
     switch self {
-    case .starWars, .subscription:
-      return graphQLFolder.appendingPathComponent("schema.graphqls")
     case .upload:
       return graphQLFolder.appendingPathComponent("schema.json")
-//    case .gitHub:
-//      fatalError("Implement!")
+
     case .animalKingdom:
       return graphQLFolder.appendingPathComponent("AnimalSchema.graphqls")
+
+    default:
+      return graphQLFolder.appendingPathComponent("schema.graphqls")
     }
   }
 
@@ -141,7 +109,7 @@ public enum Target: CaseIterable {
 
   private var includeOperationIdentifiers: Bool {
     switch self {
-    case .upload, .starWars: return true
+    case .upload, .starWars, .gitHub: return true
     default: return false
     }
   }
@@ -155,27 +123,17 @@ public enum Target: CaseIterable {
 
   public func options() -> ApolloCodegenConfiguration.OutputOptions {
     switch self {
-    case .starWars:
-      return .init(schemaDocumentation: .include, apqs: .automaticallyPersist)
-
-    case .animalKingdom:
-      return .init(schemaDocumentation: .include)
-      
-    default:
-      return .init()
+    case .starWars: return .init(schemaDocumentation: .include, apqs: .automaticallyPersist)
+    case .animalKingdom: return .init(schemaDocumentation: .include)
+    default: return .init()
     }
   }
 
   public func experimentalFeatures() -> ApolloCodegenConfiguration.ExperimentalFeatures {
     switch self {
-    case .starWars:
-      return .init(legacySafelistingCompatibleOperations: true)
-
-    case .animalKingdom:
-      return .init(clientControlledNullability: true)
-
-    default:
-      return .init()
+    case .starWars: return .init(legacySafelistingCompatibleOperations: true)
+    case .animalKingdom: return .init(clientControlledNullability: true)
+    default: return .init()
     }
   }
 }


### PR DESCRIPTION
Closes #2118 

_There will be a second PR based on this one that updates the generated code for internal APIs._

This PR brings SwiftScripts up-to-date with codegen 1.0:
* Removes the ability to download a schema from Apollo Registry; we have no internal APIs that require this.
* Updates local service (Upload, Subscription, StarWars) URLs for schema downloads.
* Re-enables the GitHub target
* Updates the README to actually be useful