### PR TITLE
Fixed casing for lowercase starting types

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/ObjectTemplate.swift
@@ -14,7 +14,7 @@ struct ObjectTemplate: TemplateRenderer {
     """
     \(documentation: graphqlObject.documentation, config: config)
     static let \(graphqlObject.name.firstUppercased) = Object(
-      typename: "\(graphqlObject.name.firstUppercased)\",
+      typename: "\(graphqlObject.name)\",
       implementedInterfaces: \(ImplementedInterfacesTemplate())
     )
     """

--- a/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -61,7 +61,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
     public static func objectType(forTypename typename: String) -> Object? {
       switch typename {
       \(schema.referencedTypes.objects.map {
-        "case \"\($0.name.firstUppercased)\": return \(schemaName).Objects.\($0.name.firstUppercased)"
+        "case \"\($0.name)\": return \(schemaName).Objects.\($0.name.firstUppercased)"
       }, separator: "\n")
       default: return nil
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/ObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/ObjectTemplateTests.swift
@@ -56,7 +56,7 @@ class ObjectTemplateTests: XCTestCase {
 
     let expected = """
     static let Dog = Object(
-      typename: "Dog",
+      typename: "dog",
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
@@ -303,9 +303,9 @@ class SchemaMetadataTemplateTests: XCTestCase {
     let expected = """
       public static func objectType(forTypename typename: String) -> Object? {
         switch typename {
-        case "ObjA": return ObjectSchema.Objects.ObjA
-        case "ObjB": return ObjectSchema.Objects.ObjB
-        case "ObjC": return ObjectSchema.Objects.ObjC
+        case "objA": return ObjectSchema.Objects.ObjA
+        case "objB": return ObjectSchema.Objects.ObjB
+        case "objC": return ObjectSchema.Objects.ObjC
         default: return nil
         }
       }


### PR DESCRIPTION
Strings here should actually remain lowercase for those types. That is because this strings are used to compare them against __typename field when parsing, currently they would not parse