### PR TITLE
Custom `Codable` to allow for optional initialization of `ApolloCodegenConfiguration`

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -367,6 +367,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       public static let cocoapodsCompatibleImportStatements: Bool = false
       public static let warningsOnDeprecatedUsage: Composition = .include
       public static let conversionStrategies: ConversionStrategies = .init()
+      public static let pruneGeneratedFiles: Bool = true
     }
 
     /// Designated initializer.
@@ -396,7 +397,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
       warningsOnDeprecatedUsage: Composition = Default.warningsOnDeprecatedUsage,
       conversionStrategies: ConversionStrategies = Default.conversionStrategies,
-			pruneGeneratedFiles: Bool = true
+      pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
@@ -420,6 +421,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case cocoapodsCompatibleImportStatements
       case warningsOnDeprecatedUsage
       case conversionStrategies
+      case pruneGeneratedFiles
     }
 
     public init(from decoder: Decoder) throws {
@@ -464,6 +466,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         ConversionStrategies.self,
         forKey: .conversionStrategies
       ) ?? Default.conversionStrategies
+
+      pruneGeneratedFiles = try values.decodeIfPresent(
+        Bool.self,
+        forKey: .pruneGeneratedFiles
+      ) ?? Default.pruneGeneratedFiles
     }
   }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -167,7 +167,14 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// An absolute location to an operation id JSON map file. If specified, also stores the
     /// operation IDs (hashes) as properties on operation types.
     public let operationIdentifiersPath: String?
-    
+
+    /// Default property values
+    public struct Default {
+      public static let operations: OperationsFileOutput = .relative(subpath: nil)
+      public static let testMocks: TestMockFileOutput = .none
+      public static let operationIdentifiersPath: String? = nil
+    }
+
     /// Designated initializer.
     ///
     /// - Parameters:
@@ -181,14 +188,38 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  Defaults to `nil`.
     public init(
       schemaTypes: SchemaTypesFileOutput,
-      operations: OperationsFileOutput = .relative(subpath: nil),
-      testMocks: TestMockFileOutput = .none,
-      operationIdentifiersPath: String? = nil
+      operations: OperationsFileOutput = Default.operations,
+      testMocks: TestMockFileOutput = Default.testMocks,
+      operationIdentifiersPath: String? = Default.operationIdentifiersPath
     ) {
       self.schemaTypes = schemaTypes
       self.operations = operations
       self.testMocks = testMocks
       self.operationIdentifiersPath = operationIdentifiersPath
+    }
+
+    // MARK: Codable
+
+    enum CodingKeys: CodingKey {
+      case schemaTypes
+      case operations
+      case testMocks
+      case operationIdentifiersPath
+    }
+
+    /// `Decodable` implementation to allow for properties to be optional in the encoded JSON with
+    /// specified defaults when not present.
+    public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      schemaTypes = try values.decode(SchemaTypesFileOutput.self, forKey: .schemaTypes)
+      operations = try values.decode(OperationsFileOutput.self, forKey: .operations)
+      testMocks = try values.decode(TestMockFileOutput.self, forKey: .testMocks)
+
+      operationIdentifiersPath = try values.decodeIfPresent(
+        String.self,
+        forKey: .operationIdentifiersPath
+      ) ?? Default.operationIdentifiersPath
     }
   }
 
@@ -326,6 +357,18 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  Defaults to `true`.
     public let pruneGeneratedFiles: Bool
 
+    /// Default property values
+    public struct Default {
+      public static let additionalInflectionRules: [InflectionRule] = []
+      public static let queryStringLiteralFormat: QueryStringLiteralFormat = .multiline
+      public static let deprecatedEnumCases: Composition = .include
+      public static let schemaDocumentation: Composition = .include
+      public static let apqs: APQConfig = .disabled
+      public static let cocoapodsCompatibleImportStatements: Bool = false
+      public static let warningsOnDeprecatedUsage: Composition = .include
+      public static let conversionStrategies: ConversionStrategies = .init()
+    }
+
     /// Designated initializer.
     ///
     /// - Parameters:
