### PR TITLE
Update SQLiteSerialization to be an enum

### DIFF
--- a/Sources/ApolloSQLite/SQLiteSerialization.swift
+++ b/Sources/ApolloSQLite/SQLiteSerialization.swift
@@ -6,7 +6,7 @@ import Apollo
 
 private let serializedReferenceKey = "$reference"
 
-final class SQLiteSerialization {
+enum SQLiteSerialization {
   static func serialize(fields: Record.Fields) throws -> Data {
     let jsonObject = try fields.compactMapValues(serialize(fieldValue:))
     return try JSONSerialization.data(withJSONObject: jsonObject, options: [])


### PR DESCRIPTION
The most minor & nittiest of changes, but a `class` with only static properties should be an `enum` so as to prevent un-intended instantiation .