### PR TITLE
Generate library for test mock target

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -49,17 +49,21 @@ struct MockObjectTemplate: TemplateRenderer {
         }, separator: "\n")
       }
     }
-
-    public extension Mock where O == \(objectName) {
-      convenience init(
-        \(fields.map { """
-          \($0.propertyName)\(ifLet: $0.initializerParameterName, {" \($0)"}): \($0.mockType)? = nil
-          """ }, separator: ",\n")
-      ) {
-        self.init()
-        \(fields.map { "self.\($0.propertyName) = \($0.initializerParameterName ?? $0.propertyName)" }, separator: "\n")
+    \(!fields.isEmpty ?
+      TemplateString("""
+      
+      public extension Mock where O == \(objectName) {
+        convenience init(
+          \(fields.map { """
+            \($0.propertyName)\(ifLet: $0.initializerParameterName, {" \($0)"}): \($0.mockType)? = nil
+            """ }, separator: ",\n")
+        ) {
+          self.init()
+          \(fields.map { "self.\($0.propertyName) = \($0.initializerParameterName ?? $0.propertyName)" }, separator: "\n")
+        }
       }
-    }
+      """) : TemplateString(stringLiteral: "")
+    )
     
     """
   }

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -30,6 +30,9 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
       ],
       products: [
         .library(name: "\(casedSchemaName)", targets: ["\(casedSchemaName)"]),
+        \(ifLet: testMockTarget(), { """
+        .library(name: "\($0.targetName)", targets: ["\($0.targetName)"]),
+        """})
       ],
       dependencies: [
         .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0"),

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -527,6 +527,25 @@ class MockObjectTemplateTests: XCTestCase {
       ignoringExtraLines: false)
     )
   }
+  
+  func test_render_givenSchemaTypeWithoutFields_doesNotgenerateConvenienceInitializer() {
+    // given
+    buildSubject(moduleType: .swiftPackageManager)
+
+    let expected = """
+    }
+    
+    """
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(
+      expected,
+      atLine: 8 + self.subject.graphqlObject.fields.count,
+      ignoringExtraLines: false)
+    )
+  }
 
   func test_render_givenFieldsWithSwiftReservedKeyworkNames_generatesConvenienceInitializerParamatersEscapedWithBackticksAndInternalNames() {
     // given

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -334,7 +334,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
   }
   
   func test__packageDescription__givenTestMockConfig_swiftPackage_withTargetName_generatesProduct() {
@@ -383,7 +383,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
   }
 
   func test__packageDescription__givenTestMockConfig_withLowercaseSchemaName_generatesTestMockTargetWithCapitalizedTargetDependency() {
@@ -400,7 +400,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 32, ignoringExtraLines: true))
   }
 
   func test__packageDescription__givenTestMockConfig_withUppercaseSchemaName_generatesTestMockTargetWithUppercaseTargetDependency() {
@@ -417,7 +417,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 32, ignoringExtraLines: true))
   }
 
   func test__packageDescription__givenTestMockConfig_withCapitalizedSchemaName_generatesTestMockTargetWithCapitalizedTargetDependency() {
@@ -434,7 +434,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 32, ignoringExtraLines: true))
   }
 
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -286,7 +286,26 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
   }
+  
+  func test__packageDescription__givenTestMockConfig_swiftPackage_noTargetName_generatesProduct() {
+    // given
+    buildSubject(testMockConfig: .swiftPackage())
 
+    let expected = """
+      products: [
+        .library(name: "TestModule", targets: ["TestModule"]),
+        .library(name: "TestModuleTestMocks", targets: ["TestModuleTestMocks"]),
+      ],
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+  }
+
+  
   func test__packageDescription__givenTestMockConfig_swiftPackage_noTargetName_generatesTargets() {
     // given
     buildSubject(testMockConfig: .swiftPackage())
@@ -316,6 +335,24 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+  }
+  
+  func test__packageDescription__givenTestMockConfig_swiftPackage_withTargetName_generatesProduct() {
+    // given
+    buildSubject(testMockConfig: .swiftPackage(targetName: "CustomMocks"))
+
+    let expected = """
+      products: [
+        .library(name: "TestModule", targets: ["TestModule"]),
+        .library(name: "CustomMocks", targets: ["CustomMocks"]),
+      ],
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
   }
 
   func test__packageDescription__givenTestMockConfig_swiftPackage_withTargetName_generatesTargets() {


### PR DESCRIPTION
Currently when you generate the test mocks for a Swift package it won't create a library for it, so you can't import the test mocks properly into your unit tests.

To fix this I've updated the SwiftPackageManagerModuleTemplate to also create a library for the test mocks if there is a testMockTarget.

