### PR TITLE
fix: Uses correct casing for schema name in generated namespace

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -251,7 +251,6 @@ public class ApolloCodegen {
       try autoreleasepool {
         try UnionFileGenerator(
           graphqlUnion: graphQLUnion,
-          schemaName: config.schemaName,
           config: config
         ).generate(
           forConfig: config,

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -31,7 +31,6 @@ struct SchemaModuleFileGenerator {
       filePath = pathURL
         .appendingPathComponent("\(config.schemaName.firstUppercased).graphql.swift").path
       rendered = SchemaModuleNamespaceTemplate(
-        namespace: config.schemaName,
         config: config
         ).render()
 

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -28,7 +28,8 @@ struct SchemaModuleFileGenerator {
       ).render()
 
     case .embeddedInTarget:
-      filePath = pathURL.appendingPathComponent("\(config.schemaName).graphql.swift").path
+      filePath = pathURL
+        .appendingPathComponent("\(config.schemaName.firstUppercased).graphql.swift").path
       rendered = SchemaModuleNamespaceTemplate(
         namespace: config.schemaName,
         config: config

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaModuleFileGenerator.swift
@@ -22,7 +22,6 @@ struct SchemaModuleFileGenerator {
     case .swiftPackageManager:
       filePath = pathURL.appendingPathComponent("Package.swift").path
       rendered = SwiftPackageManagerModuleTemplate(
-        moduleName: config.schemaName,
         testMockConfig: config.output.testMocks,
         config: config
       ).render()

--- a/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/UnionFileGenerator.swift
@@ -4,13 +4,10 @@ import Foundation
 struct UnionFileGenerator: FileGenerator {
   /// Source GraphQL union.
   let graphqlUnion: GraphQLUnionType
-  /// Schema name
-  let schemaName: String
   /// Shared codegen configuration.
   let config: ApolloCodegen.ConfigurationContext
 
   var template: TemplateRenderer { UnionTemplate(
-    moduleName: schemaName,
     graphqlUnion: graphqlUnion,
     config: config
   ) }

--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -36,7 +36,7 @@ struct MockObjectTemplate: TemplateRenderer {
 
     return """
     public class \(objectName): MockObject {
-      public static let objectType: Object = \(config.schemaName).Objects.\(objectName)
+      public static let objectType: Object = \(config.schemaName.firstUppercased).Objects.\(objectName)
       public static let _mockFields = MockFields()
       public typealias MockValueCollectionType = Array<Mock<\(objectName)>>
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -46,7 +46,7 @@ extension GraphQLType {
   ) -> String {
 
     lazy var schemaModuleName: String = {
-      !config.output.operations.isInModule ? "\(config.schemaName)." : ""
+      !config.output.operations.isInModule ? "\(config.schemaName.firstUppercased)." : ""
     }()
 
     switch self {
@@ -99,7 +99,7 @@ extension GraphQLType {
   ) -> String {
 
     lazy var schemaModuleName: String = {
-      !config.output.schemaTypes.isInModule ? "\(config.schemaName)." : ""
+      !config.output.schemaTypes.isInModule ? "\(config.schemaName.firstUppercased)." : ""
     }()
 
     switch self {

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/InputVariableRenderable.swift
@@ -83,7 +83,7 @@ fileprivate extension GraphQLInputObjectType {
     }
 
     return """
-    \(if: !config.output.operations.isInModule, "\(config.schemaName).")\(name)(\(list: entries))
+    \(if: !config.output.operations.isInModule, "\(config.schemaName.firstUppercased).")\(name)(\(list: entries))
     """
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaModuleNamespaceTemplate.swift
@@ -3,8 +3,6 @@ import Foundation
 /// Provides the format to define a namespace that is used to wrap other templates to prevent
 /// naming collisions in Swift code.
 struct SchemaModuleNamespaceTemplate: TemplateRenderer {
-  /// Module namespace.
-  let namespace: String
 
   let config: ApolloCodegen.ConfigurationContext
 
@@ -12,7 +10,7 @@ struct SchemaModuleNamespaceTemplate: TemplateRenderer {
 
   var template: TemplateString {
     TemplateString("""
-    public enum \(namespace.firstUppercased) { }
+    public enum \(config.schemaName.firstUppercased) { }
 
     """)
   }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -69,7 +69,7 @@ struct SelectionSetTemplate {
       selectionSetTypeName = "MutableInlineFragment"
     }
 
-    return "\(schema.name.firstUppercased).\(selectionSetTypeName)"
+    return "\(config.schemaName.firstUppercased).\(selectionSetTypeName)"
   }
 
   // MARK: - Selection Set Name Documentation
@@ -119,7 +119,7 @@ struct SelectionSetTemplate {
   private func ParentTypeTemplate(_ type: GraphQLCompositeType) -> String {
     """
     public static var __parentType: ParentType { \
-    \(schema.name.firstUppercased).\(type.schemaTypesNamespace).\(type.name.firstUppercased) }
+    \(config.schemaName.firstUppercased).\(type.schemaTypesNamespace).\(type.name.firstUppercased) }
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -3,8 +3,6 @@ import Foundation
 /// Provides the format to define a Swift Package Manager module in Swift code. The output must
 /// conform to the [configuration definition of a Swift package](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#).
 struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
-  /// Module name used to name the generated package.
-  let moduleName: String
 
   let testMockConfig: ApolloCodegenConfiguration.TestMockFileOutput
 
@@ -15,7 +13,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
   let config: ApolloCodegen.ConfigurationContext
 
   var template: TemplateString {
-    let casedModuleName = moduleName.firstUppercased
+    let casedSchemaName = config.schemaName.firstUppercased
 
     return TemplateString("""
     // swift-tools-version:5.3
@@ -23,7 +21,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
     import PackageDescription
 
     let package = Package(
-      name: "\(casedModuleName)",
+      name: "\(casedSchemaName)",
       platforms: [
         .iOS(.v12),
         .macOS(.v10_14),
@@ -31,14 +29,14 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
         .watchOS(.v5),
       ],
       products: [
-        .library(name: "\(casedModuleName)", targets: ["\(casedModuleName)"]),
+        .library(name: "\(casedSchemaName)", targets: ["\(casedSchemaName)"]),
       ],
       dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0"),
       ],
       targets: [
         .target(
-          name: "\(casedModuleName)",
+          name: "\(casedSchemaName)",
           dependencies: [
             .product(name: "ApolloAPI", package: "apollo-ios"),
           ],
@@ -49,7 +47,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
           name: "\($0.targetName)",
           dependencies: [
             .product(name: "ApolloTestSupport", package: "apollo-ios"),
-            .target(name: "\(casedModuleName)"),
+            .target(name: "\(casedSchemaName)"),
           ],
           path: "\($0.path)"
         ),
@@ -68,7 +66,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
       if let targetName = targetName {
         return (targetName.firstUppercased, "./\(targetName.firstUppercased)")
       } else {
-        return ("\(moduleName.firstUppercased)TestMocks", "./TestMocks")
+        return ("\(config.schemaName.firstUppercased)TestMocks", "./TestMocks")
       }
     }
   }

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -89,11 +89,11 @@ extension TemplateRenderer {
       case (false, nil):
         return nil
       case (true, nil):
-        return config.schemaName
+        return config.schemaName.firstUppercased
       case let (false, .some(schemaTypeNamespace)):
         return schemaTypeNamespace
       case let (true, .some(schemaTypeNamespace)):
-        return "\(config.schemaName).\(schemaTypeNamespace)"
+        return "\(config.schemaName.firstUppercased).\(schemaTypeNamespace)"
       }
     }()
 
@@ -115,7 +115,7 @@ extension TemplateRenderer {
     \(ImportStatementTemplate.Operation.template(for: config))
 
     \(if: config.output.operations.isInModule && !config.output.schemaTypes.isInModule,
-      template.wrappedInNamespace(config.schemaName),
+      template.wrappedInNamespace(config.schemaName.firstUppercased),
     else:
       template)
     """
@@ -154,7 +154,7 @@ extension TemplateString {
   fileprivate func wrappedInNamespace(_ namespace: String) -> Self {
     TemplateString(
     """
-    public extension \(namespace.firstUppercased) {
+    public extension \(namespace) {
       \(self)
     }
     """

--- a/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/UnionTemplate.swift
@@ -3,8 +3,6 @@ import Foundation
 /// Provides the format to convert a [GraphQL Union](https://spec.graphql.org/draft/#sec-Unions)
 /// into Swift code.
 struct UnionTemplate: TemplateRenderer {
-  /// Module name.
-  let moduleName: String
   /// IR representation of source [GraphQL Union](https://spec.graphql.org/draft/#sec-Unions).
   let graphqlUnion: GraphQLUnionType
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
@@ -38,13 +38,61 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
     expect(self.mockFileManager.allClosuresCalled).to(beTrue())
   }
 
-  func test__generate__givenModuleType_none_shouldGenerateNamespaceFile() throws {
+  func test__generate__givenModuleTypeEmbeddedInTarget_lowercaseSchemaName_shouldGenerateNamespaceFileWithCapitalizedName() throws {
     // given
-    let fileURL = rootURL.appendingPathComponent("ModuleTestSchema.graphql.swift")
+    let fileURL = rootURL.appendingPathComponent("Schema.graphql.swift")
 
     let configuration = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
       .embeddedInTarget(name: "MockApplication"),
-      schemaName: "ModuleTestSchema",
+      schemaName: "schema",
+      to: rootURL.path
+    ))
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      // then
+      expect(path).to(equal(fileURL.path))
+
+      return true
+    }))
+
+    // when
+    try SchemaModuleFileGenerator.generate(configuration, fileManager: mockFileManager)
+
+    // then
+    expect(self.mockFileManager.allClosuresCalled).to(beTrue())
+  }
+
+  func test__generate__givenModuleTypeEmbeddedInTarget_uppercaseSchemaName_shouldGenerateNamespaceFileWithUppercaseName() throws {
+    // given
+    let fileURL = rootURL.appendingPathComponent("SCHEMA.graphql.swift")
+
+    let configuration = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
+      .embeddedInTarget(name: "MockApplication"),
+      schemaName: "SCHEMA",
+      to: rootURL.path
+    ))
+
+    mockFileManager.mock(closure: .createFile({ path, data, attributes in
+      // then
+      expect(path).to(equal(fileURL.path))
+
+      return true
+    }))
+
+    // when
+    try SchemaModuleFileGenerator.generate(configuration, fileManager: mockFileManager)
+
+    // then
+    expect(self.mockFileManager.allClosuresCalled).to(beTrue())
+  }
+
+  func test__generate__givenModuleTypeEmbeddedInTarget_capitalizedSchemaName_shouldGenerateNamespaceFileWithCapitalizedName() throws {
+    // given
+    let fileURL = rootURL.appendingPathComponent("MySchema.graphql.swift")
+
+    let configuration = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
+      .embeddedInTarget(name: "MockApplication"),
+      schemaName: "MySchema",
       to: rootURL.path
     ))
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/UnionFileGeneratorTests.swift
@@ -16,7 +16,6 @@ class UnionFileGeneratorTests: XCTestCase {
   private func buildSubject() {
     subject = UnionFileGenerator(
       graphqlUnion: graphqlUnion,
-      schemaName: "MockSchema",
       config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -1865,4 +1865,260 @@ class InputObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
+  // MARK: Casing Tests
+
+  func test__casing__givenSchemaNameLowercased_nonListField_generatesWithFirstUppercasedNamespace() throws {
+    // given
+    let fields: [GraphQLInputField] = [
+      GraphQLInputField.mock(
+        "enumField",
+        type: .enum(.mock(name: "EnumValue")),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "inputField",
+        type: .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            GraphQLInputField.mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        )),
+        defaultValue: nil
+      )
+    ]
+
+    buildSubject(
+      fields: fields,
+      config: .mock(schemaName: "testschema", output: .mock(
+        moduleType: .swiftPackageManager,
+        operations: .relative(subpath: nil)))
+    )
+
+    let expected = """
+      public init(
+        enumField: GraphQLNullable<GraphQLEnum<Testschema.EnumValue>> = nil,
+        inputField: GraphQLNullable<Testschema.InnerInputObject> = nil
+      ) {
+        __data = InputDict([
+          "enumField": enumField,
+          "inputField": inputField
+        ])
+      }
+
+      public var enumField: GraphQLNullable<GraphQLEnum<Testschema.EnumValue>> {
+        get { __data.enumField }
+        set { __data.enumField = newValue }
+      }
+
+      public var inputField: GraphQLNullable<Testschema.InnerInputObject> {
+        get { __data.inputField }
+        set { __data.inputField = newValue }
+      }
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenUppercasedSchemaName_nonListField_generatesWithUppercasedNamespace() throws {
+    // given
+    let fields: [GraphQLInputField] = [
+      GraphQLInputField.mock(
+        "enumField",
+        type: .enum(.mock(name: "EnumValue")),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "inputField",
+        type: .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            GraphQLInputField.mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        )),
+        defaultValue: nil
+      )
+    ]
+
+    buildSubject(
+      fields: fields,
+      config: .mock(schemaName: "TESTSCHEMA", output: .mock(
+        moduleType: .swiftPackageManager,
+        operations: .relative(subpath: nil)))
+    )
+
+    let expected = """
+      public init(
+        enumField: GraphQLNullable<GraphQLEnum<TESTSCHEMA.EnumValue>> = nil,
+        inputField: GraphQLNullable<TESTSCHEMA.InnerInputObject> = nil
+      ) {
+        __data = InputDict([
+          "enumField": enumField,
+          "inputField": inputField
+        ])
+      }
+
+      public var enumField: GraphQLNullable<GraphQLEnum<TESTSCHEMA.EnumValue>> {
+        get { __data.enumField }
+        set { __data.enumField = newValue }
+      }
+
+      public var inputField: GraphQLNullable<TESTSCHEMA.InnerInputObject> {
+        get { __data.inputField }
+        set { __data.inputField = newValue }
+      }
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenCapitalizedSchemaName_nonListField_generatesWithCapitalizedNamespace() throws {
+    // given
+    let fields: [GraphQLInputField] = [
+      GraphQLInputField.mock(
+        "enumField",
+        type: .enum(.mock(name: "EnumValue")),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
+        "inputField",
+        type: .inputObject(.mock(
+          "InnerInputObject",
+          fields: [
+            GraphQLInputField.mock("innerStringField", type: .scalar(.string()), defaultValue: nil)
+          ]
+        )),
+        defaultValue: nil
+      )
+    ]
+
+    buildSubject(
+      fields: fields,
+      config: .mock(schemaName: "TestSchema", output: .mock(
+        moduleType: .swiftPackageManager,
+        operations: .relative(subpath: nil)))
+    )
+
+    let expected = """
+      public init(
+        enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> = nil,
+        inputField: GraphQLNullable<TestSchema.InnerInputObject> = nil
+      ) {
+        __data = InputDict([
+          "enumField": enumField,
+          "inputField": inputField
+        ])
+      }
+
+      public var enumField: GraphQLNullable<GraphQLEnum<TestSchema.EnumValue>> {
+        get { __data.enumField }
+        set { __data.enumField = newValue }
+      }
+
+      public var inputField: GraphQLNullable<TestSchema.InnerInputObject> {
+        get { __data.inputField }
+        set { __data.inputField = newValue }
+      }
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenLowercasedSchemaName_listField_generatesWithFirstUppercasedNamespace() throws {
+    // given
+    buildSubject(
+      fields: [GraphQLInputField.mock(
+        "nullableListNullableItem",
+        type: .list(.enum(.mock(name: "EnumValue"))),
+        defaultValue: nil)],
+      config: .mock(schemaName: "testschema")
+    )
+
+    let expected = """
+      public init(
+        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<Testschema.EnumValue>?]> = nil
+      ) {
+        __data = InputDict([
+          "nullableListNullableItem": nullableListNullableItem
+        ])
+      }
+
+      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<Testschema.EnumValue>?]> {
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenUppercasedSchemaName_listField_generatesWithUppercasedNamespace() throws {
+    // given
+    buildSubject(
+      fields: [GraphQLInputField.mock(
+        "nullableListNullableItem",
+        type: .list(.enum(.mock(name: "EnumValue"))),
+        defaultValue: nil)],
+      config: .mock(schemaName: "TESTSCHEMA")
+    )
+
+    let expected = """
+      public init(
+        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TESTSCHEMA.EnumValue>?]> = nil
+      ) {
+        __data = InputDict([
+          "nullableListNullableItem": nullableListNullableItem
+        ])
+      }
+
+      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TESTSCHEMA.EnumValue>?]> {
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenCapitalizedSchemaName_listField_generatesWithCapitalizedNamespace() throws {
+    // given
+    buildSubject(
+      fields: [GraphQLInputField.mock(
+        "nullableListNullableItem",
+        type: .list(.enum(.mock(name: "EnumValue"))),
+        defaultValue: nil)],
+      config: .mock(schemaName: "TestSchema")
+    )
+
+    let expected = """
+      public init(
+        nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TestSchema.EnumValue>?]> = nil
+      ) {
+        __data = InputDict([
+          "nullableListNullableItem": nullableListNullableItem
+        ])
+      }
+
+      public var nullableListNullableItem: GraphQLNullable<[GraphQLEnum<TestSchema.EnumValue>?]> {
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -20,12 +20,14 @@ class MockObjectTemplateTests: XCTestCase {
   private func buildSubject(
     name: String = "Dog",
     interfaces: [GraphQLInterfaceType] = [],
+    schemaName: String = "TestSchema",
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude
   ) {
     let config = ApolloCodegenConfiguration.mock(
       moduleType,
-      options: .init(warningsOnDeprecatedUsage: warningsOnDeprecatedUsage)      
+      options: .init(warningsOnDeprecatedUsage: warningsOnDeprecatedUsage),
+      schemaName: schemaName
     )
     ir = IR.mock(compilationResult: .mock())
 
@@ -71,9 +73,9 @@ class MockObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  // MARK: Class Definition Tests
+  // MARK: Casing Tests
 
-  func test_render_givenSchemaTypeWithLowercaseName_generatesExtensionCorrectlyCased() {
+  func test_render_givenSchemaTypeWithLowercaseName_generatesCapitalizedClassName() {
     // given
     buildSubject(name: "dog")
 
@@ -94,6 +96,51 @@ class MockObjectTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test_render_givenSchemaNameLowercased_generatesCapitalizedSchemaNameReferences() {
+    // given
+    buildSubject(schemaName: "lowercased")
+
+    let expected = """
+      public static let objectType: Object = Lowercased.Objects.Dog
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
+  }
+
+  func test_render_givenSchemaNameUppercased_generatesCapitalizedSchemaNameReferences() {
+    // given
+    buildSubject(schemaName: "UPPER")
+
+    let expected = """
+      public static let objectType: Object = UPPER.Objects.Dog
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
+  }
+
+  func test_render_givenSchemaNameCapitalized_generatesCapitalizedSchemaNameReferences() {
+    // given
+    buildSubject(schemaName: "MySchema")
+
+    let expected = """
+      public static let objectType: Object = MySchema.Objects.Dog
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
   }
 
   // MARK: Mock Field Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -98,7 +98,7 @@ class MockObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenSchemaNameLowercased_generatesCapitalizedSchemaNameReferences() {
+  func test_render_givenLowercasedSchemaName_generatesFirstUppercasedSchemaNameReferences() {
     // given
     buildSubject(schemaName: "lowercased")
 
@@ -113,7 +113,7 @@ class MockObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
   }
 
-  func test_render_givenSchemaNameUppercased_generatesCapitalizedSchemaNameReferences() {
+  func test_render_givenUppercasedSchemaName_generatesCapitalizedSchemaNameReferences() {
     // given
     buildSubject(schemaName: "UPPER")
 
@@ -128,7 +128,7 @@ class MockObjectTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 2, ignoringExtraLines: true))
   }
 
-  func test_render_givenSchemaNameCapitalized_generatesCapitalizedSchemaNameReferences() {
+  func test_render_givenCapitalizedSchemaName_generatesCapitalizedSchemaNameReferences() {
     // given
     buildSubject(schemaName: "MySchema")
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
@@ -5,19 +5,52 @@ import ApolloInternalTestHelpers
 
 class SchemaModuleNamespaceTemplateTests: XCTestCase {
 
-  // MARK: Definition Tests
+  // MARK: Casing Tests
 
-  func test__boilerplate__generatesPublicEnumCorectlyCased() throws {
+  func test__render__givenLowercaseSchemaName_generatesCapitalizedPublicEnum() throws {
     // given
     let expected = """
-    public enum NamespacedModule { }
+    public enum Schema { }
     
     """
 
     // when
     let subject = SchemaModuleNamespaceTemplate(
-      namespace: "namespacedModule",
-      config: .init(config: .mock())
+      config: .init(config: .mock(schemaName: "schema"))
+    )
+    let actual = subject.template.description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render__givenUppercaseSchemaName_generatesUppercasedPublicEnum() throws {
+    // given
+    let expected = """
+    public enum SCHEMA { }
+
+    """
+
+    // when
+    let subject = SchemaModuleNamespaceTemplate(
+      config: .init(config: .mock(schemaName: "SCHEMA"))
+    )
+    let actual = subject.template.description
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render__givenCapitalizedSchemaName_generatesCapitalizedPublicEnum() throws {
+    // given
+    let expected = """
+    public enum MySchema { }
+
+    """
+
+    // when
+    let subject = SchemaModuleNamespaceTemplate(
+      config: .init(config: .mock(schemaName: "MySchema"))
     )
     let actual = subject.template.description
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -13,12 +13,10 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
   // MARK: Helpers
 
   private func buildSubject(
-    moduleName: String = "testModule",
     testMockConfig: ApolloCodegenConfiguration.TestMockFileOutput = .none,
-    config: ApolloCodegenConfiguration = .mock()
+    config: ApolloCodegenConfiguration = .mock(schemaName: "TestModule")
   ) {
     subject = .init(
-      moduleName: moduleName,
       testMockConfig: testMockConfig,
       config: .init(config: config)
     )
@@ -62,13 +60,45 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   // MARK: PackageDescription tests
 
-  func test__packageDescription__generatesPackageDefinition() {
+  func test__packageDescription__givenLowercaseSchemaName_generatesPackageDefinitionWithCapitalizedName() {
     // given
-    buildSubject()
+    buildSubject(config: .mock(schemaName: "module"))
 
     let expected = """
     let package = Package(
-      name: "TestModule",
+      name: "Module",
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenUppercaseSchemaName_generatesPackageDefinitionWithUppercasedName() {
+    // given
+    buildSubject(config: .mock(schemaName: "MODULE"))
+
+    let expected = """
+    let package = Package(
+      name: "MODULE",
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 5, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenCapitalizedSchemaName_generatesPackageDefinitionWithCapitalizedName() {
+    // given
+    buildSubject(config: .mock(schemaName: "NewModule"))
+
+    let expected = """
+    let package = Package(
+      name: "NewModule",
     """
 
     // when
@@ -98,13 +128,47 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
-  func test__packageDescription__generatesProducts() {
+  func test__packageDescription__givenLowercasedSchemaName_generatesProductWithCapitalizedName() {
     // given
-    buildSubject()
+    buildSubject(config: .mock(schemaName: "newmodule"))
 
     let expected = """
       products: [
-        .library(name: "TestModule", targets: ["TestModule"]),
+        .library(name: "Newmodule", targets: ["Newmodule"]),
+      ],
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenUppercasedSchemaName_generatesProductWithUppercasedName() {
+    // given
+    buildSubject(config: .mock(schemaName: "NEWMODULE"))
+
+    let expected = """
+      products: [
+        .library(name: "NEWMODULE", targets: ["NEWMODULE"]),
+      ],
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenCapitalizedSchemaName_generatesProductWithCapitalizedName() {
+    // given
+    buildSubject(config: .mock(schemaName: "NewModule"))
+
+    let expected = """
+      products: [
+        .library(name: "NewModule", targets: ["NewModule"]),
       ],
     """
 
@@ -131,9 +195,55 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
-  func test__packageDescription__givenTestMockConfig_none_generatesTargets() {
+  func test__packageDescription__givenTestMockConfigNone_withLowercaseSchemaName_generatesTargetWithCapitalizedName() {
     // given
-    buildSubject()
+    buildSubject(config: .mock(schemaName: "testmodule"))
+
+    let expected = """
+      targets: [
+        .target(
+          name: "Testmodule",
+          dependencies: [
+            .product(name: "ApolloAPI", package: "apollo-ios"),
+          ],
+          path: "./Sources"
+        ),
+      ]
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenTestMockConfigNone_withUppercaseSchemaName_generatesTargetWithUppercasedName() {
+    // given
+    buildSubject(config: .mock(schemaName: "TEST"))
+
+    let expected = """
+      targets: [
+        .target(
+          name: "TEST",
+          dependencies: [
+            .product(name: "ApolloAPI", package: "apollo-ios"),
+          ],
+          path: "./Sources"
+        ),
+      ]
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenTestMockConfigNone_withCapitalizedSchemaName_generatesTargetWithCapitalizedName() {
+    // given
+    buildSubject(config: .mock(schemaName: "TestModule"))
 
     let expected = """
       targets: [
@@ -237,6 +347,57 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenTestMockConfig_withLowercaseSchemaName_generatesTestMockTargetWithCapitalizedTargetDependency() {
+    // given
+    buildSubject(
+      testMockConfig: .swiftPackage(targetName: "CustomMocks"),
+      config: .mock(schemaName: "testmodule"))
+
+    let expected = """
+            .target(name: "Testmodule"),
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenTestMockConfig_withUppercaseSchemaName_generatesTestMockTargetWithUppercaseTargetDependency() {
+    // given
+    buildSubject(
+      testMockConfig: .swiftPackage(targetName: "CustomMocks"),
+      config: .mock(schemaName: "MODULE"))
+
+    let expected = """
+            .target(name: "MODULE"),
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+  }
+
+  func test__packageDescription__givenTestMockConfig_withCapitalizedSchemaName_generatesTestMockTargetWithCapitalizedTargetDependency() {
+    // given
+    buildSubject(
+      testMockConfig: .swiftPackage(targetName: "CustomMocks"),
+      config: .mock(schemaName: "MyModule"))
+
+    let expected = """
+            .target(name: "MyModule"),
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -336,7 +336,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
   // MARK: Casing Tests
 
-  func test__casing__givenSchemaNameLowercase_shouldGenerateCapitalizedNamespace() {
+  func test__casing__givenLowercasedSchemaName_shouldGenerateFirstUppercasedNamespace() {
     // given
 
     let config = buildConfig(
@@ -357,7 +357,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameUppercase_shouldGenerateUppercasedNamespace() {
+  func test__casing__givenUppercasedSchemaName_shouldGenerateUppercasedNamespace() {
     // given
 
     let config = buildConfig(
@@ -378,7 +378,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameCapitalized_shouldGenerateCapitalizedNamespace() {
+  func test__casing__givenCapitalizedSchemaName_shouldGenerateCapitalizedNamespace() {
     // given
 
     let config = buildConfig(

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -333,4 +333,69 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
       expect(actual).to(equalLineByLine(test.expectation, atLine: test.atLine))
     }
   }
+
+  // MARK: Casing Tests
+
+  func test__casing__givenSchemaNameLowercase_shouldGenerateCapitalizedNamespace() {
+    // given
+
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "testschema",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config)
+
+    let expected = """
+    public extension Testschema {
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameUppercase_shouldGenerateUppercasedNamespace() {
+    // given
+
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "TESTSCHEMA",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config)
+
+    let expected = """
+    public extension TESTSCHEMA {
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameCapitalized_shouldGenerateCapitalizedNamespace() {
+    // given
+
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "TestSchema",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config)
+
+    let expected = """
+    public extension TestSchema {
+    """
+
+    // when
+    let actual = subject.render()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
@@ -962,5 +962,125 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     }
   }
 
+  // MARK: Casing Tests
 
+  func test__casing__givenSchemaNameLowercase_whenSchemaAndComponentNamespace_shouldGenerateCapitalizedNamespace() {
+    // given
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "testschema",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config, targetFileType: .union)
+
+    // when
+    let actual = subject.render()
+
+    // then
+    let expected = """
+    public extension Testschema.Unions {
+    """
+
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameUppercase_whenSchemaAndComponentNamespace_shouldGenerateUppercasedNamespace() {
+    // given
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "TESTSCHEMA",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config, targetFileType: .union)
+
+    // when
+    let actual = subject.render()
+
+    // then
+    let expected = """
+    public extension TESTSCHEMA.Unions {
+    """
+
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameCapitalized_whenSchemaAndComponentNamespace_shouldGenerateCapitalizedNamespace() {
+    // given
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "TestSchema",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config, targetFileType: .union)
+
+    // when
+    let actual = subject.render()
+
+    // then
+    let expected = """
+    public extension TestSchema.Unions {
+    """
+
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameLowercase_whenOnlySchemaNamespace_shouldGenerateCapitalizedNamespace() {
+    // given
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "testschema",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config, targetFileType: .customScalar)
+
+    // when
+    let actual = subject.render()
+
+    // then
+    let expected = """
+    public extension Testschema {
+    """
+
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameUppercase_whenOnlySchemaNamespace_shouldGenerateUppercasedNamespace() {
+    // given
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "TESTSCHEMA",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config, targetFileType: .customScalar)
+
+    // when
+    let actual = subject.render()
+
+    // then
+    let expected = """
+    public extension TESTSCHEMA {
+    """
+
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenSchemaNameCapitalized_whenOnlySchemaNamespace_shouldGenerateCapitalizedNamespace() {
+    // given
+    let config = buildConfig(
+      moduleType: .embeddedInTarget(name: "MockApplication"),
+      schemaName: "TestSchema",
+      operations: .inSchemaModule)
+
+    let subject = buildSubject(config: config, targetFileType: .customScalar)
+
+    // when
+    let actual = subject.render()
+
+    // then
+    let expected = """
+    public extension TestSchema {
+    """
+
+    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
@@ -964,7 +964,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
 
   // MARK: Casing Tests
 
-  func test__casing__givenSchemaNameLowercase_whenSchemaAndComponentNamespace_shouldGenerateCapitalizedNamespace() {
+  func test__casing__givenLowercasedSchemaName_whenSchemaAndComponentNamespace_shouldGenerateFirstUppercasedNamespace() {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
@@ -984,7 +984,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameUppercase_whenSchemaAndComponentNamespace_shouldGenerateUppercasedNamespace() {
+  func test__casing__givenUppercasedSchemaName_whenSchemaAndComponentNamespace_shouldGenerateUppercasedNamespace() {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
@@ -1004,7 +1004,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameCapitalized_whenSchemaAndComponentNamespace_shouldGenerateCapitalizedNamespace() {
+  func test__casing__givenCapitalizedSchemaName_whenSchemaAndComponentNamespace_shouldGenerateCapitalizedNamespace() {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
@@ -1024,7 +1024,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameLowercase_whenOnlySchemaNamespace_shouldGenerateCapitalizedNamespace() {
+  func test__casing__givenLowercasedSchemaName_whenOnlySchemaNamespace_shouldGenerateFirstUppercasedNamespace() {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
@@ -1044,7 +1044,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameUppercase_whenOnlySchemaNamespace_shouldGenerateUppercasedNamespace() {
+  func test__casing__givenUppercasedSchemaName_whenOnlySchemaNamespace_shouldGenerateUppercasedNamespace() {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
@@ -1064,7 +1064,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  func test__casing__givenSchemaNameCapitalized_whenOnlySchemaNamespace_shouldGenerateCapitalizedNamespace() {
+  func test__casing__givenCapitalizedSchemaName_whenOnlySchemaNamespace_shouldGenerateCapitalizedNamespace() {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
@@ -20,7 +20,6 @@ class UnionTemplateTests: XCTestCase {
     config: ApolloCodegenConfiguration = .mock()
   ) {
     subject = UnionTemplate(
-      moduleName: "moduleAPI",
       graphqlUnion: GraphQLUnionType.mock(
         name,
         types: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
@@ -51,6 +51,68 @@ class UnionTemplateTests: XCTestCase {
     expect(actual).to(endWith("\n)"))
   }
 
+  // MARK: CasingTests
+
+  func test_render_givenLowercaseSchemaName_generatesUsingCapitalizedSchemaName() throws {
+    // given
+    buildSubject(config: .mock(schemaName: "lowercased"))
+
+    let expected = """
+      possibleTypes: [
+        Lowercased.Objects.Cat.self,
+        Lowercased.Objects.Bird.self,
+        Lowercased.Objects.Rat.self,
+        Lowercased.Objects.PetRock.self
+      ]
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 3, ignoringExtraLines: true))
+  }
+
+  func test_render_givenUppercaseSchemaName_generatesUsingUppercaseSchemaName() throws {
+    // given
+    buildSubject(config: .mock(schemaName: "UPPER"))
+
+    let expected = """
+      possibleTypes: [
+        UPPER.Objects.Cat.self,
+        UPPER.Objects.Bird.self,
+        UPPER.Objects.Rat.self,
+        UPPER.Objects.PetRock.self
+      ]
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 3, ignoringExtraLines: true))
+  }
+
+  func test_render_givenCapitalizedSchemaName_generatesUsingCapitalizedSchemaName() throws {
+    // given
+    buildSubject(config: .mock(schemaName: "MySchema"))
+
+    let expected = """
+      possibleTypes: [
+        MySchema.Objects.Cat.self,
+        MySchema.Objects.Bird.self,
+        MySchema.Objects.Rat.self,
+        MySchema.Objects.PetRock.self
+      ]
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 3, ignoringExtraLines: true))
+  }
+
   // MARK: Enum Generation Tests
 
   func test_render_generatesSwiftEnumDefinition() throws {


### PR DESCRIPTION
PR 1 of 3 for #2546 

This PR:
* Correctly cases `schemaName` when used in namespacing
* Refactored logic to use the config schema name and not the IR schema name
* Removes schema name from function declarations when config is already present