### PR TITLE
Proposal PR: Add codegen option of EmbedSwiftOptionalInitializer

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -314,7 +314,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     public let enumCaseConvertStrategy: EnumCaseConvertStrategy
 
     /// Option to embed convenience initializer about using `GraphQLNullable`.
-    public let embedNullableVariableConvenienceInitializer: EmbedNullableVariableConvenienceInitializer
+    public let embedSwiftOptionalInitializer: EmbedSwiftOptionalInitializer
 
 >>>>>>> 214fb6f6 (Add option)
     /// Designated initializer.
@@ -337,8 +337,14 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  - enumCaseConvertStrategy: How convert strategy to Swift enum from GraphQL schema.
 =======
     ///  - enumCaseConvertStrategy: How convert strategy to Swift enum from GraphQL schema.
+<<<<<<< HEAD
     ///  - embedNullableVariableConvenienceInitializer: Embed convenience initializer about `GraphQLNullable`
 >>>>>>> 214fb6f6 (Add option)
+||||||| parent of 50f4f75d (Replace to embedSwiftOptionalInitializer)
+    ///  - embedNullableVariableConvenienceInitializer: Embed convenience initializer about `GraphQLNullable`
+=======
+    ///  - embedSwiftOptionalInitializer: Embed convenience initializer about `GraphQLNullable`
+>>>>>>> 50f4f75d (Replace to embedSwiftOptionalInitializer)
     public init(
       additionalInflectionRules: [InflectionRule] = [],
       queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
@@ -346,16 +352,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       schemaDocumentation: Composition = .include,
       apqs: APQConfig = .disabled,
       cocoapodsCompatibleImportStatements: Bool = false,
-<<<<<<< HEAD
-      warningsOnDeprecatedUsage: Composition = .include
-||||||| parent of 214fb6f6 (Add option)
-      warningsOnDeprecatedUsage: Composition = .include,
-      enumCaseConvertStrategy: EnumCaseConvertStrategy = .none
-=======
-      warningsOnDeprecatedUsage: Composition = .include,
-      enumCaseConvertStrategy: EnumCaseConvertStrategy = .none,
-      embedNullableVariableConvenienceInitializer: EmbedNullableVariableConvenienceInitializer = .none
->>>>>>> 214fb6f6 (Add option)
+      warningsondeprecatedusage: composition = .include,
+      embedSwiftOptionalInitializer: EmbedSwiftOptionalInitializer = .none
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
@@ -364,13 +362,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.apqs = apqs
       self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
       self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
-<<<<<<< HEAD
-||||||| parent of 214fb6f6 (Add option)
-      self.enumCaseConvertStrategy = enumCaseConvertStrategy
-=======
-      self.enumCaseConvertStrategy = enumCaseConvertStrategy
-      self.embedNullableVariableConvenienceInitializer = embedNullableVariableConvenienceInitializer
->>>>>>> 214fb6f6 (Add option)
+      self.embedSwiftOptionalInitializer = embedSwiftOptionalInitializer
     }
   }
 
@@ -391,7 +383,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   }
 
   /// Option to embed convenience initializer about using `GraphQLNullable`.
