### PR TITLE
feat: added `CaseIterable` to `EnumType`.

### DIFF
--- a/Sources/ApolloAPI/SchemaTypes/EnumType.swift
+++ b/Sources/ApolloAPI/SchemaTypes/EnumType.swift
@@ -8,6 +8,7 @@
 /// [GraphQLSpec - Enums](https://spec.graphql.org/draft/#sec-Enums)
 public protocol EnumType:
   RawRepresentable,
+  CaseIterable,
   JSONEncodable,
   GraphQLOperationVariableValue
 where RawValue == String {}

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -427,6 +427,14 @@ class EnumTemplateTests: XCTestCase {
       @available(*, deprecated, message: "Deprecated for tests")
       case two = "TWO"
       case three = "THREE"
+
+      static var allCases: [TestEnum] {
+        [
+          .one,
+          .two,
+          .three
+        ]
+      }
     }
 
     """
@@ -523,6 +531,14 @@ class EnumTemplateTests: XCTestCase {
       case two = "TWO"
       @available(*, deprecated, message: "Deprecated for tests")
       case three = "THREE"
+
+      static var allCases: [TestEnum] {
+        [
+          .one,
+          .two,
+          .three
+        ]
+      }
     }
 
     """


### PR DESCRIPTION
In the previous incarnation of the codegen enums implemented `CaseIterable`. We have some code that relies on this behavior. 

This PR adds back `CaseIterable` to the `EnumType` protocol.

**Update**: 

I found out (the hard way) that the compiler will not automatically synthesize the `allCases` requirement of `CaseIterable` if the enum contains cases with deprecation annotations. I modified the `EnumTemplate` to generate an `allCases` computed variable in this case; other enums rely on the automatic synthesis by the compiler.