### PR TITLE
feat: Mark `SelectionSet` properties as private metadata

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -35,7 +35,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .inlineFragment(AsAnimal.self),
     .inlineFragment(AsPet.self),
     .inlineFragment(AsWarmBlooded.self),
@@ -59,7 +59,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("species", String.self),
     ] }
 
@@ -74,7 +74,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("humanName", String?.self),
     ] }
 
@@ -89,7 +89,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("laysEggs", Bool.self),
     ] }
 
@@ -105,7 +105,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Cat }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("bodyTemperature", Int.self),
       .field("isJellicle", Bool.self),
     ] }
@@ -125,7 +125,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Bird }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("wingspan", Double.self),
     ] }
 
@@ -143,7 +143,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.PetRock }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("favoriteToy", String.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -22,7 +22,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .inlineFragment(AsAnimal.self),
   ] }
 
@@ -36,7 +36,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("height", Height.self),
     ] }
 
@@ -50,7 +50,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("inches", Int.self),
       ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
@@ -17,7 +17,7 @@ public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Dog }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("species", String.self),
   ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -20,7 +20,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("height", Height.self),
   ] }
 
@@ -34,7 +34,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("meters", Int.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
@@ -22,7 +22,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("humanName", String?.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner?.self),
@@ -40,7 +40,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Human }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("firstName", String.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -18,7 +18,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -15,7 +15,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("allAnimals", [AllAnimal].self),
     ] }
 
@@ -32,7 +32,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<SkinCovering>?.self),
         .inlineFragment(AsBird.self),
@@ -60,7 +60,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Bird }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("wingspan", Double.self),
         ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -20,7 +20,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("owner", Owner?.self),
   ] }
 
@@ -37,7 +37,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Human }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("firstName", String.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -33,7 +33,7 @@ public class PetAdoptionMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("adoptPet", AdoptPet.self, arguments: ["input": .variable("input")]),
     ] }
 
@@ -47,7 +47,7 @@ public class PetAdoptionMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -30,7 +30,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("allAnimals", [AllAnimal].self),
     ] }
 
@@ -44,7 +44,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("height", Height?.self),
       ] }
 
@@ -58,7 +58,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("feet", Int?.self),
           .field("inches", Int.self),
         ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -89,7 +89,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("allAnimals", [AllAnimal].self),
     ] }
 
@@ -103,7 +103,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("height", Height.self),
         .field("skinCovering", GraphQLEnum<SkinCovering>?.self),
         .field("predators", [Predator].self),
@@ -141,7 +141,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -159,7 +159,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .include(if: "includeSpecies", .field("species", String.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         ] }
@@ -176,7 +176,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("species", String.self),
             .fragment(WarmBloodedDetails.self),
             .field("laysEggs", Bool.self),
@@ -205,7 +205,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .fragment(WarmBloodedDetails.self),
         ] }
 
@@ -286,7 +286,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("height", Height.self),
           .inlineFragment(AsWarmBlooded.self),
           .fragment(PetDetails.self),
@@ -318,7 +318,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .include(if: "varA", [
               .field("relativeSize", GraphQLEnum<RelativeSize>.self),
               .field("centimeters", Double.self),
@@ -340,7 +340,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .fragment(WarmBloodedDetails.self),
           ] }
 
@@ -388,7 +388,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Cat }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("isJellicle", Bool.self),
         ] }
 
@@ -436,7 +436,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .inlineFragment(AsBird.self),
         ] }
 
@@ -476,7 +476,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Bird }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("wingspan", Double.self),
           ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -66,7 +66,7 @@ public class AllAnimalsQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("allAnimals", [AllAnimal].self),
     ] }
 
@@ -80,7 +80,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<SkinCovering>?.self),
@@ -119,7 +119,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -137,7 +137,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("species", String.self),
           .inlineFragment(AsWarmBlooded.self),
         ] }
@@ -154,7 +154,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("laysEggs", Bool.self),
             .fragment(WarmBloodedDetails.self),
           ] }
@@ -182,7 +182,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .fragment(WarmBloodedDetails.self),
         ] }
 
@@ -223,7 +223,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("height", Height.self),
           .inlineFragment(AsWarmBlooded.self),
           .fragment(PetDetails.self),
@@ -255,7 +255,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Height }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("relativeSize", GraphQLEnum<RelativeSize>.self),
             .field("centimeters", Double.self),
           ] }
@@ -275,7 +275,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .fragment(WarmBloodedDetails.self),
           ] }
 
@@ -323,7 +323,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Cat }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("isJellicle", Bool.self),
         ] }
 
@@ -371,7 +371,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .inlineFragment(AsBird.self),
         ] }
 
@@ -411,7 +411,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Bird }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("wingspan", Double.self),
           ] }
 
@@ -460,7 +460,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Dog }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("favoriteToy", String.self),
           .field("birthdate", CustomDate?.self),
         ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -27,7 +27,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("classroomPets", [ClassroomPet]?.self),
     ] }
 
@@ -41,7 +41,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(ClassroomPetDetailsCCN.self),
       ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -27,7 +27,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("classroomPets", [ClassroomPet?]?.self),
     ] }
 
@@ -41,7 +41,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(ClassroomPetDetails.self),
       ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -30,7 +30,7 @@ public class DogQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("allAnimals", [AllAnimal].self),
     ] }
 
@@ -44,7 +44,7 @@ public class DogQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Animal }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .inlineFragment(AsDog.self),
       ] }
@@ -61,7 +61,7 @@ public class DogQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Dog }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .fragment(DogFragment.self),
         ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -44,7 +44,7 @@ public class PetSearchQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("pets", [Pet].self, arguments: ["filters": .variable("filters")]),
     ] }
 
@@ -58,7 +58,7 @@ public class PetSearchQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -93,7 +93,7 @@ struct FieldExecutionInfo {
       guard case let .object(selectionSet) = field.type.namedType else {
         return []
       }
-      return selectionSet.selections
+      return selectionSet.__selections
     }
   }
 
@@ -181,7 +181,7 @@ final class GraphQLExecutor {
                                    schema: selectionSet.__schema,
                                    withRootCacheReference: root)
 
