### PR TITLE
feat: Builds CLI locally on CocoaPods installs

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -1,24 +1,27 @@
 Pod::Spec.new do |s|
-  s.name         = 'Apollo'
-  s.version      = `scripts/get-version.sh`
-  s.author       = 'Meteor Development Group'
-  s.homepage     = 'https://github.com/apollographql/apollo-ios'
-  s.license      = { :type => 'MIT', :file => 'LICENSE' }
-
-  s.summary      = "A GraphQL client for iOS, written in Swift."
-
-  s.source       = { :git => 'https://github.com/apollographql/apollo-ios.git', :tag => s.version }
-
+  s.name = 'Apollo'
+  s.version = `scripts/get-version.sh`
+  s.author = 'Meteor Development Group'
+  s.homepage = 'https://github.com/apollographql/apollo-ios'
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.summary = "A GraphQL client for iOS, written in Swift."
+  s.source = { :git => 'https://github.com/apollographql/apollo-ios.git', :tag => s.version }
   s.requires_arc = true
-
   s.swift_version = '5.0'
-
   s.default_subspecs = 'Core'
-
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.14'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '5.0'
+
+  cli_directory = 'CodegenCLI'
+  cli_binary_name = 'apollo-ios-cli'
+  s.preserve_paths = ['CodegenCLI/**/*', cli_binary_name]
+  s.prepare_command = <<-CMD
+    make --directory=CodegenCLI
+    cp #{cli_directory}/.build/release/#{cli_binary_name} #{cli_binary_name}
+    chmod +x #{cli_binary_name}
+  CMD
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'Sources/Apollo/*.swift','Sources/ApolloAPI/*.swift'

--- a/CodegenCLI/makefile
+++ b/CodegenCLI/makefile
@@ -1,0 +1,15 @@
+.PHONY: clean wipe build test
+
+default: clean build
+
+clean: 
+	swift package clean
+
+wipe: 
+	rm -rf .build
+
+build: 
+	swift build -c release
+
+test: 
+	swift test


### PR DESCRIPTION
PR 1 of #2381

This change is to ensure that the CLI and ApolloCodegenLib are the same version. It does this by simply building the CLI locally during a CocoaPods installation.

To manually test this do the following:
1. Create an Xcode project
2. Use `pod init` to create a Podfile and use `pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios', :branch => '1.0/versioning-cli-cocoapods'` as the Apollo dependency.
3. After installation you should have a file `apollo-ios-cli` in the `Pods/Apollo` folder.