### PR TITLE
fix: Allow quotes in query document string

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -106,7 +106,7 @@ fileprivate extension String {
         """
 
     case .singleLine:
-      return "\"\(components(separatedBy: .newlines).joined(separator: ""))\""
+      return "#\"\(components(separatedBy: .newlines).joined(separator: ""))\"#"
     }
   }
 }

--- a/Sources/GitHubAPI/GitHubAPI/Package.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Package.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Package.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Sources/UploadAPI/UploadAPI/Package.swift
+++ b/Sources/UploadAPI/UploadAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -33,6 +33,8 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     ).description
   }
 
+  // MARK: Query string formatting tests
+
   func test__generate__givenMultilineFormat_generatesWithOperationDefinition_asMultiline() throws {
     // given
     definition.source =
@@ -85,7 +87,65 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     """
     public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
-        "query NameQuery {  name}"
+        #"query NameQuery {  name}"#
+      ))
+    """
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__generate__givenMultilineFormat_withInLineQuotes_generatesWithOperationDefinitionAsMultiline_withInlineQuotes() throws {
+    // given
+    definition.source =
+    """
+    query NameQuery($filter: String = "MyName") {
+      name
+    }
+    """
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .multiline,
+      apqs: .disabled
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
+      definition: .init(
+        ""\"
+        query NameQuery($filter: String = "MyName") {
+          name
+        }
+        ""\"
+      ))
+    """
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__generate__givenSingleLineFormat_withInLineQuotes_generatesWithOperationDefinitionAsSingleLine_withInLineQuotes() throws {
+    // given
+    definition.source =
+    """
+    query NameQuery($filter: String = "MyName") {
+      name
+    }
+    """
+    config = .mock(options: .init(
+      queryStringLiteralFormat: .singleLine,
+      apqs: .disabled
+    ))
+
+    // when
+    let actual = try renderDocumentType()
+
+    // then
+    let expected =
+    """
+    public static let document: ApolloAPI.DocumentType = .notPersisted(
+      definition: .init(
+        #"query NameQuery($filter: String = "MyName") {  name}"#
       ))
     """
     expect(actual).to(equalLineByLine(expected))
@@ -154,7 +214,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     """
     public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
-        "query NameQuery {  ...NameFragment}",
+        #"query NameQuery {  ...NameFragment}"#,
         fragments: [NameFragment.self]
       ))
     """
@@ -187,7 +247,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     """
     public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
-        "query NameQuery {  ...nameFragment}",
+        #"query NameQuery {  ...nameFragment}"#,
         fragments: [NameFragment.self]
       ))
     """
@@ -277,7 +337,7 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     """
     public static let document: ApolloAPI.DocumentType = .notPersisted(
       definition: .init(
-        "query NameQuery {  ...Fragment1  ...Fragment2  ...Fragment3  ...Fragment4  ...FragmentWithLongName1234123412341234123412341234}",
+        #"query NameQuery {  ...Fragment1  ...Fragment2  ...Fragment3  ...Fragment4  ...FragmentWithLongName1234123412341234123412341234}"#,
         fragments: [Fragment1.self, Fragment2.self, Fragment3.self, Fragment4.self, FragmentWithLongName1234123412341234123412341234.self]
       ))
     """
@@ -345,6 +405,8 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
     """
     expect(actual).to(equalLineByLine(expected))
   }
+
+  // MARK: Namespacing tests
 
   func test__generate__givenCocoapodsCompatibleImportStatements_true_shouldUseCorrectNamespace() throws {
     // given

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Package.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Package.resolved
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "apollo-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apollographql/apollo-ios.git",
-      "state" : {
-        "revision" : "4b13a927b581c40d06f2c65f593f672a52c0c812",
-        "version" : "1.0.3"
-      }
-    },
-    {
       "identity" : "inflectorkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/InflectorKit",
@@ -23,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "4d543d811ee644fa4cc4bfa0be996b4dd6ba0f54",
-        "version" : "0.13.3"
+        "revision" : "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
+        "version" : "0.14.1"
       }
     },
     {

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Package.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -15,7 +15,7 @@ let package = Package(
     .library(name: "GraphQLSchemaNameTestMocks", targets: ["GraphQLSchemaNameTestMocks"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0"),
+    .package(name: "apollo-ios", path: "../../.."),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Fixes #2671 

Quotes in query strings were causing build errors because the query string itself was enclosed in quotes in the generated operation model. The fix is to use the Swift's [Extended String Delimiters](https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html#ID286) feature.

_This PR also includes updates to the internal test projects. There are no updates related to the query strings but this keeps them up to date with the latest code generation engine._