-    let rootValue = execute(selections: selectionSet.selections,
+    let rootValue = execute(selections: selectionSet.__selections,
                             on: data,
                             info: info,
                             accumulator: accumulator)
@@ -261,7 +261,7 @@ final class GraphQLExecutor {
         }
 
       case let .fragment(fragment):
-        try groupFields(fragment.selections,
+        try groupFields(fragment.__selections,
                         for: object,
                         into: &groupedFields,
                         info: info)
@@ -269,7 +269,7 @@ final class GraphQLExecutor {
       case let .inlineFragment(typeCase):
         if let runtimeType = runtimeObjectType(for: object, schema: info.schema),
            typeCase.__parentType.canBeConverted(from: runtimeType) {
-          try groupFields(typeCase.selections,
+          try groupFields(typeCase.__selections,
                           for: object,
                           into: &groupedFields,
                           info: info)

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -178,7 +178,7 @@ final class GraphQLExecutor {
     accumulator: Accumulator
   ) throws -> Accumulator.FinalResult {
     let info = ObjectExecutionInfo(variables: variables,
-                                   schema: selectionSet.schema,
+                                   schema: selectionSet.__schema,
                                    withRootCacheReference: root)
 
     let rootValue = execute(selections: selectionSet.selections,

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -1,7 +1,7 @@
 // MARK: - Type Erased SelectionSets
 
 public protocol AnySelectionSet: SelectionSetEntityValue {
-  static var schema: SchemaMetadata.Type { get }
+  static var __schema: SchemaMetadata.Type { get }
 
   static var selections: [Selection] { get }
 
@@ -65,7 +65,7 @@ public protocol SelectionSet: AnySelectionSet, Hashable {
 
 extension SelectionSet {
 
-  @inlinable public static var schema: SchemaMetadata.Type { Schema.self }
+  @inlinable public static var __schema: SchemaMetadata.Type { Schema.self }
 
   @usableFromInline var __objectType: Object? { Schema.objectType(forTypename: __typename) }
 

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -3,7 +3,7 @@
 public protocol AnySelectionSet: SelectionSetEntityValue {
   static var __schema: SchemaMetadata.Type { get }
 
-  static var selections: [Selection] { get }
+  static var __selections: [Selection] { get }
 
   /// The GraphQL type for the `SelectionSet`.
   ///
@@ -21,7 +21,7 @@ public protocol AnySelectionSet: SelectionSetEntityValue {
 }
 
 public extension AnySelectionSet {
-  static var selections: [Selection] { [] }
+  static var __selections: [Selection] { [] }
 }
 
 /// A selection set that represents the root selections on its `__parentType`. Nested selection

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -134,7 +134,7 @@ struct SelectionSetTemplate {
     config.options.warningsOnDeprecatedUsage == .include ? [] : nil
 
     let selectionsTemplate = TemplateString("""
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       \(renderedSelections(groupedSelections.unconditionalSelections, &deprecatedArguments), terminator: ",")
       \(groupedSelections.inclusionConditionGroups.map {
         renderedConditionalSelectionGroup($0, $1, in: scope, &deprecatedArguments)

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
@@ -22,7 +22,7 @@ public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { GitHubAPI.Interfaces.Actor }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("login", String.self),
     .inlineFragment(AsUser.self),
   ] }
@@ -40,7 +40,7 @@ public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { GitHubAPI.Objects.User }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("id", ID.self),
       .field("name", String?.self),
     ] }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -50,7 +50,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { GitHubAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("repository", Repository?.self, arguments: [
         "name": "apollo-ios",
         "owner": "apollographql"
@@ -68,7 +68,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { GitHubAPI.Objects.Repository }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .field("issues", Issues.self, arguments: ["last": 100]),
       ] }
@@ -86,7 +86,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { GitHubAPI.Objects.IssueConnection }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("nodes", [Node?]?.self),
         ] }
 
@@ -101,7 +101,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { GitHubAPI.Objects.Issue }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("title", String.self),
             .field("author", Author?.self),
             .field("body", String.self),
@@ -125,7 +125,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { GitHubAPI.Interfaces.Actor }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .fragment(AuthorDetails.self),
             ] }
 
@@ -173,7 +173,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { GitHubAPI.Objects.IssueCommentConnection }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .field("nodes", [Node?]?.self),
             ] }
 
@@ -188,7 +188,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
               public init(data: DataDict) { __data = data }
 
               public static var __parentType: ParentType { GitHubAPI.Objects.IssueComment }
-              public static var selections: [Selection] { [
+              public static var __selections: [Selection] { [
                 .field("body", String.self),
                 .field("author", Author?.self),
               ] }
@@ -206,7 +206,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
                 public init(data: DataDict) { __data = data }
 
                 public static var __parentType: ParentType { GitHubAPI.Interfaces.Actor }
-                public static var selections: [Selection] { [
+                public static var __selections: [Selection] { [
                   .fragment(AuthorDetails.self),
                 ] }
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
@@ -26,7 +26,7 @@ public class RepoURLQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { GitHubAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("repository", Repository?.self, arguments: [
         "owner": "apollographql",
         "name": "apollo-ios"
@@ -44,7 +44,7 @@ public class RepoURLQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { GitHubAPI.Objects.Repository }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("url", URI.self),
       ] }
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -51,7 +51,7 @@ public class RepositoryQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { GitHubAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("repository", Repository?.self, arguments: [
         "owner": "apollographql",
         "name": "apollo-ios"
@@ -69,7 +69,7 @@ public class RepositoryQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { GitHubAPI.Objects.Repository }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("issueOrPullRequest", IssueOrPullRequest?.self, arguments: ["number": 13]),
       ] }
 
@@ -84,7 +84,7 @@ public class RepositoryQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { GitHubAPI.Unions.IssueOrPullRequest }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .inlineFragment(AsIssue.self),
           .inlineFragment(AsReactable.self),
         ] }
@@ -100,7 +100,7 @@ public class RepositoryQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { GitHubAPI.Objects.Issue }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("body", String.self),
             .field("url", URI.self),
             .field("author", Author?.self),
@@ -123,7 +123,7 @@ public class RepositoryQuery: GraphQLQuery {
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { GitHubAPI.Interfaces.Actor }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .field("avatarUrl", URI.self),
             ] }
 
@@ -142,7 +142,7 @@ public class RepositoryQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { GitHubAPI.Interfaces.Reactable }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("viewerCanReact", Bool.self),
             .inlineFragment(AsComment.self),
           ] }
@@ -160,7 +160,7 @@ public class RepositoryQuery: GraphQLQuery {
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { GitHubAPI.Interfaces.Comment }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .field("author", Author?.self),
             ] }
 
@@ -177,7 +177,7 @@ public class RepositoryQuery: GraphQLQuery {
               public init(data: DataDict) { __data = data }
 
               public static var __parentType: ParentType { GitHubAPI.Interfaces.Actor }
-              public static var selections: [Selection] { [
+              public static var __selections: [Selection] { [
                 .field("login", String.self),
               ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
@@ -17,7 +17,7 @@ public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("appearsIn", [GraphQLEnum<Episode>?].self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
@@ -17,7 +17,7 @@ public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
@@ -18,7 +18,7 @@ public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
     .field("appearsIn", [GraphQLEnum<Episode>?].self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
@@ -17,7 +17,7 @@ public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.Selectio
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .fragment(CharacterNameWithNestedAppearsInFragment.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -21,7 +21,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
     .inlineFragment(AsDroid.self),
   ] }
@@ -39,7 +39,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("appearsIn", [GraphQLEnum<Episode>?].self),
     ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -18,7 +18,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .inlineFragment(AsDroid.self),
     .fragment(CharacterName.self),
   ] }
@@ -43,7 +43,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .fragment(DroidPrimaryFunction.self),
     ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -28,7 +28,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .inlineFragment(AsHuman.self),
     .inlineFragment(AsDroid.self),
   ] }
@@ -44,7 +44,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("friends", [Friend?]?.self),
     ] }
 
@@ -59,7 +59,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("appearsIn", [GraphQLEnum<Episode>?].self),
       ] }
 
@@ -78,7 +78,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .fragment(CharacterName.self),
       .fragment(FriendsNames.self),
     ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
@@ -18,7 +18,7 @@ public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
     .fragment(CharacterAppearsIn.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
@@ -18,7 +18,7 @@ public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
     .field("primaryFunction", String?.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
@@ -17,7 +17,7 @@ public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
@@ -18,7 +18,7 @@ public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .fragment(CharacterName.self),
     .fragment(DroidPrimaryFunction.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
@@ -17,7 +17,7 @@ public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("primaryFunction", String?.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
@@ -20,7 +20,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("friends", [Friend?]?.self),
   ] }
 
@@ -35,7 +35,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("name", String.self),
     ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -25,7 +25,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("name", String.self),
     .inlineFragment(AsHuman.self),
     .inlineFragment(AsDroid.self),
@@ -45,7 +45,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("height", Double?.self),
     ] }
 
@@ -63,7 +63,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("primaryFunction", String?.self),
     ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
@@ -17,7 +17,7 @@ public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
   public init(data: DataDict) { __data = data }
 
   public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("height", Double?.self, arguments: ["unit": .variable("heightUnit")]),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -28,7 +28,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("createReview", CreateReview?.self, arguments: [
         "episode": "JEDI",
         "review": [
@@ -48,7 +48,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Review }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -42,7 +42,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("createReview", CreateReview?.self, arguments: [
         "episode": .variable("episode"),
         "review": .variable("review")
@@ -59,7 +59,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Review }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -28,7 +28,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("createReview", CreateReview?.self, arguments: [
         "episode": "JEDI",
         "review": [
@@ -48,7 +48,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Review }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -34,7 +34,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .inlineFragment(AsDroid.self),
       ] }
 
@@ -62,7 +62,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .fragment(DroidDetails.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -38,7 +38,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -52,7 +52,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
@@ -73,7 +73,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("id", ID.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -51,7 +51,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
       ] }
@@ -69,7 +69,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("name", String.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -49,7 +49,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .fragment(FriendsNames.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -44,7 +44,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -58,7 +58,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friends", [Friend?]?.self),
         .inlineFragment(AsDroid.self),
       ] }
@@ -76,7 +76,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .fragment(CharacterName.self),
         ] }
 
@@ -99,7 +99,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("friends", [Friend?]?.self),
         ] }
 
@@ -114,7 +114,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .fragment(CharacterName.self),
           ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -38,7 +38,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -52,7 +52,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
@@ -73,7 +73,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("name", String.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -39,7 +39,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -53,7 +53,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
@@ -74,7 +74,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("id", ID.self),
           .field("name", String.self),
         ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -41,7 +41,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("appearsIn", [GraphQLEnum<Episode>?].self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(CharacterAppearsIn.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "includeDetails", .fragment(HeroDetails.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -51,7 +51,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "includeDetails", .inlineFragment(IfIncludeDetails.self)),
       ] }
 
@@ -65,7 +65,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("name", String.self),
           .field("appearsIn", [GraphQLEnum<Episode>?].self),
         ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -41,7 +41,7 @@ public class HeroDetailsQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -55,7 +55,7 @@ public class HeroDetailsQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
@@ -75,7 +75,7 @@ public class HeroDetailsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("height", Double?.self),
         ] }
 
@@ -93,7 +93,7 @@ public class HeroDetailsQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("primaryFunction", String?.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(HeroDetails.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -40,7 +40,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -54,7 +54,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "includeFriendsDetails", .field("friends", [Friend?]?.self)),
       ] }
 
@@ -69,7 +69,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("name", String.self),
           .inlineFragment(AsDroid.self),
         ] }
@@ -87,7 +87,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("primaryFunction", String?.self),
           ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -44,7 +44,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -58,7 +58,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friends", [Friend?]?.self),
       ] }
 
@@ -73,7 +73,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("name", String.self),
           .include(if: "includeFriendsDetails", .inlineFragment(IfIncludeFriendsDetails.self)),
         ] }
@@ -92,7 +92,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("name", String.self),
             .inlineFragment(AsDroid.self),
           ] }
@@ -110,7 +110,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .field("primaryFunction", String?.self),
             ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -40,7 +40,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -54,7 +54,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friends", [Friend?]?.self),
       ] }
 
@@ -69,7 +69,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("id", ID.self),
           .field("friends", [Friend?]?.self),
         ] }
@@ -87,7 +87,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("name", String.self),
           ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .field("appearsIn", [GraphQLEnum<Episode>?].self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(CharacterNameAndAppearsIn.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -41,7 +41,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -55,7 +55,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: !"skipName" && "includeName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -42,7 +42,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -56,7 +56,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: !"skipName" || "includeName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -47,7 +47,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: !"skipName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
     ] }
 
@@ -47,7 +47,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "includeName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroNameQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -47,7 +47,7 @@ public class HeroNameQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -45,7 +45,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -59,7 +59,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .inlineFragment(AsDroid.self),
         .include(if: "includeName", .field("name", String.self)),
       ] }
@@ -77,7 +77,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("name", String.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -49,7 +49,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .fragment(CharacterName.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(CharacterName.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("name", String.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -55,7 +55,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -69,7 +69,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
@@ -89,7 +89,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("friends", [Friend?]?.self),
         ] }
 
@@ -106,7 +106,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("name", String.self),
             .inlineFragment(AsHuman.self),
           ] }
@@ -124,7 +124,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .field("height", Double?.self, arguments: ["unit": "FOOT"]),
             ] }
 
@@ -144,7 +144,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("friends", [Friend?]?.self),
         ] }
 
@@ -161,7 +161,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("name", String.self),
             .inlineFragment(AsHuman.self),
           ] }
@@ -179,7 +179,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             public init(data: DataDict) { __data = data }
 
             public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-            public static var selections: [Selection] { [
+            public static var __selections: [Selection] { [
               .field("height", Double?.self, arguments: ["unit": "METER"]),
             ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -40,7 +40,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -54,7 +54,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
       ] }
@@ -70,7 +70,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("homePlanet", alias: "property", String?.self),
         ] }
 
@@ -86,7 +86,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("primaryFunction", alias: "property", String?.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HumanQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("human", Human?.self, arguments: ["id": .variable("id")]),
     ] }
 
@@ -48,7 +48,7 @@ public class HumanQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .field("mass", Double?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -31,7 +31,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", Hero?.self),
       .field("hero", alias: "r2", R2?.self),
     ] }
@@ -47,7 +47,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
       ] }
 
@@ -63,7 +63,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("appearsIn", [GraphQLEnum<Episode>?].self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -47,7 +47,7 @@ public class SearchQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("search", [Search?]?.self, arguments: ["text": .variable("term")]),
     ] }
 
@@ -61,7 +61,7 @@ public class SearchQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Unions.SearchResult }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
         .inlineFragment(AsStarship.self),
@@ -79,7 +79,7 @@ public class SearchQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Human }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("id", ID.self),
           .field("name", String.self),
         ] }
@@ -98,7 +98,7 @@ public class SearchQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Droid }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("id", ID.self),
           .field("name", String.self),
         ] }
@@ -117,7 +117,7 @@ public class SearchQuery: GraphQLQuery {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { StarWarsAPI.Objects.Starship }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("id", ID.self),
           .field("name", String.self),
         ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -35,7 +35,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("starshipCoordinates", StarshipCoordinates?.self, arguments: ["coordinates": .variable("coordinates")]),
     ] }
 
@@ -49,7 +49,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Starship }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .field("coordinates", [[Double]]?.self),
         .field("length", Double?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -28,7 +28,7 @@ public class StarshipQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("starship", Starship?.self, arguments: ["id": 3000]),
     ] }
 
@@ -42,7 +42,7 @@ public class StarshipQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Starship }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
         .field("coordinates", [[Double]]?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -31,7 +31,7 @@ public class TwoHeroesQuery: GraphQLQuery {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Query }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("hero", alias: "r2", R2?.self),
       .field("hero", alias: "luke", Luke?.self, arguments: ["episode": "EMPIRE"]),
     ] }
@@ -47,7 +47,7 @@ public class TwoHeroesQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
       ] }
 
@@ -63,7 +63,7 @@ public class TwoHeroesQuery: GraphQLQuery {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Interfaces.Character }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("name", String.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -35,7 +35,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { StarWarsAPI.Objects.Subscription }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("reviewAdded", ReviewAdded?.self, arguments: ["episode": .variable("episode")]),
     ] }
 
@@ -49,7 +49,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { StarWarsAPI.Objects.Review }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("episode", GraphQLEnum<Episode>?.self),
         .field("stars", Int.self),
         .field("commentary", String?.self),

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
@@ -23,7 +23,7 @@ public class IncrementingSubscription: GraphQLSubscription {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { SubscriptionAPI.Objects.Subscription }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("numberIncremented", Int?.self),
     ] }
 

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -43,7 +43,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { UploadAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("multipleParameterUpload", [MultipleParameterUpload].self, arguments: [
         "singleFile": .variable("singleFile"),
         "multipleFiles": .variable("multipleFiles")
@@ -60,7 +60,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { UploadAPI.Objects.File }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("path", String.self),
         .field("filename", String.self),

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -35,7 +35,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { UploadAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("multipleUpload", [MultipleUpload].self, arguments: ["files": .variable("files")]),
     ] }
 
@@ -49,7 +49,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { UploadAPI.Objects.File }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("path", String.self),
         .field("filename", String.self),

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -35,7 +35,7 @@ public class UploadOneFileMutation: GraphQLMutation {
     public init(data: DataDict) { __data = data }
 
     public static var __parentType: ParentType { UploadAPI.Objects.Mutation }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("singleUpload", SingleUpload.self, arguments: ["file": .variable("file")]),
     ] }
 
@@ -49,7 +49,7 @@ public class UploadOneFileMutation: GraphQLMutation {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { UploadAPI.Objects.File }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("id", ID.self),
         .field("path", String.self),
         .field("filename", String.self),

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/ClassroomPetDetails.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/ClassroomPetDetails.swift
@@ -46,7 +46,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Interface(AnimalKingdomAPI.Animal.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("species", String.self),
     ] }
 
@@ -59,7 +59,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Interface(AnimalKingdomAPI.Pet.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("humanName", String.self),
     ] }
 
@@ -73,7 +73,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Interface(AnimalKingdomAPI.Animal.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("laysEggs", Bool.self),
     ] }
 
@@ -87,7 +87,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKingdomAPI.Cat.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("bodyTemperature", Int.self),
       .field("isJellicle", Bool.self),
     ] }
@@ -105,7 +105,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKingdomAPI.Bird.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("wingspan", Int.self),
     ] }
 
@@ -121,7 +121,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKingdomAPI.PetRock.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("favoriteToy", String.self),
     ] }
 

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/HeightInMeters.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/HeightInMeters.swift
@@ -15,7 +15,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: ResponseDict) { self.data = data }
 
   public static var __parentType: ParentType { .Interface(AnimalKingdomAPI.Animal.self) }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("height", Height.self),
   ] }
 
@@ -26,7 +26,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKingdomAPI.Height.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("meters", type: Int.self),
     ] }
 

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/PetDetails.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/PetDetails.swift
@@ -17,7 +17,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: ResponseDict) { self.data = data }
 
   public static var __parentType: ParentType { .Interface(AnimalKingdomAPI.Pet.self) }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("humanName", String.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner.self),

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/WarmBloodedDetails.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Fragments/WarmBloodedDetails.swift
@@ -17,7 +17,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public init(data: ResponseDict) { self.data = data }
 
   public static var __parentType: ParentType { .Interface(AnimalKingdomAPI.WarmBlooded.self) }
-  public static var selections: [Selection] { [
+  public static var __selections: [Selection] { [
     .field("bodyTemperature", Int.self),
     .field("height", Height.self),
   ] }
@@ -30,7 +30,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKingdomAPI.Height.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("meters", Int.self),
       .field("yards", Int.self),
     ] }

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Queries/AllAnimalsQuery.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Queries/AllAnimalsQuery.swift
@@ -54,7 +54,7 @@ public class AllAnimalsQuery: GraphQLQuery {
     public init(data: DataDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKindgomAPI.Query.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("allAnimals", [AllAnimal].self),
     ] }
 
@@ -66,7 +66,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       public init(data: DataDict) { self.data = data }
 
       public static var __parentType: ParentType { .Interface(AnimalKindgomAPI.Animal.self) }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<SkinCovering>?.self),
@@ -101,7 +101,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { self.data = data }
 
         public static var __parentType: ParentType { .Object(AnimalKindgomAPI.Height.self) }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("feet", Int.self),
           .field("inches", Int.self),
         ] }
@@ -117,7 +117,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { self.data = data }
 
         public static var __parentType: ParentType { .Interface(AnimalKindgomAPI.Animal.self) }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("species", String.self),
           .typeCase(AsWarmBlooded.self),
         ] }
@@ -132,7 +132,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { self.data = data }
 
           public static var __parentType: ParentType { .Interface(AnimalKindgomAPI.WarmBlooded.self) }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("laysEggs", Bool.self),
             .fragment(WarmBloodedDetails.self),
           ] }
@@ -157,7 +157,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { self.data = data }
 
         public static var __parentType: ParentType { .Interface(AnimalKindgomAPI.WarmBlooded.self) }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .fragment(WarmBloodedDetails.self),
         ] }
 
@@ -195,7 +195,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { self.data = data }
 
         public static var __parentType: ParentType { .Interface(AnimalKindgomAPI.Pet.self) }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("height", Height.self),
           .typeCase(AsWarmBlooded.self),
           .fragment(PetDetails.self),
@@ -225,7 +225,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { self.data = data }
 
           public static var __parentType: ParentType { .Object(AnimalKindgomAPI.Height.self) }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("relativeSize", GraphQLEnum<RelativeSize>.self),
             .field("centimeters", Int.self),
           ] }
@@ -243,7 +243,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { self.data = data }
 
           public static var __parentType: ParentType { .Interface(AnimalKindgomAPI.WarmBlooded.self) }
-          public static var selections: [Selection] { [            
+          public static var __selections: [Selection] { [            
             .fragment(WarmBloodedDetails.self),
           ] }
 
@@ -288,7 +288,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { self.data = data }
 
         public static var __parentType: ParentType { .Object(AnimalKindgomAPI.Cat.self) }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("isJellicle", Bool.self),
         ] }
 
@@ -333,7 +333,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public init(data: DataDict) { self.data = data }
 
         public static var __parentType: ParentType { .Union(AnimalKindgomAPI.ClassroomPet.self) }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .typeCase(AsBird.self),
         ] }
 
@@ -357,7 +357,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public init(data: DataDict) { self.data = data }
 
           public static var __parentType: ParentType { .Object(AnimalKindgomAPI.Bird.self) }
-          public static var selections: [Selection] { [
+          public static var __selections: [Selection] { [
             .field("wingspan", Int.self),
           ] }
 

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Queries/ClassroomPetsQuery.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/ExpectedGeneratedOutput/Queries/ClassroomPetsQuery.swift
@@ -22,7 +22,7 @@ public struct ClassroomPetsQuery: GraphQLQuery {
     public init(data: ResponseDict) { self.data = data }
 
     public static var __parentType: ParentType { .Object(AnimalKingdomAPI.Query.self) }
-    public static var selections: [Selection] { [
+    public static var __selections: [Selection] { [
       .field("classroomPets", [ClassroomPetDetails].self),
     ] }
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -309,7 +309,7 @@ class FragmentTemplateTests: XCTestCase {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { TestSchema.Objects.Animal }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
       ] }
     }
 
@@ -398,7 +398,7 @@ class FragmentTemplateTests: XCTestCase {
       public init(data: DataDict) { __data = data }
 
       public static var __parentType: ParentType { TestSchema.Objects.Query }
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("allAnimals", [AllAnimal]?.self),
       ] }
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -326,7 +326,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("string", String.self),
         .field("string_optional", String?.self),
         .field("int", Int.self),
@@ -398,7 +398,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expectedWithNamespace = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("custom", TestSchema.Custom.self),
         .field("custom_optional", TestSchema.Custom?.self),
         .field("custom_required_list", [TestSchema.Custom].self),
@@ -408,7 +408,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expectedNoNamespace = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("custom", Custom.self),
         .field("custom_optional", Custom?.self),
         .field("custom_required_list", [Custom].self),
@@ -480,7 +480,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expectedNoNamespace = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("testEnum", GraphQLEnum<TestEnum>.self),
         .field("testEnumOptional", GraphQLEnum<TestEnumOptional>?.self),
         .field("lowercaseEnum", GraphQLEnum<LowercaseEnum>.self),
@@ -488,7 +488,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expectedWithNamespace = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("testEnum", GraphQLEnum<TestSchema.TestEnum>.self),
         .field("testEnumOptional", GraphQLEnum<TestSchema.TestEnumOptional>?.self),
         .field("lowercaseEnum", GraphQLEnum<TestSchema.LowercaseEnum>.self),
@@ -542,7 +542,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("FieldName", String.self),
       ] }
     """
@@ -580,7 +580,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("string", alias: "aliased", String.self),
       ] }
     """
@@ -629,7 +629,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("predator", Predator.self),
         .field("lowercaseType", LowercaseType.self),
       ] }
@@ -774,7 +774,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("associatedtype", String.self),
         .field("class", String.self),
         .field("deinit", String.self),
@@ -871,7 +871,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("_oneUnderscore", _OneUnderscore.self),
         .field("__twoUnderscore", __TwoUnderscore.self),
       ] }
@@ -969,7 +969,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("self", Self_SelectionSet.self),
         .field("parentType", ParentType_SelectionSet.self),
         .field("dataDict", DataDict_SelectionSet.self),
@@ -1023,7 +1023,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("string", alias: "aliased", String.self, arguments: ["variable": 3]),
       ] }
     """
@@ -1061,7 +1061,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("string", alias: "aliased", String.self, arguments: ["variable": .null]),
       ] }
     """
@@ -1099,7 +1099,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("string", alias: "aliased", String.self, arguments: ["variable": .variable("var")]),
       ] }
     """
@@ -1168,7 +1168,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("string", alias: "aliased", String.self, arguments: ["input": [
           "string": "ABCD",
           "int": 3,
@@ -1232,7 +1232,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .inlineFragment(AsPet.self),
         .inlineFragment(AsLowercaseInterface.self),
       ] }
@@ -1283,7 +1283,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(FragmentA.self),
         .fragment(LowercaseFragment.self),
       ] }
@@ -1324,7 +1324,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "a", .field("fieldName", String.self)),
       ] }
     """
@@ -1362,7 +1362,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: !"b", .field("fieldName", String.self)),
       ] }
     """
@@ -1400,7 +1400,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: !"b" && "a", .field("fieldName", String.self)),
       ] }
     """
@@ -1441,7 +1441,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: (!"b" && "a") || !"c" || ("d" && !"e") || "f", .field("fieldName", String.self)),
       ] }
     """
@@ -1493,7 +1493,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "a", [
           .field("fieldA", String.self),
           .field("fieldB", String.self),
@@ -1546,7 +1546,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "a", .inlineFragment(AsPet.self)),
       ] }
     """
@@ -1590,7 +1590,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .include(if: "a", .inlineFragment(IfA.self)),
       ] }
     """
