### PR TITLE
Do not generate a convience initializer for objects without fields

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -49,17 +49,21 @@ struct MockObjectTemplate: TemplateRenderer {
         }, separator: "\n")
       }
     }
-
-    public extension Mock where O == \(objectName) {
-      convenience init(
-        \(fields.map { """
-          \($0.propertyName)\(ifLet: $0.initializerParameterName, {" \($0)"}): \($0.mockType)? = nil
-          """ }, separator: ",\n")
-      ) {
-        self.init()
-        \(fields.map { "self.\($0.propertyName) = \($0.initializerParameterName ?? $0.propertyName)" }, separator: "\n")
+    \(!fields.isEmpty ?
+      TemplateString("""
+      
+      public extension Mock where O == \(objectName) {
+        convenience init(
+          \(fields.map { """
+            \($0.propertyName)\(ifLet: $0.initializerParameterName, {" \($0)"}): \($0.mockType)? = nil
+            """ }, separator: ",\n")
+        ) {
+          self.init()
+          \(fields.map { "self.\($0.propertyName) = \($0.initializerParameterName ?? $0.propertyName)" }, separator: "\n")
+        }
       }
-    }
+      """) : TemplateString(stringLiteral: "")
+    )
     
     """
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -527,6 +527,25 @@ class MockObjectTemplateTests: XCTestCase {
       ignoringExtraLines: false)
     )
   }
+  
+  func test_render_givenSchemaTypeWithoutFields_doesNotgenerateConvenienceInitializer() {
+    // given
+    buildSubject(moduleType: .swiftPackageManager)
+
+    let expected = """
+    }
+    
+    """
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(
+      expected,
+      atLine: 8 + self.subject.graphqlObject.fields.count,
+      ignoringExtraLines: false)
+    )
+  }
 
   func test_render_givenFieldsWithSwiftReservedKeyworkNames_generatesConvenienceInitializerParamatersEscapedWithBackticksAndInternalNames() {
     // given


### PR DESCRIPTION
We encountered a problem during testing with the mocks, some objects don't have fields except for their __typename. In that case the cli would still generate a convenience initializer that would call `self.init()` which causes infinite recursion.

This has been fixed by checking if the fields are empty or not.