-  public enum EmbedNullableVariableConvenienceInitializer: String, Codable, Equatable {
+  public enum EmbedSwiftOptionalInitializer: String, Codable, Equatable {
     /// No embed.
     case none
     /// Embed convenience initializer to use `GraphQLNullable.null` when passed nil to initilizer.

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -304,19 +304,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// directive.
     public let warningsOnDeprecatedUsage: Composition
 
-<<<<<<< HEAD
-||||||| parent of 214fb6f6 (Add option)
-    /// Strategy of convert to enum from GraphQL schema to swift. `.none` is a default strategy.
-    public let enumCaseConvertStrategy: EnumCaseConvertStrategy
-
-=======
-    /// Strategy of convert to enum from GraphQL schema to swift. `.none` is a default strategy.
-    public let enumCaseConvertStrategy: EnumCaseConvertStrategy
-
     /// Option to embed convenience initializer about using `GraphQLNullable`.
     public let embedSwiftOptionalInitializer: EmbedSwiftOptionalInitializer
-
->>>>>>> 214fb6f6 (Add option)
+    
     /// Designated initializer.
     ///
     /// - Parameters:
@@ -332,19 +322,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  - warningsOnDeprecatedUsage: Annotate generated Swift code with the Swift `available`
     ///    attribute and `deprecated` argument for parts of the GraphQL schema annotated with the
     ///    built-in `@deprecated` directive.
-<<<<<<< HEAD
-||||||| parent of 214fb6f6 (Add option)
-    ///  - enumCaseConvertStrategy: How convert strategy to Swift enum from GraphQL schema.
-=======
-    ///  - enumCaseConvertStrategy: How convert strategy to Swift enum from GraphQL schema.
-<<<<<<< HEAD
-    ///  - embedNullableVariableConvenienceInitializer: Embed convenience initializer about `GraphQLNullable`
->>>>>>> 214fb6f6 (Add option)
-||||||| parent of 50f4f75d (Replace to embedSwiftOptionalInitializer)
-    ///  - embedNullableVariableConvenienceInitializer: Embed convenience initializer about `GraphQLNullable`
-=======
     ///  - embedSwiftOptionalInitializer: Embed convenience initializer about `GraphQLNullable`
->>>>>>> 50f4f75d (Replace to embedSwiftOptionalInitializer)
     public init(
       additionalInflectionRules: [InflectionRule] = [],
       queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -398,6 +398,24 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     case alwaysFillNull
     /// Embed convenience initializer to use `GraphQLNullable.none` when passed nil to initilizer.
     case alwaysUndefinedField
+
+    var shouldEmbed: Bool {
+      if case .none = self {
+        return false
+      }
+      return true
+    }
+
+    var nullishWord: String {
+      switch self {
+      case .none:
+        return ""
+      case .alwaysFillNull:
+        return "null"
+      case .alwaysUndefinedField:
+        return ".none"
+      }
+    }
   }
 
   /// Enum to enable using

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -304,6 +304,19 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// directive.
     public let warningsOnDeprecatedUsage: Composition
 
+<<<<<<< HEAD
+||||||| parent of 214fb6f6 (Add option)
+    /// Strategy of convert to enum from GraphQL schema to swift. `.none` is a default strategy.
+    public let enumCaseConvertStrategy: EnumCaseConvertStrategy
+
+=======
+    /// Strategy of convert to enum from GraphQL schema to swift. `.none` is a default strategy.
+    public let enumCaseConvertStrategy: EnumCaseConvertStrategy
+
+    /// Option to embed convenience initializer about using `GraphQLNullable`.
+    public let embedNullableVariableConvenienceInitializer: EmbedNullableVariableConvenienceInitializer
+
+>>>>>>> 214fb6f6 (Add option)
     /// Designated initializer.
     ///
     /// - Parameters:
@@ -319,6 +332,13 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  - warningsOnDeprecatedUsage: Annotate generated Swift code with the Swift `available`
     ///    attribute and `deprecated` argument for parts of the GraphQL schema annotated with the
     ///    built-in `@deprecated` directive.
+<<<<<<< HEAD
+||||||| parent of 214fb6f6 (Add option)
+    ///  - enumCaseConvertStrategy: How convert strategy to Swift enum from GraphQL schema.
+=======
+    ///  - enumCaseConvertStrategy: How convert strategy to Swift enum from GraphQL schema.
+    ///  - embedNullableVariableConvenienceInitializer: Embed convenience initializer about `GraphQLNullable`
+>>>>>>> 214fb6f6 (Add option)
     public init(
       additionalInflectionRules: [InflectionRule] = [],
       queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
@@ -326,7 +346,16 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       schemaDocumentation: Composition = .include,
       apqs: APQConfig = .disabled,
       cocoapodsCompatibleImportStatements: Bool = false,
+<<<<<<< HEAD
       warningsOnDeprecatedUsage: Composition = .include
+||||||| parent of 214fb6f6 (Add option)
+      warningsOnDeprecatedUsage: Composition = .include,
+      enumCaseConvertStrategy: EnumCaseConvertStrategy = .none
+=======
+      warningsOnDeprecatedUsage: Composition = .include,
+      enumCaseConvertStrategy: EnumCaseConvertStrategy = .none,
+      embedNullableVariableConvenienceInitializer: EmbedNullableVariableConvenienceInitializer = .none
+>>>>>>> 214fb6f6 (Add option)
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
@@ -335,6 +364,13 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.apqs = apqs
       self.cocoapodsCompatibleImportStatements = cocoapodsCompatibleImportStatements
       self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
+<<<<<<< HEAD
+||||||| parent of 214fb6f6 (Add option)
+      self.enumCaseConvertStrategy = enumCaseConvertStrategy
+=======
+      self.enumCaseConvertStrategy = enumCaseConvertStrategy
+      self.embedNullableVariableConvenienceInitializer = embedNullableVariableConvenienceInitializer
+>>>>>>> 214fb6f6 (Add option)
     }
   }
 
@@ -352,6 +388,16 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   public enum Composition: String, Codable, Equatable {
     case include
     case exclude
+  }
+
+  /// Option to embed convenience initializer about using `GraphQLNullable`.
+  public enum EmbedNullableVariableConvenienceInitializer: String, Codable, Equatable {
+    /// No embed.
+    case none
+    /// Embed convenience initializer to use `GraphQLNullable.null` when passed nil to initilizer.
+    case alwaysFillNull
+    /// Embed convenience initializer to use `GraphQLNullable.none` when passed nil to initilizer.
+    case alwaysUndefinedField
   }
 
   /// Enum to enable using

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -398,12 +398,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       return true
     }
 
