### PR TITLE
Exported Import all of Apollo API in generated operations

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
   public static let operationType: GraphQLOperationType = .query

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -203,9 +203,7 @@ struct ImportStatementTemplate {
     ) -> TemplateString {
       let apolloAPITargetName = config.ApolloAPITargetName
       return """
-      import \(apolloAPITargetName)
-      @_exported import enum \(apolloAPITargetName).GraphQLEnum
-      @_exported import enum \(apolloAPITargetName).GraphQLNullable
+      @_exported import \(apolloAPITargetName)
       \(if: config.output.operations != .inSchemaModule, "import \(config.schemaModuleName)")
       """
     }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
   public static let operationName: String = "IssuesAndCommentsForRepository"

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class RepoURLQuery: GraphQLQuery {
   public static let operationName: String = "RepoURL"

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class RepositoryQuery: GraphQLQuery {
   public static let operationName: String = "Repository"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class CreateAwesomeReviewMutation: GraphQLMutation {
   public static let operationName: String = "CreateAwesomeReview"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class CreateReviewForEpisodeMutation: GraphQLMutation {
   public static let operationName: String = "CreateReviewForEpisode"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class CreateReviewWithNullFieldMutation: GraphQLMutation {
   public static let operationName: String = "CreateReviewWithNullField"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class DroidDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "DroidDetailsWithFragment"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAndFriendsIDsQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsIDs"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAndFriendsNamesQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNames"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragment"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragmentTwice"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithIDForParentOnly"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithIDs"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsIn"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsInWithFragment"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsFragmentConditionalInclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsInlineConditionalInclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroDetailsQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetails"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsWithFragment"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsDetailsConditionalInclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsDetailsUnconditionalAndConditionalInclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsOfFriendsNames"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameAndAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsIn"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsInWithFragment"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameConditionalBothQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalBoth"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalBothSeparate"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameConditionalExclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalExclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalInclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameQuery: GraphQLQuery {
   public static let operationName: String = "HeroName"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameTypeSpecificConditionalInclusion"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragmentAndID"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragment"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroNameWithIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithID"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
   public static let operationName: String = "HeroParentTypeDependentField"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
   public static let operationName: String = "HeroTypeDependentAliasedField"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class HumanQuery: GraphQLQuery {
   public static let operationName: String = "Human"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class SameHeroTwiceQuery: GraphQLQuery {
   public static let operationName: String = "SameHeroTwice"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class SearchQuery: GraphQLQuery {
   public static let operationName: String = "Search"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class StarshipCoordinatesQuery: GraphQLQuery {
   public static let operationName: String = "StarshipCoordinates"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class StarshipQuery: GraphQLQuery {
   public static let operationName: String = "Starship"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class TwoHeroesQuery: GraphQLQuery {
   public static let operationName: String = "TwoHeroes"

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ReviewAddedSubscription: GraphQLSubscription {
   public static let operationName: String = "ReviewAdded"

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class IncrementingSubscription: GraphQLSubscription {
   public static let operationName: String = "Incrementing"

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
   public static let operationName: String = "UploadMultipleFilesToDifferentParameters"

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
   public static let operationName: String = "UploadMultipleFilesToTheSameParameter"

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class UploadOneFileMutation: GraphQLMutation {
   public static let operationName: String = "UploadOneFile"

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -65,24 +65,18 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
   func test__renderTargetOperationFile__givenAllSchemaTypesOperationsCombinations_conditionallyIncludeImportStatements() {
     // given
     let expectedAPI = """
-    import ApolloAPI
-    @_exported import enum ApolloAPI.GraphQLEnum
-    @_exported import enum ApolloAPI.GraphQLNullable
+    @_exported import ApolloAPI
 
     """
 
     let expectedAPIAndSchema = """
-    import ApolloAPI
-    @_exported import enum ApolloAPI.GraphQLEnum
-    @_exported import enum ApolloAPI.GraphQLNullable
+    @_exported import ApolloAPI
     import TestSchema
 
     """
 
     let expectedAPIAndTarget = """
-    import ApolloAPI
-    @_exported import enum ApolloAPI.GraphQLEnum
-    @_exported import enum ApolloAPI.GraphQLNullable
+    @_exported import ApolloAPI
     import MockApplication
 
     """
@@ -154,24 +148,18 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
   func test__renderTargetOperationFile__given_cocoapodsCompatibleImportStatements_true_allSchemaTypesOperationsCombinations_conditionallyIncludeImportStatements() {
     // given
     let expectedAPI = """
-    import Apollo
-    @_exported import enum Apollo.GraphQLEnum
-    @_exported import enum Apollo.GraphQLNullable
+    @_exported import Apollo
 
     """
 
     let expectedAPIAndSchema = """
-    import Apollo
-    @_exported import enum Apollo.GraphQLEnum
-    @_exported import enum Apollo.GraphQLNullable
+    @_exported import Apollo
     import TestSchema
 
     """
 
     let expectedAPIAndTarget = """
-    import Apollo
-    @_exported import enum Apollo.GraphQLEnum
-    @_exported import enum Apollo.GraphQLNullable
+    @_exported import Apollo
     import MockApplication
 
     """
@@ -270,55 +258,55 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
         schemaTypes: .swiftPackageManager,
         operations: .relative(subpath: nil),
         expectation: expectedNoNamespace,
-        atLine: 9
+        atLine: 7
       ),
       (
         schemaTypes: .swiftPackageManager,
         operations: .absolute(path: "path"),
         expectation: expectedNoNamespace,
-        atLine: 9
+        atLine: 7
       ),
       (
         schemaTypes: .swiftPackageManager,
         operations: .inSchemaModule,
         expectation: expectedNoNamespace,
-        atLine: 8
+        atLine: 6
       ),
       (
         schemaTypes: .other,
         operations: .relative(subpath: nil),
         expectation: expectedNoNamespace,
-        atLine: 9
+        atLine: 7
       ),
       (
         schemaTypes: .other,
         operations: .absolute(path: "path"),
         expectation: expectedNoNamespace,
-        atLine: 9
+        atLine: 7
       ),
       (
         schemaTypes: .other,
         operations: .inSchemaModule,
         expectation: expectedNoNamespace,
-        atLine: 8
+        atLine: 6
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .relative(subpath: nil),
         expectation: expectedNoNamespace,
-        atLine: 9
+        atLine: 7
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .absolute(path: "path"),
         expectation: expectedNoNamespace,
-        atLine: 9
+        atLine: 7
       ),
       (
         schemaTypes: .embeddedInTarget(name: "MockApplication"),
         operations: .inSchemaModule,
         expectation: expectedNamespace,
-        atLine: 8
+        atLine: 6
       )
     ]
 
@@ -354,7 +342,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     let actual = subject.render()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 
   func test__casing__givenUppercasedSchemaName_shouldGenerateUppercasedNamespace() {
@@ -375,7 +363,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     let actual = subject.render()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 
   func test__casing__givenCapitalizedSchemaName_shouldGenerateCapitalizedNamespace() {
@@ -396,6 +384,6 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
     let actual = subject.render()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 6, ignoringExtraLines: true))
   }
 }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct ClassroomPetDetails: MyGraphQLSchema.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct ClassroomPetDetailsCCN: MyGraphQLSchema.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct DogFragment: MyGraphQLSchema.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct HeightInMeters: MyGraphQLSchema.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct PetDetails: MyGraphQLSchema.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct WarmBloodedDetails: MyGraphQLSchema.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class AllAnimalsLocalCacheMutation: LocalCacheMutation {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   struct PetDetailsMutation: MyGraphQLSchema.MutableSelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class PetAdoptionMutation: GraphQLMutation {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class AllAnimalsCCNQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class AllAnimalsIncludeSkipQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class AllAnimalsQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class ClassroomPetsCCNQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class ClassroomPetsQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class DogQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public extension MyGraphQLSchema {
   class PetSearchQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class AllAnimalsIncludeSkipQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class AllAnimalsLocalCacheMutation: LocalCacheMutation {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class AllAnimalsQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class ClassroomPetsQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct DogFragment: MySchemaModule.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class DogQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct HeightInMeters: MySchemaModule.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class PetAdoptionMutation: GraphQLMutation {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct PetDetails: MySchemaModule.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct PetDetailsMutation: MySchemaModule.MutableSelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class PetSearchQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct WarmBloodedDetails: MySchemaModule.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class AllAnimalsCCNQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 struct ClassroomPetDetailsCCN: MySchemaModule.SelectionSet, Fragment {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 import PackageTwo
 
 class ClassroomPetsCCNQuery: GraphQLQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageTwo/Sources/TestMocks/Human+Mock.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageTwo/Sources/TestMocks/Human+Mock.graphql.swift
@@ -11,7 +11,7 @@ public class Human: MockObject {
 
   public struct MockFields {
     @Field<Int>("bodyTemperature") public var bodyTemperature
-    @Field<Actor>("firstName") public var firstName
+    @Field<String>("firstName") public var firstName
     @Field<Height>("height") public var height
     @Field<Bool>("laysEggs") public var laysEggs
     @Field<[Animal]>("predators") public var predators
@@ -23,45 +23,7 @@ public class Human: MockObject {
 public extension Mock where O == Human {
   convenience init(
     bodyTemperature: Int? = nil,
-    firstName: Mock<Actor>? = nil,
-    height: Mock<Height>? = nil,
-    laysEggs: Bool? = nil,
-    predators: [AnyMock]? = nil,
-    skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? = nil,
-    species: String? = nil
-  ) {
-    self.init()
-    self.bodyTemperature = bodyTemperature
-    self.firstName = firstName
-    self.height = height
-    self.laysEggs = laysEggs
-    self.predators = predators
-    self.skinCovering = skinCovering
-    self.species = species
-  }
-}
-
-
-public class Actor: MockObject {
-  public static let objectType: Object = MySchemaModule.Objects.Human
-  public static let _mockFields = MockFields()
-  public typealias MockValueCollectionType = Array<Mock<Human>>
-
-  public struct MockFields {
-    @Field<Int>("bodyTemperature") public var bodyTemperature
-    @Field<Actor>("firstName") public var firstName
-    @Field<Height>("height") public var height
-    @Field<Bool>("laysEggs") public var laysEggs
-    @Field<[Animal]>("predators") public var predators
-    @Field<GraphQLEnum<MySchemaModule.SkinCovering>>("skinCovering") public var skinCovering
-    @Field<String>("species") public var species
-  }
-}
-
-public extension Mock where O == Actor {
-  convenience init(
-    bodyTemperature: Int? = nil,
-    firstName: Mock<Actor? = nil,
+    firstName: String? = nil,
     height: Mock<Height>? = nil,
     laysEggs: Bool? = nil,
     predators: [AnyMock]? = nil,

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageTwo/Sources/TestMocks/MockObject+Interfaces.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageTwo/Sources/TestMocks/MockObject+Interfaces.graphql.swift
@@ -9,6 +9,4 @@ public extension MockObject {
   typealias WarmBlooded = Interface
   typealias Pet = Interface
   typealias HousePet = Interface
-
-  typealias Actor = Interface
 }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct ClassroomPetDetailsCCN: MyCustomProject.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct DogFragment: MyCustomProject.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct HeightInMeters: MyCustomProject.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct PetDetails: MyCustomProject.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct WarmBloodedDetails: MyCustomProject.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
   public static let operationType: GraphQLOperationType = .query

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public struct PetDetailsMutation: MyCustomProject.MutableSelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import Apollo
-@_exported import enum Apollo.GraphQLEnum
-@_exported import enum Apollo.GraphQLNullable
+@_exported import Apollo
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetailsCCN: GraphQLAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DogFragment: GraphQLAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct HeightInMeters: GraphQLAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetails: GraphQLAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct WarmBloodedDetails: GraphQLAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
   public static let operationType: GraphQLOperationType = .query

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetailsMutation: GraphQLAPI.MutableSelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
   public static let operationType: GraphQLOperationType = .query

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetails: GraphQLSchemaName.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct ClassroomPetDetailsCCN: GraphQLSchemaName.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/DogFragment.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct DogFragment: GraphQLSchemaName.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/HeightInMeters.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct HeightInMeters: GraphQLSchemaName.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/PetDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetails: GraphQLSchemaName.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct WarmBloodedDetails: GraphQLSchemaName.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
   public static let operationType: GraphQLOperationType = .query

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public struct PetDetailsMutation: GraphQLSchemaName.MutableSelectionSet, Fragment {
   public static var fragmentDefinition: StaticString { """

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -1,9 +1,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import ApolloAPI
-@_exported import enum ApolloAPI.GraphQLEnum
-@_exported import enum ApolloAPI.GraphQLNullable
+@_exported import ApolloAPI
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"


### PR DESCRIPTION
This fixes https://github.com/apollographql/apollo-ios/issues/2596 by ensuring the operator overload is imported wherever you are using the generated models.