### PR TITLE
fix: Namespace `Variables` type for local cache mutations

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -759,6 +759,7 @@
 		E68D824527A1D8A60040A46F /* ObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F7EC227A1243A0059C021 /* ObjectTemplateTests.swift */; };
 		E68D824727A228A80040A46F /* SchemaModuleFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */; };
 		E6908E55282694630054682B /* ApolloCodegenConfigurationCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6908E54282694630054682B /* ApolloCodegenConfigurationCodableTests.swift */; };
+		E6936F162908AD8D0089054C /* PetSearchLocalCacheMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6936F152908AD8D0089054C /* PetSearchLocalCacheMutation.graphql.swift */; };
 		E69BEDA52798B86D00000D10 /* InputObjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */; };
 		E69BEDA72798B89600000D10 /* InputObjectTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */; };
 		E6A6866427F63AEF008A1D13 /* FileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A6866327F63AEF008A1D13 /* FileGeneratorTests.swift */; };
@@ -1895,6 +1896,7 @@
 		E687B3F328B39A9100A9551C /* Apollo-Target-CodegenCLI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Apollo-Target-CodegenCLI.xcconfig"; sourceTree = "<group>"; };
 		E68D824627A228A80040A46F /* SchemaModuleFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaModuleFileGenerator.swift; sourceTree = "<group>"; };
 		E6908E54282694630054682B /* ApolloCodegenConfigurationCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenConfigurationCodableTests.swift; sourceTree = "<group>"; };
+		E6936F152908AD8D0089054C /* PetSearchLocalCacheMutation.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetSearchLocalCacheMutation.graphql.swift; sourceTree = "<group>"; };
 		E699DE9428B3C20E004ECF19 /* CodegenCLITestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CodegenCLITestPlan.xctestplan; sourceTree = "<group>"; };
 		E69BEDA42798B86D00000D10 /* InputObjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplate.swift; sourceTree = "<group>"; };
 		E69BEDA62798B89600000D10 /* InputObjectTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObjectTemplateTests.swift; sourceTree = "<group>"; };
@@ -2983,6 +2985,7 @@
 			isa = PBXGroup;
 			children = (
 				DE6388E928D3BFBA00559697 /* PetDetailsMutation.graphql.swift */,
+				E6936F152908AD8D0089054C /* PetSearchLocalCacheMutation.graphql.swift */,
 				DE6388EA28D3BFBA00559697 /* AllAnimalsLocalCacheMutation.graphql.swift */,
 			);
 			path = LocalCacheMutations;
@@ -5595,6 +5598,7 @@
 				DE63891A28D3BFBA00559697 /* WarmBloodedDetails.graphql.swift in Sources */,
 				DE63893B28D3BFBA00559697 /* Animal.graphql.swift in Sources */,
 				DE63891928D3BFBA00559697 /* ClassroomPetDetailsCCN.graphql.swift in Sources */,
+				E6936F162908AD8D0089054C /* PetSearchLocalCacheMutation.graphql.swift in Sources */,
 				DE63892128D3BFBA00559697 /* ClassroomPetsCCNQuery.graphql.swift in Sources */,
 				DE63891E28D3BFBA00559697 /* DogQuery.graphql.swift in Sources */,
 				DE63892E28D3BFBA00559697 /* Mutation.graphql.swift in Sources */,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -1,0 +1,65 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class PetSearchLocalCacheMutation: LocalCacheMutation {
+  public static let operationType: GraphQLOperationType = .query
+
+  public var filters: GraphQLNullable<PetSearchFilters>
+
+  public init(filters: GraphQLNullable<PetSearchFilters> = .init(
+    PetSearchFilters(
+      species: ["Dog", "Cat"],
+      size: .init(.small),
+      measurements: .init(
+        MeasurementsInput(
+          height: 10.5,
+          weight: 5.0
+        )
+      )
+    )
+  )) {
+    self.filters = filters
+  }
+
+  public var __variables: GraphQLOperation.Variables? { ["filters": filters] }
+
+  public struct Data: AnimalKingdomAPI.MutableSelectionSet {
+    public var __data: DataDict
+    public init(data: DataDict) { __data = data }
+
+    public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
+    public static var __selections: [Selection] { [
+      .field("pets", [Pet].self, arguments: ["filters": .variable("filters")]),
+    ] }
+
+    public var pets: [Pet] {
+      get { __data["pets"] }
+      set { __data["pets"] = newValue }
+    }
+
+    /// Pet
+    ///
+    /// Parent Type: `Pet`
+    public struct Pet: AnimalKingdomAPI.MutableSelectionSet {
+      public var __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
+      public static var __selections: [Selection] { [
+        .field("id", ID.self),
+        .field("humanName", String?.self),
+      ] }
+
+      public var id: ID {
+        get { __data["id"] }
+        set { __data["id"] = newValue }
+      }
+      public var humanName: String? {
+        get { __data["humanName"] }
+        set { __data["humanName"] = newValue }
+      }
+    }
+  }
+}

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/PetSearchLocalCacheMutation.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/PetSearchLocalCacheMutation.graphql
@@ -1,0 +1,14 @@
+query PetSearchLocalCacheMutation($filters: PetSearchFilters = {
+  species: ["Dog", "Cat"],
+  size: SMALL,
+  measurements: {
+    height: 10.5,
+    weight: 5.0
+    }
+  }
+) @apollo_client_ios_localCacheMutation {
+  pets(filters: $filters) {
+    id
+    humanName
+  }
+}

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -21,7 +21,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(Initializer(operation.definition.variables))
 
