### PR TITLE
fix: DocumentType namespacing

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 
@@ -12,6 +12,7 @@ let package = Package(
   ],
   products: [
     .library(name: "AnimalKingdomAPI", targets: ["AnimalKingdomAPI"]),
+    .library(name: "AnimalKingdomAPITestMocks", targets: ["AnimalKingdomAPITestMocks"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0"),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsCCN {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsQuery {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPetsCCN {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPets {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query DogQuery {

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -20,8 +20,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
         operation.definition,
         identifier: operation.operationIdentifier,
         fragments: operation.referencedFragments,
-        apq: config.options.apqs,
-        queryStringLiteralFormat: config.options.queryStringLiteralFormat
+        config: config
       ))
 
       \(section: VariableProperties(operation.definition.variables))
@@ -49,20 +48,19 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
       _ operation: CompilationResult.OperationDefinition,
       identifier: @autoclosure () -> String,
       fragments: OrderedSet<IR.NamedFragment>,
-      apq: ApolloCodegenConfiguration.APQConfig,
-      queryStringLiteralFormat: ApolloCodegenConfiguration.QueryStringLiteralFormat
+      config: ApolloCodegen.ConfigurationContext
     ) -> TemplateString {
       let includeFragments = !fragments.isEmpty
-      let includeDefinition = apq != .persistedOperationsOnly
+      let includeDefinition = config.options.apqs != .persistedOperationsOnly
 
       return TemplateString("""
-      public static let document: DocumentType = .\(apq.rendered)(
-      \(if: apq != .disabled, """
+      public static let document: \(config.ApolloAPITargetName).DocumentType = .\(config.options.apqs.rendered)(
+      \(if: config.options.apqs != .disabled, """
         operationIdentifier: \"\(identifier())\"\(if: includeDefinition, ",")
       """)
       \(if: includeDefinition, """
         definition: .init(
-          \(operation.source.formatted(for: queryStringLiteralFormat))\(if: includeFragments, ",")
+          \(operation.source.formatted(for: config.options.queryStringLiteralFormat))\(if: includeFragments, ",")
           \(if: includeFragments,
                             "fragments: [\(fragments.map { "\($0.name.firstUppercased).self" }, separator: ", ")]")
         ))

--- a/Sources/GitHubAPI/GitHubAPI/Package.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
   public static let operationName: String = "IssuesAndCommentsForRepository"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query IssuesAndCommentsForRepository {

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class RepoURLQuery: GraphQLQuery {
   public static let operationName: String = "RepoURL"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query RepoURL {

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class RepositoryQuery: GraphQLQuery {
   public static let operationName: String = "Repository"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query Repository {

--- a/Sources/StarWarsAPI/StarWarsAPI/Package.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class CreateAwesomeReviewMutation: GraphQLMutation {
   public static let operationName: String = "CreateAwesomeReview"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "4a1250de93ebcb5cad5870acf15001112bf27bb963e8709555b5ff67a1405374",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class CreateReviewForEpisodeMutation: GraphQLMutation {
   public static let operationName: String = "CreateReviewForEpisode"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "9bbf5b4074d0635fb19d17c621b7b04ebfb1920d468a94266819e149841e7d5d",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class CreateReviewWithNullFieldMutation: GraphQLMutation {
   public static let operationName: String = "CreateReviewWithNullField"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "a9600d176cd7e4671b8689f1d01fe79ea896932bfafb8a925af673f0e4111828",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class DroidDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "DroidDetailsWithFragment"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "7277e97563e911ac8f5c91d401028d218aae41f38df014d7fa0b037bb2a2e739",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAndFriendsIDsQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsIDs"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "117d0f6831d8f4abe5b61ed1dbb8071b0825e19649916c0fe0906a6f578bb088",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAndFriendsNamesQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNames"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "fe3f21394eb861aa515c4d582e645469045793c9cbbeca4b5d4ce4d7dd617556",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragment"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "1d3ad903dad146ff9d7aa09813fc01becd017489bfc1af8ffd178498730a5a26",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragmentTwice"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "b5f4eca712a136f0d5d9f96203ef7d03cd119d8388f093f4b78ae124acb904cb",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithIDForParentOnly"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "f091468a629f3b757c03a1b7710c6ede8b5c8f10df7ba3238f2bbcd71c56f90f",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithIDs"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "8e4ca76c63660898cfd5a3845e3709027750b5f0151c7f9be65759b869c5486d",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsIn"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "22d772c0fc813281705e8f0a55fc70e71eeff6e98f3f9ef96cf67fb896914522",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsInWithFragment"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "1756158bd7736d58db45a48d74a724fa1b6fdac735376df8afac8318ba5431fb",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsFragmentConditionalInclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "b0fa7927ff93b4a579c3460fb04d093072d34c8018e41197c7e080aeeec5e19b",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsInlineConditionalInclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "3091d9d3f1d2374e2f835ce05d332e50b3fe61502d73213b9aa511f0f94f091c",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroDetailsQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetails"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "207d29944f5822bff08a07db4a55274ea14035bacfe20699da41a47454f1181e",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsWithFragment"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "b55bd9d56d1b5972345412b6adb88ceb64d6086c8051d2588d8ab701f0ee7c2f",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsDetailsConditionalInclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "8cada231691ff2f5a0a07c54b7332114588f11b947795da345c5b054211fbcfd",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsDetailsUnconditionalAndConditionalInclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "65381a20574db4b458a0821328252deb0da1a107f9ab77c99fb2467e66a5f12d",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsOfFriendsNames"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "37cd5626048e7243716ffda9e56503939dd189772124a1c21b0e0b87e69aae01",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameAndAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsIn"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "f714414a2002404f9943490c8cc9c1a7b8ecac3ca229fa5a326186b43c1385ce",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsInWithFragment"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "0664fed3eb4f9fbdb44e8691d9e8fd11f2b3c097ba11327592054f602bd3ba1a",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameConditionalBothQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalBoth"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "66f4dc124b6374b1912b22a2a208e34a4b1997349402a372b95bcfafc7884064",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalBothSeparate"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "d0f9e9205cdc09320035662f528a177654d3275b0bf94cf0e259a65fde33e7e5",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameConditionalExclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalExclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "3dd42259adf2d0598e89e0279bee2c128a7913f02b1da6aa43f3b5def6a8a1f8",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalInclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "338081aea3acc83d04af0741ecf0da1ec2ee8e6468a88383476b681015905ef8",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameQuery: GraphQLQuery {
   public static let operationName: String = "HeroName"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameTypeSpecificConditionalInclusion"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "76aecc75265295818d3990000b17e32d5524ca85a4bc159ae8a3f8ec7ce91cc3",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragmentAndID"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "a87a0694c09d1ed245e9a80f245d96a5f57b20a4aa936ee9ab09b2a43620db02",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragment"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "b952f0054915a32ec524ac0dde0244bcda246649debe149f9e32e303e21c8266",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroNameWithIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithID"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "83c03f612c46fca72f6cb902df267c57bffc9209bc44dd87d2524fb2b34f6f18",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
   public static let operationName: String = "HeroParentTypeDependentField"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "39eb41b5a9477c36fa529c23d6f0de6ebcc0312daf5bdcfe208d5baec752dc5b",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
   public static let operationName: String = "HeroTypeDependentAliasedField"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "eac5a52f9020fc2e9b5dc5facfd6a6295683b8d57ea62ee84254069fcd5e504c",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class HumanQuery: GraphQLQuery {
   public static let operationName: String = "Human"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "b37eb69b82fd52358321e49453769750983be1c286744dbf415735d7bcf12f1e",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class SameHeroTwiceQuery: GraphQLQuery {
   public static let operationName: String = "SameHeroTwice"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "2a8ad85a703add7d64622aaf6be76b58a1134caf28e4ff6b34dd00ba89541364",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class SearchQuery: GraphQLQuery {
   public static let operationName: String = "Search"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "477b77c476899915498a56ae7bb835667b1e875cb94f6daa7f75e05018be2c3a",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class StarshipCoordinatesQuery: GraphQLQuery {
   public static let operationName: String = "StarshipCoordinates"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "8dd77d4bc7494c184606da092a665a7c2ca3c2a3f14d3b23fa5e469e207b3406",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class StarshipQuery: GraphQLQuery {
   public static let operationName: String = "Starship"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "a3734516185da9919e3e66d74fe92b60d65292a1943dc54913f7332637dfdd2a",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class TwoHeroesQuery: GraphQLQuery {
   public static let operationName: String = "TwoHeroes"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "b868fa9c48f19b8151c08c09f46831e3b9cd09f5c617d328647de785244b52bb",
     definition: .init(
       """

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ReviewAddedSubscription: GraphQLSubscription {
   public static let operationName: String = "ReviewAdded"
-  public static let document: DocumentType = .automaticallyPersisted(
+  public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
     operationIdentifier: "38644c5e7cf4fd506b91d2e7010cabf84e63dfcd33cf1deb443b4b32b55e2cbe",
     definition: .init(
       """

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Package.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
@@ -5,7 +5,7 @@
 
 public class IncrementingSubscription: GraphQLSubscription {
   public static let operationName: String = "Incrementing"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       subscription Incrementing {

--- a/Sources/UploadAPI/UploadAPI/Package.swift
+++ b/Sources/UploadAPI/UploadAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
   public static let operationName: String = "UploadMultipleFilesToDifferentParameters"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
   public static let operationName: String = "UploadMultipleFilesToTheSameParameter"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class UploadOneFileMutation: GraphQLMutation {
   public static let operationName: String = "UploadOneFile"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation UploadOneFile($file: Upload!) {

--- a/SwiftScripts/Package.resolved
+++ b/SwiftScripts/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "df9ee6676cd5b3bf5b330ec7568a5644f547201b",
-          "version": "1.1.3"
+          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
+          "version": "1.2.0"
         }
       },
       {

--- a/SwiftScripts/Package.swift
+++ b/SwiftScripts/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "Apollo", path: ".."),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.2")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.0")),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   ],
   targets: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -248,7 +248,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
     """
     class LowercaseOperationQuery: GraphQLQuery {
       public static let operationName: String = "lowercaseOperation"
-      public static let document: DocumentType = .notPersisted(
+      public static let document: ApolloAPI.DocumentType = .notPersisted(
         definition: .init(
           \"\"\"
           query lowercaseOperation($variable: String = "TestVar") {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -29,8 +29,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
       try XCTUnwrap(definition),
       identifier: operationIdentifier,
       fragments: referencedFragments ?? [],
-      apq: try XCTUnwrap(config.options.apqs),
-      queryStringLiteralFormat: try XCTUnwrap(config.options.queryStringLiteralFormat)
+      config: ApolloCodegen.ConfigurationContext(config: config)
     ).description
   }
 
@@ -53,7 +52,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         ""\"
         query NameQuery {
@@ -84,7 +83,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         "query NameQuery {  name}"
       ))
@@ -116,7 +115,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         ""\"
         query NameQuery {
@@ -153,7 +152,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         "query NameQuery {  ...NameFragment}",
         fragments: [NameFragment.self]
@@ -186,7 +185,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         "query NameQuery {  ...nameFragment}",
         fragments: [NameFragment.self]
@@ -227,7 +226,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         ""\"
         query NameQuery {
@@ -276,7 +275,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         "query NameQuery {  ...Fragment1  ...Fragment2  ...Fragment3  ...Fragment4  ...FragmentWithLongName1234123412341234123412341234}",
         fragments: [Fragment1.self, Fragment2.self, Fragment3.self, Fragment4.self, FragmentWithLongName1234123412341234123412341234.self]
@@ -306,7 +305,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .automaticallyPersisted(
+    public static let document: ApolloAPI.DocumentType = .automaticallyPersisted(
       operationIdentifier: "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5",
       definition: .init(
         ""\"
@@ -340,10 +339,56 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     // then
     let expected =
     """
-    public static let document: DocumentType = .persistedOperationsOnly(
+    public static let document: ApolloAPI.DocumentType = .persistedOperationsOnly(
       operationIdentifier: "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5"
     )
     """
     expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__generate__givenCocoapodsCompatibleImportStatements_true_shouldUseCorrectNamespace() throws {
+    // given
+    definition.source =
+    """
+    query NameQuery {
+      name
+    }
+    """
+    config = .mock(options: .init(
+      cocoapodsCompatibleImportStatements: true
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: Apollo.DocumentType = .notPersisted(
+    """
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenCocoapodsCompatibleImportStatements_false_shouldUseCorrectNamespace() throws {
+    // given
+    definition.source =
+    """
+    query NameQuery {
+      name
+    }
+    """
+    config = .mock(options: .init(
+      cocoapodsCompatibleImportStatements: false
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
+    """
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class PetAdoptionMutation: GraphQLMutation {
     public static let operationName: String = "PetAdoptionMutation"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class AllAnimalsCCNQuery: GraphQLQuery {
     public static let operationName: String = "AllAnimalsCCN"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query AllAnimalsCCN {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class AllAnimalsIncludeSkipQuery: GraphQLQuery {
     public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class AllAnimalsQuery: GraphQLQuery {
     public static let operationName: String = "AllAnimalsQuery"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query AllAnimalsQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class ClassroomPetsCCNQuery: GraphQLQuery {
     public static let operationName: String = "ClassroomPetsCCN"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query ClassroomPetsCCN {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class ClassroomPetsQuery: GraphQLQuery {
     public static let operationName: String = "ClassroomPets"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query ClassroomPets {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class DogQuery: GraphQLQuery {
     public static let operationName: String = "DogQuery"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query DogQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/PetSearchQuery.graphql.swift
@@ -6,7 +6,7 @@
 public extension MyGraphQLSchema {
   class PetSearchQuery: GraphQLQuery {
     public static let operationName: String = "PetSearch"
-    public static let document: DocumentType = .notPersisted(
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
         """
         query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPets {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query DogQuery {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetAdoptionMutation.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetSearchQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/AllAnimalsCCNQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsCCN {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
@@ -6,7 +6,7 @@ import PackageTwo
 
 class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPetsCCN {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsCCN {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsQuery {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPetsCCN {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPets {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query DogQuery {

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/PetSearchQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: Apollo.DocumentType = .notPersisted(
     definition: .init(
       """
       query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsCCN {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsQuery {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPetsCCN {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPets {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/DogQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query DogQuery {

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/PetSearchQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsCCN {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsQuery {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPetsCCN {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPets {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query DogQuery {

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       mutation PetAdoptionMutation($input: PetAdoptionInput!) {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsCCN {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query AllAnimalsQuery {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPetsCCN {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query ClassroomPets {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query DogQuery {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -5,7 +5,7 @@
 
 public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
-  public static let document: DocumentType = .notPersisted(
+  public static let document: ApolloAPI.DocumentType = .notPersisted(
     definition: .init(
       """
       query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {


### PR DESCRIPTION
Fixes #2581 

Adds namespacing to `DocumentType` in generated operation files.