### PR TITLE
Fix crash when data contains Null value for a SelectionSet

### DIFF
--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A structure that wraps the underlying data dictionary used by `SelectionSet`s.
 public struct DataDict: Hashable {
 
@@ -61,7 +63,7 @@ extension AnySelectionSet {
 
 extension Optional: SelectionSetEntityValue where Wrapped: SelectionSetEntityValue {
   @inlinable public init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?) {
-    guard case let .some(fieldData) = fieldData else {
+    guard case let .some(fieldData) = fieldData, !(fieldData is NSNull) else {
       self = .none
       return
     }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -54,6 +54,39 @@ class SelectionSetTests: XCTestCase {
     // then
     expect(actual.name).to(beNil())
   }
+  
+  func test__selection_givenOptionalField_supportsNullValue__returnsNil() {
+    // given
+    class Hero: MockSelectionSet, SelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {[
+        .field("__typename", String.self),
+        .field("friend", Friend?.self)
+      ]}
+
+      var friend: Friend? { __data["friend"] }
+
+      class Friend: MockSelectionSet, SelectionSet {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+        ]}
+      }
+    }
+    
+    let object: JSONObject = [
+      "__typename": "Human",
+      "friend": NSNull()
+    ]
+
+    // when
+    let actual = Hero(data: DataDict(object, variables: nil))
+
+    // then
+    expect(actual.friend).to(beNil())
+  }
 
   // MARK: Scalar - Nested Array Tests
 


### PR DESCRIPTION
# Intended outcome:
Apollo should support null in optional responses from the server (distinct from nil).

# Actual outcome:
The  app would crash with a fatalError on line 55 of DataDict.swift.

```
extension AnySelectionSet {
  @inlinable public init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?) {
    guard let fieldData = fieldData as? JSONObject else {
      fatalError("\(Self.self) expected data for entity.")
    }
    self.init(data: DataDict(fieldData, variables: variables))
  }

  @inlinable public var _fieldData: AnyHashable { __data._data }
}
```

# How to reproduce the issue
Have a response that has an optional value as a null. Alternatively checkout the commit for the test which precedes the commit for the fix. Running the tests will crash

# Fix
This PR tests for Null value when unwrapping an optional in a selection set.
I don't know the Apollo code base that well so there may well be another way, or better place to fix this.

I've tested that linking directly to this modified version of the SDK fixes the crash in our app.


**Update:** Added an issue here https://github.com/apollographql/apollo-ios/issues/2725 for visibility