### PR TITLE
Added fieldInfo to GraphQLExecutionError, to enable more robust error messaging around missing values.

### DIFF
--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -128,8 +128,9 @@ fileprivate struct FieldSelectionGrouping: Sequence {
 
 /// An error which has occurred during GraphQL execution.
 public struct GraphQLExecutionError: Error, LocalizedError {
-  let path: ResponsePath
+  let fieldInfo: FieldExecutionInfo
 
+  var path: ResponsePath { fieldInfo.responsePath }
   public var pathString: String { path.description }
 
   /// The error that occurred during parsing.
@@ -320,7 +321,7 @@ final class GraphQLExecutor {
       try accumulator.accept(fieldEntry: $0, info: fieldInfo)
     }.mapError { error in
       if !(error is GraphQLExecutionError) {
-        return GraphQLExecutionError(path: fieldInfo.responsePath, underlying: error)
+        return GraphQLExecutionError(fieldInfo: fieldInfo, underlying: error)
       } else {
         return error
       }
@@ -388,7 +389,7 @@ final class GraphQLExecutor {
                       accumulator: accumulator)
             .mapError { error in
               if !(error is GraphQLExecutionError) {
-                return GraphQLExecutionError(path: elementFieldInfo.responsePath, underlying: error)
+                return GraphQLExecutionError(fieldInfo: elementFieldInfo, underlying: error)
               } else {
                 return error
               }


### PR DESCRIPTION
Right now the `GraphQLExecutionError` only includes the `path` of the error. But, in the case of an underlying `JSONDecodingError.missingValue` error, the error description doesn't provide enough information to understand what the problem actually was. You know that there was an object and a value was missing, but no idea what key wasn't found.

This PR is intended to start a discussion on how to improve this. By adding `fieldInfo` to `GraphQLExecutionError` it's possible to print out `fieldInfo.cacheKeyForField` and figure out what the key was.

I ended up taking this approach because it was the least invasive. No current consumer of `GraphQLExecutionError` has to change anything, and all the tests continue to pass. I considered adding an associated value to `JSONDecodingError.missingValue` but that would have been a much larger change. Also, there are already situations where the `FieldExecutionInfo` wouldn't make sense for `JSONDecodingError`. 

Anyway, I'm happy to change any/all of this. Like I said, I just want to start a process of improving this.