### PR TITLE
fix: Support multiline deprecation messages

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		19E9F6AC26D58A9A003AB80E /* OperationMessageIdCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9F6AA26D58A92003AB80E /* OperationMessageIdCreatorTests.swift */; };
 		19E9F6B526D6BF25003AB80E /* OperationMessageIdCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9F6A826D5867E003AB80E /* OperationMessageIdCreator.swift */; };
 		2EE7FFD0276802E30035DC39 /* CacheKeyConstructionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE7FFCF276802E30035DC39 /* CacheKeyConstructionTests.swift */; };
+		534A754528EB21D6003291BE /* TemplateString+AvailabilityDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534A754428EB21D6003291BE /* TemplateString+AvailabilityDeprecated.swift */; };
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */; };
 		5BB2C0232380836100774170 /* VersionNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2C0222380836100774170 /* VersionNumberTests.swift */; };
@@ -1074,6 +1075,7 @@
 		19E9F6A826D5867E003AB80E /* OperationMessageIdCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMessageIdCreator.swift; sourceTree = "<group>"; };
 		19E9F6AA26D58A92003AB80E /* OperationMessageIdCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMessageIdCreatorTests.swift; sourceTree = "<group>"; };
 		2EE7FFCF276802E30035DC39 /* CacheKeyConstructionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheKeyConstructionTests.swift; sourceTree = "<group>"; };
+		534A754428EB21D6003291BE /* TemplateString+AvailabilityDeprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TemplateString+AvailabilityDeprecated.swift"; sourceTree = "<group>"; };
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
 		5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPMethod.swift; sourceTree = "<group>"; };
 		5BB2C0222380836100774170 /* VersionNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionNumberTests.swift; sourceTree = "<group>"; };
@@ -2444,6 +2446,7 @@
 				E674DB40274C0A9B009BB90E /* Glob.swift */,
 				DE5FD600276923620033EE23 /* TemplateString.swift */,
 				DED5B35A286CF16600AE6BFF /* TemplateString+CodegenConfiguration.swift */,
+				534A754428EB21D6003291BE /* TemplateString+AvailabilityDeprecated.swift */,
 				DE31A437276A78140020DC44 /* Templates */,
 				E6E3BBDC276A8D6200E5218B /* FileGenerators */,
 			);
@@ -4887,6 +4890,7 @@
 				E6B42D0927A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift in Sources */,
 				DE100B1A28872D0F00BE11C2 /* Documentation.docc in Sources */,
 				E6D90D07278FA595009CAC5D /* InputObjectFileGenerator.swift in Sources */,
+				534A754528EB21D6003291BE /* TemplateString+AvailabilityDeprecated.swift in Sources */,
 				E64F7EB827A0854E0059C021 /* UnionTemplate.swift in Sources */,
 				E60AE2EE27E3FC6C003C093A /* TemplateRenderer.swift in Sources */,
 				9BCA8C0926618226004FF2F6 /* UntypedGraphQLRequestBodyCreator.swift in Sources */,