-      \(section: VariableAccessors(operation.definition.variables))
+      \(section: VariableAccessors(operation.definition.variables, graphQLOperation: false))
 
       \(SelectionSetTemplate(schema: schema, mutable: true, config: config).render(for: operation))
     }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -40,14 +40,15 @@ extension OperationTemplateRenderer {
   }
 
   func VariableAccessors(
-    _ variables: [CompilationResult.VariableDefinition]
+    _ variables: [CompilationResult.VariableDefinition],
+    graphQLOperation: Bool = true
   ) -> TemplateString {
     guard !variables.isEmpty else {
       return ""
     }
 
     return """
-      public var __variables: Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asInputParameterName)"})] }
+      public var __variables: \(if: !graphQLOperation, "GraphQLOperation.")Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asInputParameterName)"})] }
       """
   }
 

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -600,6 +600,7 @@ class ApolloCodegenTests: XCTestCase {
 
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
+      directoryURL.appendingPathComponent("Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Package.swift").path,
     ]
@@ -698,6 +699,7 @@ class ApolloCodegenTests: XCTestCase {
 
       operationsOutputURL.appendingPathComponent("LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       operationsOutputURL.appendingPathComponent("LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
+      operationsOutputURL.appendingPathComponent("LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Package.swift").path,
     ]
@@ -799,6 +801,7 @@ class ApolloCodegenTests: XCTestCase {
 
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
+      directoryURL.appendingPathComponent("Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Package.swift").path,
     ]
@@ -972,6 +975,7 @@ class ApolloCodegenTests: XCTestCase {
 
       directoryURL.appendingPathComponent("RelativePath/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativePath/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
+      directoryURL.appendingPathComponent("RelativePath/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift").path,
 
       directoryURL.appendingPathComponent("RelativePath/Package.swift").path,
     ]
@@ -1073,6 +1077,7 @@ class ApolloCodegenTests: XCTestCase {
 
       directoryURL.appendingPathComponent("RelativeOperations/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativeOperations/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
+      directoryURL.appendingPathComponent("RelativeOperations/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift").path,
 
       directoryURL.appendingPathComponent("RelativePath/Package.swift").path,
     ]

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -320,7 +320,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
          self.variable = variable
        }
 
-       public var __variables: Variables? { ["variable": variable] }
+       public var __variables: GraphQLOperation.Variables? { ["variable": variable] }
      """
 
      // when
@@ -369,7 +369,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
         self.variable3 = variable3
       }
 
-      public var __variables: Variables? { [
+      public var __variables: GraphQLOperation.Variables? { [
         "variable1": variable1,
         "variable2": variable2,
         "variable3": variable3
@@ -413,7 +413,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
         self.variable = variable
       }
 
-      public var __variables: Variables? { ["variable": variable] }
+      public var __variables: GraphQLOperation.Variables? { ["variable": variable] }
     """
 
     // when

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -1,0 +1,68 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public extension MyGraphQLSchema {
+  class PetSearchLocalCacheMutation: LocalCacheMutation {
+    public static let operationType: GraphQLOperationType = .query
+
+    public var filters: GraphQLNullable<PetSearchFilters>
+
+    public init(filters: GraphQLNullable<PetSearchFilters> = .init(
+      PetSearchFilters(
+        species: ["Dog", "Cat"],
+        size: .init(.small),
+        measurements: .init(
+          MeasurementsInput(
+            height: 10.5,
+            weight: 5.0
+          )
+        )
+      )
+    )) {
+      self.filters = filters
+    }
+
+    public var __variables: GraphQLOperation.Variables? { ["filters": filters] }
+
+    public struct Data: MyGraphQLSchema.MutableSelectionSet {
+      public var __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public static var __parentType: ParentType { MyGraphQLSchema.Objects.Query }
+      public static var __selections: [Selection] { [
+        .field("pets", [Pet].self, arguments: ["filters": .variable("filters")]),
+      ] }
+
+      public var pets: [Pet] {
+        get { __data["pets"] }
+        set { __data["pets"] = newValue }
+      }
+
+      /// Pet
+      ///
+      /// Parent Type: `Pet`
+      public struct Pet: MyGraphQLSchema.MutableSelectionSet {
+        public var __data: DataDict
+        public init(data: DataDict) { __data = data }
+
+        public static var __parentType: ParentType { MyGraphQLSchema.Interfaces.Pet }
+        public static var __selections: [Selection] { [
+          .field("id", ID.self),
+          .field("humanName", String?.self),
+        ] }
+
+        public var id: ID {
+          get { __data["id"] }
+          set { __data["id"] = newValue }
+        }
+        public var humanName: String? {
+          get { __data["humanName"] }
+          set { __data["humanName"] = newValue }
+        }
+      }
+    }
+  }
+
+}

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject.xcodeproj/project.pbxproj
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		DE3512B328E25CE1000F1E52 /* AllAnimalsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE35128B28E25CE1000F1E52 /* AllAnimalsQuery.graphql.swift */; };
 		DE3512B428E25CE1000F1E52 /* AllAnimalsIncludeSkipQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE35128C28E25CE1000F1E52 /* AllAnimalsIncludeSkipQuery.graphql.swift */; };
 		DE3512B528E25CE1000F1E52 /* PetSearchQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE35128D28E25CE1000F1E52 /* PetSearchQuery.graphql.swift */; };