-    var nullishWord: String {
+    var shortGraphQLOptionalValue: String {
       switch self {
       case .none:
         return ""
       case .alwaysFillNull:
-        return "null"
+        return ".null"
       case .alwaysUndefinedField:
         return ".none"
       }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -306,7 +306,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     /// Option to embed convenience initializer about using `GraphQLNullable`.
     public let embedSwiftOptionalInitializer: EmbedSwiftOptionalInitializer
-    
+
     /// Designated initializer.
     ///
     /// - Parameters:
@@ -330,7 +330,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       schemaDocumentation: Composition = .include,
       apqs: APQConfig = .disabled,
       cocoapodsCompatibleImportStatements: Bool = false,
-      warningsondeprecatedusage: composition = .include,
+      warningsOnDeprecatedUsage: Composition = .include,
       embedSwiftOptionalInitializer: EmbedSwiftOptionalInitializer = .none
     ) {
       self.additionalInflectionRules = additionalInflectionRules

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -21,7 +21,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedNullableVariableConvenienceInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
+      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -20,6 +20,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
       \(section: VariableProperties(operation.definition.variables))
 
       \(Initializer(operation.definition.variables))
+      \(if: config.options.embedNullableVariableConvenienceInitializer.shouldEmbed, NullishConvenienceInitializer(config: config, operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -19,9 +19,16 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableProperties(operation.definition.variables))
 
-      \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
+      \(if: shouldEmbedSwiftOptionalInitializer,
+      """
+      @_disfavoredOverload \(Initializer(operation.definition.variables))
+
+      \(SwiftOptionalInitializer(operation.definition.variables))
+      """,
+      else:
+      """
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, SwiftOptionalInitializer(operation.definition.variables))
+      """)
 
       \(section: VariableAccessors(operation.definition.variables))
 
@@ -31,4 +38,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
     """)
   }
 
+  private var shouldEmbedSwiftOptionalInitializer: Bool {
+    config.options.embedSwiftOptionalInitializer.shouldEmbed && !operation.definition.variables.allSatisfy(variableIsNonNull)
+  }
 }

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -19,8 +19,9 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableProperties(operation.definition.variables))
 
+      \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedNullableVariableConvenienceInitializer.shouldEmbed, NullishConvenienceInitializer(config: config, operation.definition.variables))
+      \(if: config.options.embedNullableVariableConvenienceInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -21,7 +21,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
+      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, SwiftOptionalInitializer(operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -26,7 +26,9 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableProperties(operation.definition.variables))
 
+      \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
       \(Initializer(operation.definition.variables))
+      \(if: config.options.embedNullableVariableConvenienceInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -28,7 +28,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
       \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
+      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, SwiftOptionalInitializer(operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -26,9 +26,16 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableProperties(operation.definition.variables))
 
-      \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
+      \(if: shouldEmbedSwiftOptionalInitializer,
+      """
+      @_disfavoredOverload \(Initializer(operation.definition.variables))
+
+      \(SwiftOptionalInitializer(operation.definition.variables))
+      """,
+      else:
+      """
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, SwiftOptionalInitializer(operation.definition.variables))
+      """)
 
       \(section: VariableAccessors(operation.definition.variables))
 
@@ -77,6 +84,9 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
     }
   }
 
+  private var shouldEmbedSwiftOptionalInitializer: Bool {
+    config.options.embedSwiftOptionalInitializer.shouldEmbed && !operation.definition.variables.allSatisfy(variableIsNonNull)
+  }
 }
 
 fileprivate extension ApolloCodegenConfiguration.APQConfig {

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -28,7 +28,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
       \(if: !operation.definition.variables.allSatisfy(variableIsNonNull), "@_disfavoredOverload")
       \(Initializer(operation.definition.variables))
-      \(if: config.options.embedNullableVariableConvenienceInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
+      \(if: config.options.embedSwiftOptionalInitializer.shouldEmbed, NullishConvenienceInitializer(operation.definition.variables))
 
       \(section: VariableAccessors(operation.definition.variables))
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
@@ -6,7 +6,7 @@ extension GraphQLInputField {
     config: ApolloCodegenConfiguration
   ) -> String {
     """
-    \(type.rendered(as: .inputValue, config: config))\
+    \(type.rendered(as: .inputValue(), config: config))\
     \(isSwiftOptional ? "?" : "")\
     \(includeDefault && hasSwiftNilDefault ? " = nil" : "")
     """

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -49,4 +49,30 @@ extension OperationTemplateRenderer {
       """
   }
 
+  func NullishConvenienceInitializer(
+    config: ApolloCodegen.ConfigurationContext.,
+    _ variables: [CompilationResult.VariableDefinition]
+  ) -> TemplateString {
+    let `init` = "public convenience init"
+    if variables.isEmpty {
+      return "\(`init`)() {}"
+    }
+
+    return """
+    \(`init`)(\(list: variables.map(SwiftOptionalVariableParameter))) {
+      self.init(\(variables.map { "\($0.name): \($0.name) ?? \(config.options.embedNullableVariableConvenienceInitializer.nullishWord))" })
+    }
+    """
+  }
+
+  private func SwiftOptionalVariableParameter(
+    _ variable: CompilationResult.VariableDefinition
+  ) -> TemplateString {
+      """
+      \(variable.name): \(variable.type.rendered(as: .inputValue(isSwiftOptional: true), config: config.config))\
+      \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue(config: config.config))
+      """
+  }
+
+
 }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -67,7 +67,7 @@ extension OperationTemplateRenderer {
         \(variables.map {
           variableIsNonNull($0) ?
             "\($0.name): \($0.name)" :
-            "\($0.name): \($0.name) ?? .\(config.options.embedNullableVariableConvenienceInitializer.nullishWord)"
+            "\($0.name): \($0.name) ?? .\(config.options.embedSwiftOptionalInitializer.nullishWord)"
         })
       )
     }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -67,7 +67,7 @@ extension OperationTemplateRenderer {
         \(variables.map {
           variableIsNonNull($0) ?
             "\($0.name): \($0.name)" :
-            "\($0.name): \($0.name) ?? .\(config.options.embedSwiftOptionalInitializer.nullishWord)"
+            "\($0.name): \($0.name) ?? \(config.options.embedSwiftOptionalInitializer.shortGraphQLOptionalValue)"
         })
       )
     }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -50,7 +50,7 @@ extension OperationTemplateRenderer {
   }
 
   func NullishConvenienceInitializer(
-    config: ApolloCodegen.ConfigurationContext.,
+    config: ApolloCodegen.ConfigurationContext,
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
     let `init` = "public convenience init"

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -24,7 +24,7 @@ extension OperationTemplateRenderer {
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
     """
-    \(variables.map { "public var \($0.name): \($0.type.rendered(as: .inputValue, config: config.config))"}, separator: "\n")
+    \(variables.map { "public var \($0.name): \($0.type.rendered(as: .inputValue(), config: config.config))"}, separator: "\n")
     """
   }
 
@@ -32,7 +32,7 @@ extension OperationTemplateRenderer {
     _ variable: CompilationResult.VariableDefinition
   ) -> TemplateString {
       """
-      \(variable.name): \(variable.type.rendered(as: .inputValue, config: config.config))\
+      \(variable.name): \(variable.type.rendered(as: .inputValue(), config: config.config))\
       \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue(config: config.config))
       """
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -64,18 +64,14 @@ extension OperationTemplateRenderer {
     return """
     \(`init`)(\(list: variables.map(SwiftOptionalVariableParameter))) {
       self.init(
-        \(variables.map(DelegateToRequiredInitializerArgument))
+        \(variables.map {
+          variableIsNonNull($0) ?
+            "\($0.name): \($0.name)" :
+            "\($0.name): \($0.name) ?? .\(config.options.embedNullableVariableConvenienceInitializer.nullishWord)"
+        })
       )
     }
     """
-  }
-
-  private func DelegateToRequiredInitializerArgument(
-    _ variable: CompilationResult.VariableDefinition
-  ) -> TemplateString {
-    variableIsNonNull(variable) ?
-    "\(variable.name): \(variable.name)" :
-    "\(variable.name): \(variable.name) ?? .\(config.options.embedNullableVariableConvenienceInitializer.nullishWord)"
   }
 
   private func SwiftOptionalVariableParameter(

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -62,7 +62,7 @@ extension OperationTemplateRenderer {
     }
 
     return """
-    \(`init`)(\(list: variables.map(SwiftOptionalVariableParameter))) {
+    \(`init`)(\(list: variables.map(SwiftOptionalInitializerParameter))) {
       self.init(
         \(variables.map {
           variableIsNonNull($0) ?
@@ -74,7 +74,7 @@ extension OperationTemplateRenderer {
     """
   }
 
-  private func SwiftOptionalVariableParameter(
+  private func SwiftOptionalInitializerParameter(
     _ variable: CompilationResult.VariableDefinition
   ) -> TemplateString {
       """

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -50,9 +50,12 @@ extension OperationTemplateRenderer {
   }
 
   func NullishConvenienceInitializer(
-    config: ApolloCodegen.ConfigurationContext,
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
+    if variables.allSatisfy(variableIsNonNull) {
+      return ""
+    }
+
     let `init` = "public convenience init"
     if variables.isEmpty {
       return "\(`init`)() {}"
@@ -60,9 +63,19 @@ extension OperationTemplateRenderer {
 
     return """
     \(`init`)(\(list: variables.map(SwiftOptionalVariableParameter))) {
-      self.init(\(variables.map { "\($0.name): \($0.name) ?? \(config.options.embedNullableVariableConvenienceInitializer.nullishWord))" })
+      self.init(
+        \(variables.map(DelegateToRequiredInitializerArgument))
+      )
     }
     """
+  }
+
+  private func DelegateToRequiredInitializerArgument(
+    _ variable: CompilationResult.VariableDefinition
+  ) -> TemplateString {
+    variableIsNonNull(variable) ?
+    "\(variable.name): \(variable.name)" :
+    "\(variable.name): \(variable.name) ?? .\(config.options.embedNullableVariableConvenienceInitializer.nullishWord)"
   }
 
   private func SwiftOptionalVariableParameter(
@@ -74,5 +87,10 @@ extension OperationTemplateRenderer {
       """
   }
 
-
+  func variableIsNonNull(_ variable: CompilationResult.VariableDefinition) -> Bool {
+    if case .nonNull = variable.type {
+      return true
+    }
+    return false
+  }
 }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -49,7 +49,7 @@ extension OperationTemplateRenderer {
       """
   }
 
-  func NullishConvenienceInitializer(
+  func SwiftOptionalInitializer(
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
     if variables.allSatisfy(variableIsNonNull) {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -396,4 +396,51 @@ class OperationDefinitionTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
+
+  func test__generate__givenQueryWithNullableScalarVariable_generatesQueryOperationWithVariable_withEmbedSwiftOptionalInitializerOption() throws {
+     // given
+     schemaSDL = """
+     type Query {
+       allAnimals: [Animal!]
+     }
+
+     type Animal {
+       species: String!
+     }
+     """
+
+     document = """
+     query TestOperation($variable: String) {
+       allAnimals {
+         species
+       }
+     }
+     """
+
+     let expected =
+     """
+       public var variable: GraphQLNullable<String>
+
+       @_disfavoredOverload public init(variable: GraphQLNullable<String>) {
+         self.variable = variable
+       }
+
+       public convenience init(variable: String?) {
+         self.init(
+           variable: variable ?? .null
+         )
+       }
+
+       public var variables: Variables? { ["variable": variable] }
+     """
+
+     // when
+     try buildSubjectAndOperation(embedSwiftOptionalInitializer: .alwaysFillNull)
+
+     let actual = renderSubject()
+
+     // then
+     expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+   }
+
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -32,8 +32,6 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
     }
     """
-
-    config = .mock()
   }
 
   override func tearDown() {
@@ -48,7 +46,8 @@ class OperationDefinitionTemplateTests: XCTestCase {
 
   // MARK: - Helpers
 
-  private func buildSubjectAndOperation(named operationName: String = "TestOperation") throws {
+  private func buildSubjectAndOperation(named operationName: String = "TestOperation", embedSwiftOptionalInitializer: ApolloCodegenConfiguration.EmbedSwiftOptionalInitializer = .none) throws {
+    config = .mock(options: .init(schemaDocumentation: .exclude, embedSwiftOptionalInitializer: embedSwiftOptionalInitializer))
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)


### PR DESCRIPTION
This pull request to release/1.0 branch. 
And this PR for proposal feature for codegen. We would like to discuss better options and changes.

## Abstract
I use apollo-ios codegen version of v1-beta3 and faced GraphQLNullable. GraphQLNullable is a good way for following GraphQL specification. 
`.none`,`.null` are helping to clearly separate meaning in the Swift code. However, my service does not require a clear separation between `.none` and `.null`. This means that I want the old way of writing Apollo using the standard Swift Optional. And I guess that many developer want that as an option.

## Problem
Call mutation named UpdateUserProfile with UpdateUserProfileInput. UpdateUserProfileInput has nullable field named `displayName: String`. That means to use GraphQLNulable<String> type on Swift code. Schema is like this.

```graphql
mutation UpdateUserProfile($input: UpdateUserProfileInput!) {
  ...
}

input UpdateUserProfileInput {
  displayName: String
}
```

Call this mutation in Swift code to fill displayName field with optional variable. I want to set `displayName` variable as it is.  But I got compile error. So, it is necessary to instantiate to use GraphQLNullable or `??` operations. 

```swift
var displayName: String?
func performUpdateUserProfile() {
  apolloClient.perform(Mutation(input: .init(displayName: displayName)) // Compile error
}
```

However, my service does not always have to choose between using `.none` or `null`, and I prefer to use `.null`. Also, when I use the `nil` literal, we would rather use `.null`.

## How
My approach is like this.

- Add type of ApolloCodegenConfiguration.EmbedSwiftOptionalInitializer, and defined as option to ApolloCodegenConfiguration.
  - `EmbedSwiftOptionalInitializer` enable to set  `alwaysFillNull` and `alwaysUndefinedField`.
- If developer set EmbedSwiftOptionalInitializer, generating convenience initializer interface using Swift Optional instead of GraphQLNullable. And fill argument with value for selected option of EmbedSwiftOptionalInitializer in convenience initializer in delegate to required init part. 
  - Type inference problems when a field is set to `nil` literal are solved by adding the `@_disfavoredOverload` compiler attribute to required initializer.
  
## Test
- Add test case to OperationDefinitionTemplateTests using EmbedSwiftOptionalInitializer.
- I exec codegen manually, I got expected generated code.
- I run my app and I confirm to pass to new feature convenience initializer.