### PR TITLE
fix: Add validation check for conflicting configuration values

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -18,21 +18,35 @@ public class ApolloCodegen {
     case schemaNameConflict(name: String)
     case cannotLoadSchema
     case cannotLoadOperations
+    case invalidConfiguration(message: String)
 
     public var errorDescription: String? {
       switch self {
       case let .graphQLSourceValidationFailure(lines):
-        return "An error occured during validation of the GraphQL schema or operations! Check \(lines)"
+        return """
+          An error occured during validation of the GraphQL schema or operations! Check \(lines)
+          """
       case .testMocksInvalidSwiftPackageConfiguration:
-        return "Schema Types must be generated with module type 'swiftPackageManager' to generate a swift package for test mocks."
+        return """
+          Schema Types must be generated with module type 'swiftPackageManager' to generate a \
+          swift package for test mocks.
+          """
       case let .inputSearchPathInvalid(path):
-        return "Input search path '\(path)' is invalid. Input search paths must include a file extension component. (eg. '.graphql')"
+        return """
+          Input search path '\(path)' is invalid. Input search paths must include a file \
+          extension component. (eg. '.graphql')
+          """
       case let .schemaNameConflict(name):
-        return "Schema name \(name) conflicts with name of a type in your GraphQL schema. Please choose a different schema name. Suggestions: \(name)Schema, \(name)GraphQL, \(name)API"
+        return """
+          Schema name \(name) conflicts with name of a type in your GraphQL schema. Please \
+          choose a different schema name. Suggestions: \(name)Schema, \(name)GraphQL, \(name)API
+          """
       case .cannotLoadSchema:
         return "A GraphQL schema could not be found. Please verify the schema search paths."
       case .cannotLoadOperations:
         return "No GraphQL operations could be found. Please verify the operation search paths."
+      case let .invalidConfiguration(message):
+        return "The codegen configuration has conflicting values: \(message)"
       }
     }
   }
@@ -124,6 +138,15 @@ public class ApolloCodegen {
     if case .swiftPackage = config.output.testMocks,
         config.output.schemaTypes.moduleType != .swiftPackageManager {
       throw Error.testMocksInvalidSwiftPackageConfiguration
+    }
+
+    if case .swiftPackageManager = config.output.schemaTypes.moduleType,
+       config.options.cocoapodsCompatibleImportStatements == true {
+      throw Error.invalidConfiguration(message: """
+        cocoapodsCompatibleImportStatements cannot be set to 'true' when the output schema types \
+        module type is Swift Package Manager. Change the cocoapodsCompatibleImportStatements \
+        value to 'false' to resolve the conflict, or choose a different module type.
+        """)
     }
 
     for searchPath in config.input.schemaSearchPaths {

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -145,7 +145,7 @@ public class ApolloCodegen {
       throw Error.invalidConfiguration(message: """
         cocoapodsCompatibleImportStatements cannot be set to 'true' when the output schema types \
         module type is Swift Package Manager. Change the cocoapodsCompatibleImportStatements \
-        value to 'false' to resolve the conflict, or choose a different module type.
+        value to 'false', or choose a different module type, to resolve the conflict.
         """)
     }
 

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -1945,7 +1945,7 @@ class ApolloCodegenTests: XCTestCase {
     expect(ApolloFileManager.default.doesFileExist(atPath: testInTestMocksFolderUserFile)).to(beTrue())
   }
 
-  // MARK: Validation Tests (test mock module type)
+  // MARK: Validation Tests
 
   func test_validation_givenTestMockConfiguration_asSwiftPackage_withSchemaTypesModule_asEmbeddedInTarget_shouldThrow() throws {
     // given
@@ -1987,8 +1987,6 @@ class ApolloCodegenTests: XCTestCase {
     expect(try ApolloCodegen.validate(config: configContext))
       .notTo(throwError())
   }
-
-  // MARK: Validation Tests (search paths)
 
   func test_validation_givenOperationSearchPathWithoutFileExtensionComponent_shouldThrow() throws {
     // given
@@ -2033,8 +2031,6 @@ class ApolloCodegenTests: XCTestCase {
     expect(try ApolloCodegen.validate(config: configContext))
       .to(throwError(ApolloCodegen.Error.inputSearchPathInvalid(path: "schema/*.")))
   }
-
-  // MARK: Validation Tests (conflicting schema name)
 
   let conflictingSchemaNames = ["rocket", "Rocket"]
 
@@ -2214,7 +2210,56 @@ class ApolloCodegenTests: XCTestCase {
     .notTo(throwError())
   }
 
-  // Special-folder Exclusion Tests
+  func test__validation__givenSchemaTypesModule_swiftPackageManager_withCocoapodsCompatibleImportStatements_true_shouldThrow() throws {
+    // given
+    let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
+      .swiftPackageManager,
+      options: .init(cocoapodsCompatibleImportStatements: true)
+    ))
+
+    // then
+    expect(try ApolloCodegen.validate(config: configContext))
+      .to(throwError(ApolloCodegen.Error.invalidConfiguration(message: """
+        cocoapodsCompatibleImportStatements cannot be set to 'true' when the output schema types \
+        module type is Swift Package Manager. Change the cocoapodsCompatibleImportStatements \
+        value to 'false' to resolve the conflict.
+        """)))
+  }
+
+  func test__validation__givenSchemaTypesModule_swiftPackageManager_withCocoapodsCompatibleImportStatements_false_shouldNotThrow() throws {
+    // given
+    let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
+      .swiftPackageManager,
+      options: .init(cocoapodsCompatibleImportStatements: false)
+    ))
+
+    // then
+    expect(try ApolloCodegen.validate(config: configContext)).notTo(throwError())
+  }
+
+  func test__validation__givenSchemaTypesModule_embeddedInTarget_withCocoapodsCompatibleImportStatements_true_shouldNotThrow() throws {
+    // given
+    let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
+      .embeddedInTarget(name: "TestTarget"),
+      options: .init(cocoapodsCompatibleImportStatements: true)
+    ))
+
+    // then
+    expect(try ApolloCodegen.validate(config: configContext)).notTo(throwError())
+  }
+
+  func test__validation__givenSchemaTypesModule_other_withCocoapodsCompatibleImportStatements_true_shouldNotThrow() throws {
+    // given
+    let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
+      .other,
+      options: .init(cocoapodsCompatibleImportStatements: true)
+    ))
+
+    // then
+    expect(try ApolloCodegen.validate(config: configContext)).notTo(throwError())
+  }
+
+  // MARK: Path Match Exclusion Tests
 
   func test__match__givenFilesInSpecialExcludedPaths_shouldNotReturnExcludedPaths() throws {
     // given


### PR DESCRIPTION
Fixes #2663 

This PR adds a validation step to check that the configured output module type does not conflict with the `cocoapodsCompatibleImportStatements` value. Incorrect combinations of these two properties can result in invalid `import` statements in the generated code. An error is now thrown informing the user of the conflict and how it can be resolved.

`Error: The codegen configuration has conflicting values: cocoapodsCompatibleImportStatements cannot be set to 'true' when the output schema types module type is Swift Package Manager. Change the cocoapodsCompatibleImportStatements value to 'false', or choose a different module type, to resolve the conflict.`