### PR TITLE
Add back mergeInFieldsFromFragmentSpreads option

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -491,10 +491,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  Defaults to `true`.
     public let pruneGeneratedFiles: Bool
 
-    /// Whether or not to merge in fields from fragment spreads.
-    ///
-    /// Defaults to `true`
-    public let mergeInFieldsFromFragmentSpreads: Bool
+    /// Fragment merging strategy determines how selections will be merged into the `SelectionSet` they are spread into.
+    /// Defaults to `mergeAllFragmentSpreads`
+    public let fragmentMergingStrategy: FragmentMergingStrategy
 
     /// Default property values
     public struct Default {
@@ -508,7 +507,20 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       public static let warningsOnDeprecatedUsage: Composition = .include
       public static let conversionStrategies: ConversionStrategies = .init()
       public static let pruneGeneratedFiles: Bool = true
-      public static let mergeInFieldsFromFragmentSpreads: Bool = true
+      public static let fragmentMergingStrategy: FragmentMergingStrategy = .mergeAllFragmentSpreads
+    }
+
+    public enum FragmentMergingStrategy: String, Codable, Equatable {
+      /// The default value.
+      /// Merges selections included from all fragments into the `SelectionSet` they are spread into.
+      case mergeAllFragmentSpreads
+
+      /// Does not merge selections included from **named or inline** fragment spreads
+      /// into the `SelectionSet` they are spread into.
+      /// Does not merges fragment accessors across child inline fragments.
+      ///
+      /// This generates completely flat models that reflect the shape of your operation/fragment definitions directly.
+      case mergeNone
     }
 
     /// Designated initializer.
@@ -542,7 +554,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       warningsOnDeprecatedUsage: Composition = Default.warningsOnDeprecatedUsage,
       conversionStrategies: ConversionStrategies = Default.conversionStrategies,
       pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles,
-      mergeInFieldsFromFragmentSpreads: Bool = Default.mergeInFieldsFromFragmentSpreads
+      fragmentMergingStrategy: FragmentMergingStrategy = Default.fragmentMergingStrategy
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
@@ -554,7 +566,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
       self.conversionStrategies = conversionStrategies
       self.pruneGeneratedFiles = pruneGeneratedFiles
-      self.mergeInFieldsFromFragmentSpreads = mergeInFieldsFromFragmentSpreads
+      self.fragmentMergingStrategy = fragmentMergingStrategy
     }
 
     // MARK: Codable
@@ -570,7 +582,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case warningsOnDeprecatedUsage
       case conversionStrategies
       case pruneGeneratedFiles
-      case mergeInFieldsFromFragmentSpreads
+      case fragmentMergingStrategy
     }
 
     public init(from decoder: Decoder) throws {
@@ -626,10 +638,10 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         forKey: .pruneGeneratedFiles
       ) ?? Default.pruneGeneratedFiles
 
-      mergeInFieldsFromFragmentSpreads = try values.decodeIfPresent(
-        Bool.self,
-        forKey: .mergeInFieldsFromFragmentSpreads
-      ) ?? Default.mergeInFieldsFromFragmentSpreads
+      fragmentMergingStrategy = try values.decodeIfPresent(
+        FragmentMergingStrategy.self,
+        forKey: .fragmentMergingStrategy
+      ) ?? Default.fragmentMergingStrategy
     }
   }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -491,6 +491,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  Defaults to `true`.
     public let pruneGeneratedFiles: Bool
 
+    /// Whether or not to merge in fields from fragment spreads.
+    ///
+    /// Defaults to `true`
+    public let mergeInFieldsFromFragmentSpreads: Bool
+
     /// Default property values
     public struct Default {
       public static let additionalInflectionRules: [InflectionRule] = []
@@ -503,6 +508,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       public static let warningsOnDeprecatedUsage: Composition = .include
       public static let conversionStrategies: ConversionStrategies = .init()
       public static let pruneGeneratedFiles: Bool = true
+      public static let mergeInFieldsFromFragmentSpreads: Bool = true
     }
 
     /// Designated initializer.
@@ -535,7 +541,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
       warningsOnDeprecatedUsage: Composition = Default.warningsOnDeprecatedUsage,
       conversionStrategies: ConversionStrategies = Default.conversionStrategies,
