### PR TITLE
feat: Add `--verbose` parameter to CLI

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -466,6 +466,8 @@
 		E6203346284F252A00A291D1 /* MockUnionsFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6203345284F252A00A291D1 /* MockUnionsFileGeneratorTests.swift */; };
 		E6203348284F25DF00A291D1 /* MockUnionsTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6203347284F25DF00A291D1 /* MockUnionsTemplateTests.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
+		E64F226D28B8B3FE0011292F /* LogLevelSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F226C28B8B3FE0011292F /* LogLevelSetter.swift */; };
+		E64F227128B8BEE10011292F /* MockLogLevelSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F227028B8BEE10011292F /* MockLogLevelSetter.swift */; };
 		E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB727A0854E0059C021 /* UnionTemplate.swift */; };
 		E64F7EBA27A085D90059C021 /* UnionTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */; };
 		E64F7EBC27A11A510059C021 /* GraphQLNamedType+SwiftName.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EBB27A11A510059C021 /* GraphQLNamedType+SwiftName.swift */; };
@@ -1593,6 +1595,8 @@
 		E6203347284F25DF00A291D1 /* MockUnionsTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUnionsTemplateTests.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
+		E64F226C28B8B3FE0011292F /* LogLevelSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevelSetter.swift; sourceTree = "<group>"; };
+		E64F227028B8BEE10011292F /* MockLogLevelSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogLevelSetter.swift; sourceTree = "<group>"; };
 		E64F7EB727A0854E0059C021 /* UnionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplate.swift; sourceTree = "<group>"; };
 		E64F7EB927A085D90059C021 /* UnionTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionTemplateTests.swift; sourceTree = "<group>"; };
 		E64F7EBB27A11A510059C021 /* GraphQLNamedType+SwiftName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLNamedType+SwiftName.swift"; sourceTree = "<group>"; };
@@ -3625,6 +3629,7 @@
 			isa = PBXGroup;
 			children = (
 				E687B3D928B398E600A9551C /* CodegenProvider.swift */,
+				E64F226C28B8B3FE0011292F /* LogLevelSetter.swift */,
 				E687B3DA28B398E600A9551C /* SchemaDownloadProvider.swift */,
 			);
 			path = Protocols;
@@ -3951,6 +3956,7 @@
 				E6DC0ACD28B3AC490064A68F /* TestSupport.swift */,
 				E6DC0ACE28B3AC490064A68F /* MockApolloSchemaDownloader.swift */,
 				E6DC0ACF28B3AC490064A68F /* MockFileManager.swift */,
+				E64F227028B8BEE10011292F /* MockLogLevelSetter.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -5645,6 +5651,7 @@
 				E687B3DF28B398E600A9551C /* ParsableCommand+RootOutputURL.swift in Sources */,
 				E687B3E028B398E600A9551C /* FileManager+Data.swift in Sources */,
 				E687B3E828B398E600A9551C /* SchemaDownloadProvider.swift in Sources */,
+				E64F226D28B8B3FE0011292F /* LogLevelSetter.swift in Sources */,
 				E687B3E428B398E600A9551C /* Initialize.swift in Sources */,
 				E687B3E128B398E600A9551C /* String+Data.swift in Sources */,
 				E687B3DD28B398E600A9551C /* InputOptions.swift in Sources */,
