### PR TITLE
feat: Mark JSON encodable/decodable properties as private

### DIFF
--- a/Sources/Apollo/GraphQLGETTransformer.swift
+++ b/Sources/Apollo/GraphQLGETTransformer.swift
@@ -31,7 +31,7 @@ public struct GraphQLGETTransformer {
     do {
       _ = try self.body.sorted(by: {$0.key < $1.key}).compactMap({ arg in
         if let value = arg.value as? JSONEncodableDictionary {
-          let data = try JSONSerialization.sortedData(withJSONObject: value.jsonValue)
+          let data = try JSONSerialization.sortedData(withJSONObject: value._jsonValue)
           if let string = String(data: data, encoding: .utf8) {
             queryItems.append(URLQueryItem(name: arg.key, value: string))
           }
@@ -60,12 +60,12 @@ public struct GraphQLGETTransformer {
 
 extension GraphQLGETTransformer: Hashable {
   public static func == (lhs: GraphQLGETTransformer, rhs: GraphQLGETTransformer) -> Bool {
-    lhs.body.jsonValue == rhs.body.jsonValue &&
+    lhs.body._jsonValue == rhs.body._jsonValue &&
     lhs.url == rhs.url
   }
 
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(body.jsonValue)
+    hasher.combine(body._jsonValue)
     hasher.combine(url)
   }
 }

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -89,7 +89,7 @@ extension GraphQLResponse: Equatable where Data: Equatable {
   public static func == (lhs: GraphQLResponse<Data>, rhs: GraphQLResponse<Data>) -> Bool {
     lhs.body == rhs.body &&
     lhs.rootKey == rhs.rootKey &&
-    lhs.variables?.jsonEncodableObject.jsonValue == rhs.variables?.jsonEncodableObject.jsonValue
+    lhs.variables?.jsonEncodableObject._jsonValue == rhs.variables?.jsonEncodableObject._jsonValue
   }
 }
 
@@ -99,6 +99,6 @@ extension GraphQLResponse: Hashable where Data: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(body)
     hasher.combine(rootKey)
-    hasher.combine(variables?.jsonEncodableValue?.jsonValue)
+    hasher.combine(variables?._jsonEncodableValue?._jsonValue)
   }
 }

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -89,7 +89,7 @@ extension GraphQLResponse: Equatable where Data: Equatable {
   public static func == (lhs: GraphQLResponse<Data>, rhs: GraphQLResponse<Data>) -> Bool {
     lhs.body == rhs.body &&
     lhs.rootKey == rhs.rootKey &&
-    lhs.variables?.jsonEncodableObject._jsonValue == rhs.variables?.jsonEncodableObject._jsonValue
+    lhs.variables?._jsonEncodableObject._jsonValue == rhs.variables?._jsonEncodableObject._jsonValue
   }
 }
 

--- a/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -10,7 +10,7 @@ final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLRes
       let .customScalar(decodable as any JSONDecodable.Type):
       // This will convert a JSON value to the expected value type,
       // which could be a custom scalar or an enum.
-      return try decodable.init(_jsonValue: scalar).asAnyHashable
+      return try decodable.init(_jsonValue: scalar)._asAnyHashable
     default:
       preconditionFailure()
     }

--- a/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -10,7 +10,7 @@ final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLRes
       let .customScalar(decodable as any JSONDecodable.Type):
       // This will convert a JSON value to the expected value type,
       // which could be a custom scalar or an enum.
-      return try decodable.init(jsonValue: scalar).asAnyHashable
+      return try decodable.init(_jsonValue: scalar).asAnyHashable
     default:
       preconditionFailure()
     }

--- a/Sources/Apollo/InputValue+Evaluation.swift
+++ b/Sources/Apollo/InputValue+Evaluation.swift
@@ -40,10 +40,10 @@ extension InputValue {
       guard let value = variables?[name] else {
         throw GraphQLError("Variable \"\(name)\" was not provided.")
       }
-      return value.jsonEncodableValue?.jsonValue
+      return value._jsonEncodableValue?._jsonValue
 
     case let .scalar(value):
-      return value.jsonValue
+      return value._jsonValue
 
     case let .list(array):
       return try InputValue.evaluate(array, with: variables)

--- a/Sources/Apollo/JSONRequest.swift
+++ b/Sources/Apollo/JSONRequest.swift
@@ -156,7 +156,7 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     lhs.useGETForQueries == rhs.useGETForQueries &&
     lhs.useGETForPersistedQueryRetry == rhs.useGETForPersistedQueryRetry &&
     lhs.isPersistedQueryRetry == rhs.isPersistedQueryRetry &&
-    lhs.body.jsonObject == rhs.body.jsonObject
+    lhs.body._jsonObject == rhs.body._jsonObject
   }
 
   public override func hash(into hasher: inout Hasher) {
@@ -166,7 +166,7 @@ open class JSONRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> {
     hasher.combine(useGETForQueries)
     hasher.combine(useGETForPersistedQueryRetry)
     hasher.combine(isPersistedQueryRetry)
-    hasher.combine(body.jsonObject)
+    hasher.combine(body._jsonObject)
   }
 
 }

--- a/Sources/Apollo/JSONSerializationFormat.swift
+++ b/Sources/Apollo/JSONSerializationFormat.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 
 public final class JSONSerializationFormat {
   public class func serialize(value: JSONEncodable) throws -> Data {
-    return try JSONSerialization.sortedData(withJSONObject: value.jsonValue)
+    return try JSONSerialization.sortedData(withJSONObject: value._jsonValue)
   }
 
   public class func serialize(value: JSONObject) throws -> Data {

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -32,7 +32,7 @@ extension RequestBodyCreator {
     ]
 
     if let variables = operation.variables {
-      body["variables"] = variables.jsonEncodableObject
+      body["variables"] = variables._jsonEncodableObject
     }
 
     if sendQueryDocument {

--- a/Sources/ApolloAPI/AnyHashableConvertible.swift
+++ b/Sources/ApolloAPI/AnyHashableConvertible.swift
@@ -9,14 +9,14 @@ import Foundation
 /// `Optional`, `Array`, and `Dictionary`.
 public protocol AnyHashableConvertible {
   /// Converts the type to an `AnyHashable`.
-  var asAnyHashable: AnyHashable { get }
+  var _asAnyHashable: AnyHashable { get }
 }
 
 extension AnyHashableConvertible where Self: Hashable {
   /// Converts the type to an `AnyHashable` by casting self.
   ///
   /// This utilizes Swift's automatic `AnyHashable` conversion functionality.
-  @inlinable public var asAnyHashable: AnyHashable { self }
+  @inlinable public var _asAnyHashable: AnyHashable { self }
 }
 
 extension AnyHashable: AnyHashableConvertible {}

--- a/Sources/ApolloAPI/CacheKeyInfo.swift
+++ b/Sources/ApolloAPI/CacheKeyInfo.swift
@@ -102,7 +102,7 @@ public struct CacheKeyInfo {
       throw JSONDecodingError.missingValue
     }
 
-    self.init(key: try String(jsonValue: jsonValue), uniqueKeyGroupId: uniqueKeyGroupId)
+    self.init(key: try String(_jsonValue: jsonValue), uniqueKeyGroupId: uniqueKeyGroupId)
   }
 
   /// The Designated Initializer

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -34,12 +34,12 @@ public struct DataDict: Hashable {
 
   @inlinable public func hash(into hasher: inout Hasher) {
     hasher.combine(_data)
-    hasher.combine(_variables?.jsonEncodableValue?.jsonValue)
+    hasher.combine(_variables?._jsonEncodableValue?._jsonValue)
   }
 
   @inlinable public static func ==(lhs: DataDict, rhs: DataDict) -> Bool {
     lhs._data == rhs._data &&
-    lhs._variables?.jsonEncodableValue?.jsonValue == rhs._variables?.jsonEncodableValue?.jsonValue
+    lhs._variables?._jsonEncodableValue?._jsonValue == rhs._variables?._jsonEncodableValue?._jsonValue
   }
 }
 

--- a/Sources/ApolloAPI/GraphQLEnum.swift
+++ b/Sources/ApolloAPI/GraphQLEnum.swift
@@ -78,7 +78,7 @@ extension GraphQLEnum: CustomScalarType {
     self.init(rawValue: stringData)
   }
 
-  @inlinable public var jsonValue: AnyHashable { rawValue }
+  @inlinable public var _jsonValue: AnyHashable { rawValue }
 }
 
 // MARK: Equatable

--- a/Sources/ApolloAPI/GraphQLEnum.swift
+++ b/Sources/ApolloAPI/GraphQLEnum.swift
@@ -71,9 +71,9 @@ public enum GraphQLEnum<T: EnumType>: CaseIterable, Hashable, RawRepresentable {
 
 // MARK: CustomScalarType
 extension GraphQLEnum: CustomScalarType {
-  @inlinable public init(jsonValue: JSONValue) throws {
-    guard let stringData = jsonValue as? String else {
-      throw JSONDecodingError.couldNotConvert(value: jsonValue, to: String.self)      
+  @inlinable public init(_jsonValue: JSONValue) throws {
+    guard let stringData = _jsonValue as? String else {
+      throw JSONDecodingError.couldNotConvert(value: _jsonValue, to: String.self)      
     }
     self.init(rawValue: stringData)
   }

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -97,11 +97,11 @@ public extension GraphQLOperation {
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.variables?.jsonEncodableValue?.jsonValue == rhs.variables?.jsonEncodableValue?.jsonValue
+    lhs.variables?._jsonEncodableValue?._jsonValue == rhs.variables?._jsonEncodableValue?._jsonValue
   }
 
   func hash(into hasher: inout Hasher) {
-    hasher.combine(variables?.jsonEncodableValue?.jsonValue)
+    hasher.combine(variables?._jsonEncodableValue?._jsonValue)
   }
 }
 
@@ -123,7 +123,7 @@ public extension GraphQLSubscription {
 // MARK: - GraphQLOperationVariableValue
 
 public protocol GraphQLOperationVariableValue {
-  var jsonEncodableValue: (any JSONEncodable)? { get }
+  var _jsonEncodableValue: (any JSONEncodable)? { get }
 }
 
 extension Array: GraphQLOperationVariableValue
@@ -131,32 +131,32 @@ where Element: GraphQLOperationVariableValue & Hashable {}
 
 extension Dictionary: GraphQLOperationVariableValue
 where Key == String, Value == GraphQLOperationVariableValue {
-  @inlinable public var jsonEncodableValue: (any JSONEncodable)? { jsonEncodableObject }
+  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? { jsonEncodableObject }
   @inlinable public var jsonEncodableObject: JSONEncodableDictionary {
-    compactMapValues { $0.jsonEncodableValue }
+    compactMapValues { $0._jsonEncodableValue }
   }
 }
 
 extension GraphQLNullable: GraphQLOperationVariableValue
 where Wrapped: GraphQLOperationVariableValue {
-  @inlinable public var jsonEncodableValue: (any JSONEncodable)? {
+  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? {
     switch self {
     case .none: return nil
     case .null: return NSNull()
-    case let .some(value): return value.jsonEncodableValue
+    case let .some(value): return value._jsonEncodableValue
     }
   }
 }
 
 extension Optional: GraphQLOperationVariableValue where Wrapped: GraphQLOperationVariableValue {
-  @inlinable public var jsonEncodableValue: (any JSONEncodable)? {
+  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? {
     switch self {
     case .none: return nil    
-    case let .some(value): return value.jsonEncodableValue
+    case let .some(value): return value._jsonEncodableValue
     }
   }
 }
 
 extension JSONEncodable where Self: GraphQLOperationVariableValue {
-  @inlinable public var jsonEncodableValue: (any JSONEncodable)? { self }
+  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? { self }
 }

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -131,8 +131,8 @@ where Element: GraphQLOperationVariableValue & Hashable {}
 
 extension Dictionary: GraphQLOperationVariableValue
 where Key == String, Value == GraphQLOperationVariableValue {
-  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? { jsonEncodableObject }
-  @inlinable public var jsonEncodableObject: JSONEncodableDictionary {
+  @inlinable public var _jsonEncodableValue: (any JSONEncodable)? { _jsonEncodableObject }
+  @inlinable public var _jsonEncodableObject: JSONEncodableDictionary {
     compactMapValues { $0._jsonEncodableValue }
   }
 }

--- a/Sources/ApolloAPI/JSON.swift
+++ b/Sources/ApolloAPI/JSON.swift
@@ -33,7 +33,7 @@ public protocol JSONDecodable: AnyHashableConvertible {
   ///
   /// - Throws: A ``JSONDecodingError`` if the `jsonValue` cannot be converted to the receiver's
   /// type.
-  init(jsonValue value: JSONValue) throws
+  init(_jsonValue value: JSONValue) throws
 }
 
 /// A protocol for a type that can be converted into a ``JSONValue``.

--- a/Sources/ApolloAPI/JSON.swift
+++ b/Sources/ApolloAPI/JSON.swift
@@ -48,5 +48,5 @@ public protocol JSONEncodable {
   /// > Important: For a type that conforms to both ``JSONEncodable`` and ``JSONDecodable``,
   /// the return value of this function, when passed to ``JSONDecodable/init(jsonValue:)`` should
   /// initialize a value equal to the receiver.
-  var jsonValue: JSONValue { get }
+  var _jsonValue: JSONValue { get }
 }

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -9,7 +9,7 @@ extension String: JSONDecodable, JSONEncodable {
   ///
   /// # See Also
   /// ``CustomScalarType``
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     switch value.base {
     case let string as String:
         self = string
@@ -30,7 +30,7 @@ extension String: JSONDecodable, JSONEncodable {
 }
 
 extension Int: JSONDecodable, JSONEncodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let number = value as? NSNumber else {
       throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
     }
@@ -43,7 +43,7 @@ extension Int: JSONDecodable, JSONEncodable {
 }
 
 extension Float: JSONDecodable, JSONEncodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let number = value as? NSNumber else {
       throw JSONDecodingError.couldNotConvert(value: value, to: Float.self)
     }
@@ -56,7 +56,7 @@ extension Float: JSONDecodable, JSONEncodable {
 }
 
 extension Double: JSONDecodable, JSONEncodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let number = value as? NSNumber else {
       throw JSONDecodingError.couldNotConvert(value: value, to: Double.self)
     }
@@ -69,7 +69,7 @@ extension Double: JSONDecodable, JSONEncodable {
 }
 
 extension Bool: JSONDecodable, JSONEncodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let bool = value as? Bool else {
         throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
     }
@@ -86,8 +86,8 @@ extension EnumType {
 }
 
 extension RawRepresentable where RawValue: JSONDecodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
-    let rawValue = try RawValue(jsonValue: value)
+  @inlinable public init(_jsonValue value: JSONValue) throws {
+    let rawValue = try RawValue(_jsonValue: value)
     if let tempSelf = Self(rawValue: rawValue) {
       self = tempSelf
     } else {
@@ -107,7 +107,7 @@ extension Optional where Wrapped: JSONDecodable {
     if value is NSNull {
       self = .none
     } else {
-      self = .some(try Wrapped(jsonValue: value))
+      self = .some(try Wrapped(_jsonValue: value))
     }
   }
 }
@@ -138,7 +138,7 @@ extension JSONEncodableDictionary: JSONEncodable {
 }
 
 extension JSONObject: JSONDecodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let dictionary = value as? JSONObject else {
       throw JSONDecodingError.couldNotConvert(value: value, to: JSONObject.self)
     }
@@ -162,7 +162,7 @@ extension Array: JSONEncodable {
 // Example custom scalar
 
 extension URL: JSONDecodable, JSONEncodable {
-  @inlinable public init(jsonValue value: JSONValue) throws {
+  @inlinable public init(_jsonValue value: JSONValue) throws {
     guard let string = value as? String else {
       throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
     }

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -130,9 +130,9 @@ extension NSNull: JSONEncodable {
 }
 
 extension JSONEncodableDictionary: JSONEncodable {
-  @inlinable public var _jsonValue: JSONValue { jsonObject }
+  @inlinable public var _jsonValue: JSONValue { _jsonObject }
 
-  @inlinable public var jsonObject: JSONObject {
+  @inlinable public var _jsonObject: JSONObject {
     mapValues(\._jsonValue)
   }
 }

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -24,7 +24,7 @@ extension String: JSONDecodable, JSONEncodable {
     }
   }
 
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return self
   }
 }
@@ -37,7 +37,7 @@ extension Int: JSONDecodable, JSONEncodable {
     self = number.intValue
   }
 
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return self
   }
 }
@@ -50,7 +50,7 @@ extension Float: JSONDecodable, JSONEncodable {
     self = number.floatValue
   }
 
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return self
   }
 }
@@ -63,7 +63,7 @@ extension Double: JSONDecodable, JSONEncodable {
     self = number.doubleValue
   }
 
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return self
   }
 }
@@ -76,13 +76,13 @@ extension Bool: JSONDecodable, JSONEncodable {
     self = bool
   }
 
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return self
   }
 }
 
 extension EnumType {
-  @inlinable public var jsonValue: JSONValue { rawValue }
+  @inlinable public var _jsonValue: JSONValue { rawValue }
 }
 
 extension RawRepresentable where RawValue: JSONDecodable {
@@ -97,8 +97,8 @@ extension RawRepresentable where RawValue: JSONDecodable {
 }
 
 extension RawRepresentable where RawValue: JSONEncodable {
-  @inlinable public var jsonValue: JSONValue {
-    return rawValue.jsonValue
+  @inlinable public var _jsonValue: JSONValue {
+    return rawValue._jsonValue
   }
 }
 
@@ -113,27 +113,27 @@ extension Optional where Wrapped: JSONDecodable {
 }
 
 extension Optional: JSONEncodable where Wrapped: JSONEncodable & Hashable {
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     switch self {
     case .none: return NSNull()
-    case let .some(value): return value.jsonValue
+    case let .some(value): return value._jsonValue
     }
   }
 }
 
 extension NSDictionary: JSONEncodable {
-  @inlinable public var jsonValue: JSONValue { self }
+  @inlinable public var _jsonValue: JSONValue { self }
 }
 
 extension NSNull: JSONEncodable {
-  @inlinable public var jsonValue: JSONValue { self }
+  @inlinable public var _jsonValue: JSONValue { self }
 }
 
 extension JSONEncodableDictionary: JSONEncodable {
-  @inlinable public var jsonValue: JSONValue { jsonObject }
+  @inlinable public var _jsonValue: JSONValue { jsonObject }
 
   @inlinable public var jsonObject: JSONObject {
-    mapValues(\.jsonValue)
+    mapValues(\._jsonValue)
   }
 }
 
@@ -148,10 +148,10 @@ extension JSONObject: JSONDecodable {
 }
 
 extension Array: JSONEncodable {
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return map { element -> JSONValue in
       if case let element as JSONEncodable = element {
-        return element.jsonValue
+        return element._jsonValue
       } else {
         fatalError("Array is only JSONEncodable if Element is")
       }
@@ -174,7 +174,7 @@ extension URL: JSONDecodable, JSONEncodable {
     }
   }
 
-  @inlinable public var jsonValue: JSONValue {
+  @inlinable public var _jsonValue: JSONValue {
     return self.absoluteString
   }
 }

--- a/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -14,11 +14,11 @@ public extension LocalCacheMutation {
   }
 
   func hash(into hasher: inout Hasher) {
-    hasher.combine(variables?.jsonEncodableValue?.jsonValue)
+    hasher.combine(variables?._jsonEncodableValue?._jsonValue)
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.variables?.jsonEncodableValue?.jsonValue == rhs.variables?.jsonEncodableValue?.jsonValue
+    lhs.variables?._jsonEncodableValue?._jsonValue == rhs.variables?._jsonEncodableValue?._jsonValue
   }
 }
 

--- a/Sources/ApolloAPI/OutputTypeConvertible.swift
+++ b/Sources/ApolloAPI/OutputTypeConvertible.swift
@@ -1,40 +1,40 @@
 public protocol OutputTypeConvertible {
-  @inlinable static var asOutputType: Selection.Field.OutputType { get }
+  @inlinable static var _asOutputType: Selection.Field.OutputType { get }
 }
 
 extension String: OutputTypeConvertible {
-  public static let asOutputType: Selection.Field.OutputType = .nonNull(.scalar(String.self))
+  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(String.self))
 }
 extension Int: OutputTypeConvertible {
-  public static let asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Int.self))
+  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Int.self))
 }
 extension Bool: OutputTypeConvertible {
-  public static let asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Bool.self))
+  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Bool.self))
 }
 extension Float: OutputTypeConvertible {
-  public static let asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Float.self))
+  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Float.self))
 }
 extension Double: OutputTypeConvertible {
-  public static let asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Double.self))
+  public static let _asOutputType: Selection.Field.OutputType = .nonNull(.scalar(Double.self))
 }
 
 extension Optional: OutputTypeConvertible where Wrapped: OutputTypeConvertible {
-  @inlinable public static var asOutputType: Selection.Field.OutputType {
-    guard case let .nonNull(wrappedOutputType) = Wrapped.asOutputType else {
-      return Wrapped.asOutputType
+  @inlinable public static var _asOutputType: Selection.Field.OutputType {
+    guard case let .nonNull(wrappedOutputType) = Wrapped._asOutputType else {
+      return Wrapped._asOutputType
     }
     return wrappedOutputType
   }
 }
 
 extension Array: OutputTypeConvertible where Element: OutputTypeConvertible {
-  @inlinable public static var asOutputType: Selection.Field.OutputType {
-    .nonNull(.list(Element.asOutputType))
+  @inlinable public static var _asOutputType: Selection.Field.OutputType {
+    .nonNull(.list(Element._asOutputType))
   }
 }
 
 extension RootSelectionSet {
-  @inlinable public static var asOutputType: Selection.Field.OutputType {
+  @inlinable public static var _asOutputType: Selection.Field.OutputType {
     .nonNull(.object(self))
   }
 }

--- a/Sources/ApolloAPI/ScalarTypes.swift
+++ b/Sources/ApolloAPI/ScalarTypes.swift
@@ -42,12 +42,15 @@ public protocol CustomScalarType:
   GraphQLOperationVariableValue
 {
   var jsonValue: JSONValue { get }
+  var _jsonValue: JSONValue { get }
 }
 
 extension CustomScalarType {
   @inlinable public static var asOutputType: Selection.Field.OutputType {
     .nonNull(.customScalar(self))
   }
+
+  @inlinable public var jsonValue: JSONValue { _jsonValue }
 }
 
 extension Array: AnyScalarType where Array.Element: AnyScalarType & Hashable {}

--- a/Sources/ApolloAPI/ScalarTypes.swift
+++ b/Sources/ApolloAPI/ScalarTypes.swift
@@ -46,7 +46,7 @@ public protocol CustomScalarType:
 }
 
 extension CustomScalarType {
-  @inlinable public static var asOutputType: Selection.Field.OutputType {
+  @inlinable public static var _asOutputType: Selection.Field.OutputType {
     .nonNull(.customScalar(self))
   }
 

--- a/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -29,7 +29,7 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
     self.data = data
   }
 
-  public var _jsonEncodableValue: (any JSONEncodable)? { data.jsonEncodableObject }
+  public var _jsonEncodableValue: (any JSONEncodable)? { data._jsonEncodableObject }
 
   public subscript<T: GraphQLOperationVariableValue>(dynamicMember key: StaticString) -> T {
     get { data[key.description] as! T }

--- a/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -7,8 +7,8 @@ public protocol InputObject: GraphQLOperationVariableValue, JSONEncodable, Hasha
 }
 
 extension InputObject {
-  public var jsonValue: JSONValue { jsonEncodableValue?.jsonValue }
-  public var jsonEncodableValue: (any JSONEncodable)? { __data.jsonEncodableValue }
+  public var _jsonValue: JSONValue { jsonEncodableValue?._jsonValue }
+  public var jsonEncodableValue: (any JSONEncodable)? { __data._jsonEncodableValue }
 
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.__data == rhs.__data
@@ -29,7 +29,7 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
     self.data = data
   }
 
-  public var jsonEncodableValue: (any JSONEncodable)? { data.jsonEncodableObject }
+  public var _jsonEncodableValue: (any JSONEncodable)? { data.jsonEncodableObject }
 
   public subscript<T: GraphQLOperationVariableValue>(dynamicMember key: StaticString) -> T {
     get { data[key.description] as! T }
@@ -37,11 +37,11 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
   }
 
   public static func == (lhs: InputDict, rhs: InputDict) -> Bool {
-    lhs.data.jsonEncodableValue?.jsonValue == rhs.data.jsonEncodableValue?.jsonValue
+    lhs.data._jsonEncodableValue?._jsonValue == rhs.data._jsonEncodableValue?._jsonValue
   }
 
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(data.jsonEncodableValue?.jsonValue)
+    hasher.combine(data._jsonEncodableValue?._jsonValue)
   }
 
 }

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -63,7 +63,7 @@ public enum Selection {
     _ type: OutputTypeConvertible.Type,
     arguments: [String: InputValue]? = nil
   ) -> Selection {
-    .field(.init(name, alias: alias, type: type.asOutputType, arguments: arguments))
+    .field(.init(name, alias: alias, type: type._asOutputType, arguments: arguments))
   }
 
   @inlinable static public func include(

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -40,7 +40,7 @@ public class Mock<O: MockObject>: AnyMock, JSONEncodable, Hashable {
 
   // MARK: JSONEncodable
 
-  public var _jsonObject: JSONObject { _data.jsonObject }
+  public var _jsonObject: JSONObject { _data._jsonObject }
   public var _jsonValue: JSONValue { _jsonObject }
 
   // MARK: Hashable

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -41,7 +41,7 @@ public class Mock<O: MockObject>: AnyMock, JSONEncodable, Hashable {
   // MARK: JSONEncodable
 
   public var _jsonObject: JSONObject { _data.jsonObject }
-  public var jsonValue: JSONValue { _jsonObject }
+  public var _jsonValue: JSONValue { _jsonObject }
 
   // MARK: Hashable
 
@@ -50,7 +50,7 @@ public class Mock<O: MockObject>: AnyMock, JSONEncodable, Hashable {
   }
 
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(_data.jsonValue)
+    hasher.combine(_data._jsonValue)
   }
 }
 

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -967,7 +967,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
   func test__booleanCondition_multipleIncludes_singleField__givenAllVariablesAreTrue_getsValueForConditionalField() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {
-      override class var selections: [Selection] {[
+      override class var __selections: [Selection] {[
         .include(if: "one" || "two", .field("name", String.self))
       ]}
     }

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -64,7 +64,7 @@ class JSONTests: XCTestCase {
     let json = try JSONSerializationFormat.deserialize(data: data)
     XCTAssertNotNil(json)
     
-    let dict = try JSONObject(jsonValue: json)
+    let dict = try JSONObject(_jsonValue: json)
     XCTAssertNotNil(dict)
     
     let reserialized = try JSONSerializationFormat.serialize(value: dict)

--- a/Tests/ApolloTests/JSONValueMatcher.swift
+++ b/Tests/ApolloTests/JSONValueMatcher.swift
@@ -7,7 +7,7 @@ public func equalJSONValue(_ expectedValue: JSONEncodable?) -> Predicate<JSONEnc
     let msg = ExpectationMessage.expectedActualValueTo("equal <\(stringify(expectedValue))>")
     if let actualValue = try actual.evaluate(), let expectedValue = expectedValue {
         return PredicateResult(
-          bool: actualValue.jsonValue == expectedValue.jsonValue,
+          bool: actualValue._jsonValue == expectedValue._jsonValue,
           message: msg
         )
     } else {

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -70,7 +70,7 @@ class RequestBodyCreatorTests: XCTestCase {
         data = value as! String
       }
 
-      var jsonValue: JSONValue { data }
+      var _jsonValue: JSONValue { data }
     }
 
     class GivenMockOperation: MockOperation<MockSelectionSet> {

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -66,7 +66,7 @@ class RequestBodyCreatorTests: XCTestCase {
         self.data = data
       }
 
-      init(jsonValue value: JSONValue) throws {
+      init(_jsonValue value: JSONValue) throws {
         data = value as! String
       }
 


### PR DESCRIPTION
_PR 2 of 3 for #2497 - I was going to submit all the 'underscore' changes as a single PR but it's going to get too big so I'm splitting them up into similar parts._

This PR marks some properties on `JSONEncodable` and `JSONDecodable` as private. They will remain accessible to developers because the access modifiers aren't changing but the underscore serves as enough of a hint of "use at your own risk, could change without warning".