### PR TITLE
Fix unqualified scalar collision

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -44,32 +44,37 @@ extension GraphQLType {
     replacingNamedTypeWith newTypeName: String? = nil,
     config: ApolloCodegenConfiguration
   ) -> String {
-
-    lazy var schemaModuleName: String = {
-      !config.output.operations.isInModule ? "\(config.schemaName.firstUppercased)." : ""
-    }()
-
     switch self {
-    case let .entity(type as GraphQLNamedType):
-      let typeName = newTypeName ?? type.swiftName.firstUppercased
+    case
+        .entity(let type as GraphQLNamedType),
+        .scalar(let type as GraphQLNamedType),
+        .enum(let type as GraphQLNamedType),
+        .inputObject(let type as GraphQLNamedType):
+
+      let typeName = type.qualifiedRootTypeName(
+        in: .selectionSetField(),
+        replacingNamedTypeWith: newTypeName,
+        config: config
+      )
+
       return containedInNonNull ? typeName : "\(typeName)?"
 
-    case let .inputObject(type as GraphQLNamedType):
-      let typeName = newTypeName ?? type.swiftName.firstUppercased
-      return TemplateString("\(schemaModuleName)\(typeName)\(if: !containedInNonNull, "?")").description
-
-    case let .scalar(type):
-      let typeName = newTypeName ?? type.swiftName.firstUppercased
-
-      return TemplateString(
-        "\(if: !type.isSwiftType, "\(schemaModuleName)")\(typeName)\(if: !containedInNonNull, "?")"
-      ).description
-
-    case let .enum(type as GraphQLNamedType):
-      let typeName = newTypeName ?? type.name.firstUppercased
-      let enumType = "GraphQLEnum<\(schemaModuleName)\(typeName)>"
-
-      return containedInNonNull ? enumType : "\(enumType)?"
+//    case let :
+//      let typeName = newTypeName ?? type.swiftName.firstUppercased
+//      return TemplateString("\(schemaModuleName)\(typeName)\(if: !containedInNonNull, "?")").description
+//
+//    case let .scalar(type):
+//      let typeName = newTypeName ?? type.swiftName.firstUppercased
+//
+//      return TemplateString(
+//        "\(if: !type.isSwiftType, "\(schemaModuleName)")\(typeName)\(if: !containedInNonNull, "?")"
+//      ).description
+//
+//    case let .enum(type as GraphQLNamedType):
+//      let typeName = newTypeName ?? type.name.firstUppercased
+//      let enumType = "GraphQLEnum<\(schemaModuleName)\(typeName)>"
+//
+//      return containedInNonNull ? enumType : "\(enumType)?"
 
     case let .nonNull(ofType):
       return ofType.renderedAsSelectionSetField(
@@ -149,18 +154,74 @@ extension GraphQLType {
     case .entity:
       preconditionFailure("Entities cannot be used as input values")
 
-    case .enum, .scalar, .inputObject:
-      let typeName = self.renderedAsSelectionSetField(containedInNonNull: true, config: config)
+    case
+        .scalar(let type as GraphQLNamedType),
+        .enum(let type as GraphQLNamedType),
+        .inputObject(let type as GraphQLNamedType):
+
+      let typeName = type.qualifiedRootTypeName(
+        in: .inputValue,
+        config: config
+      ).wrappedInGraphQLEnum(ifIsEnumType: self)
+
       return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
 
     case let .nonNull(ofType):
       return ofType.renderAsInputValue(inNullable: false, config: config)
 
     case let .list(ofType):
-      let typeName = "[\(ofType.renderedAsSelectionSetField(containedInNonNull: false, config: config))]"
+      let typeName = "[\(ofType.renderAsInputValue(inNullable: true, config: config))]"
       return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
     }
   }
+
+  // MARK: - Render Inner Type
+
+//  private func renderInnerType(
+//    in context: RenderContext,
+//    inNullable: Bool,
+//    config: ApolloCodegenConfiguration
+//  ) -> String {
+//    private func renderedAsSelectionSetField(
+//      containedInNonNull: Bool,
+//      replacingNamedTypeWith newTypeName: String? = nil,
+//      config: ApolloCodegenConfiguration
+//    ) -> String {
+//      switch self {
+//      case
+//          .entity(let type as GraphQLNamedType),
+//          .scalar(let type as GraphQLNamedType),
+//          .enum(let type as GraphQLNamedType),
+//          .inputObject(let type as GraphQLNamedType):
+//
+//        let typeName = type.qualifiedRootTypeName(
+//          in: .selectionSetField(),
+//          replacingNamedTypeWith: newTypeName,
+//          config: config
+//        )
+//
+//        return containedInNonNull ? typeName : "\(typeName)?"
+//
+//      case let .nonNull(ofType):
+//        return ofType.renderedAsSelectionSetField(
+//          containedInNonNull: true,
+//          replacingNamedTypeWith: newTypeName,
+//          config: config
+//        )
+//
+//      case let .list(ofType):
+//        let rendered = ofType.renderedAsSelectionSetField(
+//          containedInNonNull: false,
+//          replacingNamedTypeWith: newTypeName,
+//          config: config
+//        )
+//        let inner = "[\(rendered)]"
+//
+//        return containedInNonNull ? inner : "\(inner)?"
+//      }
+//    }
+//  }
+
 }
 
 extension GraphQLNamedType {
@@ -172,5 +233,48 @@ extension GraphQLNamedType {
     }
 
     return swiftName
+  }
+
+  fileprivate func qualifiedRootTypeName(
+    in context: GraphQLType.RenderContext,
+    replacingNamedTypeWith newTypeName: String? = nil,
+    config: ApolloCodegenConfiguration
+  ) -> String {
+    lazy var typeName = { newTypeName ?? self.swiftName.firstUppercased }()
+
+    lazy var schemaModuleName: String = {
+      switch self {
+      case is GraphQLCompositeType:
+        return ""
+
+      case let scalar as GraphQLScalarType where scalar.isSwiftType:
+        return ""
+
+      default:
+        switch context {
+        case .testMockField, .inputValue:
+          if !config.output.operations.isInModule {
+            fallthrough
+          } else {
+            return ""
+          }
+
+        case .selectionSetField:
+          return "\(config.schemaName.firstUppercased)."
+        }
+      }
+    }()
+
+    return "\(schemaModuleName)\(typeName)"
+  }
+}
+
+fileprivate extension String {
+  func wrappedInGraphQLEnum(ifIsEnumType type: GraphQLType) -> String {
+    if case .enum = type {
+      return "GraphQLEnum<\(self)>"
+    } else {
+      return self
+    }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -44,55 +44,12 @@ extension GraphQLType {
     replacingNamedTypeWith newTypeName: String? = nil,
     config: ApolloCodegenConfiguration
   ) -> String {
-    switch self {
-    case
-        .entity(let type as GraphQLNamedType),
-        .scalar(let type as GraphQLNamedType),
-        .enum(let type as GraphQLNamedType),
-        .inputObject(let type as GraphQLNamedType):
-
-      let typeName = type.qualifiedRootTypeName(
-        in: .selectionSetField(),
-        replacingNamedTypeWith: newTypeName,
-        config: config
-      )
-
-      return containedInNonNull ? typeName : "\(typeName)?"
-
-//    case let :
-//      let typeName = newTypeName ?? type.swiftName.firstUppercased
-//      return TemplateString("\(schemaModuleName)\(typeName)\(if: !containedInNonNull, "?")").description
-//
-//    case let .scalar(type):
-//      let typeName = newTypeName ?? type.swiftName.firstUppercased
-//
-//      return TemplateString(
-//        "\(if: !type.isSwiftType, "\(schemaModuleName)")\(typeName)\(if: !containedInNonNull, "?")"
-//      ).description
-//
-//    case let .enum(type as GraphQLNamedType):
-//      let typeName = newTypeName ?? type.name.firstUppercased
-//      let enumType = "GraphQLEnum<\(schemaModuleName)\(typeName)>"
-//
-//      return containedInNonNull ? enumType : "\(enumType)?"
-
-    case let .nonNull(ofType):
-      return ofType.renderedAsSelectionSetField(
-        containedInNonNull: true,
-        replacingNamedTypeWith: newTypeName,
-        config: config
-      )
-
-    case let .list(ofType):
-      let rendered = ofType.renderedAsSelectionSetField(
-        containedInNonNull: false,
-        replacingNamedTypeWith: newTypeName,
-        config: config
-      )
-      let inner = "[\(rendered)]"
-
-      return containedInNonNull ? inner : "\(inner)?"
-    }
+    renderType(
+      in: .selectionSetField(),
+      containedInNonNull: containedInNonNull,
+      replacingNamedTypeWith: newTypeName,
+      config: config
+    )
   }
 
   // MARK: Mock Object Field
@@ -151,76 +108,62 @@ extension GraphQLType {
     config: ApolloCodegenConfiguration
   ) -> String {
     switch self {
-    case .entity:
-      preconditionFailure("Entities cannot be used as input values")
+    case let .nonNull(ofType):
+      return ofType.renderAsInputValue(inNullable: false, config: config)
 
+    case let .list(ofType):
+      let typeName = "[\(ofType.renderType(in: .inputValue, config: config))]"
+      return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
+
+    default:
+      let typeName = renderType(in: .inputValue, containedInNonNull: true, config: config)
+      return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
+    }
+  }
+
+  // MARK: - Render Type
+
+  private func renderType(
+    in context: RenderContext,
+    containedInNonNull: Bool = false,
+    replacingNamedTypeWith newTypeName: String? = nil,
+    config: ApolloCodegenConfiguration
+  ) -> String {
+    switch self {
     case
+        .entity(let type as GraphQLNamedType),
         .scalar(let type as GraphQLNamedType),
         .enum(let type as GraphQLNamedType),
         .inputObject(let type as GraphQLNamedType):
 
       let typeName = type.qualifiedRootTypeName(
-        in: .inputValue,
+        in: context,
+        replacingNamedTypeWith: newTypeName,
         config: config
       ).wrappedInGraphQLEnum(ifIsEnumType: self)
 
-      return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
+      return containedInNonNull ? typeName : "\(typeName)?"
 
     case let .nonNull(ofType):
-      return ofType.renderAsInputValue(inNullable: false, config: config)
+      return ofType.renderType(
+        in: context,
+        containedInNonNull: true,
+        replacingNamedTypeWith: newTypeName,
+        config: config
+      )
 
     case let .list(ofType):
-      let typeName = "[\(ofType.renderAsInputValue(inNullable: true, config: config))]"
-      return inNullable ? "GraphQLNullable<\(typeName)>" : typeName
+      let rendered = ofType.renderType(
+        in: context,
+        containedInNonNull: false,
+        replacingNamedTypeWith: newTypeName,
+        config: config
+      )
+      let inner = "[\(rendered)]"
+
+      return containedInNonNull ? inner : "\(inner)?"
     }
   }
-
-  // MARK: - Render Inner Type
-
-//  private func renderInnerType(
-//    in context: RenderContext,
-//    inNullable: Bool,
-//    config: ApolloCodegenConfiguration
-//  ) -> String {
-//    private func renderedAsSelectionSetField(
-//      containedInNonNull: Bool,
-//      replacingNamedTypeWith newTypeName: String? = nil,
-//      config: ApolloCodegenConfiguration
-//    ) -> String {
-//      switch self {
-//      case
-//          .entity(let type as GraphQLNamedType),
-//          .scalar(let type as GraphQLNamedType),
-//          .enum(let type as GraphQLNamedType),
-//          .inputObject(let type as GraphQLNamedType):
-//
-//        let typeName = type.qualifiedRootTypeName(
-//          in: .selectionSetField(),
-//          replacingNamedTypeWith: newTypeName,
-//          config: config
-//        )
-//
-//        return containedInNonNull ? typeName : "\(typeName)?"
-//
-//      case let .nonNull(ofType):
-//        return ofType.renderedAsSelectionSetField(
-//          containedInNonNull: true,
-//          replacingNamedTypeWith: newTypeName,
-//          config: config
-//        )
-//
-//      case let .list(ofType):
-//        let rendered = ofType.renderedAsSelectionSetField(
-//          containedInNonNull: false,
-//          replacingNamedTypeWith: newTypeName,
-//          config: config
-//        )
-//        let inner = "[\(rendered)]"
-//
-//        return containedInNonNull ? inner : "\(inner)?"
-//      }
-//    }
-//  }
 
 }
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -445,7 +445,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
-  func test__render_selections__givenCustomScalar_rendersFieldSelections_withNamespaceWhenRequired() throws {
+  func test__render_selections__givenCustomScalar_rendersFieldSelectionsWithNamespaceInAllConfigurations() throws {
     // given
     schemaSDL = """
     type Query {
@@ -476,7 +476,7 @@ class SelectionSetTemplateTests: XCTestCase {
     }
     """
 
-    let expectedWithNamespace = """
+    let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
         .field("custom", TestSchema.Custom.self),
         .field("custom_optional", TestSchema.Custom?.self),
@@ -486,31 +486,21 @@ class SelectionSetTemplateTests: XCTestCase {
       ] }
     """
 
-    let expectedNoNamespace = """
-      public static var __selections: [ApolloAPI.Selection] { [
-        .field("custom", Custom.self),
-        .field("custom_optional", Custom?.self),
-        .field("custom_required_list", [Custom].self),
-        .field("custom_optional_list", [Custom]?.self),
-        .field("lowercaseCustom", LowercaseCustom.self),
-      ] }
-    """
-
-    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    let tests: [ApolloCodegenConfiguration.FileOutput] = [
+      .mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)),
+      .mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")),
+      .mock(moduleType: .swiftPackageManager, operations: .inSchemaModule),
+      .mock(moduleType: .other, operations: .relative(subpath: nil)),
+      .mock(moduleType: .other, operations: .absolute(path: "custom")),
+      .mock(moduleType: .other, operations: .inSchemaModule),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule)
     ]
 
     for test in tests {
       // when
-      try buildSubjectAndOperation(configOutput: test.config)
+      try buildSubjectAndOperation(configOutput: test)
       let allAnimals = try XCTUnwrap(
         operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
       )
@@ -518,11 +508,11 @@ class SelectionSetTemplateTests: XCTestCase {
       let actual = subject.render(field: allAnimals)
 
       // then
-      expect(actual).to(equalLineByLine(test.expected, atLine: 7, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
     }
   }
 
-  func test__render_selections__givenEnumField_rendersFieldSelections_withNamespaceWhenRequired() throws {
+  func test__render_selections__givenEnumField_rendersFieldSelectionsWithNamespaceInAllConfigurations() throws {
     // given
     schemaSDL = """
     type Query {
@@ -558,15 +548,7 @@ class SelectionSetTemplateTests: XCTestCase {
     }
     """
 
-    let expectedNoNamespace = """
-      public static var __selections: [ApolloAPI.Selection] { [
-        .field("testEnum", GraphQLEnum<TestEnum>.self),
-        .field("testEnumOptional", GraphQLEnum<TestEnumOptional>?.self),
-        .field("lowercaseEnum", GraphQLEnum<LowercaseEnum>.self),
-      ] }
-    """
-
-    let expectedWithNamespace = """
+    let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
         .field("testEnum", GraphQLEnum<TestSchema.TestEnum>.self),
         .field("testEnumOptional", GraphQLEnum<TestSchema.TestEnumOptional>?.self),
@@ -574,21 +556,21 @@ class SelectionSetTemplateTests: XCTestCase {
       ] }
     """
 
-    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    let tests: [ApolloCodegenConfiguration.FileOutput] = [
+      .mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)),
+      .mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")),
+      .mock(moduleType: .swiftPackageManager, operations: .inSchemaModule),
+      .mock(moduleType: .other, operations: .relative(subpath: nil)),
+      .mock(moduleType: .other, operations: .absolute(path: "custom")),
+      .mock(moduleType: .other, operations: .inSchemaModule),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule)
     ]
 
     for test in tests {
       // when
-      try buildSubjectAndOperation(configOutput: test.config)
+      try buildSubjectAndOperation(configOutput: test)
       let allAnimals = try XCTUnwrap(
         operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
       )
@@ -596,7 +578,7 @@ class SelectionSetTemplateTests: XCTestCase {
       let actual = subject.render(field: allAnimals)
 
       // then
-      expect(actual).to(equalLineByLine(test.expected, atLine: 7, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
     }
   }
 
@@ -1848,7 +1830,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 34, ignoringExtraLines: true))
   }
 
