### PR TITLE
feat: Custom `Codable` for `ApolloSchemaDownloadConfiguration`

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -783,6 +783,8 @@
 		E6D90D09278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */; };
 		E6D90D0B278FFDDA009CAC5D /* SchemaMetadataFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D0A278FFDDA009CAC5D /* SchemaMetadataFileGenerator.swift */; };
 		E6D90D0D278FFE35009CAC5D /* SchemaMetadataFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D90D0C278FFE35009CAC5D /* SchemaMetadataFileGeneratorTests.swift */; };
+		E6D9212928DA631D00AF12E6 /* ApolloSchemaDownloadConfigurationCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D9212828DA631D00AF12E6 /* ApolloSchemaDownloadConfigurationCodableTests.swift */; };
+		E6D9212B28DA66B300AF12E6 /* String+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D9212A28DA66B300AF12E6 /* String+Data.swift */; };
 		E6DC0AC228B3AB890064A68F /* CodegenCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E687B3C128B398CB00A9551C /* CodegenCLI.framework */; };
 		E6DC0AD728B3AC490064A68F /* MockApolloCodegen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DC0ACB28B3AC490064A68F /* MockApolloCodegen.swift */; };
 		E6DC0AD828B3AC490064A68F /* MockApolloCodegenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DC0ACC28B3AC490064A68F /* MockApolloCodegenConfiguration.swift */; };
@@ -1914,6 +1916,8 @@
 		E6D90D08278FA5C3009CAC5D /* InputObjectFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E6D90D0A278FFDDA009CAC5D /* SchemaMetadataFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaMetadataFileGenerator.swift; sourceTree = "<group>"; };
 		E6D90D0C278FFE35009CAC5D /* SchemaMetadataFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaMetadataFileGeneratorTests.swift; sourceTree = "<group>"; };
+		E6D9212828DA631D00AF12E6 /* ApolloSchemaDownloadConfigurationCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloSchemaDownloadConfigurationCodableTests.swift; sourceTree = "<group>"; };
+		E6D9212A28DA66B300AF12E6 /* String+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Data.swift"; sourceTree = "<group>"; };
 		E6DC0ABE28B3AB890064A68F /* CodegenCLITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CodegenCLITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6DC0ACB28B3AC490064A68F /* MockApolloCodegen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockApolloCodegen.swift; sourceTree = "<group>"; };
 		E6DC0ACC28B3AC490064A68F /* MockApolloCodegenConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockApolloCodegenConfiguration.swift; sourceTree = "<group>"; };
@@ -2354,6 +2358,7 @@
 				E61EF712275EC99A00191DA7 /* ApolloCodegenTests.swift */,
 				9BAEEC18234C297800808306 /* ApolloCodegenConfigurationTests.swift */,
 				E6908E54282694630054682B /* ApolloCodegenConfigurationCodableTests.swift */,
+				E6D9212828DA631D00AF12E6 /* ApolloSchemaDownloadConfigurationCodableTests.swift */,
 				9BAEEC0D234BB95B00808306 /* FileManagerExtensionTests.swift */,
 				9B4751AC2575B5070001FB87 /* PluralizerTests.swift */,
 				9B8C3FB4248DA3E000707B13 /* URLExtensionsTests.swift */,
@@ -3851,6 +3856,7 @@
 			isa = PBXGroup;
 			children = (
 				E64F7EBE27A11B110059C021 /* GraphQLNamedType+SwiftTests.swift */,
+				E6D9212A28DA66B300AF12E6 /* String+Data.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5000,6 +5006,7 @@
 				DEAFB77B2706444B00BE02F3 /* IRRootFieldBuilderTests.swift in Sources */,
 				E6EFDD1527EAB55B00B17FE5 /* TemplateRenderer_OperationFile_Tests.swift in Sources */,
 				DE454BB528B43058009DC80E /* SchemaConfigurationTemplateTests.swift in Sources */,
+				E6D9212B28DA66B300AF12E6 /* String+Data.swift in Sources */,
 				E6B42D0D27A4749100A3BD58 /* SwiftPackageManagerModuleTemplateTests.swift in Sources */,
 				DE296539279B3B8200BF9B49 /* SelectionSetTemplateTests.swift in Sources */,
 				E66F8897276C136B0000BDA8 /* ObjectFileGeneratorTests.swift in Sources */,
@@ -5046,6 +5053,7 @@
 				9B4751AD2575B5070001FB87 /* PluralizerTests.swift in Sources */,
 				E6B4E9982798A8C6004EC8C4 /* FragmentTemplateTests.swift in Sources */,
 				9BAEEC19234C297800808306 /* ApolloCodegenConfigurationTests.swift in Sources */,
+				E6D9212928DA631D00AF12E6 /* ApolloSchemaDownloadConfigurationCodableTests.swift in Sources */,
 				DE9CEAF1282C632B00959AF9 /* MockObjectTemplateTests.swift in Sources */,
 				E610D8E1278F8F3D0023E495 /* UnionFileGeneratorTests.swift in Sources */,
 			);

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -126,7 +126,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let encodedJSON = try testJSONEncoder.encode(subject)
-    let actual = String(data: encodedJSON, encoding: .utf8)!
+    let actual = encodedJSON.asString
 
     // then
     expect(actual).to(equal(MockApolloCodegenConfiguration.encodedJSON))
