### PR TITLE
fix: Add missing `InstallCLI` plugin product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
     .library(name: "ApolloWebSocket", targets: ["ApolloWebSocket"]),
     .library(name: "ApolloTestSupport", targets: ["ApolloTestSupport"]),
     .executable(name: "apollo-ios-cli", targets: ["apollo-ios-cli"]),
+    .plugin(name: "InstallCLI", targets: ["Install CLI"]),
   ],
   dependencies: [
     .package(
@@ -103,7 +104,7 @@ let package = Package(
         "Info.plist",
       ]),
     .plugin(
-      name: "InstallCLI",
+      name: "Install CLI",
       capability: .command(
         intent: .custom(
           verb: "apollo-cli-install",
@@ -113,6 +114,7 @@ let package = Package(
         ]),
       dependencies: [
         "apollo-ios-cli"
-      ])
+      ],
+      path: "Plugins/InstallCLI"),
   ]
 )


### PR DESCRIPTION
Fixes #2682 

The `.plugin` product is missing, effectively 'hiding' the new plugin from SPM and Xcode.
* adds the missing `.plugin` product
* uses a custom path in the target definition so the menu name can get a space between the two words