### PR TITLE
feat: Mark operation `variables` as private

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -26,7 +26,7 @@ public class PetAdoptionMutation: GraphQLMutation {
     self.input = input
   }
 
-  public var _variables: Variables? { ["input": input] }
+  public var __variables: Variables? { ["input": input] }
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -26,7 +26,7 @@ public class PetAdoptionMutation: GraphQLMutation {
     self.input = input
   }
 
-  public var variables: Variables? { ["input": input] }
+  public var _variables: Variables? { ["input": input] }
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -76,7 +76,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
     self.varA = varA
   }
 
-  public var variables: Variables? { [
+  public var _variables: Variables? { [
     "includeSpecies": includeSpecies,
     "skipHeightInMeters": skipHeightInMeters,
     "getCat": getCat,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -76,7 +76,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
     self.varA = varA
   }
 
-  public var _variables: Variables? { [
+  public var __variables: Variables? { [
     "includeSpecies": includeSpecies,
     "skipHeightInMeters": skipHeightInMeters,
     "getCat": getCat,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -37,7 +37,7 @@ public class PetSearchQuery: GraphQLQuery {
     self.filters = filters
   }
 
-  public var variables: Variables? { ["filters": filters] }
+  public var _variables: Variables? { ["filters": filters] }
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -37,7 +37,7 @@ public class PetSearchQuery: GraphQLQuery {
     self.filters = filters
   }
 
-  public var _variables: Variables? { ["filters": filters] }
+  public var __variables: Variables? { ["filters": filters] }
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -161,7 +161,7 @@ public class ApolloStore {
       let (data, dependentKeys) = try transaction.readObject(
         ofType: Operation.Data.self,
         withKey: CacheReference.rootCacheReference(for: Operation.operationType).key,
-        variables: operation.variables,
+        variables: operation._variables,
         accumulator: zip(GraphQLSelectionSetMapper<Operation.Data>(),
                          GraphQLDependencyTracker())
       )
@@ -201,7 +201,7 @@ public class ApolloStore {
       return try readObject(
         ofType: Query.Data.self,
         withKey: CacheReference.rootCacheReference(for: Query.operationType).key,
-        variables: query.variables
+        variables: query._variables
       )
     }
 

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -161,7 +161,7 @@ public class ApolloStore {
       let (data, dependentKeys) = try transaction.readObject(
         ofType: Operation.Data.self,
         withKey: CacheReference.rootCacheReference(for: Operation.operationType).key,
-        variables: operation._variables,
+        variables: operation.__variables,
         accumulator: zip(GraphQLSelectionSetMapper<Operation.Data>(),
                          GraphQLDependencyTracker())
       )
@@ -201,7 +201,7 @@ public class ApolloStore {
       return try readObject(
         ofType: Query.Data.self,
         withKey: CacheReference.rootCacheReference(for: Query.operationType).key,
-        variables: query._variables
+        variables: query.__variables
       )
     }
 
@@ -259,7 +259,7 @@ public class ApolloStore {
       try updateObject(
         ofType: CacheMutation.Data.self,
         withKey: CacheReference.rootCacheReference(for: CacheMutation.operationType).key,
-        variables: cacheMutation._variables,
+        variables: cacheMutation.__variables,
         body
       )
     }
@@ -283,7 +283,7 @@ public class ApolloStore {
     ) throws {
       try write(selectionSet: data,
                 withKey: CacheReference.rootCacheReference(for: CacheMutation.operationType).key,
-                variables: cacheMutation._variables)
+                variables: cacheMutation.__variables)
     }
 
     public func write<SelectionSet: MutableRootSelectionSet>(

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -259,7 +259,7 @@ public class ApolloStore {
       try updateObject(
         ofType: CacheMutation.Data.self,
         withKey: CacheReference.rootCacheReference(for: CacheMutation.operationType).key,
-        variables: cacheMutation.variables,
+        variables: cacheMutation._variables,
         body
       )
     }
@@ -283,7 +283,7 @@ public class ApolloStore {
     ) throws {
       try write(selectionSet: data,
                 withKey: CacheReference.rootCacheReference(for: CacheMutation.operationType).key,
-                variables: cacheMutation.variables)
+                variables: cacheMutation._variables)
     }
 
     public func write<SelectionSet: MutableRootSelectionSet>(

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -13,7 +13,7 @@ public final class GraphQLResponse<Data: RootSelectionSet> {
   public init<Operation: GraphQLOperation>(operation: Operation, body: JSONObject) where Operation.Data == Data {
     self.body = body
     rootKey = CacheReference.rootCacheReference(for: Operation.operationType)
-    variables = operation.variables
+    variables = operation._variables
   }
 
   /// Parses a response into a `GraphQLResult` and a `RecordSet`.

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -13,7 +13,7 @@ public final class GraphQLResponse<Data: RootSelectionSet> {
   public init<Operation: GraphQLOperation>(operation: Operation, body: JSONObject) where Operation.Data == Data {
     self.body = body
     rootKey = CacheReference.rootCacheReference(for: Operation.operationType)
-    variables = operation._variables
+    variables = operation.__variables
   }
 
   /// Parses a response into a `GraphQLResult` and a `RecordSet`.

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -31,7 +31,7 @@ extension RequestBodyCreator {
       "operationName": Operation.operationName,
     ]
 
-    if let variables = operation._variables {
+    if let variables = operation.__variables {
       body["variables"] = variables._jsonEncodableObject
     }
 

--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -31,7 +31,7 @@ extension RequestBodyCreator {
       "operationName": Operation.operationName,
     ]
 
-    if let variables = operation.variables {
+    if let variables = operation._variables {
       body["variables"] = variables._jsonEncodableObject
     }
 

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -68,13 +68,13 @@ public protocol GraphQLOperation: AnyObject, Hashable {
   static var operationType: GraphQLOperationType { get }
   static var document: DocumentType { get }
 
-  var _variables: Variables? { get }
+  var __variables: Variables? { get }
 
   associatedtype Data: RootSelectionSet
 }
 
 public extension GraphQLOperation {
-  var _variables: Variables? {
+  var __variables: Variables? {
     return nil
   }
 
@@ -97,11 +97,11 @@ public extension GraphQLOperation {
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs._variables?._jsonEncodableValue?._jsonValue == rhs._variables?._jsonEncodableValue?._jsonValue
+    lhs.__variables?._jsonEncodableValue?._jsonValue == rhs.__variables?._jsonEncodableValue?._jsonValue
   }
 
   func hash(into hasher: inout Hasher) {
-    hasher.combine(_variables?._jsonEncodableValue?._jsonValue)
+    hasher.combine(__variables?._jsonEncodableValue?._jsonValue)
   }
 }
 

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -68,13 +68,13 @@ public protocol GraphQLOperation: AnyObject, Hashable {
   static var operationType: GraphQLOperationType { get }
   static var document: DocumentType { get }
 
-  var variables: Variables? { get }
+  var _variables: Variables? { get }
 
   associatedtype Data: RootSelectionSet
 }
 
 public extension GraphQLOperation {
-  var variables: Variables? {
+  var _variables: Variables? {
     return nil
   }
 
@@ -97,11 +97,11 @@ public extension GraphQLOperation {
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.variables?._jsonEncodableValue?._jsonValue == rhs.variables?._jsonEncodableValue?._jsonValue
+    lhs._variables?._jsonEncodableValue?._jsonValue == rhs._variables?._jsonEncodableValue?._jsonValue
   }
 
   func hash(into hasher: inout Hasher) {
-    hasher.combine(variables?._jsonEncodableValue?._jsonValue)
+    hasher.combine(_variables?._jsonEncodableValue?._jsonValue)
   }
 }
 

--- a/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -3,22 +3,22 @@ import Foundation
 public protocol LocalCacheMutation: AnyObject, Hashable {
   static var operationType: GraphQLOperationType { get }
 
-  var _variables: GraphQLOperation.Variables? { get }
+  var __variables: GraphQLOperation.Variables? { get }
 
   associatedtype Data: MutableRootSelectionSet
 }
 
 public extension LocalCacheMutation {
-  var _variables: GraphQLOperation.Variables? {
+  var __variables: GraphQLOperation.Variables? {
     return nil
   }
 
   func hash(into hasher: inout Hasher) {
-    hasher.combine(_variables?._jsonEncodableValue?._jsonValue)
+    hasher.combine(__variables?._jsonEncodableValue?._jsonValue)
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs._variables?._jsonEncodableValue?._jsonValue == rhs._variables?._jsonEncodableValue?._jsonValue
+    lhs.__variables?._jsonEncodableValue?._jsonValue == rhs.__variables?._jsonEncodableValue?._jsonValue
   }
 }
 

--- a/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -3,22 +3,22 @@ import Foundation
 public protocol LocalCacheMutation: AnyObject, Hashable {
   static var operationType: GraphQLOperationType { get }
 
-  var variables: GraphQLOperation.Variables? { get }
+  var _variables: GraphQLOperation.Variables? { get }
 
   associatedtype Data: MutableRootSelectionSet
 }
 
 public extension LocalCacheMutation {
-  var variables: GraphQLOperation.Variables? {
+  var _variables: GraphQLOperation.Variables? {
     return nil
   }
 
   func hash(into hasher: inout Hasher) {
-    hasher.combine(variables?._jsonEncodableValue?._jsonValue)
+    hasher.combine(_variables?._jsonEncodableValue?._jsonValue)
   }
 
   static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.variables?._jsonEncodableValue?._jsonValue == rhs.variables?._jsonEncodableValue?._jsonValue
+    lhs._variables?._jsonEncodableValue?._jsonValue == rhs._variables?._jsonEncodableValue?._jsonValue
   }
 }
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -47,7 +47,7 @@ extension OperationTemplateRenderer {
     }
 
     return """
-      public var _variables: Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asInputParameterName)"})] }
+      public var __variables: Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asInputParameterName)"})] }
       """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -47,7 +47,7 @@ extension OperationTemplateRenderer {
     }
 
     return """
-      public var variables: Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asInputParameterName)"})] }
+      public var _variables: Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asInputParameterName)"})] }
       """
   }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -32,7 +32,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
     self.review = review
   }
 
-  public var _variables: Variables? { [
+  public var __variables: Variables? { [
     "episode": episode,
     "review": review
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -32,7 +32,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
     self.review = review
   }
 
-  public var variables: Variables? { [
+  public var _variables: Variables? { [
     "episode": episode,
     "review": review
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -31,7 +31,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -31,7 +31,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -30,7 +30,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -30,7 +30,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -31,7 +31,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -31,7 +31,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -32,7 +32,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -32,7 +32,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
     self.includeDetails = includeDetails
   }
 
-  public var _variables: Variables? { ["includeDetails": includeDetails] }
+  public var __variables: Variables? { ["includeDetails": includeDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
     self.includeDetails = includeDetails
   }
 
-  public var variables: Variables? { ["includeDetails": includeDetails] }
+  public var _variables: Variables? { ["includeDetails": includeDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -30,7 +30,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
     self.includeDetails = includeDetails
   }
 
-  public var variables: Variables? { ["includeDetails": includeDetails] }
+  public var _variables: Variables? { ["includeDetails": includeDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -30,7 +30,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
     self.includeDetails = includeDetails
   }
 
-  public var _variables: Variables? { ["includeDetails": includeDetails] }
+  public var __variables: Variables? { ["includeDetails": includeDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroDetailsQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroDetailsQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
     self.includeFriendsDetails = includeFriendsDetails
   }
 
-  public var _variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
+  public var __variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
     self.includeFriendsDetails = includeFriendsDetails
   }
 
-  public var variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
+  public var _variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
     self.includeFriendsDetails = includeFriendsDetails
   }
 
-  public var _variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
+  public var __variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
     self.includeFriendsDetails = includeFriendsDetails
   }
 
-  public var variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
+  public var _variables: Variables? { ["includeFriendsDetails": includeFriendsDetails] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -31,7 +31,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var _variables: Variables? { [
+  public var __variables: Variables? { [
     "skipName": skipName,
     "includeName": includeName
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -31,7 +31,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var variables: Variables? { [
+  public var _variables: Variables? { [
     "skipName": skipName,
     "includeName": includeName
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -32,7 +32,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var variables: Variables? { [
+  public var _variables: Variables? { [
     "skipName": skipName,
     "includeName": includeName
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -32,7 +32,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var _variables: Variables? { [
+  public var __variables: Variables? { [
     "skipName": skipName,
     "includeName": includeName
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -26,7 +26,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
     self.skipName = skipName
   }
 
-  public var _variables: Variables? { ["skipName": skipName] }
+  public var __variables: Variables? { ["skipName": skipName] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -26,7 +26,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
     self.skipName = skipName
   }
 
-  public var variables: Variables? { ["skipName": skipName] }
+  public var _variables: Variables? { ["skipName": skipName] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -26,7 +26,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var _variables: Variables? { ["includeName": includeName] }
+  public var __variables: Variables? { ["includeName": includeName] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -26,7 +26,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var variables: Variables? { ["includeName": includeName] }
+  public var _variables: Variables? { ["includeName": includeName] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -26,7 +26,7 @@ public class HeroNameQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -26,7 +26,7 @@ public class HeroNameQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var variables: Variables? { [
+  public var _variables: Variables? { [
     "episode": episode,
     "includeName": includeName
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
     self.includeName = includeName
   }
 
-  public var _variables: Variables? { [
+  public var __variables: Variables? { [
     "episode": episode,
     "includeName": includeName
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -48,7 +48,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -48,7 +48,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HumanQuery: GraphQLQuery {
     self.id = id
   }
 
-  public var variables: Variables? { ["id": id] }
+  public var _variables: Variables? { ["id": id] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -27,7 +27,7 @@ public class HumanQuery: GraphQLQuery {
     self.id = id
   }
 
-  public var _variables: Variables? { ["id": id] }
+  public var __variables: Variables? { ["id": id] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -40,7 +40,7 @@ public class SearchQuery: GraphQLQuery {
     self.term = term
   }
 
-  public var _variables: Variables? { ["term": term] }
+  public var __variables: Variables? { ["term": term] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -40,7 +40,7 @@ public class SearchQuery: GraphQLQuery {
     self.term = term
   }
 
-  public var variables: Variables? { ["term": term] }
+  public var _variables: Variables? { ["term": term] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -28,7 +28,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
     self.coordinates = coordinates
   }
 
-  public var variables: Variables? { ["coordinates": coordinates] }
+  public var _variables: Variables? { ["coordinates": coordinates] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -28,7 +28,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
     self.coordinates = coordinates
   }
 
-  public var _variables: Variables? { ["coordinates": coordinates] }
+  public var __variables: Variables? { ["coordinates": coordinates] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -28,7 +28,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
     self.episode = episode
   }
 
-  public var variables: Variables? { ["episode": episode] }
+  public var _variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -28,7 +28,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
     self.episode = episode
   }
 
-  public var _variables: Variables? { ["episode": episode] }
+  public var __variables: Variables? { ["episode": episode] }
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -33,7 +33,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
     self.multipleFiles = multipleFiles
   }
 
-  public var variables: Variables? { [
+  public var _variables: Variables? { [
     "singleFile": singleFile,
     "multipleFiles": multipleFiles
   ] }

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -33,7 +33,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
     self.multipleFiles = multipleFiles
   }
 
-  public var _variables: Variables? { [
+  public var __variables: Variables? { [
     "singleFile": singleFile,
     "multipleFiles": multipleFiles
   ] }

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -28,7 +28,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
     self.files = files
   }
 
-  public var _variables: Variables? { ["files": files] }
+  public var __variables: Variables? { ["files": files] }
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -28,7 +28,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
     self.files = files
   }
 
-  public var variables: Variables? { ["files": files] }
+  public var _variables: Variables? { ["files": files] }
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -28,7 +28,7 @@ public class UploadOneFileMutation: GraphQLMutation {
     self.file = file
   }
 
-  public var variables: Variables? { ["file": file] }
+  public var _variables: Variables? { ["file": file] }
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -28,7 +28,7 @@ public class UploadOneFileMutation: GraphQLMutation {
     self.file = file
   }
 
-  public var _variables: Variables? { ["file": file] }
+  public var __variables: Variables? { ["file": file] }
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -320,7 +320,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
          self.variable = variable
        }
 
-       public var _variables: Variables? { ["variable": variable] }
+       public var __variables: Variables? { ["variable": variable] }
      """
 
      // when
@@ -369,7 +369,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
         self.variable3 = variable3
       }
 
-      public var _variables: Variables? { [
+      public var __variables: Variables? { [
         "variable1": variable1,
         "variable2": variable2,
         "variable3": variable3
@@ -413,7 +413,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var _variables: Variables? { ["variable": variable] }
+      public var __variables: Variables? { ["variable": variable] }
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -320,7 +320,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
          self.variable = variable
        }
 
-       public var variables: Variables? { ["variable": variable] }
+       public var _variables: Variables? { ["variable": variable] }
      """
 
      // when
@@ -369,7 +369,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
         self.variable3 = variable3
       }
 
-      public var variables: Variables? { [
+      public var _variables: Variables? { [
         "variable1": variable1,
         "variable2": variable2,
         "variable3": variable3
@@ -413,7 +413,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var variables: Variables? { ["variable": variable] }
+      public var _variables: Variables? { ["variable": variable] }
     """
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -293,7 +293,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
          self.variable = variable
        }
 
-       public var variables: Variables? { ["variable": variable] }
+       public var _variables: Variables? { ["variable": variable] }
      """
 
      // when
@@ -342,7 +342,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.variable3 = variable3
       }
 
-      public var variables: Variables? { [
+      public var _variables: Variables? { [
         "variable1": variable1,
         "variable2": variable2,
         "variable3": variable3
@@ -386,7 +386,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var variables: Variables? { ["variable": variable] }
+      public var _variables: Variables? { ["variable": variable] }
     """
 
     // when
@@ -426,7 +426,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var variables: Variables? { ["Variable": variable] }
+      public var _variables: Variables? { ["Variable": variable] }
     """
 
     // when
@@ -665,7 +665,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.`while` = `while`
       }
 
-      public var variables: Variables? { [
+      public var _variables: Variables? { [
         "as": `as`,
         "associatedtype": `associatedtype`,
         "break": `break`,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -293,7 +293,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
          self.variable = variable
        }
 
-       public var _variables: Variables? { ["variable": variable] }
+       public var __variables: Variables? { ["variable": variable] }
      """
 
      // when
@@ -342,7 +342,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.variable3 = variable3
       }
 
-      public var _variables: Variables? { [
+      public var __variables: Variables? { [
         "variable1": variable1,
         "variable2": variable2,
         "variable3": variable3
@@ -386,7 +386,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var _variables: Variables? { ["variable": variable] }
+      public var __variables: Variables? { ["variable": variable] }
     """
 
     // when
@@ -426,7 +426,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var _variables: Variables? { ["Variable": variable] }
+      public var __variables: Variables? { ["Variable": variable] }
     """
 
     // when
@@ -665,7 +665,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.`while` = `while`
       }
 
-      public var _variables: Variables? { [
+      public var __variables: Variables? { [
         "as": `as`,
         "associatedtype": `associatedtype`,
         "break": `break`,

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -6,7 +6,7 @@ open class MockLocalCacheMutation<SelectionSet: MutableRootSelectionSet>: LocalC
 
   public typealias Data = SelectionSet
 
-  open var _variables: GraphQLOperation.Variables?
+  open var __variables: GraphQLOperation.Variables?
 
   public init() {}
 

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -6,7 +6,7 @@ open class MockLocalCacheMutation<SelectionSet: MutableRootSelectionSet>: LocalC
 
   public typealias Data = SelectionSet
 
-  open var variables: GraphQLOperation.Variables?
+  open var _variables: GraphQLOperation.Variables?
 
   public init() {}
 

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -11,7 +11,7 @@ open class MockOperation<SelectionSet: RootSelectionSet>: GraphQLOperation {
     .notPersisted(definition: .init("Mock Operation Definition"))
   }
 
-  open var variables: Variables?
+  open var _variables: Variables?
 
   public init() {}
 

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -11,7 +11,7 @@ open class MockOperation<SelectionSet: RootSelectionSet>: GraphQLOperation {
     .notPersisted(definition: .init("Mock Operation Definition"))
   }
 
-  open var _variables: Variables?
+  open var __variables: Variables?
 
   public init() {}
 

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -41,14 +41,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
 
     var episode: GraphQLNullable<MockEnum> {
       didSet {
-        self.variables = ["episode": episode]
+        self._variables = ["episode": episode]
       }
     }
 
     init(episode: GraphQLNullable<MockEnum> = .none) {
       self.episode = episode
       super.init()
-      self.variables = ["episode": episode]
+      self._variables = ["episode": episode]
     }
   }
 

--- a/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
+++ b/Tests/ApolloTests/AutomaticPersistedQueriesTests.swift
@@ -41,14 +41,14 @@ class AutomaticPersistedQueriesTests: XCTestCase {
 
     var episode: GraphQLNullable<MockEnum> {
       didSet {
-        self._variables = ["episode": episode]
+        self.__variables = ["episode": episode]
       }
     }
 
     init(episode: GraphQLNullable<MockEnum> = .none) {
       self.episode = episode
       super.init()
-      self._variables = ["episode": episode]
+      self.__variables = ["episode": episode]
     }
   }
 

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -87,7 +87,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     // when
     let query = MockQuery<GivenSelectionSet>()
-    query.variables = ["episode": "JEDI"]
+    query._variables = ["episode": "JEDI"]
     
     loadFromStore(operation: query) { result in
       // then

--- a/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/LoadQueryFromStoreTests.swift
@@ -87,7 +87,7 @@ class LoadQueryFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     // when
     let query = MockQuery<GivenSelectionSet>()
-    query._variables = ["episode": "JEDI"]
+    query.__variables = ["episode": "JEDI"]
     
     loadFromStore(operation: query) { result in
       // then

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -545,7 +545,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     runActivity("update mutation") { _ in
       let updateCompletedExpectation = expectation(description: "Update completed")
       let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
-      cacheMutation.variables = ["episode": Episode.JEDI]
+      cacheMutation._variables = ["episode": Episode.JEDI]
 
       store.withinReadWriteTransaction({ transaction in
         try transaction.update(cacheMutation) { data in

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -116,7 +116,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     let query = MockQuery<HeroNameSelectionSet>()
-    query.variables = ["episode": Episode.JEDI]
+    query._variables = ["episode": Episode.JEDI]
 
     mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
@@ -163,7 +163,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     let query = MockQuery<HeroNameSelectionSet>()
-    query.variables = ["episode": Episode.PHANTOM_MENACE]
+    query._variables = ["episode": Episode.PHANTOM_MENACE]
 
     mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
@@ -564,7 +564,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       readCompletedExpectation.expectedFulfillmentCount = 2
 
       let query = MockQuery<GivenSelectionSet>()
-      query.variables = ["episode": Episode.JEDI]
+      query._variables = ["episode": Episode.JEDI]
 
       loadFromStore(operation: query) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
@@ -578,7 +578,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         }
       }
 
-      query.variables = ["episode": Episode.PHANTOM_MENACE]
+      query._variables = ["episode": Episode.PHANTOM_MENACE]
 
       loadFromStore(operation: query) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
@@ -1729,7 +1729,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     store.withinReadTransaction({ transaction in
       let query = MockQuery<HeroFriendsSelectionSet>()
-      query.variables = ["episode": "NEWHOPE"]
+      query._variables = ["episode": "NEWHOPE"]
       _ = try transaction.read(query: query)
 
     }, completion: { newHopeResult in
@@ -1749,7 +1749,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     store.withinReadTransaction({ transaction in
       let query = MockQuery<HeroFriendsSelectionSet>()
-      query.variables = ["episode": "JEDI"]
+      query._variables = ["episode": "JEDI"]
       let data = try transaction.read(query: query)
 
       XCTAssertEqual(data.hero.__typename, "Human")
@@ -1765,7 +1765,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     store.withinReadTransaction({ transaction in
       let query = MockQuery<HeroFriendsSelectionSet>()
-      query.variables = ["episode": "EMPIRE"]
+      query._variables = ["episode": "EMPIRE"]
       _ = try transaction.read(query: query)
 
     }, completion: { empireResult in

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -116,7 +116,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     let query = MockQuery<HeroNameSelectionSet>()
-    query._variables = ["episode": Episode.JEDI]
+    query.__variables = ["episode": Episode.JEDI]
 
     mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
@@ -163,7 +163,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     let query = MockQuery<HeroNameSelectionSet>()
-    query._variables = ["episode": Episode.PHANTOM_MENACE]
+    query.__variables = ["episode": Episode.PHANTOM_MENACE]
 
     mergeRecordsIntoCache([
       "QUERY_ROOT": ["hero(episode:JEDI)": CacheReference("hero(episode:JEDI)")],
@@ -545,7 +545,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     runActivity("update mutation") { _ in
       let updateCompletedExpectation = expectation(description: "Update completed")
       let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
-      cacheMutation._variables = ["episode": Episode.JEDI]
+      cacheMutation.__variables = ["episode": Episode.JEDI]
 
       store.withinReadWriteTransaction({ transaction in
         try transaction.update(cacheMutation) { data in
@@ -564,7 +564,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       readCompletedExpectation.expectedFulfillmentCount = 2
 
       let query = MockQuery<GivenSelectionSet>()
-      query._variables = ["episode": Episode.JEDI]
+      query.__variables = ["episode": Episode.JEDI]
 
       loadFromStore(operation: query) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
@@ -578,7 +578,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         }
       }
 
-      query._variables = ["episode": Episode.PHANTOM_MENACE]
+      query.__variables = ["episode": Episode.PHANTOM_MENACE]
 
       loadFromStore(operation: query) { result in
         try XCTAssertSuccessResult(result) { graphQLResult in
@@ -1729,7 +1729,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     store.withinReadTransaction({ transaction in
       let query = MockQuery<HeroFriendsSelectionSet>()
-      query._variables = ["episode": "NEWHOPE"]
+      query.__variables = ["episode": "NEWHOPE"]
       _ = try transaction.read(query: query)
 
     }, completion: { newHopeResult in
@@ -1749,7 +1749,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     store.withinReadTransaction({ transaction in
       let query = MockQuery<HeroFriendsSelectionSet>()
-      query._variables = ["episode": "JEDI"]
+      query.__variables = ["episode": "JEDI"]
       let data = try transaction.read(query: query)
 
       XCTAssertEqual(data.hero.__typename, "Human")
@@ -1765,7 +1765,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     store.withinReadTransaction({ transaction in
       let query = MockQuery<HeroFriendsSelectionSet>()
-      query._variables = ["episode": "EMPIRE"]
+      query.__variables = ["episode": "EMPIRE"]
       _ = try transaction.read(query: query)
 
     }, completion: { empireResult in

--- a/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
+++ b/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
@@ -98,7 +98,7 @@ class CachePersistenceTests: XCTestCase {
     }
 
     let query = MockQuery<GivenSelectionSet>()
-    query.variables = ["term": "Luke.Skywalker"]
+    query._variables = ["term": "Luke.Skywalker"]
 
     let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
 

--- a/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
+++ b/Tests/ApolloTests/Cache/SQLite/CachePersistenceTests.swift
@@ -98,7 +98,7 @@ class CachePersistenceTests: XCTestCase {
     }
 
     let query = MockQuery<GivenSelectionSet>()
-    query._variables = ["term": "Luke.Skywalker"]
+    query.__variables = ["term": "Luke.Skywalker"]
 
     let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
 

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -224,7 +224,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     let watchedQuery = MockQuery<GivenMockSelectionSet>()
-    watchedQuery._variables = ["episode": "EMPIRE"]
+    watchedQuery.__variables = ["episode": "EMPIRE"]
     
     let resultObserver = makeResultObserver(for: watchedQuery)
     
@@ -264,7 +264,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     runActivity("Fetch same query from server with different argument") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<GivenMockSelectionSet>.self) { request in
-          expect(request.operation._variables?["episode"] as? String).to(equal("JEDI"))
+          expect(request.operation.__variables?["episode"] as? String).to(equal("JEDI"))
 
           return [
             "data": [
@@ -284,7 +284,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
 
       let newQuery = MockQuery<GivenMockSelectionSet>()
-      newQuery._variables = ["episode": "JEDI"]
+      newQuery.__variables = ["episode": "JEDI"]
 
       client.fetch(query: newQuery, cachePolicy: .fetchIgnoringCacheData) { result in
         defer { otherFetchCompletedExpectation.fulfill() }
@@ -313,7 +313,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
 
     let watchedQuery = MockQuery<GivenSelectionSet>()
-    watchedQuery._variables = ["episode": "EMPIRE"]
+    watchedQuery.__variables = ["episode": "EMPIRE"]
     
     let resultObserver = makeResultObserver(for: watchedQuery)
     
@@ -324,7 +324,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     
     runActivity("Initial fetch from server") { _ in
       let serverRequestExpectation = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        expect(request.operation._variables?["episode"] as? String).to(equal("EMPIRE"))
+        expect(request.operation.__variables?["episode"] as? String).to(equal("EMPIRE"))
         return [
           "data": [
             "hero": [
@@ -354,7 +354,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     
     runActivity("Fetch same query from server with different argument but returning same object with changed data") { _ in
       let serverRequestExpectation = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        expect(request.operation._variables?["episode"] as? String).to(equal("JEDI"))
+        expect(request.operation.__variables?["episode"] as? String).to(equal("JEDI"))
         return [
           "data": [
             "hero": [
@@ -379,7 +379,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
 
       let query = MockQuery<GivenSelectionSet>()
-      query._variables = ["episode": "JEDI"]
+      query.__variables = ["episode": "JEDI"]
 
       client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { result in
         defer { otherFetchCompletedExpectation.fulfill() }

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -224,7 +224,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     let watchedQuery = MockQuery<GivenMockSelectionSet>()
-    watchedQuery.variables = ["episode": "EMPIRE"]
+    watchedQuery._variables = ["episode": "EMPIRE"]
     
     let resultObserver = makeResultObserver(for: watchedQuery)
     
@@ -264,7 +264,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     runActivity("Fetch same query from server with different argument") { _ in
       let serverRequestExpectation =
         server.expect(MockQuery<GivenMockSelectionSet>.self) { request in
-          expect(request.operation.variables?["episode"] as? String).to(equal("JEDI"))
+          expect(request.operation._variables?["episode"] as? String).to(equal("JEDI"))
 
           return [
             "data": [
@@ -284,7 +284,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
 
       let newQuery = MockQuery<GivenMockSelectionSet>()
-      newQuery.variables = ["episode": "JEDI"]
+      newQuery._variables = ["episode": "JEDI"]
 
       client.fetch(query: newQuery, cachePolicy: .fetchIgnoringCacheData) { result in
         defer { otherFetchCompletedExpectation.fulfill() }
@@ -313,7 +313,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
 
     let watchedQuery = MockQuery<GivenSelectionSet>()
-    watchedQuery.variables = ["episode": "EMPIRE"]
+    watchedQuery._variables = ["episode": "EMPIRE"]
     
     let resultObserver = makeResultObserver(for: watchedQuery)
     
@@ -324,7 +324,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     
     runActivity("Initial fetch from server") { _ in
       let serverRequestExpectation = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        expect(request.operation.variables?["episode"] as? String).to(equal("EMPIRE"))
+        expect(request.operation._variables?["episode"] as? String).to(equal("EMPIRE"))
         return [
           "data": [
             "hero": [
@@ -354,7 +354,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     
     runActivity("Fetch same query from server with different argument but returning same object with changed data") { _ in
       let serverRequestExpectation = server.expect(MockQuery<GivenSelectionSet>.self) { request in
-        expect(request.operation.variables?["episode"] as? String).to(equal("JEDI"))
+        expect(request.operation._variables?["episode"] as? String).to(equal("JEDI"))
         return [
           "data": [
             "hero": [
@@ -379,7 +379,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       let otherFetchCompletedExpectation = expectation(description: "Other fetch completed")
 
       let query = MockQuery<GivenSelectionSet>()
-      query.variables = ["episode": "JEDI"]
+      query._variables = ["episode": "JEDI"]
 
       client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { result in
         defer { otherFetchCompletedExpectation.fulfill() }

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -43,7 +43,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation.variables = ["param": "TestParamValue"]
+    operation._variables = ["param": "TestParamValue"]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,
@@ -75,7 +75,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation.variables = ["param": MockEnum.LARGE]
+    operation._variables = ["param": MockEnum.LARGE]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,
@@ -107,7 +107,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation.variables = ["a": "TestParamValue", "b": true]
+    operation._variables = ["a": "TestParamValue", "b": true]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,
@@ -239,7 +239,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation.variables = ["param": GraphQLNullable<String>.null]
+    operation._variables = ["param": GraphQLNullable<String>.null]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,

--- a/Tests/ApolloTests/GETTransformerTests.swift
+++ b/Tests/ApolloTests/GETTransformerTests.swift
@@ -43,7 +43,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation._variables = ["param": "TestParamValue"]
+    operation.__variables = ["param": "TestParamValue"]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,
@@ -75,7 +75,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation._variables = ["param": MockEnum.LARGE]
+    operation.__variables = ["param": MockEnum.LARGE]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,
@@ -107,7 +107,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation._variables = ["a": "TestParamValue", "b": true]
+    operation.__variables = ["a": "TestParamValue", "b": true]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,
@@ -239,7 +239,7 @@ class GETTransformerTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation._variables = ["param": GraphQLNullable<String>.null]
+    operation.__variables = ["param": GraphQLNullable<String>.null]
 
     let body = requestBodyCreator.requestBody(for: operation,
                                               sendQueryDocument: true,

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -33,7 +33,7 @@ class RequestBodyCreatorTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation.variables = ["TestVar": 123]
+    operation._variables = ["TestVar": 123]
 
     let creator = ApolloRequestBodyCreator()
 
@@ -79,7 +79,7 @@ class RequestBodyCreatorTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation.variables = ["TestVar": MockScalar("123")]
+    operation._variables = ["TestVar": MockScalar("123")]
 
     let creator = ApolloRequestBodyCreator()
 

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -33,7 +33,7 @@ class RequestBodyCreatorTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation._variables = ["TestVar": 123]
+    operation.__variables = ["TestVar": 123]
 
     let creator = ApolloRequestBodyCreator()
 
@@ -79,7 +79,7 @@ class RequestBodyCreatorTests: XCTestCase {
     }
 
     let operation = GivenMockOperation()
-    operation._variables = ["TestVar": MockScalar("123")]
+    operation.__variables = ["TestVar": MockScalar("123")]
 
     let creator = ApolloRequestBodyCreator()
 


### PR DESCRIPTION
_PR 3 of 3 for #2497 - I was going to submit all the 'underscore' changes as a single PR but it's going to get too big so I'm splitting them up into similar parts._

This PR marks the `variables` property on `GraphQLOperation` and `LocalCacheMutation` as private. They will remain accessible to developers because the access modifiers aren't changing but the underscore serves as enough of a hint of "use at your own risk, could change without warning".