### PR TITLE
tests: Fix CodegenCLI skipped tests

### DIFF
--- a/Sources/CodegenCLI/Commands/Initialize.swift
+++ b/Sources/CodegenCLI/Commands/Initialize.swift
@@ -34,17 +34,19 @@ struct Initialize: ParsableCommand {
 
   // MARK: - Implementation
 
+  typealias OutputClosure = ((String) -> ())
+
   func run() throws {
     try _run()
   }
 
-  func _run(fileManager: ApolloFileManager = .default) throws {
+  func _run(fileManager: ApolloFileManager = .default, output: OutputClosure? = nil) throws {
     let encoded = try ApolloCodegenConfiguration
       .default
       .encoded()
 
     if print {
-      try print(data: encoded)
+      try print(data: encoded, output: output)
       return
     }
 
@@ -52,7 +54,8 @@ struct Initialize: ParsableCommand {
       data: encoded,
       toPath: path,
       overwrite: overwrite,
-      fileManager: fileManager
+      fileManager: fileManager,
+      output: output
     )
   }
 
@@ -60,7 +63,8 @@ struct Initialize: ParsableCommand {
     data: Data,
     toPath path: String,
     overwrite: Bool,
-    fileManager: ApolloFileManager
+    fileManager: ApolloFileManager,
+    output: OutputClosure? = nil
   ) throws {
     if !overwrite && fileManager.doesFileExist(atPath: path) {
       throw Error(
@@ -76,17 +80,25 @@ struct Initialize: ParsableCommand {
       data: data
     )
 
-    Swift.print("New configuration output to \(path).")
+    print(message: "New configuration output to \(path).", output: output)
   }
 
-  private func print(data: Data) throws {
+  private func print(data: Data, output: OutputClosure? = nil) throws {
     guard let json = String(data: data, encoding: .utf8) else {
       throw Error(
         errorDescription: "Could not print the configuration, the JSON was not valid UTF-8."
       )
     }
 
-    Swift.print(json)
+    print(message: json, output: output)
+  }
+
+  private func print(message: String, output: OutputClosure? = nil) {
+    if let output = output {
+      output(message)
+    } else {
+      Swift.print(message)
+    }
   }
 }
 

--- a/Tests/CodegenCLITests/Commands/InitializeTests.swift
+++ b/Tests/CodegenCLITests/Commands/InitializeTests.swift
@@ -281,61 +281,42 @@ class InitializeTests: XCTestCase {
   }
 
   func test__output__givenParameters_printTrue_shouldPrintToStandardOutput() throws {
-    throw XCTSkip("this needs to be fixed once the executable target is created")
-
     // given
-    let executable = TestSupport.productsDirectory.appendingPathComponent("apollo-ios-cli")
-
-    let subject = Process()
-    subject.executableURL = executable
-    subject.arguments = [
+    let options = [
       "--print"
     ]
 
-    let pipe = Pipe()
-    subject.standardOutput = pipe
+    let command = try parse(options)
 
     // when
-    try subject.run()
-    subject.waitUntilExit()
-
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-
-    // Printing to STDOUT appends a newline
-    let expected = expectedJSON + "\n"
+    var output: String?
+    try command._run() { message in
+      output = message
+    }
 
     // then
-    expect(data.asString).to(equal(expected))
+    expect(output).toEventuallyNot(beNil())
+    expect(output).to(equal(expectedJSON))
   }
 
   func test__output__givenParameters_bothPathAndPrint_shouldPrintToStandardOutput() throws {
-    throw XCTSkip("this needs to be fixed once the executable target is created")
-
     // given
-    let executable = TestSupport.productsDirectory.appendingPathComponent("apollo-ios-cli")
-
-    let subject = Process()
-    subject.executableURL = executable
-    subject.arguments = [
-      "init",
+    let options = [
       "--path=./path/to/file",
       "--print"
     ]
 
-    let pipe = Pipe()
-    subject.standardOutput = pipe
+    let command = try parse(options)
 
     // when
-    try subject.run()
-    subject.waitUntilExit()
-
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-
-    // Printing to STDOUT appends a newline
-    let expected = expectedJSON + "\n"
+    var output: String?
+    try command._run() { message in
+      output = message
+    }
 
     // then
-    expect(data.asString).to(equal(expected))
+    expect(output).toEventuallyNot(beNil())
+    expect(output).to(equal(expectedJSON))
   }
 }
 


### PR DESCRIPTION
Provides an optional closure to receive output from the `Initialize` command; if not provided then the output is written to `Swift.print`.

Related of #2381.