-  func test__render_fieldAccessors__givenCustomScalarFields_rendersFieldAccessors_withNamespaceWhenRequired() throws {
+  func test__render_fieldAccessors__givenCustomScalarFields_rendersFieldAccessorsWithNamespaceWhenRequiredInAllConfigurations() throws {
     // given
     schemaSDL = """
     type Query {
@@ -1879,7 +1861,7 @@ class SelectionSetTemplateTests: XCTestCase {
     }
     """
 
-    let expectedWithNamespace = """
+    let expected = """
       public var custom: TestSchema.Custom { __data["custom"] }
       public var custom_optional: TestSchema.Custom? { __data["custom_optional"] }
       public var custom_required_list: [TestSchema.Custom] { __data["custom_required_list"] }
@@ -1887,29 +1869,21 @@ class SelectionSetTemplateTests: XCTestCase {
       public var lowercaseScalar: TestSchema.LowercaseScalar { __data["lowercaseScalar"] }
     """
 
-    let expectedNoNamespace = """
-      public var custom: Custom { __data["custom"] }
-      public var custom_optional: Custom? { __data["custom_optional"] }
-      public var custom_required_list: [Custom] { __data["custom_required_list"] }
-      public var custom_optional_list: [Custom]? { __data["custom_optional_list"] }
-      public var lowercaseScalar: LowercaseScalar { __data["lowercaseScalar"] }
-    """
-
-    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    let tests: [ApolloCodegenConfiguration.FileOutput] = [
+      .mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)),
+      .mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")),
+      .mock(moduleType: .swiftPackageManager, operations: .inSchemaModule),
+      .mock(moduleType: .other, operations: .relative(subpath: nil)),
+      .mock(moduleType: .other, operations: .absolute(path: "custom")),
+      .mock(moduleType: .other, operations: .inSchemaModule),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule)
     ]
 
     for test in tests {
       // when
-      try buildSubjectAndOperation(configOutput: test.config)
+      try buildSubjectAndOperation(configOutput: test)
       let allAnimals = try XCTUnwrap(
         operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
       )
@@ -1917,11 +1891,11 @@ class SelectionSetTemplateTests: XCTestCase {
       let actual = subject.render(field: allAnimals)
 
       // then
-      expect(actual).to(equalLineByLine(test.expected, atLine: 15, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
     }
   }
 
-  func test__render_fieldAccessors__givenEnumField_rendersFieldAccessors_namespacedWhenRequired() throws {
+  func test__render_fieldAccessors__givenEnumField_rendersFieldAccessorsWithNamespacedInAllConfigurations() throws {
     // given
     schemaSDL = """
     type Query {
@@ -1957,33 +1931,27 @@ class SelectionSetTemplateTests: XCTestCase {
     }
     """
 
-    let expectedWithNamespace = """
+    let expected = """
       public var testEnum: GraphQLEnum<TestSchema.TestEnum> { __data["testEnum"] }
       public var testEnumOptional: GraphQLEnum<TestSchema.TestEnumOptional>? { __data["testEnumOptional"] }
       public var lowercaseEnum: GraphQLEnum<TestSchema.LowercaseEnum> { __data["lowercaseEnum"] }
     """
 
-    let expectedNoNamespace = """
-      public var testEnum: GraphQLEnum<TestEnum> { __data["testEnum"] }
-      public var testEnumOptional: GraphQLEnum<TestEnumOptional>? { __data["testEnumOptional"] }
-      public var lowercaseEnum: GraphQLEnum<LowercaseEnum> { __data["lowercaseEnum"] }
-    """
-
-    let tests: [(config: ApolloCodegenConfiguration.FileOutput, expected: String)] = [
-      (.mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .swiftPackageManager, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .other, operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .other, operations: .inSchemaModule), expectedNoNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")), expectedWithNamespace),
-      (.mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule), expectedNoNamespace)
+    let tests: [ApolloCodegenConfiguration.FileOutput] = [
+      .mock(moduleType: .swiftPackageManager, operations: .relative(subpath: nil)),
+      .mock(moduleType: .swiftPackageManager, operations: .absolute(path: "custom")),
+      .mock(moduleType: .swiftPackageManager, operations: .inSchemaModule),
+      .mock(moduleType: .other, operations: .relative(subpath: nil)),
+      .mock(moduleType: .other, operations: .absolute(path: "custom")),
+      .mock(moduleType: .other, operations: .inSchemaModule),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .relative(subpath: nil)),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .absolute(path: "custom")),
+      .mock(moduleType: .embeddedInTarget(name: "CustomTarget"), operations: .inSchemaModule)
     ]
 
     for test in tests {
       // when
-      try buildSubjectAndOperation(configOutput: test.config)
+      try buildSubjectAndOperation(configOutput: test)
       let allAnimals = try XCTUnwrap(
         operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
       )
@@ -1991,7 +1959,7 @@ class SelectionSetTemplateTests: XCTestCase {
       let actual = subject.render(field: allAnimals)
 
       // then
-      expect(actual).to(equalLineByLine(test.expected, atLine: 13, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
     }
   }
 

--- a/Tests/CodegenIntegrationTests/Tests/2691-scalarNameConflictsWithSelectionSet/README.MD
+++ b/Tests/CodegenIntegrationTests/Tests/2691-scalarNameConflictsWithSelectionSet/README.MD
@@ -1,0 +1,11 @@
+# Overview
+ 
+When a field has a custom scalar type that conflicts with the name of a `SelectionSet` in the generated operation, we get a naming conflict and compilation error.
+
+In this example the `title` field is of a custom scalar `Text` type. The `text` field is of an entity type, and so the model contains a `SelectionSet` named `Text`. These conflict and create ambiguity.  
+
+## Reference Issue: https://github.com/apollographql/apollo-ios/issues/2691
+
+## Solution
+
+All custom scalar usages in generated code should use the qualified namespace of the containing schema.

--- a/Tests/CodegenIntegrationTests/Tests/2691-scalarNameConflictsWithSelectionSet/operation.graphql
+++ b/Tests/CodegenIntegrationTests/Tests/2691-scalarNameConflictsWithSelectionSet/operation.graphql
@@ -1,0 +1,12 @@
+query EventQuery {
+  event {
+    ...EventFragment
+  }
+}
+
+fragment EventFragment on Event {
+  title
+  text {
+    body
+  }
+}

--- a/Tests/CodegenIntegrationTests/Tests/2691-scalarNameConflictsWithSelectionSet/schema.graphqls
+++ b/Tests/CodegenIntegrationTests/Tests/2691-scalarNameConflictsWithSelectionSet/schema.graphqls
@@ -1,0 +1,14 @@
+type Query {
+  event: Event!
+}
+
+type Event {
+  title: Text!
+  text: EventText!
+}
+
+type EventText {
+  body: Text!
+}
+
+scalar Text


### PR DESCRIPTION
Fixes #2691 

Always qualify names of shared schema types referenced as the types of fields in selections sets. This prevents collisions with names of other generated selection sets for entity type fields whose names are the same as a referenced schema type.

This namespaces enums, custom scalars, and input objects.