### PR TITLE
Escape swift reserved words for generated enum case name

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -38,13 +38,13 @@ struct EnumTemplate: TemplateRenderer {
       return """
         \(documentation: graphqlEnumValue.documentation, config: config)
         @available(*, deprecated, message: \"\(reason)\")
-        case \(graphqlEnumValue.name)
+        case \(graphqlEnumValue.name.asEnumCaseName)
         """
 
     default:
       return """
         \(documentation: graphqlEnumValue.documentation, config: config)
-        case \(graphqlEnumValue.name)
+        case \(graphqlEnumValue.name.asEnumCaseName)
         """
     }
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -8,6 +8,10 @@ extension String {
     escapeIf(in: SwiftKeywords.FieldAccessorNamesToEscape)
   }
 
+  var asEnumCaseName: String {
+    escapeIf(in: SwiftKeywords.FieldAccessorNamesToEscape)
+  }
+
   var asSelectionSetName: String {
     SwiftKeywords.SelectionSetTypeNamesToSuffix.contains(self) ?
     "\(self)_SelectionSet" : self

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -117,7 +117,8 @@ class EnumTemplateTests: XCTestCase {
       values: [
         ("lower", nil, nil),
         ("UPPER", nil, nil),
-        ("Capitalized", nil, nil)
+        ("Capitalized", nil, nil),
+        ("public", nil, nil)
       ]
     )
 
@@ -126,6 +127,7 @@ class EnumTemplateTests: XCTestCase {
       case lower
       case UPPER
       case Capitalized
+      case `public`
     }
     
     """


### PR DESCRIPTION

This pull request to `release/1.0` branch.

## Abstract
I use apollo-ios codegen version of v1-beta3 and got compile error when genarated enum case name samely swift reserved words. This PR escape swift reserved word for enum case name

## Test
I confirmed to behavior with executing codegen script in my local. And Run UnitTests are passed.