-      pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles
+      pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles,
+      mergeInFieldsFromFragmentSpreads: Bool = Default.mergeInFieldsFromFragmentSpreads
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.queryStringLiteralFormat = queryStringLiteralFormat
@@ -547,6 +554,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
       self.conversionStrategies = conversionStrategies
       self.pruneGeneratedFiles = pruneGeneratedFiles
+      self.mergeInFieldsFromFragmentSpreads = mergeInFieldsFromFragmentSpreads
     }
 
     // MARK: Codable
@@ -562,6 +570,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case warningsOnDeprecatedUsage
       case conversionStrategies
       case pruneGeneratedFiles
+      case mergeInFieldsFromFragmentSpreads
     }
 
     public init(from decoder: Decoder) throws {
@@ -616,6 +625,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         Bool.self,
         forKey: .pruneGeneratedFiles
       ) ?? Default.pruneGeneratedFiles
+
+      mergeInFieldsFromFragmentSpreads = try values.decodeIfPresent(
+        Bool.self,
+        forKey: .mergeInFieldsFromFragmentSpreads
+      ) ?? Default.mergeInFieldsFromFragmentSpreads
     }
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -298,7 +298,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.fields.values, {
       "\($0.map { FieldAccessorTemplate($0, in: scope) }, separator: "\n")"
       })
-    \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.fields.values.map { FieldAccessorTemplate($0, in: scope) }, separator: "\n")")
+    \(if: config.config.options.fragmentMergingStrategy == .mergeAllFragmentSpreads, "\(selections.merged.fields.values.map { FieldAccessorTemplate($0, in: scope) }, separator: "\n")")
     """
   }
 
@@ -331,7 +331,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.inlineFragments.values, {
         "\($0.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")"
       })
-    \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")")
+    \(if: config.config.options.fragmentMergingStrategy == .mergeAllFragmentSpreads, "\(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")")
     """
   }
 
@@ -367,7 +367,7 @@ struct SelectionSetTemplate {
       \(ifLet: selections.direct?.fragments.values, {
         "\($0.map { FragmentAccessorTemplate($0, in: scope) }, separator: "\n")"
         })
-      \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.fragments.values.map { FragmentAccessorTemplate($0, in: scope) }, separator: "\n")")
+      \(if: config.config.options.fragmentMergingStrategy == .mergeAllFragmentSpreads, "\(selections.merged.fragments.values.map { FragmentAccessorTemplate($0, in: scope) }, separator: "\n")")
     }
     """
   }
@@ -532,7 +532,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.inlineFragments.values, {
         "\($0.map { render(inlineFragment: $0) }, separator: "\n\n")"
       })
-    \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")")
+    \(if: config.config.options.fragmentMergingStrategy == .mergeAllFragmentSpreads, "\(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")")
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -298,7 +298,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.fields.values, {
       "\($0.map { FieldAccessorTemplate($0, in: scope) }, separator: "\n")"
       })
-    \(selections.merged.fields.values.map { FieldAccessorTemplate($0, in: scope) }, separator: "\n")
+    \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.fields.values.map { FieldAccessorTemplate($0, in: scope) }, separator: "\n")")
     """
   }
 
@@ -331,7 +331,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.inlineFragments.values, {
         "\($0.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")"
       })
-    \(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")
+    \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")")
     """
   }
 
@@ -367,9 +367,7 @@ struct SelectionSetTemplate {
       \(ifLet: selections.direct?.fragments.values, {
         "\($0.map { FragmentAccessorTemplate($0, in: scope) }, separator: "\n")"
         })
-      \(selections.merged.fragments.values.map {
-          FragmentAccessorTemplate($0, in: scope)
-        }, separator: "\n")
+      \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.fragments.values.map { FragmentAccessorTemplate($0, in: scope) }, separator: "\n")")
     }
     """
   }
@@ -534,8 +532,8 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.inlineFragments.values, {
         "\($0.map { render(inlineFragment: $0) }, separator: "\n\n")"
       })
-    \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")
-    """    
+    \(if: config.config.options.mergeInFieldsFromFragmentSpreads, "\(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")")
+    """
   }
 
 }
