### PR TITLE
fix: Fork PRs failing CocoaPods integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
       - common_test_setup
       - build_and_run_xcode_tests
   
-  CodegenIntegration_macOS_current:
+  CocoaPodsIntegration_macOS_current:
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -262,5 +262,5 @@ workflows:
           name: Codegen Lib Unit Tests - macOS << pipeline.parameters.macos_version >>
       - CodegenCLI_macOS_current:
           name: Codegen CLI Unit Tests - macOS << pipeline.parameters.macos_version >>
-      - CodegenIntegration_macOS_current:
-          name: Codegen CLI Integration Tests - macOS << pipeline.parameters.macos_version >>
+      - CocoaPodsIntegration_macOS_current:
+          name: CocoaPods Integration Tests - macOS << pipeline.parameters.macos_version >>

--- a/Tests/CodegenCLITests/pod-install-test/Podfile
+++ b/Tests/CodegenCLITests/pod-install-test/Podfile
@@ -6,5 +6,9 @@ target 'pod-install-test' do
   use_frameworks!
 
   # Pods for codegen-cli-issue
-  pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios.git', :branch => ENV['CIRCLE_BRANCH']
+  if ENV['CIRCLE_PR_REPONAME'] != nil
+    pod 'Apollo', :git => "https://github.com/#{ENV['CIRCLE_PR_USERNAME']}/#{ENV['CIRCLE_PR_REPONAME']}.git", :commit => ENV['CIRCLE_SHA1']
+  else
+    pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios.git', :branch => ENV['CIRCLE_BRANCH']
+  end
 end

--- a/docs/shared/cli-install/pods.mdx
+++ b/docs/shared/cli-install/pods.mdx
@@ -5,3 +5,5 @@ After installing the Apollo iOS pod, you can run the Codegen CLI from the direct
 ```bash
 ./Pods/Apollo/apollo-ios-cli ${Command Name} -${Command Arguments}
 ```
+
+> **Note:** If you are using `:path` in your Podfile to link to a local copy of Apollo iOS, the CLI will not be automatically available. You will need to manually build the Codegen CLI. See the [CLI installation guide](/ios/code-generation/codegen-cli#installation) for directions on how to do that.


### PR DESCRIPTION
Part of #2563 

* This PR changes the Podfile for the `pod-install-project` test project to build the pod location from CircleCI environment variables based on whether it is a forked PR or not.
* There is also an update to the documentation to inform users that when installing Apollo iOS with CocoaPods from a local development path, the CLI will not be automatically built for them.

There are three PRs to verify the change works as expected in each case:

1.  **PRs on the official repo - `apollographql/apollo-ios`**
* These PRs use a branch as the pod source - [Podfile line 12](https://github.com/apollographql/apollo-ios/compare/main...calvincestari:apollo-ios:fix/fork-pr-pod-test?expand=1#diff-c76ab14169f6e66310ded3bfc77ca59d6dc78eacdb0325898a2c06c72698c26eR12).
* PR #2714 is an example, which results in `pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios.git', :branch => 'test/ci-env-dump'`.
* CI builds of that PR can be found [here](https://app.circleci.com/pipelines/github/apollographql/apollo-ios?branch=test%2Fci-env-dump).
* Looking at the [CocoaPods Integration Tests](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4100/workflows/04bd2222-adfb-4dee-93af-a087caeb805a/jobs/32711) job on the last build of that PR, for commit 6e34253, you can see the environment variables that are used in the "Preparing environment variables" step, and the successful "CocoaPods - Install" step.

2. **PRs from forked repos with the same repo name - `calvincestari/apollo-ios`**
* These PRs use a combination of the PR username/reponame and commit hash as the pod source - [Podfile line 10](https://github.com/apollographql/apollo-ios/compare/main...calvincestari:apollo-ios:fix/fork-pr-pod-test?expand=1#diff-c76ab14169f6e66310ded3bfc77ca59d6dc78eacdb0325898a2c06c72698c26eR10).
* PR #2713 is an example, which results in `pod 'Apollo', :git => "https://github.com/calvincestari/apollo-ios.git", :commit => '48f33050a57d2b5cd07a820bc310add2e272ac73'`.
* CI builds of that PR can be found [here](https://app.circleci.com/pipelines/github/apollographql/apollo-ios?branch=pull%2F2713).
* Looking at the [CocoaPods Integration Tests](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4102/workflows/30ee9e65-c271-41c3-b1cc-6eaad00c0b8e/jobs/32734) job on the last build of that PR, for commit 48f3305, you can see the environment variables that are used in the "Preparing environment variables" step, and the successful "CocoaPods - Install" step.

3. **PRs from forked repos but with a different repo name - `calvincestari/custom-repo-name`**
* These PRs use a combination of the PR username/reponame and commit hash as the pod source - [Podfile line 10](https://github.com/apollographql/apollo-ios/compare/main...calvincestari:apollo-ios:fix/fork-pr-pod-test?expand=1#diff-c76ab14169f6e66310ded3bfc77ca59d6dc78eacdb0325898a2c06c72698c26eR10).
* PR #2712 is an example, which results in `pod 'Apollo', :git => "https://github.com/calvincestari/apollo-ios.git", :commit => '53ed7befddde11085243671c07c952346b000d3f'`.
* CI builds of that PR can be found [here](https://app.circleci.com/pipelines/github/apollographql/apollo-ios?branch=pull%2F2712).
* Looking at the [CocoaPods Integration Tests](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4099/workflows/ccb93237-7f90-4072-9440-e6acb8af5e67/jobs/32699) job on the last build of that PR, for commit 53ed7be, you can see the environment variables that are used in the "Preparing environment variables" step, and the successful "CocoaPods - Install" step.

There is also the fact that this PR is from my fork of the repo and it has a successful CI pass.