@@ -5658,6 +5665,7 @@
 			files = (
 				E6DC0ADF28B3AC490064A68F /* ErrorMatchers.swift in Sources */,
 				E6DC0ADD28B3AC490064A68F /* GenerateTests.swift in Sources */,
+				E64F227128B8BEE10011292F /* MockLogLevelSetter.swift in Sources */,
 				E6DC0ADA28B3AC490064A68F /* MockApolloSchemaDownloader.swift in Sources */,
 				E6DC0AD928B3AC490064A68F /* TestSupport.swift in Sources */,
 				E6DC0AD728B3AC490064A68F /* MockApolloCodegen.swift in Sources */,

--- a/Sources/CodegenCLI/Commands/FetchSchema.swift
+++ b/Sources/CodegenCLI/Commands/FetchSchema.swift
@@ -23,8 +23,11 @@ public struct FetchSchema: ParsableCommand {
 
   func _run(
     fileManager: FileManager = .default,
-    schemaDownloadProvider: SchemaDownloadProvider.Type = ApolloSchemaDownloader.self
+    schemaDownloadProvider: SchemaDownloadProvider.Type = ApolloSchemaDownloader.self,
+    logger: LogLevelSetter.Type = CodegenLogger.self
   ) throws {
+    logger.SetLoggingLevel(verbose: inputs.verbose)
+
     switch (inputs.string, inputs.path) {
     case let (.some(string), _):
       try fetchSchema(data: try string.asData(), schemaDownloadProvider: schemaDownloadProvider)
@@ -48,8 +51,6 @@ public struct FetchSchema: ParsableCommand {
         """
       )
     }
-
-    CodegenLogger.level = .warning
 
     try schemaDownloadProvider.fetch(
       configuration: schemaDownloadConfiguration,

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -29,8 +29,11 @@ public struct Generate: ParsableCommand {
   func _run(
     fileManager: FileManager = .default,
     codegenProvider: CodegenProvider.Type = ApolloCodegen.self,
-    schemaDownloadProvider: SchemaDownloadProvider.Type = ApolloSchemaDownloader.self
+    schemaDownloadProvider: SchemaDownloadProvider.Type = ApolloSchemaDownloader.self,
+    logger: LogLevelSetter.Type = CodegenLogger.self
   ) throws {
+    logger.SetLoggingLevel(verbose: inputs.verbose)
+
     switch (inputs.string, inputs.path) {
     case let (.some(string), _):
       try generate(
@@ -55,8 +58,6 @@ public struct Generate: ParsableCommand {
     schemaDownloadProvider: SchemaDownloadProvider.Type
   ) throws {
     let configuration = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: data)
-
-    CodegenLogger.level = .warning
 
     if fetchSchema {
       guard

--- a/Sources/CodegenCLI/OptionGroups/InputOptions.swift
+++ b/Sources/CodegenCLI/OptionGroups/InputOptions.swift
@@ -1,7 +1,5 @@
 import ArgumentParser
 
-#warning("TODO - We should be able to pass `--verbose` to set the `CodegenLogger.level = .debug` instead of the default of `.warning`.")
-
 /// Shared group of common arguments used in commands for input parameters.
 struct InputOptions: ParsableArguments {
   @Option(

--- a/Sources/CodegenCLI/OptionGroups/InputOptions.swift
+++ b/Sources/CodegenCLI/OptionGroups/InputOptions.swift
@@ -18,4 +18,10 @@ struct InputOptions: ParsableArguments {
     help: "Configuration string in JSON format. This option overrides --path."
   )
   var string: String?
+
+  @Flag(
+    name: .shortAndLong,
+    help: "Increase verbosity to include debug output."
+  )
+  var verbose: Bool = false
 }

--- a/Sources/CodegenCLI/Protocols/LogLevelSetter.swift
+++ b/Sources/CodegenCLI/Protocols/LogLevelSetter.swift
@@ -1,0 +1,18 @@
+import ApolloCodegenLib
+
+public protocol LogLevelSetter {
+  static func SetLoggingLevel(verbose: Bool)
+  static func SetLoggingLevel(_ level: CodegenLogger.LogLevel)
+}
+
+extension LogLevelSetter {
+  public static func SetLoggingLevel(verbose: Bool) {
+    SetLoggingLevel(verbose ? .debug : .warning)
+  }
+
+  public static func SetLoggingLevel(_ level: CodegenLogger.LogLevel) {
+    CodegenLogger.level = level
+  }
+}
+
+extension CodegenLogger: LogLevelSetter { }

--- a/Sources/apollo-ios-cli/README.md
+++ b/Sources/apollo-ios-cli/README.md
@@ -36,12 +36,14 @@ OPTIONS:
 ```
 OVERVIEW: Generate Swift source code based on a code generation configuration.
 
-USAGE: apollo-ios-cli generate [--path <path>] [--string <string>] [--fetch-schema]
+USAGE: apollo-ios-cli generate [--path <path>] [--string <string>] [--verbose] [--fetch-schema]
 
 OPTIONS:
-  -p, --path <path>       Read the configuration from a file at the path. --string overrides this option if used together.
-                          (default: ./apollo-codegen-config.json)
+  -p, --path <path>       Read the configuration from a file at the path. --string
+                          overrides this option if used together. (default:
+                          ./apollo-codegen-config.json)
   -s, --string <string>   Configuration string in JSON format. This option overrides --path.
+  -v, --verbose           Increase verbosity to include debug output
   -f, --fetch-schema      Fetch the GraphQL schema before Swift code generation.
   --version               Show the version.
   -h, --help              Show help information.
@@ -51,12 +53,14 @@ OPTIONS:
 ```
 OVERVIEW: Download a GraphQL schema from the Apollo Registry or GraphQL introspection.
 
-USAGE: apollo-ios-cli fetch-schema [--path <path>] [--string <string>]
+USAGE: apollo-ios-cli fetch-schema [--path <path>] [--string <string>] [--verbose]
 
 OPTIONS:
-  -p, --path <path>       Read the configuration from a file at the path. --string overrides this option if used together.
-                          (default: ./apollo-codegen-config.json)
+  -p, --path <path>       Read the configuration from a file at the path. --string
+                          overrides this option if used together. (default:
+                          ./apollo-codegen-config.json)
   -s, --string <string>   Configuration string in JSON format. This option overrides --path.
+  -v, --verbose           Increase verbosity to include debug output
   --version               Show the version.
   -h, --help              Show help information.
 ```

--- a/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
+++ b/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
@@ -220,4 +220,69 @@ class FetchSchemaTests: XCTestCase {
     // then
     expect(didCallFetch).to(beTrue())
   }
+
+  func test__fetchSchema__givenDefaultParameter_verbose_shouldSetLogLevelWarning() throws {
+    // given
+    let mockConfiguration = ApolloCodegenConfiguration.mock()
+
+    let jsonString = String(
+      data: try! JSONEncoder().encode(mockConfiguration),
+      encoding: .utf8
+    )!
+
+    let options = [
+      "--string=\(jsonString)"
+    ]
+
+    MockApolloSchemaDownloader.fetchHandler = { configuration in }
+
+    var level: CodegenLogger.LogLevel?
+    MockLogLevelSetter.levelHandler = { value in
+      level = value
+    }
+
+    // when
+    let command = try parse(options)
+
+    try command._run(
+      schemaDownloadProvider: MockApolloSchemaDownloader.self,
+      logger: CodegenLogger.mock
+    )
+
+    // then
+    expect(level).toEventually(equal(.warning))
+  }
+
+  func test__fetchSchema__givenParameter_verbose_shouldSetLogLevelDebug() throws {
+    // given
+    let mockConfiguration = ApolloCodegenConfiguration.mock()
+
+    let jsonString = String(
+      data: try! JSONEncoder().encode(mockConfiguration),
+      encoding: .utf8
+    )!
+
+    let options = [
+      "--string=\(jsonString)",
+      "--verbose"
+    ]
+
+    MockApolloSchemaDownloader.fetchHandler = { configuration in }
+
+    var level: CodegenLogger.LogLevel?
+    MockLogLevelSetter.levelHandler = { value in
+      level = value
+    }
+
+    // when
+    let command = try parse(options)
+
+    try command._run(
+      schemaDownloadProvider: MockApolloSchemaDownloader.self,
+      logger: CodegenLogger.mock
+    )
+
+    // then
+    expect(level).toEventually(equal(.debug))
+  }
 }

--- a/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
+++ b/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
@@ -21,6 +21,7 @@ class FetchSchemaTests: XCTestCase {
     // then
     expect(command.inputs.path).to(equal(Constants.defaultFilePath))
     expect(command.inputs.string).to(beNil())
+    expect(command.inputs.verbose).to(beFalse())
   }
 
   func test__parsing__givenParameters_pathLongFormat_shouldParse() throws {
@@ -81,6 +82,32 @@ class FetchSchemaTests: XCTestCase {
 
     // then
     expect(command.inputs.string).to(equal(string))
+  }
+
+  func test__parsing__givenParameters_verboseLongFormat_shouldParse() throws {
+    // given
+    let options = [
+      "--verbose"
+    ]
+
+    // when
+    let command = try parse(options)
+
+    // then
+    expect(command.inputs.verbose).to(beTrue())
+  }
+
+  func test__parsing__givenParameters_verboseShortFormat_shouldParse() throws {
+    // given
+    let options = [
+      "-v"
+    ]
+
+    // when
+    let command = try parse(options)
+
+    // then
+    expect(command.inputs.verbose).to(beTrue())
   }
 
   func test__parsing__givenParameters_unknown_shouldThrow() throws {

--- a/Tests/CodegenCLITests/Commands/GenerateTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateTests.swift
@@ -376,4 +376,73 @@ class GenerateTests: XCTestCase {
     expect(didCallBuild).to(beFalse())
     expect(didCallFetch).to(beFalse())
   }
+
+  func test__generate__givenDefaultParameter_verbose_shouldSetLogLevelWarning() throws {
+    // given
+    let mockConfiguration = ApolloCodegenConfiguration.mock()
+
+    let jsonString = String(
+      data: try! JSONEncoder().encode(mockConfiguration),
+      encoding: .utf8
+    )!
+
+    let options = [
+      "--string=\(jsonString)"
+    ]
+
+    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloSchemaDownloader.fetchHandler = { configuration in }
+
+    var level: CodegenLogger.LogLevel?
+    MockLogLevelSetter.levelHandler = { value in
+      level = value
+    }
+
+    // when
+    let command = try parse(options)
+
+    try command._run(
+      codegenProvider: MockApolloCodegen.self,
+      schemaDownloadProvider: MockApolloSchemaDownloader.self,
+      logger: CodegenLogger.mock
+    )
+
+    // then
+    expect(level).toEventually(equal(.warning))
+  }
+
+  func test__generate__givenParameter_verbose_shouldSetLogLevelDebug() throws {
+    // given
+    let mockConfiguration = ApolloCodegenConfiguration.mock()
+
+    let jsonString = String(
+      data: try! JSONEncoder().encode(mockConfiguration),
+      encoding: .utf8
+    )!
+
+    let options = [
+      "--string=\(jsonString)",
+      "--verbose"
+    ]
+
+    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloSchemaDownloader.fetchHandler = { configuration in }
+
+    var level: CodegenLogger.LogLevel?
+    MockLogLevelSetter.levelHandler = { value in
+      level = value
+    }
+
+    // when
+    let command = try parse(options)
+
+    try command._run(
+      codegenProvider: MockApolloCodegen.self,
+      schemaDownloadProvider: MockApolloSchemaDownloader.self,
+      logger: CodegenLogger.mock
+    )
+
+    // then
+    expect(level).toEventually(equal(.debug))
+  }
 }

--- a/Tests/CodegenCLITests/Commands/GenerateTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateTests.swift
@@ -21,6 +21,7 @@ class GenerateTests: XCTestCase {
     // then
     expect(command.inputs.path).to(equal(Constants.defaultFilePath))
     expect(command.inputs.string).to(beNil())
+    expect(command.inputs.verbose).to(beFalse())
   }
 
   func test__parsing__givenParameters_pathLongFormat_shouldParse() throws {
@@ -107,6 +108,32 @@ class GenerateTests: XCTestCase {
 
     // then
     expect(command.fetchSchema).to(beTrue())
+  }
+
+  func test__parsing__givenParameters_verboseLongFormat_shouldParse() throws {
+    // given
+    let options = [
+      "--verbose"
+    ]
+
+    // when
+    let command = try parse(options)
+
+    // then
+    expect(command.inputs.verbose).to(beTrue())
+  }
+
+  func test__parsing__givenParameters_verboseShortFormat_shouldParse() throws {
+    // given
+    let options = [
+      "-v"
+    ]
+
+    // when
+    let command = try parse(options)
+
+    // then
+    expect(command.inputs.verbose).to(beTrue())
   }
 
   func test__parsing__givenParameters_unknown_shouldThrow() throws {

--- a/Tests/CodegenCLITests/Support/MockLogLevelSetter.swift
+++ b/Tests/CodegenCLITests/Support/MockLogLevelSetter.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CodegenCLI
+import ApolloCodegenLib
+
+extension LogLevelSetter {
+  static var mock: LogLevelSetter.Type {
+    MockLogLevelSetter.self
+  }
+}
+
+struct MockLogLevelSetter: LogLevelSetter {
+  static var levelHandler: ((CodegenLogger.LogLevel) -> Void)? = nil
+
+  static func SetLoggingLevel(_ level: CodegenLogger.LogLevel) {
+    guard let levelHandler = levelHandler else {
+      fatalError("You must set levelHandler before calling \(#function)!")
+    }
+
+    levelHandler(level)
+  }
+}


### PR DESCRIPTION
Part of #2381 

Adds a command line parameter to change the level of verbosity in the CLI output for `fetch-schema` and `generate`; the default remains `.warning` but the user can change the level to include debug output (`.debug`)
```
-v, --verbose            Increase verbosity to include debug output
```