@@ -1638,7 +1638,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .fragment(FragmentA.self),
       ] }
     """
@@ -4455,7 +4455,7 @@ class SelectionSetTemplateTests: XCTestCase {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { TestSchema.Objects.Badge }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("a", String?.self),
         ] }
 
@@ -4468,7 +4468,7 @@ class SelectionSetTemplateTests: XCTestCase {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { TestSchema.Objects.ProductBadge }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("b", String?.self),
         ] }
 
@@ -4529,7 +4529,7 @@ class SelectionSetTemplateTests: XCTestCase {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { TestSchema.Objects.Badge }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("a", String?.self),
         ] }
 
@@ -4542,7 +4542,7 @@ class SelectionSetTemplateTests: XCTestCase {
         public init(data: DataDict) { __data = data }
 
         public static var __parentType: ParentType { TestSchema.Objects.ProductBadge }
-        public static var selections: [Selection] { [
+        public static var __selections: [Selection] { [
           .field("b", String?.self),
         ] }
 
@@ -5494,7 +5494,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       #warning("Argument 'species' of field 'friend' is deprecated. Reason: 'Who cares?'")
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friend", Friend?.self, arguments: [
           "name": .variable("name"),
           "species": .variable("species")
@@ -5540,7 +5540,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     let expected = """
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friend", Friend?.self, arguments: [
           "name": .variable("name"),
           "species": .variable("species")