@@ -345,15 +388,15 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///    generated code.
     ///  - pruneGeneratedFiles: Whether unused generated files will be automatically deleted.
     public init(
-      additionalInflectionRules: [InflectionRule] = [],
-      queryStringLiteralFormat: QueryStringLiteralFormat = .multiline,
-      deprecatedEnumCases: Composition = .include,
-      schemaDocumentation: Composition = .include,
-      apqs: APQConfig = .disabled,
-      cocoapodsCompatibleImportStatements: Bool = false,
-      warningsOnDeprecatedUsage: Composition = .include,
-      conversionStrategies: ConversionStrategies = .init(),
-      pruneGeneratedFiles: Bool = true
+      additionalInflectionRules: [InflectionRule] = Default.additionalInflectionRules,
+      queryStringLiteralFormat: QueryStringLiteralFormat = Default.queryStringLiteralFormat,
+      deprecatedEnumCases: Composition = Default.deprecatedEnumCases,
+      schemaDocumentation: Composition = Default.schemaDocumentation,
+      apqs: APQConfig = Default.apqs,
+      cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
+      warningsOnDeprecatedUsage: Composition = Default.warningsOnDeprecatedUsage,
+      conversionStrategies: ConversionStrategies = Default.conversionStrategies,
+			pruneGeneratedFiles: Bool = true
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
@@ -364,6 +407,63 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
       self.conversionStrategies = conversionStrategies
       self.pruneGeneratedFiles = pruneGeneratedFiles
+    }
+
+    // MARK: Codable
+
+    enum CodingKeys: CodingKey {
+      case additionalInflectionRules
+      case queryStringLiteralFormat
+      case deprecatedEnumCases
+      case schemaDocumentation
+      case apqs
+      case cocoapodsCompatibleImportStatements
+      case warningsOnDeprecatedUsage
+      case conversionStrategies
+    }
+
+    public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      additionalInflectionRules = try values.decodeIfPresent(
+        [InflectionRule].self,
+        forKey: .additionalInflectionRules
+      ) ?? Default.additionalInflectionRules
+
+      queryStringLiteralFormat = try values.decodeIfPresent(
+        QueryStringLiteralFormat.self,
+        forKey: .queryStringLiteralFormat
+      ) ?? Default.queryStringLiteralFormat
+
+      deprecatedEnumCases = try values.decodeIfPresent(
+        Composition.self,
+        forKey: .deprecatedEnumCases
+      ) ?? Default.deprecatedEnumCases
+
+      schemaDocumentation = try values.decodeIfPresent(
+        Composition.self,
+        forKey: .schemaDocumentation
+      ) ?? Default.schemaDocumentation
+
+      apqs = try values.decodeIfPresent(
+        APQConfig.self,
+        forKey: .apqs
+      ) ?? Default.apqs
+
+      cocoapodsCompatibleImportStatements = try values.decodeIfPresent(
+        Bool.self,
+        forKey: .cocoapodsCompatibleImportStatements
+      ) ?? Default.cocoapodsCompatibleImportStatements
+
+      warningsOnDeprecatedUsage = try values.decodeIfPresent(
+        Composition.self,
+        forKey: .warningsOnDeprecatedUsage
+      ) ?? Default.warningsOnDeprecatedUsage
+
+      conversionStrategies = try values.decodeIfPresent(
+        ConversionStrategies.self,
+        forKey: .conversionStrategies
+      ) ?? Default.conversionStrategies
     }
   }
 
@@ -465,12 +565,39 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
      */
     public let legacySafelistingCompatibleOperations: Bool
 
+    /// Default property values
+    public struct Default {
+      public static let clientControlledNullability: Bool = false
+      public static let legacySafelistingCompatibleOperations: Bool = false
+    }
+
     public init(
-      clientControlledNullability: Bool = false,
-      legacySafelistingCompatibleOperations: Bool = false
+      clientControlledNullability: Bool = Default.clientControlledNullability,
+      legacySafelistingCompatibleOperations: Bool = Default.legacySafelistingCompatibleOperations
     ) {
       self.clientControlledNullability = clientControlledNullability
       self.legacySafelistingCompatibleOperations = legacySafelistingCompatibleOperations
+    }
+
+    // MARK: Codable
+
+    public enum CodingKeys: CodingKey {
+      case clientControlledNullability
+      case legacySafelistingCompatibleOperations
+    }
+
+    public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      clientControlledNullability = try values.decodeIfPresent(
+        Bool.self,
+        forKey: .clientControlledNullability
+      ) ?? Default.clientControlledNullability
+
+      legacySafelistingCompatibleOperations = try values.decodeIfPresent(
+        Bool.self,
+        forKey: .legacySafelistingCompatibleOperations
+      ) ?? Default.legacySafelistingCompatibleOperations
     }
   }
 
