### PR TITLE
fix: checkout starwars-server repo at tag with legacy optionals behavior

### DIFF
--- a/scripts/install-or-update-starwars-server.sh
+++ b/scripts/install-or-update-starwars-server.sh
@@ -3,6 +3,7 @@
 cd $(dirname "$0")/../..
 
 git -C starwars-server pull || git clone https://github.com/apollographql/starwars-server
+git -C starwars-server checkout 0.x-legacy-optionals
 
 cd starwars-server
 


### PR DESCRIPTION
Closes #2413 

Turns out when I [updated](https://github.com/apollographql/starwars-server/commit/29d51889d64281c0e71854330d582b9ad0432a59) the starwars-server code to correctly handle GraphQLNullable it broke it for `main`. 🤦🏻‍♂️ 

This fix simply does a checkout at the previous commit, tagged as `0.x-legacy-optionals` to get back to the legacy behavior for `main`.