### PR TITLE
Adds disallowed names to schema namespace validation

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -38,8 +38,8 @@ public class ApolloCodegen {
           """
       case let .schemaNameConflict(name):
         return """
-          Schema name \(name) conflicts with name of a type in your GraphQL schema. Please \
-          choose a different schema name. Suggestions: \(name)Schema, \(name)GraphQL, \(name)API
+          Schema name '\(name)' conflicts with name of a type in the generated code. Please choose \
+          a different schema name. Suggestions: \(name)Schema, \(name)GraphQL, \(name)API.
           """
       case .cannotLoadSchema:
         return "A GraphQL schema could not be found. Please verify the schema search paths."
@@ -162,6 +162,7 @@ public class ApolloCodegen {
 
   static func validate(schemaName: String, compilationResult: CompilationResult) throws {
     guard
+      !SwiftKeywords.DisallowedSchemaNamespaceNames.contains(schemaName.lowercased()),
       !compilationResult.referencedTypes.contains(where: { namedType in
         namedType.swiftName == schemaName.firstUppercased
       }),

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -45,6 +45,10 @@ enum SwiftKeywords {
     "self", "_"
   ]
 
+  static let DisallowedSchemaNamespaceNames: Set<String> = [
+    "schema"
+  ]
+
   static let SelectionSetTypeNamesToSuffix: Set<String> = [
     "Any",
     "DataDict",

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -46,7 +46,7 @@ enum SwiftKeywords {
   ]
 
   static let DisallowedSchemaNamespaceNames: Set<String> = [
-    "schema"
+    "schema", "apolloapi"
   ]
 
   static let SelectionSetTypeNamesToSuffix: Set<String> = [

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2158,6 +2158,24 @@ class ApolloCodegenTests: XCTestCase {
     }
   }
 
+  func test__validation__givenSchemaName_matchingDisallowedSchemaNamespaceName_shouldThrow() throws {
+    // given
+    let disallowedNames = ["schema", "Schema"]
+
+    // when
+    for name in disallowedNames {
+      let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
+        schemaName: name
+      ), rootURL: nil)
+
+      // then
+      expect(try ApolloCodegen.validate(
+        schemaName: configContext.schemaName,
+        compilationResult: CompilationResult.mock()))
+      .to(throwError(ApolloCodegen.Error.schemaNameConflict(name: configContext.schemaName)))
+    }
+  }
+
   func test__validation__givenUniqueSchemaName_shouldNotThrow() throws {
     // given
     let object = GraphQLObjectType.mock("MockObject")

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2160,7 +2160,7 @@ class ApolloCodegenTests: XCTestCase {
 
   func test__validation__givenSchemaName_matchingDisallowedSchemaNamespaceName_shouldThrow() throws {
     // given
-    let disallowedNames = ["schema", "Schema"]
+    let disallowedNames = ["schema", "Schema", "ApolloAPI", "apolloapi"]
 
     // when
     for name in disallowedNames {


### PR DESCRIPTION
Fixes #2664 

* Repurposes the `schemaNameConflict` error to be more a more general purpose type collision error
* Adds logic to validate the given schema namespace name against a new list of disallowed names