### PR TITLE
Remove Selection.Conditions ExpressibleByLiterals

### DIFF
--- a/Sources/ApolloAPI/Selection+Conditions.swift
+++ b/Sources/ApolloAPI/Selection+Conditions.swift
@@ -6,43 +6,28 @@ public extension Selection {
   /// The conditions are a two-dimensional array of `Selection.Condition`s.
   /// The outer array represents groups of conditions joined together with a logical "or".
   /// Conditions in the same inner array are joined together with a logical "and".
-  struct Conditions: ExpressibleByArrayLiteral, ExpressibleByStringLiteral, Hashable {
+  struct Conditions: Hashable {
     public let value: [[Condition]]
 
-    @inlinable
-    public init(_ value: [[Condition]]) {
+    @inlinable public init(_ value: [[Condition]]) {
       self.value = value
     }
 
-    @inlinable
-    public init(arrayLiteral elements: [Condition]...) {
-      self.value = Array(elements)
-    }
-
-    @inlinable
-    public init(_ conditions: [Condition]...) {
+    @inlinable public init(_ conditions: [Condition]...) {
       self.value = Array(conditions)
     }
 
-    @inlinable
-    public init(stringLiteral string: String) {
-      self.value = [[.init(stringLiteral: string)]]
-    }
-
-    @inlinable
-    public init(_ condition: Condition) {
+    @inlinable public init(_ condition: Condition) {
       self.value = [[condition]]
     }
 
-    @inlinable
-    public static func ||(_ lhs: Conditions, rhs: [Condition]) -> Conditions {
+    @inlinable public static func ||(_ lhs: Conditions, rhs: [Condition]) -> Conditions {
       var newValue = lhs.value
       newValue.append(rhs)
       return .init(newValue)
     }
 
-    @inlinable
-    public static func ||(_ lhs: Conditions, rhs: Condition) -> Conditions {
+    @inlinable public static func ||(_ lhs: Conditions, rhs: Condition) -> Conditions {
       lhs || [rhs]
     }
   }
@@ -51,8 +36,7 @@ public extension Selection {
     public let variableName: String
     public let inverted: Bool
 
-    @inlinable
-    public init(
+    @inlinable public init(
       variableName: String,
       inverted: Bool
     ) {
@@ -60,36 +44,30 @@ public extension Selection {
       self.inverted = inverted;
     }
 
-    @inlinable
-    public init(stringLiteral value: StringLiteralType) {
+    @inlinable public init(stringLiteral value: StringLiteralType) {
       self.variableName = value
       self.inverted = false
     }
 
-    @inlinable
-    public static prefix func !(value: Condition) -> Condition {
+    @inlinable public static prefix func !(value: Condition) -> Condition {
       .init(variableName: value.variableName, inverted: !value.inverted)
     }
 
-    @inlinable
-    public static func &&(_ lhs: Condition, rhs: Condition) -> [Condition] {
+    @inlinable public static func &&(_ lhs: Condition, rhs: Condition) -> [Condition] {
       [lhs, rhs]
     }
 
-    @inlinable
-    public static func &&(_ lhs: [Condition], rhs: Condition) -> [Condition] {
+    @inlinable public static func &&(_ lhs: [Condition], rhs: Condition) -> [Condition] {
       var newValue = lhs
       newValue.append(rhs)
       return newValue
     }
 
-    @inlinable
-    public static func ||(_ lhs: Condition, rhs: Condition) -> Conditions {
+    @inlinable public static func ||(_ lhs: Condition, rhs: Condition) -> Conditions {
       .init([[lhs], [rhs]])
     }
 
-    @inlinable
-    public static func ||(_ lhs: [Condition], rhs: Condition) -> Conditions {
+    @inlinable public static func ||(_ lhs: [Condition], rhs: Condition) -> Conditions {
       .init([lhs, [rhs]])
     }
 

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -20,7 +20,7 @@ public enum Selection {
       return alias ?? name
     }
 
-    public init(
+    @inlinable public init(
       _ name: String,
       alias: String? = nil,
       type: OutputType,
@@ -28,9 +28,7 @@ public enum Selection {
     ) {
       self.name = name
       self.alias = alias
-
       self.arguments = arguments
-
       self.type = type
     }
 
@@ -59,69 +57,69 @@ public enum Selection {
 
   // MARK: - Convenience Initializers
 
-  static public func field(
+  @inlinable static public func field(
     _ name: String,
     alias: String? = nil,
     _ type: OutputTypeConvertible.Type,
     arguments: [String: InputValue]? = nil
   ) -> Selection {
     .field(.init(name, alias: alias, type: type.asOutputType, arguments: arguments))
-  }  
+  }
 
-  static public func include(
+  @inlinable static public func include(
     if condition: String,
     _ selection: Selection
   ) -> Selection {
-    .conditional([[Selection.Condition(stringLiteral: condition)]], [selection])
+    .conditional(Conditions([[Selection.Condition(stringLiteral: condition)]]), [selection])
   }
 
-  static public func include(
+  @inlinable static public func include(
     if condition: String,
     _ selections: [Selection]
   ) -> Selection {
-    .conditional([[Selection.Condition(stringLiteral: condition)]], selections)
+    .conditional(Conditions([[Selection.Condition(stringLiteral: condition)]]), selections)
   }
-  
-  static public func include(
+
+  @inlinable static public func include(
     if conditions: Conditions,
     _ selection: Selection
   ) -> Selection {
     .conditional(conditions, [selection])
   }
 
-  static public func include(
+  @inlinable static public func include(
     if conditions: Conditions,
     _ selections: [Selection]
   ) -> Selection {
     .conditional(conditions, selections)
   }
 
-  static public func include(
+  @inlinable static public func include(
     if condition: Condition,
     _ selection: Selection
   ) -> Selection {
-    .conditional([[condition]], [selection])
+    .conditional(Conditions([[condition]]), [selection])
   }
 
-  static public func include(
+  @inlinable static public func include(
     if condition: Condition,
     _ selections: [Selection]
   ) -> Selection {
-    .conditional([[condition]], selections)
+    .conditional(Conditions([[condition]]), selections)
   }
 
-  static public func include(
+  @inlinable static public func include(
     if conditions: [Condition],
     _ selection: Selection
   ) -> Selection {
-    .conditional([conditions], [selection])
+    .conditional(Conditions([conditions]), [selection])
   }
 
-  static public func include(
+  @inlinable static public func include(
     if conditions: [Condition],
     _ selections: [Selection]
   ) -> Selection {
-    .conditional([conditions], selections)
+    .conditional(Conditions([conditions]), selections)
   }
 
 }

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -964,6 +964,23 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     expect(data.name).to(beNil())
   }
 
+  func test__booleanCondition_multipleIncludes_singleField__givenAllVariablesAreTrue_getsValueForConditionalField() throws {
+    // given
+    class GivenSelectionSet: MockSelectionSet {
+      override class var selections: [Selection] {[
+        .include(if: "one" || "two", .field("name", String.self))
+      ]}
+    }
+    let object: JSONObject = ["name": "Luke Skywalker"]
+    let variables = ["one": true, "two": true]
+
+    // when
+    let data = try readValues(GivenSelectionSet.self, from: object, variables: variables)
+
+    // then
+    expect(data.name).to(equal("Luke Skywalker"))
+  }
+
   func test__booleanCondition_include_singleField__givenVariableIsFalse_givenOtherSelection_doesNotGetsValueForConditionalField_doesGetOtherSelection() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {


### PR DESCRIPTION
Closes #2500 

This removes ambiguity in initializing either a `Condition` or a `Conditions` from a string literal. String literal should always create a `Condition` and the `include(if:selection:)` function overloads are used to wrap those up into a `Conditions` object properly.

Also clean up some formatting