@@ -492,6 +619,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// Schema download configuration.
   public let schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration?
 
+  public struct Default {
+    public static let options: OutputOptions = OutputOptions()
+    public static let experimentalFeatures: ExperimentalFeatures = ExperimentalFeatures()
+    public static let schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = nil
+  }
+
   // MARK: Initializers
 
   /// Designated initializer.
@@ -506,9 +639,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     schemaName: String,
     input: FileInput,
     output: FileOutput,
-    options: OutputOptions = OutputOptions(),
-    experimentalFeatures: ExperimentalFeatures = ExperimentalFeatures(),
-    schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = nil
+    options: OutputOptions = Default.options,
+    experimentalFeatures: ExperimentalFeatures = Default.experimentalFeatures,
+    schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = Default.schemaDownloadConfiguration
   ) {
     self.schemaName = schemaName
     self.input = input
@@ -518,6 +651,39 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     self.schemaDownloadConfiguration = schemaDownloadConfiguration
   }
 
+  // MARK: Codable
+
+  enum CodingKeys: CodingKey {
+    case schemaName
+    case input
+    case output
+    case options
+    case experimentalFeatures
+    case schemaDownloadConfiguration
+  }
+
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+
+    schemaName = try values.decode(String.self, forKey: .schemaName)
+    input = try values.decode(FileInput.self, forKey: .input)
+    output = try values.decode(FileOutput.self, forKey: .output)
+
+    options = try values.decodeIfPresent(
+      OutputOptions.self,
+      forKey: .options
+    ) ?? Default.options
+
+    experimentalFeatures = try values.decodeIfPresent(
+      ExperimentalFeatures.self,
+      forKey: .experimentalFeatures
+    ) ?? Default.experimentalFeatures
+
+    schemaDownloadConfiguration = try values.decodeIfPresent(
+      ApolloSchemaDownloadConfiguration.self,
+      forKey: .schemaDownloadConfiguration
+    ) ?? Default.schemaDownloadConfiguration
+  }
 }
 
 // MARK: - Helpers

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -305,7 +305,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     case swiftPackage(targetName: String? = nil)
   }
 
-  // MARK: - Output Options
+  // MARK: - Other Types
   public struct OutputOptions: Codable, Equatable {
     /// Any non-default rules for pluralization or singularization you wish to include.
     public let additionalInflectionRules: [InflectionRule]
@@ -530,8 +530,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     case persistedOperationsOnly
   }
 