@@ -5591,7 +5591,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let expected = """
       #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'"),
       #warning("Argument 'species' of field 'friend' is deprecated. Reason: 'Who cares?'")
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friend", Friend?.self, arguments: [
           "name": .variable("name"),
           "species": .variable("species")
@@ -5640,7 +5640,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let expected = """
       #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'"),
       #warning("Argument 'species' of field 'species' is deprecated. Reason: 'Redundant'")
-      public static var selections: [Selection] { [
+      public static var __selections: [Selection] { [
         .field("friend", Friend?.self, arguments: ["name": .variable("name")]),
         .field("species", String?.self, arguments: ["species": .variable("species")]),
       ] }

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -45,7 +45,7 @@ open class MockSubscription<SelectionSet: RootSelectionSet>: MockOperation<Selec
 
 @dynamicMemberLookup
 open class AbstractMockSelectionSet: AnySelectionSet {
-  open class var schema: SchemaMetadata.Type { MockSchemaMetadata.self }
+  open class var __schema: SchemaMetadata.Type { MockSchemaMetadata.self }
   open class var selections: [Selection] { [] }
   open class var __parentType: ParentType { Object.mock }
 

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -46,7 +46,7 @@ open class MockSubscription<SelectionSet: RootSelectionSet>: MockOperation<Selec
 @dynamicMemberLookup
 open class AbstractMockSelectionSet: AnySelectionSet {
   open class var __schema: SchemaMetadata.Type { MockSchemaMetadata.self }
-  open class var selections: [Selection] { [] }
+  open class var __selections: [Selection] { [] }
   open class var __parentType: ParentType { Object.mock }
 
   public var __data: DataDict = DataDict([:], variables: nil)

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -44,13 +44,13 @@ final class ApolloClientOperationTests: XCTestCase {
   func test__performMutation_givenPublishResultToStore_false_doesNotPublishResultsToStore() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("createReview", CreateReview.self,
                arguments: ["episode": .variable("episode"), "review": .variable("review")])
       ] }
 
       class CreateReview: MockSelectionSet {
-        override class var selections: [Selection] { [
+        override class var __selections: [Selection] { [
           .field("__typename", String.self),
           .field("stars", Int.self),
           .field("commentary", String?.self)

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -10,14 +10,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
 
   // MARK: - Mocks
   class HeroNameSelectionSet: MockSelectionSet {
-    override class var selections: [Selection] {[
+    override class var __selections: [Selection] {[
       .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
     ]}
 
     var hero: Hero? { __data["hero"] }
 
     class Hero: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("name", String.self),
       ]}

--- a/Tests/ApolloTests/BatchedLoadTests.swift
+++ b/Tests/ApolloTests/BatchedLoadTests.swift
@@ -74,14 +74,14 @@ class BatchedLoadTests: XCTestCase {
   func testListsAreLoadedInASingleBatch() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self),
@@ -90,7 +90,7 @@ class BatchedLoadTests: XCTestCase {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self),
           ]}
@@ -151,14 +151,14 @@ class BatchedLoadTests: XCTestCase {
   func testParallelLoadsUseIndependentBatching() {
     // given // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self),
@@ -167,7 +167,7 @@ class BatchedLoadTests: XCTestCase {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self),
           ]}

--- a/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
+++ b/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
@@ -28,12 +28,12 @@ class CacheDependentInterceptorTests: XCTestCase, CacheDependentTesting {
   func testChangingCachePolicyInErrorInterceptorWorks() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}

--- a/Tests/ApolloTests/Cache/FetchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/FetchQueryTests.swift
@@ -37,12 +37,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch__givenCachePolicy_fetchIgnoringCacheData_onlyHitsNetwork() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -92,12 +92,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch__givenCachePolicy_returnCacheDataAndFetch_hitsCacheFirstAndNetworkAfter() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -159,12 +159,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch__givenCachePolicy_returnCacheDataElseFetch_givenDataIsCached_doesntHitNetwork() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -204,12 +204,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch__givenCachePolicy_returnCacheDataElseFetch_givenNotAllDataIsCached_hitsNetwork() throws {
     class HeroNameAndAppearsInSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("appearsIn", [String]?.self)
@@ -260,12 +260,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch__givenCachePolicy_returnCacheDataDontFetch_givenDataIsCached_doesntHitNetwork() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -301,12 +301,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch__givenCachePolicy_returnCacheDataDontFetch_givenNotAllDataIsCached_returnsError() throws {
     class HeroNameAndAppearsInSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("appearsIn", [String]?.self)
@@ -340,12 +340,12 @@ class FetchQueryTests: XCTestCase, CacheDependentTesting {
   
   func test__fetch_afterClearCache_givenCachePolicy_returnCacheDataDontFetch_throwsCacheMissError() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -33,12 +33,12 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroNameQuery() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -68,12 +68,12 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroNameQueryWithVariable() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -104,12 +104,12 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroNameQueryWithMissingName_throwsMissingValueError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -140,12 +140,12 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroNameQueryWithNullName_throwsNullValueError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -176,13 +176,13 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroAndFriendsNamesQueryWithoutIDs() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self)
@@ -190,7 +190,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend] { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self)
           ]}
@@ -235,13 +235,13 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroAndFriendsNamesQueryWithIDs() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self)
@@ -249,7 +249,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend] { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self)
           ]}
@@ -294,13 +294,13 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withNullFriends() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self)
@@ -308,7 +308,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self)
           ]}
