### PR TITLE
update: Raise minimum Swift tools version to `5.7`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SwiftPackageManagerModuleTemplate.swift
@@ -16,7 +16,7 @@ struct SwiftPackageManagerModuleTemplate: TemplateRenderer {
     let casedSchemaName = config.schemaName.firstUppercased
 
     return TemplateString("""
-    // swift-tools-version:5.6
+    // swift-tools-version:5.7
 
     import PackageDescription
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -33,7 +33,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     buildSubject()
 
     let expected = """
-    // swift-tools-version:5.6
+    // swift-tools-version:5.7
     """
 
     // when


### PR DESCRIPTION
Closes #2688 

Apollo iOS contains code that will only build with Swift `5.7`, such as the new `if let` shorthand from [SE-0435](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md). It's not a great experience to have the project load only to result a build error if you're using a version of Xcode that doesn't support Swift `5.7`; < `14.0`.

This PR simply raises the required version of Swift to build the project making the user aware earlier of their tool versioning mismatch.