### PR TITLE
fix: Remove `@inlinable` from `ApolloAPI` to enable xcframework builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,21 @@ jobs:
       - run:
           command: swift build
 
+  XCFramework_Build:
+    macos:
+      xcode: << pipeline.parameters.xcode_version >>
+    steps:
+      - common_test_setup
+      - run:
+          name: Build XCArchive (iOS Simulator)
+          command: xcodebuild archive -configuration Release -project "Apollo.xcodeproj" -scheme "Apollo" -destination 'generic/platform=iOS Simulator' -archivePath "./build/iphonesimulator.xcarchive" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+      - run:
+          name: Build XCArchive (iOS)
+          command: xcodebuild archive -configuration Release -project "Apollo.xcodeproj" -scheme "Apollo" -destination 'generic/platform=iOS' -archivePath "./build/iphoneos.xcarchive" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+      - run:
+          name: Build XCFramework
+          command: xcodebuild -create-xcframework -output ./build/Apollo.xcframework -framework ./build/iphonesimulator.xcarchive/Products/@rpath/Apollo.framework -framework ./build/iphoneos.xcarchive/Products/@rpath/Apollo.framework
+
   IntegrationTests_macOS_current:
     macos:
       xcode: << pipeline.parameters.xcode_version >>
@@ -242,6 +257,8 @@ workflows:
     jobs:
       - Swift_Build:
           name: Build as Swift package
+      - XCFramework_Build:
+          name: Build XCFramework
       - IntegrationTests_macOS_current:
           name: Apollo Integration Tests - macOS << pipeline.parameters.macos_version >>
       - macOS_current:

--- a/Sources/ApolloAPI/CacheKeyInfo.swift
+++ b/Sources/ApolloAPI/CacheKeyInfo.swift
@@ -111,7 +111,7 @@ public struct CacheKeyInfo {
   ///   - id: The unique cache key for the response object for the ``CacheKeyInfo``.
   ///   - uniqueKeyGroup: An optional identifier for a group of objects that should be grouped
   ///     together in the `NormalizedCache`.
-  @inlinable public init(id: String, uniqueKeyGroup: String? = nil) {
+  public init(id: String, uniqueKeyGroup: String? = nil) {
     self.id = id
     self.uniqueKeyGroup = uniqueKeyGroup
   }

--- a/Sources/ApolloAPI/CacheReference.swift
+++ b/Sources/ApolloAPI/CacheReference.swift
@@ -61,7 +61,7 @@ public struct CacheReference: Hashable {
   ///
   /// - Parameters:
   ///   - key: The unique identifier for the referenced object.
-  @inlinable public init(_ key: String) {
+  public init(_ key: String) {
     self.key = key
   }
 

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -4,7 +4,7 @@ public struct DataDict: Hashable {
   public var _data: JSONObject
   public let _variables: GraphQLOperation.Variables?
 
-  @inlinable public init(
+  public init(
     _ data: JSONObject,
     variables: GraphQLOperation.Variables?
   ) {

--- a/Sources/ApolloAPI/Selection+Conditions.swift
+++ b/Sources/ApolloAPI/Selection+Conditions.swift
@@ -9,15 +9,15 @@ public extension Selection {
   struct Conditions: Hashable {
     public let value: [[Condition]]
 
-    @inlinable public init(_ value: [[Condition]]) {
+    public init(_ value: [[Condition]]) {
       self.value = value
     }
 
-    @inlinable public init(_ conditions: [Condition]...) {
+    public init(_ conditions: [Condition]...) {
       self.value = Array(conditions)
     }
 
-    @inlinable public init(_ condition: Condition) {
+    public init(_ condition: Condition) {
       self.value = [[condition]]
     }
 
@@ -36,7 +36,7 @@ public extension Selection {
     public let variableName: String
     public let inverted: Bool
 
-    @inlinable public init(
+    public init(
       variableName: String,
       inverted: Bool
     ) {
@@ -44,7 +44,7 @@ public extension Selection {
       self.inverted = inverted;
     }
 
-    @inlinable public init(stringLiteral value: StringLiteralType) {
+    public init(stringLiteral value: StringLiteralType) {
       self.variableName = value
       self.inverted = false
     }

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -20,7 +20,7 @@ public enum Selection {
       return alias ?? name
     }
 
-    @inlinable public init(
+    public init(
       _ name: String,
       alias: String? = nil,
       type: OutputType,


### PR DESCRIPTION
Closes #2555 

This PR enables `BUILD_LIBRARY_FOR_DISTRIBUTION` to be used when building an xcarchive which in turn enables building of an xcframework. 
* Removes `@inlinable` where needed from ApolloAPI function declarations.
* This does not change our stance on Library Evolution, it is still not officially supported. If there is a way in the future to disassociate swiftinterface generation from the BUILD_LIBRARY_FOR_DISTRIBUTION build setting we will likely make that choice.
* This does not change our stance on Carthage, we are still moving away from officially supporting it.