-  // MARK: - Other Types
-
   public struct ExperimentalFeatures: Codable, Equatable {
     /**
      * **EXPERIMENTAL**: If enabled, the parser will understand and parse Client Controlled Nullability
@@ -601,7 +599,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     }
   }
 
-  // MARK: Properties
+  // MARK: - Properties
 
   /// Name used to scope the generated schema type files.
   public let schemaName: String

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -508,8 +508,28 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// Defaultss to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
     public let enumCases: CaseConversionStrategy
 
-    public init(enumCases: CaseConversionStrategy = .camelCase) {
+    /// Default property values
+    public struct Default {
+      public static let enumCases: CaseConversionStrategy = .camelCase
+    }
+
+    public init(enumCases: CaseConversionStrategy = Default.enumCases) {
       self.enumCases = enumCases
+    }
+
+    // MARK: Codable
+
+    public enum CodingKeys: CodingKey {
+      case enumCases
+    }
+
+    public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      enumCases = try values.decodeIfPresent(
+        CaseConversionStrategy.self,
+        forKey: .enumCases
+      ) ?? Default.enumCases
     }
   }
 

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -124,10 +124,10 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let encodedJSON = try testJSONEncoder.encode(subject)
-    let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: encodedJSON)
+    let actual = String(data: encodedJSON, encoding: .utf8)!
 
     // then
-    expect(actual).to(equal(MockApolloCodegenConfiguration.decoded))
+    expect(actual).to(equal(MockApolloCodegenConfiguration.encoded))
   }
 
   func test__decodeApolloCodegenConfiguration__givenAllParameters_shouldReturnStruct() throws {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -201,6 +201,22 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     expect(actual).to(equal(expected))
   }
 
+  func test__decodeApolloCodegenConfiguration__givenMissingRequiredParameters_shouldThrow() throws {
+    // given
+    let subject = """
+      {
+        "input" : {
+        },
+        "output" : {
+        }
+      }
+      """.asData
+
+    // then
+    expect(try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject))
+      .to(throwError())
+  }
+
   // MARK: - QueryStringLiteralFormat Tests
 
   func encodedValue(_ case: ApolloCodegenConfiguration.QueryStringLiteralFormat) -> String {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -49,7 +49,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(enumCases: .none),
-					pruneGeneratedFiles: true
+					pruneGeneratedFiles: false
         ),
         experimentalFeatures: .init(
           clientControlledNullability: true,
@@ -88,6 +88,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "enumCases" : "none"
           },
           "deprecatedEnumCases" : "exclude",
+          "pruneGeneratedFiles" : false,
           "queryStringLiteralFormat" : "singleLine",
           "schemaDocumentation" : "exclude",
           "warningsOnDeprecatedUsage" : "exclude"

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -49,7 +49,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(enumCases: .none),
-					pruneGeneratedFiles: false
+          pruneGeneratedFiles: false
         ),
         experimentalFeatures: .init(
           clientControlledNullability: true,

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -34,9 +34,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             path: "/output/path",
             moduleType: .embeddedInTarget(name: "SomeTarget")
           ),
-          operations: .relative(subpath: "/relative/subpath"),
+          operations: .absolute(path: "/absolute/path"),
           testMocks: .swiftPackage(targetName: "SchemaTestMocks"),
-          operationIdentifiersPath: nil
+          operationIdentifiersPath: "/operation/identifiers/path"
         ),
         options: .init(
           additionalInflectionRules: [
@@ -46,9 +46,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           deprecatedEnumCases: .exclude,
           schemaDocumentation: .exclude,
           apqs: .persistedOperationsOnly,
-          cocoapodsCompatibleImportStatements: false,
+          cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
-          conversionStrategies:.init(enumCases: .camelCase),
+          conversionStrategies:.init(enumCases: .none),
 					pruneGeneratedFiles: true
         ),
         experimentalFeatures: .init(
@@ -83,9 +83,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             }
           ],
           "apqs" : "persistedOperationsOnly",
-          "cocoapodsCompatibleImportStatements" : false,
+          "cocoapodsCompatibleImportStatements" : true,
           "conversionStrategies" : {
-            "enumCases" : "camelCase"
+            "enumCases" : "none"
           },
           "deprecatedEnumCases" : "exclude",
           "queryStringLiteralFormat" : "singleLine",
@@ -93,9 +93,10 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           "warningsOnDeprecatedUsage" : "exclude"
         },
         "output" : {
+          "operationIdentifiersPath" : "/operation/identifiers/path",
           "operations" : {
-            "relative" : {
-              "subpath" : "/relative/subpath"
+            "absolute" : {
+              "path" : "/absolute/path"
             }
           },
           "schemaTypes" : {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -20,7 +20,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
   }
 
   enum MockApolloCodegenConfiguration {
-    static var decoded: ApolloCodegenConfiguration {
+    static var decodedStruct: ApolloCodegenConfiguration {
       .init(
         schemaName: "SerializedSchema",
         input: .init(
@@ -58,7 +58,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
       )
     }
 
-    static var encoded: String {
+    static var encodedJSON: String {
       """
       {
         "experimentalFeatures" : {
@@ -121,25 +121,25 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeApolloCodegenConfiguration__givenAllParameters_shouldReturnJSON() throws {
     // given
-    let subject = MockApolloCodegenConfiguration.decoded
+    let subject = MockApolloCodegenConfiguration.decodedStruct
 
     // when
     let encodedJSON = try testJSONEncoder.encode(subject)
     let actual = String(data: encodedJSON, encoding: .utf8)!
 
     // then
-    expect(actual).to(equal(MockApolloCodegenConfiguration.encoded))
+    expect(actual).to(equal(MockApolloCodegenConfiguration.encodedJSON))
   }
 
   func test__decodeApolloCodegenConfiguration__givenAllParameters_shouldReturnStruct() throws {
     // given
-    let subject = MockApolloCodegenConfiguration.encoded.asData
+    let subject = MockApolloCodegenConfiguration.encodedJSON.asData
 
     // when
     let actual = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
 
     // then
-    expect(actual).to(equal(MockApolloCodegenConfiguration.decoded))
+    expect(actual).to(equal(MockApolloCodegenConfiguration.decodedStruct))
   }
 
   func test__decodeApolloCodegenConfiguration__givenOnlyRequiredParameters_shouldReturnStruct() throws {
@@ -156,8 +156,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
         },
         "output" : {
           "operations" : {
-            "relative" : {
-              "subpath" : "/relative/subpath"
+            "absolute" : {
+              "path" : "/absolute/path"
             }
           },
           "schemaTypes" : {
@@ -189,7 +189,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           path: "/output/path",
           moduleType: .embeddedInTarget(name: "SomeTarget")
         ),
-        operations: .relative(subpath: "/relative/subpath"),
+        operations: .absolute(path: "/absolute/path"),
         testMocks: .swiftPackage(targetName: "SchemaTestMocks")
       )
     )


### PR DESCRIPTION
Closes #2439 

This change allows an `ApolloCodegenConfiguration` object to be decoded with some properties being optional:
* allows users who are satisfied with the default property values to maintain a minimal JSON configuration file
* prevents users from having to constantly update their JSON configuration file if we add new properties to the struct (newly added _required_ fields are the exception)

The list of required vs. optional properties is as follows:

**ApolloCodegenConfiguration**
`schemaName` - **required** (`String`)
`input` - **required** (`ApolloCodegenConfiguration.FileInput`)
`output` - **required** (`ApolloCodegenConfiguration.FileOutput`)
`options` - optional (`ApolloCodegenConfiguration.OutputOptions`)
`experimentalFeatures` - optional (`ApolloCodegenConfiguration.ExperimentalFeatures`)
`schemaDownloadConfiguration` - optional (`ApolloSchemaDownloadConfiguration`)

**ApolloCodegenConfiguration.FileInput**
`schemaSearchPaths` - **required** (`[String]`)
`operationSearchPaths` - **required** (`[String]`)

**ApolloCodegenConfiguration.FileOutput**
`schemaTypes` - **required** (`ApolloCodegenConfiguration.SchemaTypesFileOutput`)
`operations` - **required** (`enum`)
`testMocks` - **required** (`enum`)
`operationIdentifiersPath` - optional (`String`)

**ApolloCodegenConfiguration.SchemaTypesFileOutput**
`path` - **required** (`String`)
`moduleType` - **required** (`String`)

**ApolloCodegenConfiguration.OutputOptions**
`additionalInflectionRules` - optional (`[]`)
`queryStringLiteralFormat` - optional (`enum`)
`deprecatedEnumCases` - optional (`enum`)
`schemaDocumentation` - optional (`enum`)
`apqs` - optional (`enum`)
`cocoapodsCompatibleImportStatements` - optional (`enum`)
`warningsOnDeprecatedUsage` - optional (`enum`)
`conversionStrategies` - optional (`ConversionStrategies`)
`pruneGeneratedFiles` - optional (`enum`)

**ApolloCodegenConfiguration.ConversionStrategies**
`enumCases` - Optional (`enum`)

**ApolloCodegenConfiguration.ExperimentalFeatures**
`clientControlledNullability` - optional (`Bool`)
`legacySafelistingCompatibleOperations` - optional (`Bool`)