### PR TITLE
Optionally include deprecated inputs

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
@@ -9,7 +9,7 @@ public struct ApolloSchemaDownloadConfiguration {
     /// The Apollo Schema Registry, which serves as a central hub for managing your graph.
     case apolloRegistry(_ settings: ApolloRegistrySettings)
     /// GraphQL Introspection connecting to the specified URL.
-    case introspection(endpointURL: URL, httpMethod: HTTPMethod = .POST)
+    case introspection(endpointURL: URL, httpMethod: HTTPMethod = .POST, includeDeprecatedInputValues: Bool = false)
 
     public struct ApolloRegistrySettings: Equatable {
       /// The API key to use when retrieving your schema from the Apollo Registry.
@@ -55,8 +55,8 @@ public struct ApolloSchemaDownloadConfiguration {
     
     public static func == (lhs: DownloadMethod, rhs: DownloadMethod) -> Bool {
       switch (lhs, rhs) {
-      case (.introspection(let lhsURL, let lhsHTTPMethod), .introspection(let rhsURL, let rhsHTTPMethod)):
-        return lhsURL == rhsURL && lhsHTTPMethod == rhsHTTPMethod
+      case (.introspection(let lhsURL, let lhsHTTPMethod, let lhsIncludeDeprecatedInputValues), .introspection(let rhsURL, let rhsHTTPMethod, let rhsIncludeDeprecatedInputValues)):
+        return lhsURL == rhsURL && lhsHTTPMethod == rhsHTTPMethod && lhsIncludeDeprecatedInputValues == rhsIncludeDeprecatedInputValues
       case (.apolloRegistry(let lhsSettings), .apolloRegistry(let rhsSettings)):
         return lhsSettings == rhsSettings
       default:

--- a/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
@@ -63,7 +63,35 @@ class ApolloSchemaInternalTests: XCTestCase {
     XCTAssertNotNil(components?.url)
     XCTAssertEqual(request.url, components?.url)
   }
+  
+  func testRequest_givenIntrospectionGETDownload_andIncludeDeprecatedInputValues_shouldOutputGETRequest() throws {
+    let url = ApolloTestSupport.TestURL.mockServer.url
+    let queryParameterName = "customParam"
+    let headers: [ApolloSchemaDownloadConfiguration.HTTPHeader] = [
+      .init(key: "key1", value: "value1"),
+      .init(key: "key2", value: "value2")
+    ]
 
+    let request = try ApolloSchemaDownloader.introspectionRequest(from: url,
+                                                                  httpMethod: .GET(queryParameterName: queryParameterName),
+                                                                  includeDeprecatedInputValues: true,
+                                                                  headers: headers)
+
+    XCTAssertEqual(request.httpMethod, "GET")
+    XCTAssertNil(request.httpBody)
+
+    XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
+    for header in headers {
+      XCTAssertEqual(request.allHTTPHeaderFields?[header.key], header.value)
+    }
+
+    var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+    components?.queryItems = [URLQueryItem(name: queryParameterName, value: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: true))]
+
+    XCTAssertNotNil(components?.url)
+    XCTAssertEqual(request.url, components?.url)
+  }
+  
   func testRequest_givenIntrospectionPOSTDownload_shouldOutputPOSTRequest() throws {
     let url = ApolloTestSupport.TestURL.mockServer.url
     let headers: [ApolloSchemaDownloadConfiguration.HTTPHeader] = [
@@ -71,7 +99,10 @@ class ApolloSchemaInternalTests: XCTestCase {
       .init(key: "key2", value: "value2")
     ]
 
-    let request = try ApolloSchemaDownloader.introspectionRequest(from: url, httpMethod: .POST, includeDeprecatedInputValues: false, headers: headers)
+    let request = try ApolloSchemaDownloader.introspectionRequest(from: url,
+                                                                  httpMethod: .POST,
+                                                                  includeDeprecatedInputValues: false,
+                                                                  headers: headers)
 
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(request.url, url)
@@ -82,6 +113,34 @@ class ApolloSchemaInternalTests: XCTestCase {
     }
 
     let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: false),
+                                                                   variables: nil,
+                                                                   operationName: "IntrospectionQuery")
+    let bodyData = try JSONSerialization.data(withJSONObject: requestBody, options: [.sortedKeys])
+
+    XCTAssertEqual(request.httpBody, bodyData)
+  }
+  
+  func testRequest_givenIntrospectionPOSTDownload_andIncludeDeprecatedInputValues_shouldOutputPOSTRequest() throws {
+    let url = ApolloTestSupport.TestURL.mockServer.url
+    let headers: [ApolloSchemaDownloadConfiguration.HTTPHeader] = [
+      .init(key: "key1", value: "value1"),
+      .init(key: "key2", value: "value2")
+    ]
+
+    let request = try ApolloSchemaDownloader.introspectionRequest(from: url,
+                                                                  httpMethod: .POST,
+                                                                  includeDeprecatedInputValues: true,
+                                                                  headers: headers)
+
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url, url)
+
+    XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
+    for header in headers {
+      XCTAssertEqual(request.allHTTPHeaderFields?[header.key], header.value)
+    }
+
+    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: true),
                                                                    variables: nil,
                                                                    operationName: "IntrospectionQuery")
     let bodyData = try JSONSerialization.data(withJSONObject: requestBody, options: [.sortedKeys])

--- a/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
@@ -46,6 +46,7 @@ class ApolloSchemaInternalTests: XCTestCase {
 
     let request = try ApolloSchemaDownloader.introspectionRequest(from: url,
                                                                   httpMethod: .GET(queryParameterName: queryParameterName),
+                                                                  includeDeprecatedInputValues: false,
                                                                   headers: headers)
 
     XCTAssertEqual(request.httpMethod, "GET")
@@ -57,7 +58,7 @@ class ApolloSchemaInternalTests: XCTestCase {
     }
 
     var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    components?.queryItems = [URLQueryItem(name: queryParameterName, value: ApolloSchemaDownloader.IntrospectionQuery)]
+    components?.queryItems = [URLQueryItem(name: queryParameterName, value: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: false))]
 
     XCTAssertNotNil(components?.url)
     XCTAssertEqual(request.url, components?.url)
@@ -70,7 +71,7 @@ class ApolloSchemaInternalTests: XCTestCase {
       .init(key: "key2", value: "value2")
     ]
 
-    let request = try ApolloSchemaDownloader.introspectionRequest(from: url, httpMethod: .POST, headers: headers)
+    let request = try ApolloSchemaDownloader.introspectionRequest(from: url, httpMethod: .POST, includeDeprecatedInputValues: false, headers: headers)
 
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(request.url, url)
@@ -80,7 +81,7 @@ class ApolloSchemaInternalTests: XCTestCase {
       XCTAssertEqual(request.allHTTPHeaderFields?[header.key], header.value)
     }
 
-    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: ApolloSchemaDownloader.IntrospectionQuery,
+    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: false),
                                                                    variables: nil,
                                                                    operationName: "IntrospectionQuery")
     let bodyData = try JSONSerialization.data(withJSONObject: requestBody, options: [.sortedKeys])


### PR DESCRIPTION
Following up on https://github.com/apollographql/apollo-ios/pull/2394

Will create a PR for v1.x when merged too.

Looking for a steer on where you'd like to include this in the documentation.