### PR TITLE
Xcode 14 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,28 @@ version: 2.1
 parameters:
   xcode_version:
     type: string
-    default: "13.4.1"
+    default: "14.0"
   ios_current_version:
     type: string
-    default: "15.5"
+    default: "16.0"
   ios_previous_version:
     type: string
-    default: "14.5"
+    default: "15.5"
   ios_sdk:
     type: string
-    default: "iphonesimulator15.5"
+    default: "iphonesimulator16.0"
   macos_version: # The user-facing version string for macOS builds
     type: string
-    default: "12.3.1"
+    default: "12.5.1"
   macos_sdk: # The full SDK string to use for macOS builds
     type: string
     default: "macosx12.3"
   tvos_version: # The user-facing version string of tvOS builds
     type: string
-    default: "15.4"
+    default: "16.0"
   tvos_sdk:
     type: string
-    default: "appletvsimulator15.4"
+    default: "appletvsimulator16.0"
 
 commands:
   integration_test_setup:
@@ -151,7 +151,7 @@ jobs:
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
-      DESTINATION: platform=iOS Simulator,OS=<< pipeline.parameters.ios_current_version >>,name=iPhone 12
+      DESTINATION: platform=iOS Simulator,OS=<< pipeline.parameters.ios_current_version >>,name=iPhone 14
       CIRCLE_XCODE_SCHEME: Apollo
       CIRCLE_XCODE_TEST_PLAN: Apollo-CITestPlan
       CIRCLE_XCODE_SDK: << pipeline.parameters.ios_sdk >>
@@ -163,7 +163,7 @@ jobs:
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
-      DESTINATION: platform=iOS Simulator,OS=<< pipeline.parameters.ios_previous_version >>,name=iPhone 12
+      DESTINATION: platform=iOS Simulator,OS=<< pipeline.parameters.ios_previous_version >>,name=iPhone 13
       CIRCLE_XCODE_SCHEME: Apollo
       CIRCLE_XCODE_TEST_PLAN: Apollo-CITestPlan
       CIRCLE_XCODE_SDK: << pipeline.parameters.ios_sdk >>

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2574,7 +2574,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"${SRCROOT}/SwiftScripts\"\nxcrun -sdk macosx swift run --build-path \"./.build-StarWars\" Codegen -t \"StarWars\"\n";
+			shellScript = "cd \"${SRCROOT}/SwiftScripts\"\nxcrun -sdk macosx swift run --scratch-path \"./.build-StarWars\" Codegen -t \"StarWars\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -2529,6 +2529,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		90690D322243442F00FC2E54 /* Ensure no build settings are in the Xcode project */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2547,6 +2548,7 @@
 		};
 		9FACA9BA1F42E67200AE2DBD /* Generate Apollo Client API */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2561,6 +2563,7 @@
 		};
 		9FCE2D061E6C251100E34457 /* Generate Apollo Client API */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -112,7 +112,7 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
   ///   - files: The files you wish to upload
   ///   - manualBoundary: [optional] A manually set boundary for your upload request. Defaults to nil. 
   /// - Returns: The created request.
-  open func constructUploadRequest<Operation: GraphQLOperation>(
+  public func constructUploadRequest<Operation: GraphQLOperation>(
     for operation: Operation,
     with files: [GraphQLFile],
     manualBoundary: String? = nil) -> HTTPRequest<Operation> {

--- a/scripts/install-node-v12.sh
+++ b/scripts/install-node-v12.sh
@@ -5,4 +5,4 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 echo nvm install v12.22.10 >> $BASH_ENV
-echo nvm use v16.15.1 >> $BASH_ENV
+echo nvm use v16.17.0 >> $BASH_ENV


### PR DESCRIPTION
This is PR #2493 updated for `main` with some changes to silence additional warnings:
* Use new tooling versions on CI
* Tell Xcode that the build scripts should always run regardless of input file changes
* Update extension method access control modifier for Swift 5.7