### PR TITLE
fix: Ignore special folder contents

### DIFF
--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -136,7 +136,7 @@ public struct Glob {
       }
     }()
 
-    var directories: [String] = [searchURL.path] // include searching the globstar root directory
+    var directories: [URL] = [searchURL] // include searching the globstar root directory
 
     do {
       let resourceKeys: [URLResourceKey] = [.isDirectoryKey]
@@ -164,7 +164,7 @@ public struct Glob {
           isDirectory == true
         else { continue }
 
-        directories.append(url.path)
+        directories.append(url)
       }
 
     } catch(let error) {
@@ -172,7 +172,7 @@ public struct Glob {
     }
 
     return OrderedSet<String>(directories.compactMap({ directory in
-      var path = URL(fileURLWithPath: directory).appendingPathComponent(lastPart).standardizedFileURL.path
+      var path = directory.appendingPathComponent(lastPart).standardizedFileURL.path
       if isExclude {
         path.insert("!", at: path.startIndex)
       }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2217,9 +2217,9 @@ class ApolloCodegenTests: XCTestCase {
     .notTo(throwError())
   }
 
-  // Glob Exclusion Tests
+  // Special-folder Exclusion Tests
 
-  func test__match__givenFilesInExcludedPaths_shouldNotReturnExcludedPaths() throws {
+  func test__match__givenFilesInSpecialExcludedPaths_shouldNotReturnExcludedPaths() throws {
     // given
     createFile(filename: "included.file")
 
@@ -2253,7 +2253,7 @@ class ApolloCodegenTests: XCTestCase {
     expect(matches.contains(where: { $0.contains(".Pods") })).to(beFalse())
   }
 
-  func test__match__givenFilesInExcludedPaths_usingRelativeDirectory_shouldNotReturnExcludedPaths() throws {
+  func test__match__givenFilesInSpecialExcludedPaths_usingRelativeDirectory_shouldNotReturnExcludedPaths() throws {
     // given
     createFile(filename: "included.file")
 

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -584,4 +584,25 @@ class GlobTests: XCTestCase {
     ]))
   }
 
+  func test_match_givenExcludedDirectories_shouldNotMatchExcludedFiles() throws {
+    // given
+    let pattern = baseURL.appendingPathComponent("**/file.xyz").path
+
+    // when
+    try create(files: [
+      baseURL.appendingPathComponent("file.xyz").path,
+      baseURL.appendingPathComponent("nested/file.xyz").path,
+      baseURL.appendingPathComponent("nested/two/file.xyz").path,
+      baseURL.appendingPathComponent("DoNotInclude/file.xyz").path,
+      baseURL.appendingPathComponent("nested/DoNotInclude/file.xyz").path
+    ])
+
+    // then
+    expect(try Glob([pattern]).match(excludingDirectories: ["DoNotInclude"])).to(equal([
+      baseURL.appendingPathComponent("file.xyz").path,
+      baseURL.appendingPathComponent("nested/file.xyz").path,
+      baseURL.appendingPathComponent("nested/two/file.xyz").path
+    ]))
+  }
+
 }

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -4,7 +4,7 @@ import Nimble
 import ApolloCodegenInternalTestHelpers
 
 class GlobTests: XCTestCase {
-  let baseURL = CodegenTestHelper.outputFolderURL().appendingPathComponent("Glob")
+  var baseURL: URL!
   let fileManager = ApolloFileManager.default
 
   // MARK: Setup
@@ -12,6 +12,7 @@ class GlobTests: XCTestCase {
   override func setUpWithError() throws {
     try super.setUpWithError()
 
+    baseURL = CodegenTestHelper.outputFolderURL().appendingPathComponent("Glob/\(UUID().uuidString)")
     try fileManager.createDirectoryIfNeeded(atPath: baseURL.path)
   }
 

--- a/Tests/ApolloCodegenTests/GlobTests.swift
+++ b/Tests/ApolloCodegenTests/GlobTests.swift
@@ -65,7 +65,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path
     ]))
   }
@@ -83,7 +83,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("file.two").path,
       baseURL.appendingPathComponent("file.one").path,
     ]))