--- a/Sources/ApolloCodegenLib/TemplateString+AvailabilityDeprecated.swift
+++ b/Sources/ApolloCodegenLib/TemplateString+AvailabilityDeprecated.swift
@@ -1,0 +1,30 @@
+extension TemplateString.StringInterpolation {
+
+  mutating func appendInterpolation(
+    deprecationReason: String?,
+    config: ApolloCodegen.ConfigurationContext
+  ) {
+    guard
+      config.options.warningsOnDeprecatedUsage == .include,
+      let deprecationReason = deprecationReason
+    else {
+      removeLineIfEmpty()
+      return
+    }
+
+    if deprecationReason.contains("\n") {
+      let indentedDeprecationReason = deprecationReason
+        .split(separator: "\n").map { "    \($0)" }.joined(separator: "\n")
+
+      appendInterpolation("""
+        @available(*, deprecated, message: \"\"\"
+        \(indentedDeprecationReason)
+            \"\"\")
+        """)
+    } else {
+      appendInterpolation("""
+        @available(*, deprecated, message: \"\(deprecationReason)\")
+        """)
+    }
+  }
+}

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -32,9 +32,7 @@ struct EnumTemplate: TemplateRenderer {
 
     return """
     \(documentation: graphqlEnumValue.documentation, config: config)
-    \(ifLet: graphqlEnumValue.deprecationReason, where: config.options.warningsOnDeprecatedUsage == .include, {"""
-      @available(*, deprecated, message: \"\($0)\")
-      """})
+    \(deprecationReason: graphqlEnumValue.deprecationReason, config: config)
     \(caseDefinition(for: graphqlEnumValue))
     """
   }

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -109,10 +109,7 @@ struct InputObjectTemplate: TemplateRenderer {
   private func FieldPropertyTemplate(_ field: GraphQLInputField) -> TemplateString {
     """
     \(documentation: field.documentation, config: config)
-    \(ifLet: field.deprecationReason,
-      where: config.options.warningsOnDeprecatedUsage == .include, {
-        "@available(*, deprecated, message: \"\($0)\")"
-      })
+    \(deprecationReason: field.deprecationReason, config: config)
     public var \(field.name): \(field.renderInputValueType(config: config.config)) {
       get { __data.\(field.name) }
       set { __data.\(field.name) = newValue }

--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -43,10 +43,7 @@ struct MockObjectTemplate: TemplateRenderer {
       public struct MockFields {
         \(fields.map {
           TemplateString("""
-          \(ifLet: $0.deprecationReason,
-            where: config.options.warningsOnDeprecatedUsage == .include, {
-              "@available(*, deprecated, message: \"\($0)\")"
-            })
+          \(deprecationReason: $0.deprecationReason, config: config)
           @Field<\($0.type)>("\($0.responseKey)") public var \($0.propertyName)
           """)
         }, separator: "\n")

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -265,10 +265,7 @@ struct SelectionSetTemplate {
     }()
     return """
     \(documentation: field.underlyingField.documentation, config: config)
-    \(ifLet: field.underlyingField.deprecationReason,
-      where: config.options.warningsOnDeprecatedUsage == .include, {
-        "@available(*, deprecated, message: \"\($0)\")"
-      })
+    \(deprecationReason: field.underlyingField.deprecationReason, config: config)
     public var \(field.responseKey.firstLowercased.asFieldAccessorPropertyName): \
     \(typeName(for: field, forceOptional: isConditionallyIncluded)) {\
     \(if: isMutable,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -5443,9 +5443,10 @@ class SelectionSetTemplateTests: XCTestCase {
 
     type Animal {
       "This field is a string."
-      string: String! @deprecated(reason: "Cause I\nsaid so!")
+      string: String! @deprecated(reason: "Cause I\\nsaid so!")
     }
-    """
+    """ // Escaping the backslash is required to allow the frontend to parse correctly this string.
+    // Removing the escape leads to a "unterminated string literal" error when parsing the schema.
 
     document = """
     query TestOperation {


### PR DESCRIPTION
Hello everyone, 

I was trying out the new version of the library in our codebase, and I found a small issue: our schema defines a deprecation warning that spans multiple lines. 
This causes the current version of the codegen to output stuff like this: 
```swift
@available(*, deprecated, message: "Very long deprecation message that 
                         spans multiple lines but 
                         without a triple quote, resulting in a \"Unterminated literal\" error.")
```

This PR adds a test case that reproduces the error, and a new string interpolation method on `TemplateString` that makes it easier to add deprecation warnings wherever they're needed.

The new result looks like this: 
```swift
@available(*, deprecated, message: """
    Very long deprecation message that 
    spans multiple lines but 
    without a triple quote, resulting in a \"Unterminated literal\" error.
    """)
```