@@ -429,14 +429,4 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
       try JSONDecoder().decode(ApolloCodegenConfiguration.APQConfig.self, from: subject)
     ).to(throwError())
   }
-}
-
-// MARK: - Test Helpers
-
-fileprivate extension String {
-  var asData: Data { self.data(using: .utf8)! }
-}
-
-fileprivate extension Data {
-  var asString: String { String(data: self, encoding: .utf8)! }
 }

--- a/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+import Nimble
+import ApolloCodegenLib
+
+class ApolloSchemaDownloadConfigurationCodableTests: XCTestCase {
+
+  var testJSONEncoder: JSONEncoder!
+
+  override func setUp() {
+    super.setUp()
+
+    testJSONEncoder = JSONEncoder()
+    testJSONEncoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+  }
+
+  override func tearDown() {
+    testJSONEncoder = nil
+
+    super.tearDown()
+  }
+
+  // MARK: - ApolloSchemaDownloadConfiguration Tests
+
+  enum MockApolloSchemaDownloadConfiguration {
+    static var decodedStruct: ApolloSchemaDownloadConfiguration {
+      .init(
+        using: .introspection(
+          endpointURL: URL(string: "http://server.com")!,
+          httpMethod: .POST,
+          outputFormat: .SDL,
+          includeDeprecatedInputValues: true),
+        timeout: 120,
+        headers: [],
+        outputPath: "ServerSchema.graphqls"
+      )
+    }
+
+    static var encodedJSON: String {
+      """
+      {
+        "downloadMethod" : {
+          "introspection" : {
+            "endpointURL" : "http://server.com",
+            "httpMethod" : {
+              "POST" : {
+
+              }
+            },
+            "includeDeprecatedInputValues" : true,
+            "outputFormat" : "SDL"
+          }
+        },
+        "downloadTimeout" : 120,
+        "headers" : [
+
+        ],
+        "outputPath" : "ServerSchema.graphqls"
+      }
+      """
+    }
+  }
+
+  func test__encodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnJSON() throws {
+    // given
+    let subject = MockApolloSchemaDownloadConfiguration.decodedStruct
+
+    // when
+    let encodedJSON = try testJSONEncoder.encode(subject)
+    let actual = encodedJSON.asString
+
+    // then
+    expect(actual).to(equal(MockApolloSchemaDownloadConfiguration.encodedJSON))
+  }
+
+  func test__decodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnStruct() throws {
+    // given
+    let subject = MockApolloSchemaDownloadConfiguration.encodedJSON.asData
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloSchemaDownloadConfiguration.self, from: subject)
+
+    // then
+    expect(actual).to(equal(MockApolloSchemaDownloadConfiguration.decodedStruct))
+  }
+
+  func test__decodeApolloSchemaDownloadConfiguration__givenOnlyRequiredParameters_shouldReturnStruct() throws {
+    // given
+    let subject = """
+      {
+        "downloadMethod" : {
+          "introspection" : {
+            "endpointURL" : "http://server.com",
+            "httpMethod" : {
+              "POST" : {
+
+              }
+            },
+            "includeDeprecatedInputValues" : true,
+            "outputFormat" : "SDL"
+          }
+        },
+        "outputPath" : "ServerSchema.graphqls"
+      }
+      """.asData
+
+    let expected = ApolloSchemaDownloadConfiguration(
+      using: .introspection(
+        endpointURL: URL(string: "http://server.com")!,
+        httpMethod: .POST,
+        outputFormat: .SDL,
+        includeDeprecatedInputValues: true),
+      outputPath: "ServerSchema.graphqls")
+
+    // when
+    let actual = try JSONDecoder().decode(ApolloSchemaDownloadConfiguration.self, from: subject)
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decodeApolloSchemaDownloadConfiguration__givenMissingRequiredParameters_shouldThrow() throws {
+    // given
+    let subject = """
+      {}
+      """.asData
+
+    // then
+    expect(try JSONDecoder().decode(ApolloSchemaDownloadConfiguration.self, from: subject))
+      .to(throwError())
+  }
+
+  // MARK: - ApolloRegistrySettings Tests
+
+  enum MockApolloRegistrySettings {
+    static var decodedStruct: ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings {
+      .init(apiKey: "ABC123", graphID: "DEF456", variant: "final")
+    }
+
+    static var encodedJSON: String {
+      """
+      {
+        "apiKey" : "ABC123",
+        "graphID" : "DEF456",
+        "variant" : "final"
+      }
+      """
+    }
+  }
+
+  func test__encodeApolloRegistrySettings__givenAllParameters_shouldReturnJSON() throws {
+    // given
+    let subject = MockApolloRegistrySettings.decodedStruct
+
+    // when
+    let encodedJSON = try testJSONEncoder.encode(subject)
+    let actual = encodedJSON.asString
+
+    // then
+    expect(actual).to(equal(MockApolloRegistrySettings.encodedJSON))
+  }
+
+  func test__decodeApolloRegistrySettings__givenAllParameters_shouldReturnStruct() throws {
+    // given
+    let subject = MockApolloRegistrySettings.encodedJSON.asData
+
+    // when
+    let actual = try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings.self,
+      from: subject
+    )
+
+    // then
+    expect(actual).to(equal(MockApolloRegistrySettings.decodedStruct))
+  }
+
+  func test__decodeApolloRegistrySettings__givenOnlyRequiredParameters_shouldReturnStruct() throws {
+    // given
+    let subject = """
+      {
+        "apiKey" : "EGWRB",
+        "graphID" : "YUNRT"
+      }
+      """.asData
+
+    let expected = ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings(
+      apiKey: "EGWRB",
+      graphID: "YUNRT"
+    )
+
+    // when
+    let actual = try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings.self,
+      from: subject
+    )
+
+    // then
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decodeApolloRegistrySettings__givenMissingRequiredParameters_shouldThrow() throws {
+    // given
+    let subject = """
+      {}
+      """.asData
+
+    // then
+    expect(try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.DownloadMethod.ApolloRegistrySettings.self,
+      from: subject
+    )).to(throwError())
+  }
+
+  // MARK: - OutputFormat Tests
+
+  func encodedValue(_ case: ApolloSchemaDownloadConfiguration.DownloadMethod.OutputFormat) -> String {
+    switch `case` {
+    case .SDL: return "\"SDL\""
+    case .JSON: return "\"JSON\""
+    }
+  }
+
+  func test__encodeOutputFormat__givenSDL_shouldReturnString() throws {
+    // given
+    let subject = ApolloSchemaDownloadConfiguration.DownloadMethod.OutputFormat.SDL
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.SDL)))
+  }
+
+  func test__encodeOutputFormat__givenJSON_shouldReturnString() throws {
+    // given
+    let subject = ApolloSchemaDownloadConfiguration.DownloadMethod.OutputFormat.JSON
+
+    // when
+    let actual = try testJSONEncoder.encode(subject).asString
+
+    // then
+    expect(actual).to(equal(encodedValue(.JSON)))
+  }
+
+  func test__decodeOutputFormat__givenSDL_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.SDL).asData
+
+    // when
+    let actual = try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.DownloadMethod.OutputFormat.self,
+      from: subject
+    )
+
+    // then
+    expect(actual).to(equal(.SDL))
+  }
+
+  func test__decodeOutputFormat__givenJSON_shouldReturnEnum() throws {
+    // given
+    let subject = encodedValue(.JSON).asData
+
+    // when
+    let actual = try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.DownloadMethod.OutputFormat.self,
+      from: subject
+    )
+
+    // then
+    expect(actual).to(equal(.JSON))
+  }
+
+  func test__decodeOutputFormat__givenUnknown_shouldThrow() throws {
+    // given
+    let subject = "\"unknown\"".asData
+
+    // then
+    expect(
+      try JSONDecoder().decode(
+        ApolloSchemaDownloadConfiguration.DownloadMethod.OutputFormat.self,
+        from: subject
+      )
+    ).to(throwError())
+  }
+}

--- a/Tests/ApolloCodegenTests/Extensions/String+Data.swift
+++ b/Tests/ApolloCodegenTests/Extensions/String+Data.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension String {
+  var asData: Data { self.data(using: .utf8)! }
+}
+
+extension Data {
+  var asString: String { String(data: self, encoding: .utf8)! }
+}


### PR DESCRIPTION
This is to support optional properties for `ApolloSchemaDownloadConfiguration` and it's subtypes.