@@ -345,13 +345,13 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingHeroAndFriendsNamesQuery_withOptionalFriendsSelection_withFriendsNotInCache_throwsMissingValueError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self)
@@ -359,7 +359,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self)
           ]}
@@ -392,13 +392,13 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func testLoadingWithBadCacheSerialization() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self)
@@ -406,7 +406,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self)
           ]}
@@ -455,12 +455,12 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let coordinates: [[Double]] = [[38.857150, -94.798464]]
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("starshipCoordinates", Starship.self)
       ]}
 
       class Starship: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("length", Float.self),

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -33,12 +33,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
   func test_readQuery_givenQueryDataInCache_returnsData() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -70,7 +70,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_readQuery_givenQueryDataDoesNotExist_throwsMissingValueError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("name", String.self)
       ]}
     }
@@ -103,12 +103,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -150,12 +150,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -189,14 +189,14 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_readQuery_withCacheReferencesByCustomKey_resolvesReferences() throws {
     // given
     class HeroFriendsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -206,7 +206,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend] { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -266,7 +266,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     class GivenSelectionSet: MockFragment, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("__typename", String.self),
         .field("name", String.self),
         .inlineFragment(AsDroid.self),
@@ -278,7 +278,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: ParentType { Types.Droid }
 
-        override class var selections: [Selection] { [
+        override class var __selections: [Selection] { [
           .field("primaryFunction", String.self),
         ]}
       }
@@ -322,7 +322,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     class GivenSelectionSet: MockFragment, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("__typename", String.self),
         .field("name", String.self),
         .inlineFragment(AsDroid.self),
@@ -334,7 +334,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: ParentType { Types.Droid }
 
-        override class var selections: [Selection] { [
+        override class var __selections: [Selection] { [
           .field("primaryFunction", String.self),
         ]}
       }
@@ -374,7 +374,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -387,7 +387,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -439,7 +439,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -452,7 +452,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -509,7 +509,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
@@ -522,7 +522,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -613,7 +613,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -626,7 +626,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("__typename", String.self),
           .field("name", String.self),
           .inlineFragment(AsDroid.self),
@@ -647,7 +647,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           static let __parentType: ParentType = Types.Droid
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] { [
+          static var __selections: [Selection] { [
             .field("primaryFunction", String.self),
           ]}
 
@@ -714,7 +714,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("__typename", String.self),
         .field("name", String.self),
         .inlineFragment(AsDroid.self),
@@ -735,7 +735,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         static let __parentType: ParentType = Types.Droid
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("primaryFunction", String.self),
         ]}
 
@@ -750,7 +750,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -763,7 +763,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("__typename", String.self),
           .field("name", String.self),
           .fragment(GivenFragment.self),
@@ -845,7 +845,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("__typename", String.self),
         .field("name", String.self),
         .inlineFragment(AsDroid.self),
@@ -866,7 +866,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         static let __parentType: ParentType = Types.Droid
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("primaryFunction", String.self),
         ]}
 
@@ -881,7 +881,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -894,7 +894,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("__typename", String.self),
           .field("name", String.self),
           .fragment(GivenFragment.self),
@@ -915,7 +915,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           static let __parentType: ParentType = Types.Droid
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] { [
+          static var __selections: [Selection] { [
             .field("primaryFunction", String.self),
           ]}
 
@@ -982,7 +982,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -995,7 +995,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("id", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self),
@@ -1015,7 +1015,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] { [
+          static var __selections: [Selection] { [
             .field("id", String.self),
             .field("name", String.self),
           ]}
@@ -1099,7 +1099,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -1112,7 +1112,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -1165,7 +1165,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -1178,7 +1178,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -1220,7 +1220,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -1233,7 +1233,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -1285,7 +1285,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -1298,7 +1298,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("name", String.self)
         ]}
 
@@ -1347,7 +1347,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("id", String.self),
         .field("friends", [Friend].self),
       ]}
@@ -1361,7 +1361,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("id", String.self),
           .field("name", String.self),
         ]}
