### PR TITLE
fix: Use correct schema namespace casing in fragments

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -267,7 +267,7 @@ public class ApolloCodegen {
     for fragment in compilationResult.fragments {
       try autoreleasepool {
         let irFragment = ir.build(fragment: fragment)
-        try FragmentFileGenerator(irFragment: irFragment, schema: ir.schema, config: config)
+        try FragmentFileGenerator(irFragment: irFragment, config: config)
           .generate(forConfig: config, fileManager: fileManager)
       }
     }
@@ -277,7 +277,7 @@ public class ApolloCodegen {
     for operation in compilationResult.operations {
       try autoreleasepool {
         let irOperation = ir.build(operation: operation)
-        try OperationFileGenerator(irOperation: irOperation, schema: ir.schema, config: config)
+        try OperationFileGenerator(irOperation: irOperation, config: config)
           .generate(forConfig: config, fileManager: fileManager)
 
         operationIDsFileGenerator?.collectOperationIdentifier(irOperation)
@@ -340,7 +340,6 @@ public class ApolloCodegen {
       try autoreleasepool {
         try InputObjectFileGenerator(
           graphqlInputObject: graphQLInputObject,
-          schema: ir.schema,
           config: config
         ).generate(
           forConfig: config,
@@ -375,7 +374,7 @@ public class ApolloCodegen {
 
     try SchemaMetadataFileGenerator(schema: ir.schema, config: config)
       .generate(forConfig: config, fileManager: fileManager)
-    try SchemaConfigurationFileGenerator(schema: ir.schema, config: config)
+    try SchemaConfigurationFileGenerator(config: config)
       .generate(forConfig: config, fileManager: fileManager)
 
     try SchemaModuleFileGenerator.generate(config, fileManager: fileManager)

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -85,10 +85,7 @@ public class ApolloCodegen {
 
     try validate(schemaName: configContext.schemaName, compilationResult: compilationResult)
 
-    let ir = IR(
-      schemaName: configContext.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     var existingGeneratedFilePaths = configuration.options.pruneGeneratedFiles ?
     try findExistingGeneratedFilePaths(

--- a/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FragmentFileGenerator.swift
@@ -4,14 +4,11 @@ import Foundation
 struct FragmentFileGenerator: FileGenerator {
   /// Source IR fragment.
   let irFragment: IR.NamedFragment
-  /// Source IR schema.
-  let schema: IR.Schema
   /// Shared codegen configuration.
   let config: ApolloCodegen.ConfigurationContext
   
   var template: TemplateRenderer { FragmentTemplate(
     fragment: irFragment,
-    schema: schema,
     config: config
   ) }
   var target: FileTarget { .fragment(irFragment.definition) }

--- a/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/InputObjectFileGenerator.swift
@@ -5,13 +5,11 @@ import Foundation
 struct InputObjectFileGenerator: FileGenerator {
   /// Source GraphQL input object.
   let graphqlInputObject: GraphQLInputObjectType
-  /// IR representation of a GraphQL schema.
-  let schema: IR.Schema
   /// Shared codegen configuration.
   let config: ApolloCodegen.ConfigurationContext
 
   var template: TemplateRenderer {
-    InputObjectTemplate(graphqlInputObject: graphqlInputObject, schema: schema, config: config)
+    InputObjectTemplate(graphqlInputObject: graphqlInputObject, config: config)
   }
   var target: FileTarget { .inputObject }
   var fileName: String { graphqlInputObject.name }

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationFileGenerator.swift
@@ -4,8 +4,6 @@ import Foundation
 struct OperationFileGenerator: FileGenerator {
   /// Source IR operation.
   let irOperation: IR.Operation
-  /// Source IR schema.
-  let schema: IR.Schema
   /// Shared codegen configuration
   let config: ApolloCodegen.ConfigurationContext
   
@@ -13,12 +11,10 @@ struct OperationFileGenerator: FileGenerator {
     irOperation.definition.isLocalCacheMutation ?
     LocalCacheMutationDefinitionTemplate(
       operation: irOperation,
-      schema: schema,
       config: config
     ) :
     OperationDefinitionTemplate(
       operation: irOperation,
-      schema: schema,
       config: config
     )
   }

--- a/Sources/ApolloCodegenLib/FileGenerators/SchemaConfigurationFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/SchemaConfigurationFileGenerator.swift
@@ -3,12 +3,10 @@ import OrderedCollections
 
 /// Generates a file containing schema metadata used by the GraphQL executor at runtime.
 struct SchemaConfigurationFileGenerator: FileGenerator {
-  /// Source IR schema.
-  let schema: IR.Schema
   /// Shared codegen configuration
   let config: ApolloCodegen.ConfigurationContext
 
-  var template: TemplateRenderer { SchemaConfigurationTemplate(schema: schema, config: config) }
+  var template: TemplateRenderer { SchemaConfigurationTemplate(config: config) }
   var overwrite: Bool { false }
   var target: FileTarget { .schema }
   var fileName: String { "SchemaConfiguration" }

--- a/Sources/ApolloCodegenLib/IR/IR+Schema.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+Schema.swift
@@ -3,7 +3,6 @@ import OrderedCollections
 
 extension IR {
   final class Schema {
-    let name: String
     let referencedTypes: ReferencedTypes
     let documentation: String?
 
@@ -12,7 +11,6 @@ extension IR {
       referencedTypes: IR.Schema.ReferencedTypes,
       documentation: String? = nil
     ) {
-      self.name = name
       self.referencedTypes = referencedTypes
       self.documentation = documentation
     }

--- a/Sources/ApolloCodegenLib/IR/IR+Schema.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+Schema.swift
@@ -7,7 +7,6 @@ extension IR {
     let documentation: String?
 
     init(
-      name: String,
       referencedTypes: IR.Schema.ReferencedTypes,
       documentation: String? = nil
     ) {

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -11,10 +11,9 @@ class IR {
 
   var builtFragments: [String: NamedFragment] = [:]
 
-  init(schemaName: String, compilationResult: CompilationResult) {
+  init(compilationResult: CompilationResult) {
     self.compilationResult = compilationResult
     self.schema = Schema(
-      name: schemaName,
       referencedTypes: .init(compilationResult.referencedTypes),
       documentation: compilationResult.schemaDocumentation
     )

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -16,7 +16,7 @@ struct FragmentTemplate: TemplateRenderer {
     TemplateString(
     """
     \(embeddedAccessControlModifier)\
-    struct \(fragment.name.firstUppercased): \(schema.name)\
+    struct \(fragment.name.firstUppercased): \(config.schemaName.firstUppercased)\
     .\(if: isMutable, "Mutable")SelectionSet, Fragment {
       public static var fragmentDefinition: StaticString { ""\"
         \(fragment.definition.source)

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -5,8 +5,6 @@ import Foundation
 struct FragmentTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Fragment](https://spec.graphql.org/draft/#sec-Language.Fragments).
   let fragment: IR.NamedFragment
-  /// IR representation of source GraphQL schema.
-  let schema: IR.Schema
 
   let config: ApolloCodegen.ConfigurationContext
 
@@ -23,7 +21,6 @@ struct FragmentTemplate: TemplateRenderer {
         ""\" }
 
       \(SelectionSetTemplate(
-        schema: schema,
         mutable: isMutable,
         config: config
       ).BodyTemplate(fragment.rootField.selectionSet))

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -5,8 +5,6 @@ import Foundation
 struct InputObjectTemplate: TemplateRenderer {
   /// IR representation of source [GraphQL Input Object](https://spec.graphql.org/draft/#sec-Input-Objects).
   let graphqlInputObject: GraphQLInputObjectType
-  /// IR representation of a GraphQL schema.
-  let schema: IR.Schema
 
   let config: ApolloCodegen.ConfigurationContext
 

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -3,8 +3,6 @@ import OrderedCollections
 struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
   /// IR representation of source [GraphQL Operation](https://spec.graphql.org/draft/#sec-Language.Operations).
   let operation: IR.Operation
-  /// IR representation of source GraphQL schema.
-  let schema: IR.Schema
 
   let config: ApolloCodegen.ConfigurationContext
 
@@ -23,7 +21,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableAccessors(operation.definition.variables, graphQLOperation: false))
 
-      \(SelectionSetTemplate(schema: schema, mutable: true, config: config).render(for: operation))
+      \(SelectionSetTemplate(mutable: true, config: config).render(for: operation))
     }
     
     """)

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -5,8 +5,6 @@ import OrderedCollections
 struct OperationDefinitionTemplate: OperationTemplateRenderer {
   /// IR representation of source [GraphQL Operation](https://spec.graphql.org/draft/#sec-Language.Operations).
   let operation: IR.Operation
-  /// IR representation of source GraphQL schema.
-  let schema: IR.Schema
 
   let config: ApolloCodegen.ConfigurationContext
 
@@ -29,7 +27,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
 
       \(section: VariableAccessors(operation.definition.variables))
 
-      \(SelectionSetTemplate(schema: schema, config: config).render(for: operation))
+      \(SelectionSetTemplate(config: config).render(for: operation))
     }
 
     """)

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -1,8 +1,6 @@
 /// Protocol for a `TemplateRenderer` that renders an operation definition template.
 /// This protocol provides rendering helper functions for common template elements.
-protocol OperationTemplateRenderer: TemplateRenderer {
-  var schema: IR.Schema { get }
-}
+protocol OperationTemplateRenderer: TemplateRenderer { }
 
 extension OperationTemplateRenderer {
   func Initializer(

--- a/Sources/ApolloCodegenLib/Templates/SchemaConfigurationTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaConfigurationTemplate.swift
@@ -2,9 +2,6 @@ import Foundation
 
 /// Renders the Cache Key Resolution extension for a generated schema.
 struct SchemaConfigurationTemplate: TemplateRenderer {
-
-  /// Source IR schema.
-  let schema: IR.Schema
   /// Shared codegen configuration
   let config: ApolloCodegen.ConfigurationContext
 

--- a/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -77,7 +77,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
 
   init(schema: IR.Schema, config: ApolloCodegen.ConfigurationContext) {
     self.schema = schema
-    self.schemaName = schema.name.firstUppercased
+    self.schemaName = config.schemaName.firstUppercased
     self.config = config
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -2,22 +2,19 @@ import InflectorKit
 
 struct SelectionSetTemplate {
 
-  let schema: IR.Schema
   let isMutable: Bool
   let config: ApolloCodegen.ConfigurationContext
 
   private let nameCache: SelectionSetNameCache
 
   init(
-    schema: IR.Schema,
     mutable: Bool = false,
     config: ApolloCodegen.ConfigurationContext
   ) {
-    self.schema = schema
     self.isMutable = mutable
     self.config = config
 
-    self.nameCache = SelectionSetNameCache(schema: schema, config: config)
+    self.nameCache = SelectionSetNameCache(config: config)
   }
 
   // MARK: - Operation
@@ -416,11 +413,9 @@ struct SelectionSetTemplate {
 fileprivate class SelectionSetNameCache {
   private var generatedSelectionSetNames: [ObjectIdentifier: String] = [:]
 
-  unowned let schema: IR.Schema
   let config: ApolloCodegen.ConfigurationContext
 
-  init(schema: IR.Schema, config: ApolloCodegen.ConfigurationContext) {
-    self.schema = schema
+  init(config: ApolloCodegen.ConfigurationContext) {
     self.config = config
   }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
@@ -49,7 +49,7 @@ extension IR {
     schemaName: String = "TestSchema",
     compilationResult: CompilationResult
   ) -> IR {
-    return IR(schemaName: schemaName, compilationResult: compilationResult)
+    return IR(compilationResult: compilationResult)
   }
 
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -664,10 +664,7 @@ class ApolloCodegenTests: XCTestCase {
     // when
     let compilationResult = try ApolloCodegen.compileGraphQLResult(config)
 
-    let ir = IR(
-      schemaName: config.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     try ApolloCodegen.generateFiles(
       compilationResult: compilationResult,
@@ -763,10 +760,7 @@ class ApolloCodegenTests: XCTestCase {
     // when
     let compilationResult = try ApolloCodegen.compileGraphQLResult(config)
 
-    let ir = IR(
-      schemaName: config.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     try ApolloCodegen.generateFiles(
       compilationResult: compilationResult,
@@ -868,10 +862,7 @@ class ApolloCodegenTests: XCTestCase {
       experimentalFeatures: .init(clientControlledNullability: true)
     )
 
-    let ir = IR(
-      schemaName: config.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     try ApolloCodegen.generateFiles(
       compilationResult: compilationResult,
@@ -935,10 +926,7 @@ class ApolloCodegenTests: XCTestCase {
       experimentalFeatures: .init(clientControlledNullability: true)
     )
 
-    let ir = IR(
-      schemaName: config.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     try ApolloCodegen.generateFiles(
       compilationResult: compilationResult,
@@ -1039,10 +1027,7 @@ class ApolloCodegenTests: XCTestCase {
     // when
     let compilationResult = try ApolloCodegen.compileGraphQLResult(config)
 
-    let ir = IR(
-      schemaName: config.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     try ApolloCodegen.generateFiles(
       compilationResult: compilationResult,
@@ -1141,10 +1126,7 @@ class ApolloCodegenTests: XCTestCase {
     // when
     let compilationResult = try ApolloCodegen.compileGraphQLResult(config)
 
-    let ir = IR(
-      schemaName: config.schemaName,
-      compilationResult: compilationResult
-    )
+    let ir = IR(compilationResult: compilationResult)
 
     try ApolloCodegen.generateFiles(
       compilationResult: compilationResult,

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/FragmentFileGeneratorTests.swift
@@ -49,7 +49,6 @@ class FragmentFileGeneratorTests: XCTestCase {
     
     subject = FragmentFileGenerator(
       irFragment: irFragment,
-      schema: ir.schema,
       config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InputObjectFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/InputObjectFileGeneratorTests.swift
@@ -13,11 +13,9 @@ class InputObjectFileGeneratorTests: XCTestCase {
 
   // MARK: Test Helpers
 
-  private func buildSubject() {
-    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([]))    
+  private func buildSubject() { 
     subject = InputObjectFileGenerator(
       graphqlInputObject: graphqlInputObject,
-      schema: schema,
       config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationFileGeneratorTests.swift
@@ -45,7 +45,7 @@ class OperationFileGeneratorTests: XCTestCase {
 
     let config = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
     
-    subject = OperationFileGenerator(irOperation: irOperation, schema: ir.schema, config: config)
+    subject = OperationFileGenerator(irOperation: irOperation, config: config)
   }
 
   // MARK: Property Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaConfigurationFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaConfigurationFileGeneratorTests.swift
@@ -15,7 +15,6 @@ class SchemaConfigurationFileGeneratorTests: XCTestCase {
 
   private func buildSubject() {
     subject = SchemaConfigurationFileGenerator(
-      schema: irSchema,
       config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock())
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaConfigurationFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaConfigurationFileGeneratorTests.swift
@@ -3,7 +3,7 @@ import Nimble
 @testable import ApolloCodegenLib
 
 class SchemaConfigurationFileGeneratorTests: XCTestCase {
-  let irSchema = IR.Schema(name: "MockSchema", referencedTypes: .init([]))
+  let irSchema = IR.Schema(referencedTypes: .init([]))
 
   var subject: SchemaConfigurationFileGenerator!
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaMetadataFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaMetadataFileGeneratorTests.swift
@@ -3,7 +3,7 @@ import Nimble
 @testable import ApolloCodegenLib
 
 class SchemaMetadataFileGeneratorTests: XCTestCase {
-  let irSchema = IR.Schema(name: "MockSchema", referencedTypes: .init([]))
+  let irSchema = IR.Schema(referencedTypes: .init([]))
 
   var subject: SchemaMetadataFileGenerator!
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -52,7 +52,6 @@ class FragmentTemplateTests: XCTestCase {
     fragment = ir.build(fragment: fragmentDefinition)
     subject = FragmentTemplate(
       fragment: fragment,
-      schema: ir.schema,
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -417,4 +417,47 @@ class FragmentTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
+  // MARK: Casing
+
+  func test__casing__givenLowercasedSchemaName_generatesWithFirstUppercasedNamespace() throws {
+    // given
+    try buildSubjectAndFragment(config: .mock(schemaName: "mySchema"))
+
+    // then
+    let expected = """
+      struct TestFragment: MySchema.SelectionSet, Fragment {
+      """
+
+    let actual = renderSubject()
+
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenUppercasedSchemaName_generatesWithUppercasedNamespace() throws {
+    // given
+    try buildSubjectAndFragment(config: .mock(schemaName: "MY_SCHEMA"))
+
+    // then
+    let expected = """
+      struct TestFragment: MY_SCHEMA.SelectionSet, Fragment {
+      """
+
+    let actual = renderSubject()
+
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+  func test__casing__givenCapitalizedSchemaName_generatesWithCapitalizedNamespace() throws {
+    // given
+    try buildSubjectAndFragment(config: .mock(schemaName: "MySchema"))
+
+    // then
+    let expected = """
+      struct TestFragment: MySchema.SelectionSet, Fragment {
+      """
+
+    let actual = renderSubject()
+
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
 }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -17,14 +17,12 @@ class InputObjectTemplateTests: XCTestCase {
     documentation: String? = nil,
     config: ApolloCodegenConfiguration = .mock()
   ) {
-    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([]))
     subject = InputObjectTemplate(
       graphqlInputObject: GraphQLInputObjectType.mock(
         name,
         fields: fields,
         documentation: documentation
       ),
-      schema: schema,
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -54,7 +54,6 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     operation = ir.build(operation: operationDefinition)
     subject = LocalCacheMutationDefinitionTemplate(
       operation: operation,
-      schema: ir.schema,
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -54,7 +54,6 @@ class OperationDefinitionTemplateTests: XCTestCase {
     operation = ir.build(operation: operationDefinition)
     subject = OperationDefinitionTemplate(
       operation: operation,
-      schema: ir.schema,
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -18,11 +18,8 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
     configOutput: ApolloCodegenConfiguration.FileOutput = .mock(),
     options: ApolloCodegenConfiguration.OutputOptions = .init()
   ) {
-    let schema = IR.Schema(name: "TestSchema", referencedTypes: .init([]))
-
     template = OperationDefinitionTemplate(
       operation: .mock(),
-      schema: schema,
       config: .init(config: .mock(output: configOutput, options: options))
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaConfigurationTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaConfigurationTemplateTests.swift
@@ -19,7 +19,6 @@ class SchemaConfigurationTemplateTests: XCTestCase {
     config: ApolloCodegenConfiguration = ApolloCodegenConfiguration.mock(.swiftPackageManager)
   ) {
     subject = SchemaConfigurationTemplate(
-      schema: IR.Schema(name: name, referencedTypes: .init([])),
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
@@ -15,13 +15,12 @@ class SchemaMetadataTemplateTests: XCTestCase {
   // MARK: Helpers
 
   private func buildSubject(
-    name: String = "testSchema",
     referencedTypes: IR.Schema.ReferencedTypes = .init([]),
     documentation: String? = nil,
     config: ApolloCodegenConfiguration = ApolloCodegenConfiguration.mock()
   ) {
     subject = SchemaMetadataTemplate(
-      schema: IR.Schema(name: name, referencedTypes: referencedTypes, documentation: documentation),
+      schema: IR.Schema(referencedTypes: referencedTypes, documentation: documentation),
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }
@@ -87,8 +86,10 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__givenModuleEmbeddedInTarget_shouldGenerateDetachedProtocols_withTypealias_withCorrectCasing_noPublicModifier() {
     // given
     buildSubject(
-      name: "aName",
-      config: .mock(.embeddedInTarget(name: "CustomTarget"))
+      config: .mock(
+        .embeddedInTarget(name: "CustomTarget"),
+        schemaName: "aName"
+      )
     )
 
     let expectedTemplate = """
@@ -130,8 +131,10 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__givenModuleSwiftPackageManager_shouldGenerateEmbeddedProtocols_noTypealias_withCorrectCasing_withPublicModifier() {
     // given
     buildSubject(
-      name: "aName",
-      config: .mock(.swiftPackageManager)
+      config: .mock(
+        .swiftPackageManager,
+        schemaName: "aName"
+      )
     )
 
     let expectedTemplate = """
@@ -162,8 +165,10 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__givenModuleOther_shouldGenerateEmbeddedProtocols_noTypealias_withCorrectCasing_withPublicModifier() {
     // given
     buildSubject(
-      name: "aName",
-      config: .mock(.other)
+      config: .mock(
+        .other,
+        schemaName: "aName"
+      )
     )
 
     let expectedTemplate = """
@@ -194,8 +199,11 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__given_cocoapodsCompatibleImportStatements_true_shouldGenerateEmbeddedProtocols_withApolloTargetName() {
     // given
     buildSubject(
-      name: "aName",
-      config: .mock(.other, options: .init(cocoapodsCompatibleImportStatements: true))
+      config: .mock(
+        .other,
+        options: .init(cocoapodsCompatibleImportStatements: true),
+        schemaName: "aName"
+      )
     )
 
     let expectedTemplate = """
@@ -292,12 +300,12 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__givenWithReferencedObjects_generatesObjectTypeFunctionCorrectlyCased() {
     // given
     buildSubject(
-      name: "objectSchema",
       referencedTypes: .init([
         GraphQLObjectType.mock("objA"),
         GraphQLObjectType.mock("objB"),
         GraphQLObjectType.mock("objC"),
-      ])
+      ]),
+      config: .mock(schemaName: "objectSchema")
     )
 
     let expected = """
@@ -323,7 +331,6 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__givenWithReferencedOtherTypes_generatesObjectTypeNotIncludingNonObjectTypesFunction() {
     // given
     buildSubject(
-      name: "ObjectSchema",
       referencedTypes: .init([
         GraphQLObjectType.mock("ObjectA"),
         GraphQLInterfaceType.mock("InterfaceB"),
@@ -331,7 +338,8 @@ class SchemaMetadataTemplateTests: XCTestCase {
         GraphQLScalarType.mock(name: "ScalarD"),
         GraphQLEnumType.mock(name: "EnumE"),
         GraphQLInputObjectType.mock("InputObjectC"),
-      ])
+      ]),
+      config: .mock(schemaName: "ObjectSchema")
     )
 
     let expected = """
@@ -355,7 +363,6 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__rendersTypeNamespaceEnums() {
     // given
     buildSubject(
-      name: "ObjectSchema",
       referencedTypes: .init([
         GraphQLObjectType.mock("ObjectA"),
         GraphQLInterfaceType.mock("InterfaceB"),
@@ -363,7 +370,8 @@ class SchemaMetadataTemplateTests: XCTestCase {
         GraphQLScalarType.mock(name: "ScalarD"),
         GraphQLEnumType.mock(name: "EnumE"),
         GraphQLInputObjectType.mock("InputObjectC"),
-      ])
+      ]),
+      config: .mock(schemaName: "ObjectSchema")
     )
 
     let expected = """
@@ -383,7 +391,6 @@ class SchemaMetadataTemplateTests: XCTestCase {
   func test__render__givenModuleSwiftPackageManager_rendersTypeNamespaceEnumsAsPublic() {
     // given
     buildSubject(
-      name: "ObjectSchema",
       referencedTypes: .init([
         GraphQLObjectType.mock("ObjectA"),
         GraphQLInterfaceType.mock("InterfaceB"),
@@ -392,7 +399,10 @@ class SchemaMetadataTemplateTests: XCTestCase {
         GraphQLEnumType.mock(name: "EnumE"),
         GraphQLInputObjectType.mock("InputObjectC"),
       ]),
-      config: .mock(.swiftPackageManager)
+      config: .mock(
+        .swiftPackageManager,
+        schemaName: "ObjectSchema"
+      )
     )
 
     let expected = """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -46,7 +46,6 @@ class SelectionSetTemplateTests: XCTestCase {
       )
     )
     subject = SelectionSetTemplate(
-      schema: ir.schema,
       config: ApolloCodegen.ConfigurationContext(config: config)
     )
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -34,7 +34,6 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
     subject = SelectionSetTemplate(
-      schema: ir.schema,
       mutable: true,
       config: .init(config: .mock(schemaName: schemaName))
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_RenderOperation_Tests.swift
@@ -31,7 +31,6 @@ class SelectionSetTemplate_RenderOperation_Tests: XCTestCase {
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
     subject = SelectionSetTemplate(
-      schema: ir.schema,
       config: ApolloCodegen.ConfigurationContext(config: .mock())
     )
   }


### PR DESCRIPTION
Fixes #2705 

`FragmentTemplate` was a template still using schema name from the IR schema. It now uses schema name from the codegen configuration.

I thought we'd caught all these places in #2586 but it turns out not. So I've now removed schema name from `IR.Schema` so it cannot be had from there anymore and I've removed the IR schema from templates and file generators where it's not used.

_I'd prefer to have a centralized place where `config.schemaName` is first capitalized without having to do it in many different places but I'll handle that in the next round of config changes._