### PR TITLE
fix: fields labeled `_`

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -38,7 +38,7 @@ extension String {
 enum SwiftKeywords {
 
   static let DisallowedFieldNames: Set<String> = [
-    "__data", "fragments", "_"
+    "__data", "fragments"
   ]
 
   static let DisallowedInputParameterNames: Set<String> = [
@@ -133,6 +133,7 @@ enum SwiftKeywords {
     "throws",
     "true",
     "try",
+    "_",
   ]
 
   fileprivate static let InputParameterNamesToEscape: Set<String> = FieldAccessorNamesToEscape

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -66,7 +66,8 @@ enum SwiftKeywords {
     "Float",
     "Double",
     "ID",
-    "Type"
+    "Type",
+    "_",
   ]
 
   /// When an interface or union named "Actor" is used as the type for a field on a test mock,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -1494,7 +1494,12 @@ class InputObjectTemplateTests: XCTestCase {
         "try",
         type: .nonNull(.string()),
         defaultValue: nil
-      )
+      ),
+      GraphQLInputField.mock(
+        "_",
+        type: .nonNull(.string()),
+        defaultValue: nil
+      ),
     ]
 
     buildSubject(fields: fields, config: .mock(schemaName: "TestSchema"))
@@ -1550,7 +1555,8 @@ class InputObjectTemplateTests: XCTestCase {
         `super`: String,
         `throws`: String,
         `true`: String,
-        `try`: String
+        `try`: String,
+        `_`: String
       ) {
         __data = InputDict([
           "associatedtype": `associatedtype`,
@@ -1602,7 +1608,8 @@ class InputObjectTemplateTests: XCTestCase {
           "super": `super`,
           "throws": `throws`,
           "true": `true`,
-          "try": `try`
+          "try": `try`,
+          "_": `_`
         ])
       }
 
@@ -1854,6 +1861,11 @@ class InputObjectTemplateTests: XCTestCase {
       public var `try`: String {
         get { __data["`try`"] }
         set { __data["`try`"] = newValue }
+      }
+
+      public var `_`: String {
+        get { __data["`_`"] }
+        set { __data["`_`"] = newValue }
       }
     """
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -975,6 +975,7 @@ class SelectionSetTemplateTests: XCTestCase {
       protocol: Animal!
       type: Animal!
       species: String!
+      _: Animal!
     }
     """
 
@@ -1029,6 +1030,9 @@ class SelectionSetTemplateTests: XCTestCase {
         type {
           species
         }
+        _ {
+          species
+        }
       }
     }
     """
@@ -1051,6 +1055,7 @@ class SelectionSetTemplateTests: XCTestCase {
         .field("any", Any_SelectionSet.self),
         .field("protocol", Protocol_SelectionSet.self),
         .field("type", Type_SelectionSet.self),
+        .field("_", __SelectionSet.self),
       ] }
     """
 

--- a/Tests/ApolloCodegenTests/Frontend/DocumentParsingAndValidationTests.swift
+++ b/Tests/ApolloCodegenTests/Frontend/DocumentParsingAndValidationTests.swift
@@ -191,7 +191,7 @@ class DocumentParsingAndValidationTests: XCTestCase {
   }
 
   func test__validateDocument__givenFieldNameDisallowed_throwsError() throws {
-    let disallowedFields = ["__data", "fragments", "Fragments", "_"]
+    let disallowedFields = ["__data", "fragments", "Fragments"]
 
     for field in disallowedFields {
       let schema = try codegenFrontend.loadSchema(


### PR DESCRIPTION
Fixes #2753 

This PR brings back the `_` character as an allowed field name. Removing it from `DisallowedFieldNames` and adding it to `FieldAccessorNamesToEscape` causes it to be escaped as expected in all property and initializer definitions.

_This functionality is dependent on #2759 being fixed too._