### PR TITLE
docs: change command to run-codegen.sh

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -132,7 +132,7 @@ If you're using a tool like Interface Builder or SwiftUI to talk to a module wit
 For example, if you're using something like this to run your code generation for a target called `YourTarget`:
 
 ```
-"${SCRIPT_PATH}"/run-bundled-codegen.sh codegen:generate --target=swift --includes=./**/*.graphql --localSchemaFile="schema.json" API.swift
+"${SCRIPT_PATH}"/run-codegen.sh codegen:generate --target=swift --includes=./**/*.graphql --localSchemaFile="schema.json" API.swift
 ```
 
 Assuming you've set the script to run from `$(SRCROOT)/YourTarget`, you can add `$(SRCROOT)/YourTarget/**/*.graphql` (the path you're running it from + the glob you're passing to the `includes` CLI parameter) to the list of `Input Files` for your Apollo Run Script Build phase. Then, you can add `$(SRCROOT)/YourTarget/API.swift` (the path you're running it from + the output file) to the list of `Output Files`:


### PR DESCRIPTION
there is no `run-bundled-codegen.sh` but `run-codegen.sh` in v1:

https://github.com/apollographql/apollo-ios/blob/1.0.0-beta.2/scripts/run-codegen.sh