### PR TITLE
Fix crash in codegen compiler for #2434

### DIFF
--- a/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
@@ -468,7 +468,7 @@ extension IR.EntitySelectionTree.EnclosingEntityNode {
       let fragmentType = fragment.typeInfo.parentType
       let nextNode = nodeRootType == fragmentType ?
       self.childAsEnclosingEntityNode() :
-      self.scopeConditionNode(for: IR.ScopeCondition(type: fragmentType))
+      self.scopeConditionNode(for: IR.ScopeCondition(type: fragmentType)).childAsEnclosingEntityNode()
 
       nextNode.mergeIn(
         otherNextNode,


### PR DESCRIPTION
This happens in a very specific edge case when merging nested fragments with inline fragments on non matching parent types. Closes #2434 