@@ -1417,14 +1417,14 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     self.wait(for: [updateCompletedExpectation], timeout: Self.defaultWaitTimeout)
 
     class HeroFriendsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -1434,7 +1434,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend] { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -1465,7 +1465,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -1478,7 +1478,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("id", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self),
@@ -1498,7 +1498,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] { [
+          static var __selections: [Selection] { [
             .field("id", String.self),
             .field("name", String.self),
           ]}
@@ -1568,12 +1568,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_removeObjectsMatchingPattern_givenPatternNotMatchingKeyCase_deletesCaseInsensitiveMatchingRecords() throws {
     // given
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -1645,14 +1645,14 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     class HeroFriendsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -1662,7 +1662,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         var friends: [Friend] { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -1789,12 +1789,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_readTransaction_readQuery_afterTransaction_releasesReadTransaction() throws {
     // given
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}

--- a/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
+++ b/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
@@ -11,12 +11,12 @@ class CachePersistenceTests: XCTestCase {
   func testFetchAndPersist() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -86,12 +86,12 @@ class CachePersistenceTests: XCTestCase {
   func testFetchAndPersistWithPeriodArguments() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["text": .variable("term")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -172,12 +172,12 @@ class CachePersistenceTests: XCTestCase {
   func testClearCache() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}

--- a/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
+++ b/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
@@ -31,14 +31,14 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
   // MARK: - Mocks
 
   class GivenSelectionSet: MockSelectionSet {
-    override class var selections: [Selection] {[
+    override class var __selections: [Selection] {[
       .field("hero", Hero?.self)
     ]}
 
     var hero: Hero? { __data["hero"] }
 
     class Hero: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("name", String.self),
         .field("friends", [Friend]?.self),
@@ -47,7 +47,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
       var friends: [Friend]? { __data["friends"] }
 
       class Friend: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
         ]}
@@ -145,7 +145,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -158,7 +158,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("id", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self),
@@ -183,7 +183,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] { [
+          static var __selections: [Selection] { [
             .field("id", String.self),
             .field("name", String.self),
           ]}
@@ -269,7 +269,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] { [
+      static var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
@@ -282,7 +282,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] { [
+        static var __selections: [Selection] { [
           .field("id", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self),
@@ -307,7 +307,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] { [
+          static var __selections: [Selection] { [
             .field("id", String.self),
             .field("name", String.self),
           ]}

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -40,12 +40,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
   func testRefetchWatchedQueryFromServerThroughWatcherReturnsRefetchedResults() throws {
     class SimpleMockSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -123,12 +123,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   
   func testWatchedQueryGetsUpdatedAfterFetchingSameQueryWithChangedData() throws {
     class SimpleMockSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -211,12 +211,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   
   func testWatchedQueryDoesNotRefetchAfterSameQueryWithDifferentArgument() throws {
     class GivenMockSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -297,12 +297,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   
   func testWatchedQueryGetsUpdatedWhenSameObjectHasChangedInAnotherQueryWithDifferentVariables() throws {
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self)
@@ -392,12 +392,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   
   func testWatchedQueryGetsUpdatedWhenOverlappingQueryReturnsChangedData() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -405,14 +405,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     class HeroAndFriendsNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self),
@@ -421,7 +421,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self),
           ]}
@@ -518,14 +518,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   
   func testListInWatchedQueryGetsUpdatedByListOfKeysFromOtherQuery() throws {
     class HeroAndFriendsIdsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -535,7 +535,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
           ]}
@@ -544,14 +544,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     class HeroAndFriendsNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -561,7 +561,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -663,14 +663,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   
   func testWatchedQueryRefetchesFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
     class HeroAndFriendsIDsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("friends", [Friend]?.self),
@@ -679,7 +679,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
           ]}
@@ -688,14 +688,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -705,7 +705,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -831,7 +831,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] {[
+      static var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
@@ -844,7 +844,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] {[
+        static var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self),
           .field("friends", [Friend]?.self),
@@ -864,7 +864,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] {[
+          static var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", String.self),
           ]}
@@ -958,7 +958,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] {[
+      static var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
@@ -971,7 +971,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] {[
+        static var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -997,7 +997,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] {[
+          static var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -1020,7 +1020,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] {[
+      static var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
@@ -1033,7 +1033,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] {[
+        static var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("friends", [Friend].self),
@@ -1053,7 +1053,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] {[
+          static var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
           ]}
@@ -1159,12 +1159,12 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
   func testWatchedQueryIsOnlyUpdatedOnceIfConcurrentFetchesAllReturnTheSameResult() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -1257,14 +1257,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
   func testWatchedQueryIsUpdatedMultipleTimesIfConcurrentFetchesReturnChangedData() throws {
     class HeroNameSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       var hero: Hero { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -1369,7 +1369,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       public var __data: DataDict = DataDict([:], variables: nil)
       init(data: DataDict) { __data = data }
 
-      static var selections: [Selection] {[
+      static var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
@@ -1382,7 +1382,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         public var __data: DataDict = DataDict([:], variables: nil)
         init(data: DataDict) { __data = data }
 
-        static var selections: [Selection] {[
+        static var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -1408,7 +1408,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
           public var __data: DataDict = DataDict([:], variables: nil)
           init(data: DataDict) { __data = data }
 
-          static var selections: [Selection] {[
+          static var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -1533,14 +1533,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
   func testWatchedQueryDependentKeysAreUpdatedAfterOtherFetchReturnsChangedData() {
     class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -1550,7 +1550,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),
@@ -1683,14 +1683,14 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
   func testQueryWatcherDoesNotHaveARetainCycle() {
     class HeroAndFriendsNameWithIDsSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero?.self)
       ]}
 
       var hero: Hero? { __data["hero"] }
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
@@ -1700,7 +1700,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         var friends: [Friend]? { __data["friends"] }
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("id", String.self),
             .field("name", String.self),

--- a/Tests/ApolloTests/DefaultInterceptorProviderTests.swift
+++ b/Tests/ApolloTests/DefaultInterceptorProviderTests.swift
@@ -35,12 +35,12 @@ class DefaultInterceptorProviderTests: XCTestCase {
   func testLoading() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
@@ -67,12 +67,12 @@ class DefaultInterceptorProviderTests: XCTestCase {
   func testInitialLoadFromNetworkAndSecondaryLoadFromCache() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}

--- a/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
@@ -35,12 +35,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
   func test__execute__givenObjectWithNoCacheKey_normalizesRecordToPathFromQueryRoot() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -64,12 +64,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
   func test__execute__givenObjectWithNoCacheKey_forFieldWithStringArgument_normalizesRecordToPathFromQueryRootIncludingArgument() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -101,12 +101,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -132,18 +132,18 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
   func test__execute__givenObjectWithNoCacheKey_andNestedArrayOfObjectsWithNoCacheKey_normalizesRecordsToPathsFromQueryRoot() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self),
           .field("friends", [Friend].self)
         ]}
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("name", String.self)
           ]}
         }
@@ -183,19 +183,19 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
   func test__execute__givenObjectWithCacheKey_andNestedArrayOfObjectsWithCacheKey_normalizesRecordsToIndividualReferences() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("id", String.self),
           .field("name", String.self),
           .field("friends", [Friend].self)
         ]}
 
         class Friend: MockSelectionSet {
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("id", String.self),
             .field("name", String.self)
           ]}
@@ -245,20 +245,20 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
   func test__execute__givenFieldForObjectWithNoCacheKey_andAliasedFieldForSameFieldName_normalizesRecordsForBothFieldsIntoOneRecord() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self),
         .field("hero", alias: "r2", R2.self)
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .field("name", String.self)
         ]}
       }
 
       class R2: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("catchphrase", String.self)
         ]}
       }
@@ -295,12 +295,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self),
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .inlineFragment(AsHuman.self),
           .inlineFragment(AsDroid.self),
@@ -308,14 +308,14 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
 
         class AsHuman: MockTypeCase {
           override class var __parentType: ParentType { Types.Human }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("name", alias: "property", String.self)
           ]}
         }
 
         class AsDroid: MockTypeCase {
           override class var __parentType: ParentType { Types.Droid }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("primaryFunction", alias: "property", String.self)
           ]}
         }
@@ -352,19 +352,19 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self),
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .inlineFragment(AsHuman.self),
           .inlineFragment(AsDroid.self),
         ]}
 
         class AsHuman: MockTypeCase {
           override class var __parentType: ParentType { Types.Human }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("name", alias: "property", String.self)
           ]}
@@ -372,7 +372,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
 
         class AsDroid: MockTypeCase {
           override class var __parentType: ParentType { Types.Droid }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("__typename", String.self),
             .field("primaryFunction", alias: "property", String.self)
           ]}
@@ -409,12 +409,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       }
     }
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self),
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .inlineFragment(AsHuman.self),
           .inlineFragment(AsDroid.self),
@@ -422,12 +422,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
 
         class AsHuman: MockTypeCase {
           override class var __parentType: ParentType { Types.Human }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("friend", Friend.self),
           ]}
 
           class Friend: MockSelectionSet {
-            override class var selections: [Selection] {[
+            override class var __selections: [Selection] {[
               .field("height", Double.self, arguments: ["unit": "FOOT"])
             ]}
           }
@@ -435,12 +435,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
 
         class AsDroid: MockTypeCase {
           override class var __parentType: ParentType { Types.Droid }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("friend", Friend.self),
           ]}
 
           class Friend: MockSelectionSet {
-            override class var selections: [Selection] {[
+            override class var __selections: [Selection] {[
               .field("height", Double.self, arguments: ["unit": "METER"])
             ]}
           }
@@ -482,12 +482,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("hero", Hero.self),
       ]}
 
       class Hero: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
           .inlineFragment(AsHuman.self),
           .inlineFragment(AsDroid.self),
@@ -495,12 +495,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
 
         class AsHuman: MockTypeCase {
           override class var __parentType: ParentType { Types.Human }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("friend", Friend.self),
           ]}
 
           class Friend: MockSelectionSet {
-            override class var selections: [Selection] {[
+            override class var __selections: [Selection] {[
               .field("height", Double.self, arguments: ["unit": "FOOT"])
             ]}
           }
@@ -508,12 +508,12 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
 
         class AsDroid: MockTypeCase {
           override class var __parentType: ParentType { Types.Droid }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("friend", Friend.self),
           ]}
 
           class Friend: MockSelectionSet {
-            override class var selections: [Selection] {[
+            override class var __selections: [Selection] {[
               .field("height", Double.self, arguments: ["unit": "METER"])
             ]}
           }

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -37,7 +37,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_scalar__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String.self)] }
+      override class var __selections: [Selection] { [.field("name", String.self)] }
     }
     let object: JSONObject = ["name": "Luke Skywalker"]
 
@@ -51,7 +51,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_scalar__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String.self)] }
+      override class var __selections: [Selection] { [.field("name", String.self)] }
     }
     let object: JSONObject = [:]
 
@@ -70,7 +70,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_scalar__givenDataHasNullValueForField_throwsNullValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String.self)] }
+      override class var __selections: [Selection] { [.field("name", String.self)] }
     }
     let object: JSONObject = ["name": NSNull()]
 
@@ -89,7 +89,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_scalar__givenDataWithTypeConvertibleToFieldType_getsConvertedValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String.self)] }
+      override class var __selections: [Selection] { [.field("name", String.self)] }
     }
     let object: JSONObject = ["name": 10]
 
