### PR TITLE
fix: "No such module 'ApolloAPI'"

### DIFF
--- a/Apollo.podspec
+++ b/Apollo.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   CMD
 
   s.subspec 'Core' do |ss|
-    ss.source_files = 'Sources/Apollo/*.swift','Sources/ApolloAPI/*.swift'
+    ss.source_files = 'Sources/Apollo/*.swift','Sources/ApolloAPI/**/*.swift'
   end
 
   # Apollo provides exactly one persistent cache out-of-the-box, as a reasonable default choice for

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -259,7 +259,7 @@ public class ApolloStore {
       )
     }
 
-    public func updateObject<SelectionSet: ApolloAPI.MutableRootSelectionSet>(
+    public func updateObject<SelectionSet: MutableRootSelectionSet>(
       ofType type: SelectionSet.Type,
       withKey key: CacheKey,
       variables: GraphQLOperation.Variables? = nil,

--- a/Sources/Apollo/GraphQLResult.swift
+++ b/Sources/Apollo/GraphQLResult.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if !COCOAPODS
 import ApolloAPI
+#endif
 
 /// Represents the result of a GraphQL operation.
 public struct GraphQLResult<Data: RootSelectionSet> {

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -6,7 +6,7 @@ public enum Selection {
   /// A fragment spread of a named fragment definition.
   case fragment(Fragment.Type)
   /// An inline fragment with a child selection set nested in a parent selection set.
-  case inlineFragment(ApolloAPI.InlineFragment.Type)
+  case inlineFragment(InlineFragment.Type)
   /// A group of selections that have `@include/@skip` directives.
   case conditional(Conditions, [Selection])
 

--- a/Sources/ApolloTestSupport/Field.swift
+++ b/Sources/ApolloTestSupport/Field.swift
@@ -1,4 +1,6 @@
+#if !COCOAPODS
 import ApolloAPI
+#endif
 
 @propertyWrapper
 public struct Field<T> {

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -1,4 +1,6 @@
+#if !COCOAPODS
 @_exported import ApolloAPI
+#endif
 import Foundation
 
 @dynamicMemberLookup

--- a/Tests/ApolloTests/ParseQueryResponseTests.swift
+++ b/Tests/ApolloTests/ParseQueryResponseTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Apollo
 import ApolloAPI
 import ApolloInternalTestHelpers
+import ApolloAPI
 
 class ParseQueryResponseTests: XCTestCase {
 

--- a/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
@@ -3,6 +3,7 @@ import Apollo
 import ApolloAPI
 import ApolloInternalTestHelpers
 @testable import ApolloWebSocket
+import ApolloAPI
 
 class WebSocketTransportTests: XCTestCase {
 


### PR DESCRIPTION
Closes #2418 

Fixes a couple recent bugs:
1. Don't import ApolloAPI if the environment is CocoaPods
2. ApolloAPI subfolder source files should be included in the podspec
3. Remove duplicate typealias definitions and import ApolloAPI in the modules where those definitions are needed