@@ -102,7 +102,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path
     ]))
   }
@@ -120,7 +120,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("other/file.oye").path,
       baseURL.appendingPathComponent("other/file.one").path,
     ]))
@@ -143,7 +143,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path
     ]))
   }
@@ -168,7 +168,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path,
       baseURL.appendingPathComponent("other/file.oye").path,
       baseURL.appendingPathComponent("other/file.one").path,
@@ -192,7 +192,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path
     ]))
   }
@@ -214,7 +214,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path,
       baseURL.appendingPathComponent("other/file.oye").path,
       baseURL.appendingPathComponent("other/file.one").path,
@@ -233,7 +233,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path
     ]))
   }
@@ -256,7 +256,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("file.two").path,
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("other/file.oye").path,
@@ -277,7 +277,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
     ]))
   }
@@ -296,7 +296,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/file.one").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
@@ -316,7 +316,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path
     ]))
   }
@@ -335,7 +335,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.two").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
@@ -347,7 +347,7 @@ class GlobTests: XCTestCase {
     let pattern = baseURL.appendingPathComponent("a/b/c/d/**/!file.swift").path
 
     // then
-    expect(Glob([pattern]).match).to(throwError(Glob.MatchError.invalidExclude(path: pattern)))
+    expect(try Glob([pattern]).match()).to(throwError(Glob.MatchError.invalidExclude(path: pattern)))
   }
 
   func test_match_givenGlobstarPattern_usingPathExclude_whenMultipleMatch_shouldExclude() throws {
@@ -367,7 +367,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.ext").path,
       baseURL.appendingPathComponent("a/b/c/d/e/f/file.one").path,
     ]))
@@ -393,7 +393,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("other/file.one").path,
       baseURL.appendingPathComponent("a/file.one").path,
@@ -423,7 +423,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path,
       baseURL.appendingPathComponent("a/b/file.one").path,
       baseURL.appendingPathComponent("a/b/c/file.one").path,
@@ -451,7 +451,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern).match).to(equal([
+    expect(try Glob(pattern).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("other/file.one").path,
       baseURL.appendingPathComponent("a/file.one").path,
@@ -481,7 +481,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern, relativeTo: rootURL).match).to(equal([
+    expect(try Glob(pattern, relativeTo: rootURL).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path,
       baseURL.appendingPathComponent("a/b/file.one").path,
       baseURL.appendingPathComponent("a/b/c/file.one").path,
@@ -509,7 +509,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern, relativeTo: rootURL).match).to(equal([
+    expect(try Glob(pattern, relativeTo: rootURL).match()).to(equal([
       baseURL.appendingPathComponent("a/file.one").path,
       baseURL.appendingPathComponent("a/b/file.one").path,
       baseURL.appendingPathComponent("a/b/c/file.one").path,
@@ -530,7 +530,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern, relativeTo: rootURL).match).to(equal([
+    expect(try Glob(pattern, relativeTo: rootURL).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path,
     ]))
   }
@@ -556,7 +556,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob(pattern, relativeTo: rootURL).match).to(equal([
+    expect(try Glob(pattern, relativeTo: rootURL).match()).to(equal([
       baseURL.appendingPathComponent("file.one").path,
       baseURL.appendingPathComponent("other/file.one").path,
       baseURL.appendingPathComponent("a/file.one").path,
@@ -579,7 +579,7 @@ class GlobTests: XCTestCase {
     ])
 
     // then
-    expect(Glob([pattern]).match).to(equal([
+    expect(try Glob([pattern]).match()).to(equal([
       baseURL.appendingPathComponent("other/file.xyz").path
     ]))
   }


### PR DESCRIPTION
Fixes #2552 

I tried to get this to work using the `!` pattern and existing `Glob` logic but since ours is a little more custom it was not as cut-and-dry as I'd hoped. This solution simply looks for an intersection of enumerated directory paths and excluded directory paths to drop the path from the included search paths. There is a small chance that performance could suffer but I think it'll be negligible ~and I'll adapt based on feedback~, I'll add a performance-based test added to measure this.