@@ -103,7 +103,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_scalar__givenDataWithTypeNotConvertibleToFieldType_throwsCouldNotConvertError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String.self)] }
+      override class var __selections: [Selection] { [.field("name", String.self)] }
     }
     let object: JSONObject = ["name": false]
 
@@ -127,7 +127,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     typealias GivenCustomScalar = String
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
+      override class var __selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
     }
     let object: JSONObject = ["customScalar": Int(12345678)]
 
@@ -143,7 +143,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     typealias GivenCustomScalar = String
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
+      override class var __selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
     }
     let object: JSONObject = ["customScalar": Int64(989561700)]
 
@@ -159,7 +159,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     typealias GivenCustomScalar = String
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
+      override class var __selections: [Selection] { [.field("customScalar", GivenCustomScalar.self)] }
     }
     let object: JSONObject = ["customScalar": Double(1234.5678)]
 
@@ -175,7 +175,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_scalar__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String?.self)] }
+      override class var __selections: [Selection] { [.field("name", String?.self)] }
     }
     let object: JSONObject = ["name": "Luke Skywalker"]
 
@@ -189,7 +189,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_scalar__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String?.self)] }
+      override class var __selections: [Selection] { [.field("name", String?.self)] }
     }
     let object: JSONObject = [:]
 
@@ -208,7 +208,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_scalar__givenDataHasNullValueForField_returnsNilValueForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String?.self)] }
+      override class var __selections: [Selection] { [.field("name", String?.self)] }
     }
     let object: JSONObject = ["name": NSNull()]
 
@@ -222,7 +222,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_scalar__givenDataWithTypeConvertibleToFieldType_getsConvertedValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String?.self)] }
+      override class var __selections: [Selection] { [.field("name", String?.self)] }
     }
     let object: JSONObject = ["name": 10]
 
@@ -236,7 +236,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_scalar__givenDataWithTypeNotConvertibleToFieldType_throwsCouldNotConvertError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("name", String?.self)] }
+      override class var __selections: [Selection] { [.field("name", String?.self)] }
     }
     let object: JSONObject = ["name": false]
 
@@ -264,7 +264,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_enum__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
+      override class var __selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
     }
     let object: JSONObject = ["size": "SMALL"]
 
@@ -278,7 +278,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_enum__givenDataIsNotAnEnumCase_getsValueAsUnknownCase() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
+      override class var __selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
     }
     let object: JSONObject = ["size": "GIGANTIC"]
 
@@ -292,7 +292,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_enum__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
+      override class var __selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
     }
     let object: JSONObject = [:]
 
@@ -311,7 +311,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_enum__givenDataHasNullValueForField_throwsNullValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("size", GraphQLEnum<MockEnum>.self)
       ]}
     }
@@ -332,7 +332,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_enum__givenDataWithType_Int_throwsCouldNotConvertError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
+      override class var __selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
     }
     let object: JSONObject = ["size": 10]
 
@@ -352,7 +352,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_enum__givenDataWithType_Double_throwsCouldNotConvertError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
+      override class var __selections: [Selection] { [.field("size", GraphQLEnum<MockEnum>.self)] }
     }
     let object: JSONObject = ["size": 10.0]
 
@@ -374,7 +374,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_scalar__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String].self)] }
     }
     let object: JSONObject = ["favorites": ["Purple", "Potatoes", "iPhone"]]
 
@@ -388,7 +388,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_scalar__givenEmptyDataArray_getsValueAsEmptyArray() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String].self)] }
     }
     let object: JSONObject = ["favorites": []]
 
@@ -402,7 +402,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_scalar__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String].self)] }
     }
     let object: JSONObject = [:]
 
@@ -421,7 +421,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_scalar__givenDataIsNullForField_throwsNullValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String].self)] }
     }
     let object: JSONObject = ["favorites": NSNull()]
 
@@ -440,7 +440,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_scalar__givenDataWithElementTypeConvertibleToFieldType_getsConvertedValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String].self)] }
     }
     let object: JSONObject = ["favorites": [10, 20, 30]]
 
@@ -454,7 +454,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_enum__givenDataWithStringsNotEnumValue_getsValueAsUnknownCase() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("favorites", [GraphQLEnum<MockEnum>].self)
       ] }
     }
@@ -473,7 +473,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_scalar__givenDataWithElementTypeNotConvertibleToFieldType_throwsCouldNotConvertError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String].self)] }
     }
     let object: JSONObject = ["favorites": [true, false, true]]
 
@@ -496,7 +496,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_nonnull_scalar__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String]?.self)] }
     }
     let object: JSONObject = ["favorites": ["Purple", "Potatoes", "iPhone"]]
 
@@ -510,7 +510,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_nonnull_scalar__givenEmptyDataArray_getsValueAsEmptyArray() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String]?.self)] }
     }
     let object: JSONObject = ["favorites": []]
 
@@ -524,7 +524,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_nonnull_scalar__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String]?.self)] }
     }
     let object: JSONObject = [:]
 
@@ -543,7 +543,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_nonnull_scalar__givenDataIsNullForField_valueIsNil() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String]?.self)] }
     }
     let object: JSONObject = ["favorites": NSNull()]
 
@@ -557,7 +557,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_nonnull_scalar__givenDataWithElementTypeConvertibleToFieldType_getsConvertedValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String]?.self)] }
     }
     let object: JSONObject = ["favorites": [10, 20, 30]]
 
@@ -571,7 +571,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_nonnull_scalar__givenDataWithElementTypeNotConvertibleToFieldType_throwsCouldNotConvertError() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String]?.self)] }
     }
     let object: JSONObject = ["favorites": [true, false, false]]
 
@@ -594,7 +594,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_optional_scalar__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String?].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String?].self)] }
     }
     let object: JSONObject = ["favorites": ["Purple", "Potatoes", "iPhone"]]
 
@@ -608,7 +608,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_optional_scalar__givenEmptyDataArray_getsValueAsEmptyArray() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String?].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String?].self)] }
     }
     let object: JSONObject = ["favorites": []]
 
@@ -622,7 +622,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_optional_scalar__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String?].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String?].self)] }
     }
     let object: JSONObject = [:]
 
@@ -641,7 +641,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_optional__givenDataIsNullForField_throwsNullValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String?].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String?].self)] }
     }
     let object: JSONObject = ["favorites": NSNull()]
 
@@ -660,7 +660,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_list_nonnull_optional__givenDataIsArrayWithNullElement_valueIsArrayWithValuesIncludingNilElement() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String?].self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String?].self)] }
     }
     let object: JSONObject = ["favorites": ["Red", NSNull(), "Bird"]]
 
@@ -675,7 +675,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_optional_scalar__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [.field("favorites", [String?]?.self)] }
+      override class var __selections: [Selection] { [.field("favorites", [String?]?.self)] }
     }
     let object: JSONObject = ["favorites": ["Purple", "Potatoes", "iPhone"]]
 
@@ -689,7 +689,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_optional_enum__givenDataWithUnknownEnumCaseElement_getsValueWithUnknownEnumCaseElement() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("favorites", [GraphQLEnum<MockEnum>?]?.self)
       ] }
     }
@@ -705,7 +705,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__optional_list_optional_enum__givenDataWithNonConvertibleTypeElement_getsValueWithUnknownEnumCaseElement() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("favorites", [GraphQLEnum<MockEnum>?]?.self)
       ] }
     }
@@ -730,12 +730,12 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_nestedObject__givenData_getsValue() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("child", Child.self)
       ]}
 
       class Child: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -758,12 +758,12 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_nestedObject__givenDataMissingKeyForField_throwsMissingValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("child", Child.self)
       ]}
 
       class Child: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -785,12 +785,12 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__nonnull_nestedObject__givenDataHasNullValueForField_throwsNullValueError() {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("child", Child.self)
       ]}
 
       class Child: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -826,7 +826,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     class GivenSelectionSet: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
       override class var __parentType: ParentType { Object.mock }
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("child", Child.self),
       ]}
 
@@ -834,13 +834,13 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.MockChildObject }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .inlineFragment(AsHuman.self)
         ]}
 
         class AsHuman: MockTypeCase {
           override class var __parentType: ParentType { Types.Human }
-          override class var selections: [Selection] {[
+          override class var __selections: [Selection] {[
             .field("name", String.self),
           ]}
         }
@@ -882,12 +882,12 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
     class GivenFragment: MockFragment {
       override class var __parentType: ParentType { Types.MockChildObject }
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("child", Child.self)
       ]}
 
       class Child: MockSelectionSet {
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -897,7 +897,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: ParentType { Types.MockChildObject }
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .fragment(GivenFragment.self)
       ]}
 
@@ -933,7 +933,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_singleField__givenVariableIsTrue_getsValueForConditionalField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "variable", .field("name", String.self))
       ]}
     }
@@ -950,7 +950,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_singleField__givenVariableIsFalse_doesNotGetsValueForConditionalField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "variable", .field("name", String.self))
       ]}
     }
@@ -967,7 +967,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_singleField__givenVariableIsFalse_givenOtherSelection_doesNotGetsValueForConditionalField_doesGetOtherSelection() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("id", String.self),
         .include(if: "variable", .field("name", String.self))
       ]}
