### PR TITLE
Fix issues 1918 and 2129 by websocket disconnect forceTimeout

### DIFF
--- a/Sources/ApolloTestSupport/MockWebSocket.swift
+++ b/Sources/ApolloTestSupport/MockWebSocket.swift
@@ -29,7 +29,7 @@ public class MockWebSocket: WebSocketClient {
   open func write(ping: Data, completion: (() -> ())?) {
   }
 
-  public func disconnect() {
+  public func disconnect(forceTimeout: TimeInterval?) {
   }
   
   public func connect() {

--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -290,8 +290,8 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
     }
   }
 
-  public func disconnect() {
-    self.disconnect(forceTimeout: nil, closeCode: CloseCode.normal.rawValue)
+  public func disconnect(forceTimeout: TimeInterval? = nil) {
+    self.disconnect(forceTimeout: forceTimeout, closeCode: CloseCode.normal.rawValue)
   }
 
   /**

--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -261,14 +261,22 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
   }
 
   /**
-   Disconnect from the server. I send a Close control frame to the server, then expect the server to respond with a Close control frame and close the socket from its end. I notify my delegate once the socket has been closed.
+   Disconnect from the server. Send a Close control frame to the server, then expect the server to
+   respond with a Close control frame and close the socket from its end. Notify the delegate once
+   the socket has been closed.
 
-   If you supply a non-nil `forceTimeout`, I wait at most that long (in seconds) for the server to close the socket. After the timeout expires, I close the socket and notify my delegate.
+   If `forceTimeout` > 0, wait at most that long (in seconds) for the server to close the socket.
+   After the timeout expires, close the socket (without sending a Close control frame) and notify
+   the delegate.
 
-   If you supply a zero (or negative) `forceTimeout`, I immediately close the socket (without sending a Close control frame) and notify my delegate.
+   If `forceTimeout` <= 0, immediately close the socket (without sending a Close control frame)
+   and notify the delegate.
+
+   If `forceTimeout` is `nil`, send the Close control frame to the server.
 
    - Parameter forceTimeout: Maximum time to wait for the server to close the socket.
-   - Parameter closeCode: The code to send on disconnect. The default is the normal close code for cleanly disconnecting a webSocket.
+   - Parameter closeCode: The code to send on disconnect. The default is the normal close code for
+   cleanly disconnecting a webSocket.
    */
   func disconnect(
     forceTimeout: TimeInterval? = nil,

--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -298,6 +298,22 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
     }
   }
 
+  /**
+   Disconnect from the server. Send a Close control frame to the server, then expect the server to
+   respond with a Close control frame and close the socket from its end. Notify the delegate once
+   the socket has been closed.
+
+   If `forceTimeout` > 0, wait at most that long (in seconds) for the server to close the socket.
+   After the timeout expires, close the socket (without sending a Close control frame) and notify
+   the delegate.
+
+   If `forceTimeout` <= 0, immediately close the socket (without sending a Close control frame)
+   and notify the delegate.
+
+   If `forceTimeout` is `nil`, send the Close control frame to the server.
+
+   - Parameter forceTimeout: Maximum time to wait for the server to close the socket.
+   */
   public func disconnect(forceTimeout: TimeInterval?) {
     self.disconnect(forceTimeout: forceTimeout, closeCode: CloseCode.normal.rawValue)
   }

--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -298,7 +298,7 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
     }
   }
 
-  public func disconnect(forceTimeout: TimeInterval? = nil) {
+  public func disconnect(forceTimeout: TimeInterval?) {
     self.disconnect(forceTimeout: forceTimeout, closeCode: CloseCode.normal.rawValue)
   }
 

--- a/Sources/ApolloWebSocket/WebSocketClient.swift
+++ b/Sources/ApolloWebSocket/WebSocketClient.swift
@@ -23,7 +23,7 @@ public protocol WebSocketClient: AnyObject {
   func connect()
 
   /// Disconnects from the websocket server.
-  func disconnect()
+  func disconnect(forceTimeout: TimeInterval?)
 
   /// Writes ping data to the websocket.
   func write(ping: Data, completion: (() -> Void)?)

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -269,7 +269,7 @@ public class WebSocketTransport {
   }
 
   deinit {
-    websocket.disconnect()
+    websocket.disconnect(forceTimeout: nil)
     self.websocket.delegate = nil
   }
 
@@ -343,7 +343,7 @@ public class WebSocketTransport {
     let oldReconnectValue = reconnect.value
     self.reconnect.mutate { $0 = false }
 
-    self.websocket.disconnect()
+    self.websocket.disconnect(forceTimeout: 0)
     self.websocket.connect()
 
     self.reconnect.mutate { $0 = oldReconnectValue }
@@ -352,10 +352,11 @@ public class WebSocketTransport {
   /// Disconnects the websocket while setting the auto-reconnect value to false,
   /// allowing purposeful disconnects that do not dump existing subscriptions.
   /// NOTE: You will receive an error on the subscription (should be a `WebSocket.WSError` with code 1000) when the socket disconnects.
+  /// ALSO NOTE: In case pauseWebSocketConnection is called when app is backgrounded, app might get suspended within 5 seconds. In case disconnect did not complete within that time, websocket won't resume properly. That is why forceTimeout is set to 2 seconds.
   /// ALSO NOTE: To reconnect after calling this, you will need to call `resumeWebSocketConnection`.
   public func pauseWebSocketConnection() {
     self.reconnect.mutate { $0 = false }
-    self.websocket.disconnect()
+    self.websocket.disconnect(forceTimeout: 2.0)
   }
   
   /// Reconnects a paused web socket.


### PR DESCRIPTION
This fixes problem mentioned in issue, https://github.com/apollographql/apollo-ios/issues/1918
I also have been able to reproduce this by calling pauseWebSocketConnection() when app is going to background.
Like mentioned in comment https://github.com/apollographql/apollo-ios/issues/1918#issuecomment-1012505222

Issue https://github.com/apollographql/apollo-ios/issues/2129 is fixed by calling disconnect with timeout of 0:
    
`self.websocket.disconnect(forceTimeout: 0)`

Timeout of 0 is required since 
`self.websocket.connect()`
Is called on the immediately following code line and this is unreliable if connection has not closed.

I don't really know how to write unit test for these issues.