### PR TITLE
fix: Typename collisions in generated test mocks

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLType+Rendered.swift
@@ -168,14 +168,14 @@ extension GraphQLNamedType {
 
       default:
         switch context {
-        case .testMockField, .inputValue:
+        case .inputValue:
           if !config.output.operations.isInModule {
             fallthrough
           } else {
             return ""
           }
 
-        case .selectionSetField:
+        case .selectionSetField, .testMockField:
           return "\(config.schemaName.firstUppercased)."
         }
       }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -170,7 +170,7 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expected = """
       public struct MockFields {
-        @Field<CustomScalar>("customScalar") public var customScalar
+        @Field<TestSchema.CustomScalar>("customScalar") public var customScalar
         @Field<Cat>("object") public var object
         @Field<[Cat]>("objectList") public var objectList
         @Field<[[Cat]]>("objectNestedList") public var objectNestedList
@@ -207,8 +207,8 @@ class MockObjectTemplateTests: XCTestCase {
 
     let expected = """
       public struct MockFields {
-        @Field<CustomScalar>("customScalar") public var customScalar
-        @Field<GraphQLEnum<EnumType>>("enumType") public var enumType
+        @Field<TestSchema.CustomScalar>("customScalar") public var customScalar
+        @Field<GraphQLEnum<TestSchema.EnumType>>("enumType") public var enumType
         @Field<Cat>("object") public var object
       }
     """
@@ -467,6 +467,7 @@ class MockObjectTemplateTests: XCTestCase {
       "unionList": .mock("unionList", type: .list(.nonNull(Pet))),
       "unionNestedList": .mock("unionNestedList", type: .list(.nonNull(.list(.nonNull(Pet))))),
       "unionOptionalList": .mock("unionOptionalList", type: .list(Pet)),
+      "enumType": .mock("enumType", type: .enum(.mock(name: "enumType"))),
     ]
 
     ir.fieldCollector.add(
@@ -481,7 +482,8 @@ class MockObjectTemplateTests: XCTestCase {
 
     public extension Mock where O == Dog {
       convenience init(
-        customScalar: CustomScalar? = nil,
+        customScalar: TestSchema.CustomScalar? = nil,
+        enumType: GraphQLEnum<TestSchema.EnumType>? = nil,
         interface: AnyMock? = nil,
         interfaceList: [AnyMock]? = nil,
         interfaceNestedList: [[AnyMock]]? = nil,
@@ -499,6 +501,7 @@ class MockObjectTemplateTests: XCTestCase {
       ) {
         self.init()
         self.customScalar = customScalar
+        self.enumType = enumType
         self.interface = interface
         self.interfaceList = interfaceList
         self.interfaceNestedList = interfaceNestedList


### PR DESCRIPTION
Fixes #2719 

* Refactors test mock field rendering to use the functions from #2757 
* All schema referenced types within test mocks now use a fully qualified namespace