### PR TITLE
fix: GraphQLEnum value camelCase conversion strategy

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -23,64 +23,23 @@ extension GraphQLEnumValue.Name {
     }
   }
 
-  /// Convert to `camelCase` from `snake_case`, `UpperCamelCase`, or `UPPERCASE`.
+  /// Convert to `camelCase` from a number of different `snake_case` variants.
   ///
-  /// 1. Returns a first lowercased string
-  /// 1. Capitalizes the word starting after each `_`
-  /// 2. Removes all inner `_`
-  /// 3. Preserves leading and trailing `_`
-  /// 4. Converts an all uppercase string into all lowercase
+  /// All inner `_` characters will be removed, each 'word' will be capitalized, returning a final
+  /// firstLowercased string while preserving original leading and trailing `_` characters.
   private func convertToCamelCase(_ value: String) -> String {
-    // The source for this function is from the JSONDecoder implementation in Swift Foundation,
-    // licensed under Apache License v2.0 with Runtime Library Exception. Modifications were made
-    // to the return when no underscore characters are found.
-    //
-    // See https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/JSONDecoder.swift
-
-    // Find the first non-underscore character
-    guard let firstNonUnderscore = value.firstIndex(where: { $0 != "_" }) else {
-      return value
-    }
-
-    // Find the last non-underscore character
-    var lastNonUnderscore = value.index(before: value.endIndex)
-    while lastNonUnderscore > firstNonUnderscore && value[lastNonUnderscore] == "_" {
-      value.formIndex(before: &lastNonUnderscore)
-    }
-
-    // Cater for leading and trailing underscore characters
-    let valueRange = firstNonUnderscore...lastNonUnderscore
-    let leadingUnderscoreRange = value.startIndex..<firstNonUnderscore
-    let trailingUnderscoreRange = value.index(after: lastNonUnderscore)..<value.endIndex
-
-    // Split inner string into 'words'
-    let components = value[valueRange].split(separator: "_")
-    let joinedString: String
-    if components.count == 1 {
+    guard value.firstIndex(of: "_") != nil else {
       if value.firstIndex(where: { $0.isLowercase }) != nil {
-        joinedString = String(value[valueRange]).firstLowercased
+        return value.firstLowercased
       } else {
-        joinedString = String(value[valueRange]).lowercased()
+        return value.lowercased()
       }
-    } else {
-      joinedString = ([components[0].lowercased()] + components[1...].map { $0.capitalized }).joined()
     }
 
-    // Do a cheap isEmpty check before creating and appending potentially empty strings
-    let result: String
-    if (leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty) {
-      result = joinedString
-    } else if (!leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty) {
-      // Both leading and trailing underscores
-      result = String(value[leadingUnderscoreRange]) + joinedString + String(value[trailingUnderscoreRange])
-    } else if (!leadingUnderscoreRange.isEmpty) {
-      // Just leading
-      result = String(value[leadingUnderscoreRange]) + joinedString
-    } else {
-      // Just trailing
-      result = joinedString + String(value[trailingUnderscoreRange])
-    }
-    return result
+    return value.components(separatedBy: "_")
+      .map({ $0.isEmpty ? "_" : $0.capitalized })
+      .joined()
+      .firstLowercased
   }
 
 }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -24,6 +24,12 @@ extension GraphQLEnumValue.Name {
   }
 
   private func convertToCamelCase(_ value: String) -> String {
+    // The source for this function is from the JSONDecoder implementation in Swift Foundation,
+    // licensed under Apache License v2.0 with Runtime Library Exception. Modifications were made
+    // to the return when no underscore characters are found.
+    //
+    // See https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/JSONDecoder.swift
+
     // Find the first non-underscore character
     guard let firstNonUnderscore = value.firstIndex(where: { $0 != "_" }) else {
       return value

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -57,11 +57,10 @@ extension GraphQLEnumValue.Name {
     let components = value[valueRange].split(separator: "_")
     let joinedString: String
     if components.count == 1 {
-      // No underscore character found
-      if value.allSatisfy({ $0.isUppercase }) {
-        joinedString = String(value[valueRange]).lowercased()
-      } else {
+      if value.firstIndex(where: { $0.isLowercase }) != nil {
         joinedString = String(value[valueRange]).firstLowercased
+      } else {
+        joinedString = String(value[valueRange]).lowercased()
       }
     } else {
       joinedString = ([components[0].lowercased()] + components[1...].map { $0.capitalized }).joined()

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -23,6 +23,13 @@ extension GraphQLEnumValue.Name {
     }
   }
 
+  /// Convert to `camelCase` from `snake_case`, `UpperCamelCase`, or `UPPERCASE`.
+  ///
+  /// 1. Returns a first lowercased string
+  /// 1. Capitalizes the word starting after each `_`
+  /// 2. Removes all inner `_`
+  /// 3. Preserves leading and trailing `_`
+  /// 4. Converts an all uppercase string into all lowercase
   private func convertToCamelCase(_ value: String) -> String {
     // The source for this function is from the JSONDecoder implementation in Swift Foundation,
     // licensed under Apache License v2.0 with Runtime Library Exception. Modifications were made

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -110,14 +110,23 @@ class EnumTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  func test_render_givenCaseConversionStrategy_camelCase_generatesSwiftEnum_convertedToCamelCase() {
+  func test_render_givenOption_caseConversionStrategy_camelCase_generatesSwiftEnumValues_convertedToCamelCase() {
     // given
     buildSubject(
       name: "casedEnum",
       values: [
-        ("lower", nil, nil),
-        ("UPPER", nil, nil),
+        // Mixed case
+        ("lowercase", nil, nil),
+        ("UPPERCASE", nil, nil),
         ("Capitalized", nil, nil),
+        ("snake_case", nil, nil),
+        ("UPPER_SNAKE_CASE", nil, nil),
+        ("_1", nil, nil),
+        ("_one_two_three_", nil, nil),
+        ("camelCased", nil, nil),
+        ("UpperCamelCase", nil, nil),
+
+        // Escaped keywords
         ("associatedtype", nil, nil),
         ("class", nil, nil),
         ("deinit", nil, nil),
@@ -170,14 +179,23 @@ class EnumTemplateTests: XCTestCase {
         ("throws", nil, nil),
         ("true", nil, nil),
         ("try", nil, nil),
-      ]
+      ],
+      config: .mock(
+        options: .init(conversionStrategies: .init(enumCases: .camelCase))
+      )
     )
 
     let expected = """
     enum CasedEnum: String, EnumType {
-      case lower = "lower"
-      case upper = "UPPER"
+      case lowercase = "lowercase"
+      case uppercase = "UPPERCASE"
       case capitalized = "Capitalized"
+      case snakeCase = "snake_case"
+      case upperSnakeCase = "UPPER_SNAKE_CASE"
+      case _1 = "_1"
+      case _oneTwoThree_ = "_one_two_three_"
+      case camelCased = "camelCased"
+      case upperCamelCase = "UpperCamelCase"
       case `associatedtype` = "associatedtype"
       case `class` = "class"
       case `deinit` = "deinit"
@@ -241,14 +259,23 @@ class EnumTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test_render_givenSchemaEnum_noneConveersionStrategies_generatesSwiftEnumRespectingValueCasing() throws {
+  func test_render_givenOption_caseConversionStrategy_none_generatesSwiftEnumValues_respectingSchemaValueCasing() throws {
     // given
     buildSubject(
       name: "casedEnum",
       values: [
-        ("lower", nil, nil),
-        ("UPPER", nil, nil),
+        // Mixed case
+        ("lowercase", nil, nil),
+        ("UPPERCASE", nil, nil),
         ("Capitalized", nil, nil),
+        ("snake_case", nil, nil),
+        ("UPPER_SNAKE_CASE", nil, nil),
+        ("_1", nil, nil),
+        ("_one_two_three_", nil, nil),
+        ("camelCased", nil, nil),
+        ("UpperCamelCase", nil, nil),
+
+        // Escaped keywords
         ("associatedtype", nil, nil),
         ("class", nil, nil),
         ("deinit", nil, nil),
@@ -309,9 +336,15 @@ class EnumTemplateTests: XCTestCase {
 
     let expected = """
     enum CasedEnum: String, EnumType {
-      case lower
-      case UPPER
+      case lowercase
+      case UPPERCASE
       case Capitalized
+      case snake_case
+      case UPPER_SNAKE_CASE
+      case _1
+      case _one_two_three_
+      case camelCased
+      case UpperCamelCase
       case `associatedtype`
       case `class`
       case `deinit`

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -125,6 +125,7 @@ class EnumTemplateTests: XCTestCase {
         ("_one_two_three_", nil, nil),
         ("camelCased", nil, nil),
         ("UpperCamelCase", nil, nil),
+        ("BEFORE2023", nil, nil),
 
         // Escaped keywords
         ("associatedtype", nil, nil),
@@ -196,6 +197,7 @@ class EnumTemplateTests: XCTestCase {
       case _oneTwoThree_ = "_one_two_three_"
       case camelCased = "camelCased"
       case upperCamelCase = "UpperCamelCase"
+      case before2023 = "BEFORE2023"
       case `associatedtype` = "associatedtype"
       case `class` = "class"
       case `deinit` = "deinit"
@@ -274,6 +276,7 @@ class EnumTemplateTests: XCTestCase {
         ("_one_two_three_", nil, nil),
         ("camelCased", nil, nil),
         ("UpperCamelCase", nil, nil),
+        ("BEFORE2023", nil, nil),
 
         // Escaped keywords
         ("associatedtype", nil, nil),
@@ -345,6 +348,7 @@ class EnumTemplateTests: XCTestCase {
       case _one_two_three_
       case camelCased
       case UpperCamelCase
+      case BEFORE2023
       case `associatedtype`
       case `class`
       case `deinit`


### PR DESCRIPTION
This PR refactors the `.camelCase` conversation strategy implementation
* Fixes #2640 
* Fixes #2745 
* Uses the [`_convertFromSnakeCase`](https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/JSONDecoder.swift#L103) implementation from `JSONDecoder` in `Foundation` with modifications. _This [question](https://forums.swift.org/t/support-for-string-transformation-from-camelcase-to-snake-case-and-vice-versa/38045) in the Swift forums makes me hopeful that one day we can remove this code and use a Swift standard library implementation, but we're not there yet._
* Adds Swift enum value test cases. _I checked the original PR (#2478) and oddly there weren't any in there, I'm not sure why._