### PR TITLE
Optionally include deprecated inputs 1.0

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloadConfiguration.swift
@@ -12,7 +12,8 @@ public struct ApolloSchemaDownloadConfiguration: Equatable, Codable {
     case introspection(
       endpointURL: URL,
       httpMethod: HTTPMethod = .POST,
-      outputFormat: OutputFormat = .SDL
+      outputFormat: OutputFormat = .SDL,
+      includeDeprecatedInputValues: Bool = false
     )
 
     public struct ApolloRegistrySettings: Equatable, Codable {
@@ -71,11 +72,12 @@ public struct ApolloSchemaDownloadConfiguration: Equatable, Codable {
     
     public static func == (lhs: DownloadMethod, rhs: DownloadMethod) -> Bool {
       switch (lhs, rhs) {
-      case let (.introspection(lhsURL, lhsHTTPMethod, lhsOutputFormat),
-                .introspection(rhsURL, rhsHTTPMethod, rhsOutputFormat)):
+      case let (.introspection(lhsURL, lhsHTTPMethod, lhsOutputFormat, lhsIncludeDeprecatedInputValues),
+                .introspection(rhsURL, rhsHTTPMethod, rhsOutputFormat, rhsIncludeDeprecatedInputValues)):
         return lhsURL == rhsURL &&
         lhsHTTPMethod == rhsHTTPMethod &&
-        lhsOutputFormat == rhsOutputFormat
+        lhsOutputFormat == rhsOutputFormat &&
+        lhsIncludeDeprecatedInputValues == rhsIncludeDeprecatedInputValues
 
       case let (.apolloRegistry(lhsSettings), .apolloRegistry(rhsSettings)):
         return lhsSettings == rhsSettings
@@ -134,7 +136,7 @@ public struct ApolloSchemaDownloadConfiguration: Equatable, Codable {
   public var outputFormat: DownloadMethod.OutputFormat {
     switch self.downloadMethod {
     case .apolloRegistry: return .SDL
-    case let .introspection(_, _, outputFormat): return outputFormat
+    case let .introspection(_, _, outputFormat, _): return outputFormat
     }
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
@@ -40,7 +40,8 @@ class ApolloSchemaInternalTests: XCTestCase {
 
     let request = try ApolloSchemaDownloader.introspectionRequest(from: url,
                                                                   httpMethod: .GET(queryParameterName: queryParameterName),
-                                                                  headers: headers)
+                                                                  headers: headers,
+                                                                  includeDeprecatedInputValues: false)
 
     XCTAssertEqual(request.httpMethod, "GET")
     XCTAssertNil(request.httpBody)
@@ -51,7 +52,7 @@ class ApolloSchemaInternalTests: XCTestCase {
     }
 
     var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
-    components?.queryItems = [URLQueryItem(name: queryParameterName, value: ApolloSchemaDownloader.IntrospectionQuery)]
+    components?.queryItems = [URLQueryItem(name: queryParameterName, value: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: false))]
 
     XCTAssertNotNil(components?.url)
     XCTAssertEqual(request.url, components?.url)
@@ -64,7 +65,7 @@ class ApolloSchemaInternalTests: XCTestCase {
       .init(key: "key2", value: "value2")
     ]
 
-    let request = try ApolloSchemaDownloader.introspectionRequest(from: url, httpMethod: .POST, headers: headers)
+    let request = try ApolloSchemaDownloader.introspectionRequest(from: url, httpMethod: .POST, headers: headers, includeDeprecatedInputValues: false)
 
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(request.url, url)
@@ -74,7 +75,7 @@ class ApolloSchemaInternalTests: XCTestCase {
       XCTAssertEqual(request.allHTTPHeaderFields?[header.key], header.value)
     }
 
-    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: ApolloSchemaDownloader.IntrospectionQuery,
+    let requestBody = UntypedGraphQLRequestBodyCreator.requestBody(for: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: false),
                                                                    variables: nil,
                                                                    operationName: "IntrospectionQuery")
     let bodyData = try JSONSerialization.data(withJSONObject: requestBody, options: [.sortedKeys])

--- a/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaInternalTests.swift
@@ -57,6 +57,34 @@ class ApolloSchemaInternalTests: XCTestCase {
     XCTAssertNotNil(components?.url)
     XCTAssertEqual(request.url, components?.url)
   }
+  
+  func testRequest_givenIntrospectionGETDownload_andIncludeDeprecatedInputValues_shouldOutputGETRequest() throws {
+    let url = ApolloInternalTestHelpers.TestURL.mockServer.url
+    let queryParameterName = "customParam"
+    let headers: [ApolloSchemaDownloadConfiguration.HTTPHeader] = [
+      .init(key: "key1", value: "value1"),
+      .init(key: "key2", value: "value2")
+    ]
+
+    let request = try ApolloSchemaDownloader.introspectionRequest(from: url,
+                                                                  httpMethod: .GET(queryParameterName: queryParameterName),
+                                                                  headers: headers,
+                                                                  includeDeprecatedInputValues: true)
+
+    XCTAssertEqual(request.httpMethod, "GET")
+    XCTAssertNil(request.httpBody)
+
+    XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
+    for header in headers {
+      XCTAssertEqual(request.allHTTPHeaderFields?[header.key], header.value)
+    }
+
+    var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+    components?.queryItems = [URLQueryItem(name: queryParameterName, value: ApolloSchemaDownloader.introspectionQuery(includeDeprecatedInputValues: true))]
+
+    XCTAssertNotNil(components?.url)
+    XCTAssertEqual(request.url, components?.url)
+  }
 
   func testRequest_givenIntrospectionPOSTDownload_shouldOutputPOSTRequest() throws {
     let url = ApolloInternalTestHelpers.TestURL.mockServer.url


### PR DESCRIPTION
Following up on https://github.com/apollographql/apollo-ios/pull/2466 but for 1.0 release.