+		E6B13119290A56F50059C9B0 /* PetSearchLocalCacheMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B13118290A56F50059C9B0 /* PetSearchLocalCacheMutation.graphql.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +136,7 @@
 		DE35128B28E25CE1000F1E52 /* AllAnimalsQuery.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllAnimalsQuery.graphql.swift; sourceTree = "<group>"; };
 		DE35128C28E25CE1000F1E52 /* AllAnimalsIncludeSkipQuery.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllAnimalsIncludeSkipQuery.graphql.swift; sourceTree = "<group>"; };
 		DE35128D28E25CE1000F1E52 /* PetSearchQuery.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetSearchQuery.graphql.swift; sourceTree = "<group>"; };
+		E6B13118290A56F50059C9B0 /* PetSearchLocalCacheMutation.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetSearchLocalCacheMutation.graphql.swift; sourceTree = "<group>"; };
 		F5DEBE445719BEA0FEF902CF /* Pods-MyCustomProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MyCustomProject.release.xcconfig"; path = "Target Support Files/Pods-MyCustomProject/Pods-MyCustomProject.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -255,6 +257,7 @@
 		DE35125A28E25CE1000F1E52 /* LocalCacheMutations */ = {
 			isa = PBXGroup;
 			children = (
+				E6B13118290A56F50059C9B0 /* PetSearchLocalCacheMutation.graphql.swift */,
 				DE35125B28E25CE1000F1E52 /* PetDetailsMutation.graphql.swift */,
 				DE35125C28E25CE1000F1E52 /* AllAnimalsLocalCacheMutation.graphql.swift */,
 			);
@@ -624,6 +627,7 @@
 			files = (
 				DE3512A428E25CE1000F1E52 /* HousePet.graphql.swift in Sources */,
 				DE35129C28E25CE1000F1E52 /* Fish.graphql.swift in Sources */,
+				E6B13119290A56F50059C9B0 /* PetSearchLocalCacheMutation.graphql.swift in Sources */,
 				DE3512B128E25CE1000F1E52 /* ClassroomPetsQuery.graphql.swift in Sources */,
 				DE35129828E25CE1000F1E52 /* Height.graphql.swift in Sources */,
 				DE3512A228E25CE1000F1E52 /* MeasurementsInput.graphql.swift in Sources */,

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -1,0 +1,65 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import Apollo
+
+public class PetSearchLocalCacheMutation: LocalCacheMutation {
+  public static let operationType: GraphQLOperationType = .query
+
+  public var filters: GraphQLNullable<PetSearchFilters>
+
+  public init(filters: GraphQLNullable<PetSearchFilters> = .init(
+    PetSearchFilters(
+      species: ["Dog", "Cat"],
+      size: .init(.small),
+      measurements: .init(
+        MeasurementsInput(
+          height: 10.5,
+          weight: 5.0
+        )
+      )
+    )
+  )) {
+    self.filters = filters
+  }
+
+  public var __variables: GraphQLOperation.Variables? { ["filters": filters] }
+
+  public struct Data: MyCustomProject.MutableSelectionSet {
+    public var __data: DataDict
+    public init(data: DataDict) { __data = data }
+
+    public static var __parentType: ParentType { MyCustomProject.Objects.Query }
+    public static var __selections: [Selection] { [
+      .field("pets", [Pet].self, arguments: ["filters": .variable("filters")]),
+    ] }
+
+    public var pets: [Pet] {
+      get { __data["pets"] }
+      set { __data["pets"] = newValue }
+    }
+
+    /// Pet
+    ///
+    /// Parent Type: `Pet`
+    public struct Pet: MyCustomProject.MutableSelectionSet {
+      public var __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public static var __parentType: ParentType { MyCustomProject.Interfaces.Pet }
+      public static var __selections: [Selection] { [
+        .field("id", ID.self),
+        .field("humanName", String?.self),
+      ] }
+
+      public var id: ID {
+        get { __data["id"] }
+        set { __data["id"] = newValue }
+      }
+      public var humanName: String? {
+        get { __data["humanName"] }
+        set { __data["humanName"] = newValue }
+      }
+    }
+  }
+}

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -1,0 +1,65 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class PetSearchLocalCacheMutation: LocalCacheMutation {
+  public static let operationType: GraphQLOperationType = .query
+
+  public var filters: GraphQLNullable<PetSearchFilters>
+
+  public init(filters: GraphQLNullable<PetSearchFilters> = .init(
+    PetSearchFilters(
+      species: ["Dog", "Cat"],
+      size: .init(.small),
+      measurements: .init(
+        MeasurementsInput(
+          height: 10.5,
+          weight: 5.0
+        )
+      )
+    )
+  )) {
+    self.filters = filters
+  }
+
+  public var __variables: GraphQLOperation.Variables? { ["filters": filters] }
+
+  public struct Data: AnimalKingdomAPI.MutableSelectionSet {
+    public var __data: DataDict
+    public init(data: DataDict) { __data = data }
+
+    public static var __parentType: ParentType { AnimalKingdomAPI.Objects.Query }
+    public static var __selections: [Selection] { [
+      .field("pets", [Pet].self, arguments: ["filters": .variable("filters")]),
+    ] }
+
+    public var pets: [Pet] {
+      get { __data["pets"] }
+      set { __data["pets"] = newValue }
+    }
+
+    /// Pet
+    ///
+    /// Parent Type: `Pet`
+    public struct Pet: AnimalKingdomAPI.MutableSelectionSet {
+      public var __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public static var __parentType: ParentType { AnimalKingdomAPI.Interfaces.Pet }
+      public static var __selections: [Selection] { [
+        .field("id", ID.self),
+        .field("humanName", String?.self),
+      ] }
+
+      public var id: ID {
+        get { __data["id"] }
+        set { __data["id"] = newValue }
+      }
+      public var humanName: String? {
+        get { __data["humanName"] }
+        set { __data["humanName"] = newValue }
+      }
+    }
+  }
+}

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -1,0 +1,65 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class PetSearchLocalCacheMutation: LocalCacheMutation {
+  public static let operationType: GraphQLOperationType = .query
+
+  public var filters: GraphQLNullable<PetSearchFilters>
+
+  public init(filters: GraphQLNullable<PetSearchFilters> = .init(
+    PetSearchFilters(
+      species: ["Dog", "Cat"],
+      size: .init(.small),
+      measurements: .init(
+        MeasurementsInput(
+          height: 10.5,
+          weight: 5.0
+        )
+      )
+    )
+  )) {
+    self.filters = filters
+  }
+
+  public var __variables: GraphQLOperation.Variables? { ["filters": filters] }
+
+  public struct Data: GraphQLSchemaName.MutableSelectionSet {
+    public var __data: DataDict
+    public init(data: DataDict) { __data = data }
+
+    public static var __parentType: ParentType { GraphQLSchemaName.Objects.Query }
+    public static var __selections: [Selection] { [
+      .field("pets", [Pet].self, arguments: ["filters": .variable("filters")]),
+    ] }
+
+    public var pets: [Pet] {
+      get { __data["pets"] }
+      set { __data["pets"] = newValue }
+    }
+
+    /// Pet
+    ///
+    /// Parent Type: `Pet`
+    public struct Pet: GraphQLSchemaName.MutableSelectionSet {
+      public var __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public static var __parentType: ParentType { GraphQLSchemaName.Interfaces.Pet }
+      public static var __selections: [Selection] { [
+        .field("id", ID.self),
+        .field("humanName", String?.self),
+      ] }
+
+      public var id: ID {
+        get { __data["id"] }
+        set { __data["id"] = newValue }
+      }
+      public var humanName: String? {
+        get { __data["humanName"] }
+        set { __data["humanName"] = newValue }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Conditionally prefixes the `Variables` type with `GraphQLOperation.` for `LocalCacheMutation` objects.