### PR TITLE
Include deprecated args and inputFields

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -200,7 +200,7 @@ public struct ApolloSchemaDownloader {
           fields(includeDeprecated: true) {
             name
             description
-            args {
+            args(includeDeprecated: true) {
               ...InputValue
             }
             type {
@@ -209,7 +209,7 @@ public struct ApolloSchemaDownloader {
             isDeprecated
             deprecationReason
           }
-          inputFields {
+          inputFields(includeDeprecated: true) {
             ...InputValue
           }
           interfaces {

--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -230,6 +230,8 @@ public struct ApolloSchemaDownloader {
           description
           type { ...TypeRef }
           defaultValue
+          isDeprecated
+          deprecationReason
         }
         fragment TypeRef on __Type {
           kind


### PR DESCRIPTION
Noticed that deprecated args and inputFields were not being generated from introspection.