@@ -986,7 +986,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_multipleFields__givenVariableIsTrue_getsValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "variable", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1007,7 +1007,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_multipleFields__givenVariableIsFalse_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "variable", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1028,13 +1028,13 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_fragment__givenVariableIsTrue_getsValuesForFragmentFields() throws {
     // given
     class GivenFragment: MockFragment {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("name", String.self),
       ]}
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("id", String.self),
         .include(if: "variable", .fragment(GivenFragment.self))
       ]}
@@ -1053,13 +1053,13 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_include_fragment__givenVariableIsFalse_doesNotGetValuesForFragmentFields() throws {
     // given
     class GivenFragment: MockFragment {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("name", String.self),
       ]}
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("id", String.self),
         .include(if: "variable", .fragment(GivenFragment.self))
       ]}
@@ -1082,7 +1082,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("id", String.self),
         .include(if: "variable", .inlineFragment(AsPerson.self))
@@ -1090,7 +1090,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { Types.Person }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self),
         ]}
       }
@@ -1116,7 +1116,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("id", String.self),
         .include(if: "variable", .inlineFragment(AsPerson.self))
@@ -1124,7 +1124,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { Types.Person }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self),
         ]}
       }
@@ -1150,7 +1150,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("id", String.self),
         .include(if: "variable", .inlineFragment(AsPerson.self))
@@ -1158,7 +1158,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { Types.Person }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self),
         ]}
       }
@@ -1184,7 +1184,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("id", String.self),
         .inlineFragment(AsPerson.self)
@@ -1192,7 +1192,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { Types.Person }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .include(if: "variable", .field("name", String.self)),
         ]}
       }
@@ -1218,7 +1218,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("id", String.self),
         .inlineFragment(AsPerson.self)
@@ -1226,7 +1226,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { Types.Person }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .include(if: "variable", .field("name", String.self)),
         ]}
       }
@@ -1252,12 +1252,12 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
     }
 
     class GivenFragment: MockFragment {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("name", String.self),
       ]}
     }
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("id", String.self),
         .include(if: "variable", .inlineFragment(AsPerson.self))
@@ -1265,7 +1265,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
       class AsPerson: MockTypeCase {
         override class var __parentType: ParentType { Types.Person }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .fragment(GivenFragment.self),
         ]}
       }
@@ -1288,7 +1288,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_skip_singleField__givenVariableIsFalse_getsValueForConditionalField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"variable", .field("name", String.self))
       ]}
     }
@@ -1305,7 +1305,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_skip_singleField__givenVariableIsTrue_doesNotGetsValueForConditionalField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"variable", .field("name", String.self))
       ]}
     }
@@ -1322,7 +1322,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_skip_multipleFields__givenVariableIsFalse_getsValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"variable", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1343,7 +1343,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_skip_multipleFields__givenVariableIsTrue_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"variable", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1364,13 +1364,13 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_skip_singleField__givenVariableIsTrue_givenFieldIdSelectedByAnotherSelection_getsValueForField() throws {
     // given
     class GivenFragment: MockFragment {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("name", String.self),
       ]}
     }
 
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"variable", .field("name", String.self)),
         .fragment(GivenFragment.self)
       ]}
@@ -1391,7 +1391,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_multipleFields__givenSkipIsTrue_includeIsTrue_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip" && "include", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1413,7 +1413,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_multipleFields__givenSkipIsTrue_includeIsFalse_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip" && "include", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1435,7 +1435,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_multipleFields__givenSkipIsFalse_includeIsFalse_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip" && "include", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1457,7 +1457,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_multipleFields__givenSkipIsFalse_includeIsTrue_getValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip" && "include", [
           .field("name", String.self),
           .field("id", String.self),
@@ -1479,7 +1479,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelection__givenSkipIsTrue_includeIsTrue_getsValuesForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip", .field("name", String.self)),
         .include(if: "include", .field("name", String.self))
       ]}
@@ -1498,7 +1498,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelectionMergedAsOrCondition__givenSkipIsTrue_includeIsTrue_getsValuesForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "include" || !"skip", .field("name", String.self))
       ]}
     }
@@ -1516,7 +1516,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelection__givenSkipIsFalse_includeIsFalse_getsValuesForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip", .field("name", String.self)),
         .include(if: "include", .field("name", String.self))
       ]}
@@ -1535,7 +1535,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelectionMergedAsOrCondition__givenSkipIsFalse_includeIsFalse_getsValuesForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "include" || !"skip", .field("name", String.self))
       ]}
     }
@@ -1553,7 +1553,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelection__givenSkipIsFalse_includeIsTrue_getsValuesForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip", .field("name", String.self)),
         .include(if: "include", .field("name", String.self))
       ]}
@@ -1572,7 +1572,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelectionMergedAsOrCondition__givenSkipIsFalse_includeIsTrue_getsValuesForField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "include" || !"skip", .field("name", String.self))
       ]}
     }
@@ -1590,7 +1590,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelection__givenSkipIsTrue_includeIsFalse_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: !"skip", .field("name", String.self)),
         .include(if: "include", .field("name", String.self))
       ]}
@@ -1609,7 +1609,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_onSeperateFieldsForSameSelectionMergedAsOrCondition__givenSkipIsTrue_includeIsFalse_doesNotGetValuesForConditionalFields() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "include" || !"skip", .field("name", String.self))
       ]}
     }
@@ -1627,7 +1627,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_bothSkipAndInclude_mergedAsComplexLogicalCondition_correctlyEvaluatesConditionalSelections() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: ("a" && !"b" && "c") || "d" || !"e", .field("name", String?.self))
       ]}
 

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -11,7 +11,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("name", String?.self)
       ]}
@@ -36,7 +36,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("name", String?.self)
       ]}
@@ -62,7 +62,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("nestedList", [[String]].self)
       ]}
@@ -89,7 +89,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friend", Friend.self)
       ]}
@@ -99,7 +99,7 @@ class SelectionSetTests: XCTestCase {
       class Friend: MockSelectionSet, SelectionSet {
         typealias Schema = MockSchemaMetadata
 
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("__typename", String.self),
         ]}
       }
@@ -126,7 +126,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friend", Hero?.self)
       ]}
@@ -155,7 +155,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friend", Hero?.self)
       ]}
@@ -181,7 +181,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friends", [Hero].self)
       ]}
@@ -219,7 +219,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friends", [Hero?].self)
       ]}
@@ -257,7 +257,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friends", [Hero?].self)
       ]}
@@ -294,7 +294,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friends", [Hero]?.self)
       ]}
@@ -332,7 +332,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("friends", [Hero]?.self)
       ]}
@@ -358,7 +358,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("nestedList", [[Hero]].self)
       ]}
@@ -396,7 +396,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("nestedList", [[Hero]?].self)
       ]}
@@ -434,7 +434,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("nestedList", [[Hero]?].self)
       ]}
@@ -470,7 +470,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("nestedList", [[Hero?]].self)
       ]}
@@ -508,7 +508,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .field("nestedList", [[Hero]]?.self)
       ]}
@@ -561,7 +561,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
@@ -574,7 +574,7 @@ class SelectionSetTests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Human }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -583,7 +583,7 @@ class SelectionSetTests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Droid }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("primaryFunction", String.self)
         ]}
       }
@@ -619,7 +619,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .inlineFragment(AsHumanoid.self),
       ]}
@@ -630,7 +630,7 @@ class SelectionSetTests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Humanoid }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -666,7 +666,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .inlineFragment(AsHumanoid.self),
       ]}
@@ -677,7 +677,7 @@ class SelectionSetTests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Humanoid }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -713,7 +713,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .inlineFragment(AsCharacter.self),
       ]}
@@ -724,7 +724,7 @@ class SelectionSetTests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Character }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -759,7 +759,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .inlineFragment(AsCharacter.self),
       ]}
@@ -770,7 +770,7 @@ class SelectionSetTests: XCTestCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Character }
-        override class var selections: [Selection] {[
+        override class var __selections: [Selection] {[
           .field("name", String.self)
         ]}
       }
@@ -797,7 +797,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .include(if: "includeFragment", .fragment(GivenFragment.self))
       ]}
@@ -829,7 +829,7 @@ class SelectionSetTests: XCTestCase {
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
 
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .include(if: "includeFragment", .fragment(GivenFragment.self))
       ]}

--- a/Tests/ApolloTests/WebSocket/WebSocketTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTests.swift
@@ -26,12 +26,12 @@ class WebSocketTests: XCTestCase {
   }
 
   class ReviewAddedData: MockSelectionSet {
-    override class var selections: [Selection] { [
+    override class var __selections: [Selection] { [
       .field("reviewAdded", ReviewAdded.self),
     ]}
 
     class ReviewAdded: MockSelectionSet {
-      override class var selections: [Selection] { [
+      override class var __selections: [Selection] { [
         .field("__typename", String.self),
         .field("stars", Int.self),
         .field("commentary", String?.self),


### PR DESCRIPTION
_PR 1 of 3 for #2497 - I was going to submit all the 'underscore' changes as a single PR but it's going to get too big so I'm splitting them up into similar parts._

This PR adds an `_` to some properties of the `SelectionSet` protocol to mark them as private metadata. They will remain accessible to developers because the access modifiers aren't changing but the underscore serves as enough of a hint of "use at your own risk, could change without warning".