@@ -677,7 +675,7 @@ fileprivate extension IR.MergedSelections.MergedSource {
     if let fragmentNestedTypePath = rootEntityScopePath.next {
       let fieldPath = typeInfo.entity.location
         .fieldPath!
-        .head      
+        .head
 
       selectionSetNameComponents.append(
         SelectionSetNameGenerator.generatedSelectionSetName(
@@ -870,7 +868,7 @@ fileprivate extension IR.ScopeCondition {
     \(ifLet: conditions, { "If\($0.typeNameComponents)"})
     """).description
   }
-  
+
 }
 
 fileprivate extension AnyOf where T == IR.InclusionConditions {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -49,7 +49,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(enumCases: .none),
-          pruneGeneratedFiles: false
+          pruneGeneratedFiles: false,
+          mergeInFieldsFromFragmentSpreads: false
         ),
         experimentalFeatures: .init(
           clientControlledNullability: true,
@@ -88,6 +89,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "enumCases" : "none"
           },
           "deprecatedEnumCases" : "exclude",
+          "mergeInFieldsFromFragmentSpreads" : false,
           "pruneGeneratedFiles" : false,
           "queryStringLiteralFormat" : "singleLine",
           "schemaDocumentation" : "exclude",

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -50,7 +50,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(enumCases: .none),
           pruneGeneratedFiles: false,
-          mergeInFieldsFromFragmentSpreads: false
+          fragmentMergingStrategy: .mergeNone
         ),
         experimentalFeatures: .init(
           clientControlledNullability: true,
@@ -89,7 +89,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "enumCases" : "none"
           },
           "deprecatedEnumCases" : "exclude",
-          "mergeInFieldsFromFragmentSpreads" : false,
+          "fragmentMergingStrategy" : "mergeNone",
           "pruneGeneratedFiles" : false,
           "queryStringLiteralFormat" : "singleLine",
           "schemaDocumentation" : "exclude",

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -33,7 +33,7 @@ class SelectionSetTemplateTests: XCTestCase {
     schemaDocumentation: ApolloCodegenConfiguration.Composition = .exclude,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude,
     cocoapodsImportStatements: Bool = false,
-    mergeInFieldsFromFragmentSpreads: Bool = true
+    fragmentMergingStrategy: ApolloCodegenConfiguration.OutputOptions.FragmentMergingStrategy = .mergeAllFragmentSpreads
   ) throws {
     ir = try .mock(schema: schemaSDL, document: document)
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
@@ -46,7 +46,7 @@ class SelectionSetTemplateTests: XCTestCase {
         schemaDocumentation: schemaDocumentation,
         cocoapodsCompatibleImportStatements: cocoapodsImportStatements,
         warningsOnDeprecatedUsage: warningsOnDeprecatedUsage,
-        mergeInFieldsFromFragmentSpreads: mergeInFieldsFromFragmentSpreads
+        fragmentMergingStrategy: fragmentMergingStrategy
       )
     ))
     let mockTemplateRenderer = MockTemplateRenderer(
@@ -1487,7 +1487,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
-  func test__render_selections__givenMergeInFieldsFromFragmentSpreads_rendersBody() throws {
+  func test__render_selections__givenFragmentMergingStrategy_mergeAll_rendersBody() throws {
     // given
     schemaSDL = """
     type Query {
@@ -1541,7 +1541,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
-  func test__render_selections__givenMergeInFieldsFromFragmentSpreads_false_rendersBody() throws {
+  func test__render_selections__givenFragmentMergingStrategy_mergeNone_rendersBody() throws {
     // given
     schemaSDL = """
     type Query {
@@ -1581,7 +1581,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(mergeInFieldsFromFragmentSpreads: false)
+    try buildSubjectAndOperation(fragmentMergingStrategy: .mergeNone)
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )


### PR DESCRIPTION
Adding back the option to merge in fields from fragment spreads. This configuration option will allow a smaller code size for people who have a huge number of fragments.

This PR is still a draft because I want to add tests first but creating a PR for early review.

I know this feature has been planned for 1.3 but I still wanted to see if I can help speed up some parts of it.

Closes #2560