### PR TITLE
Fixed String jsonValue initialiser for large numbers

### DIFF
--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -15,6 +15,8 @@ extension String: JSONDecodable, JSONEncodable {
         self = string
     case let int as Int:
       self = String(int)
+    case let int64 as Int64:
+      self = String(int)
     case let double as Double:
       self = String(double)
     default:

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -16,7 +16,7 @@ extension String: JSONDecodable, JSONEncodable {
     case let int as Int:
       self = String(int)
     case let int64 as Int64:
-      self = String(int)
+      self = String(int64)
     case let double as Double:
       self = String(double)
     default:

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -145,7 +145,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     class GivenSelectionSet: MockSelectionSet {
       override class var selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
     }
-    let object: JSONObject = ["customScalar": Int64(12345678)]
+    let object: JSONObject = ["customScalar": Int64(989561700)]
 
     // when
     let data = try readValues(GivenSelectionSet.self, from: object)

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -138,6 +138,22 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     XCTAssertEqual(data.customScalar, "12345678")
   }
 
+  func test__nonnull_customScalar_asString__givenDataAsInt64_getsValue() throws {
+    // given
+    typealias GivenCustomScalar = String
+
+    class GivenSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
+    }
+    let object: JSONObject = ["customScalar": Int64(12345678)]
+
+    // when
+    let data = try readValues(GivenSelectionSet.self, from: object)
+
+    // then
+    XCTAssertEqual(data.customScalar, "989561700")
+  }
+
   func test__nonnull_customScalar_asString__givenDataAsDouble_getsValue() throws {
     // given
     typealias GivenCustomScalar = String


### PR DESCRIPTION
Large numbers is interpreted as Int64 instead of just Int (in my case is was timestamps). In this case parsing to string would fail.