### PR TITLE
fix: Additional reserved keyword

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -114,6 +114,7 @@ enum SwiftKeywords {
     "do",
     "else",
     "fallthrough",
+    "for",
     "guard",
     "if",
     "in",

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -129,57 +129,7 @@ class EnumTemplateTests: XCTestCase {
 
         // Escaped keywords
         ("associatedtype", nil, nil),
-        ("class", nil, nil),
-        ("deinit", nil, nil),
-        ("enum", nil, nil),
-        ("extension", nil, nil),
-        ("fileprivate", nil, nil),
-        ("func", nil, nil),
-        ("import", nil, nil),
-        ("init", nil, nil),
-        ("inout", nil, nil),
-        ("internal", nil, nil),
-        ("let", nil, nil),
-        ("operator", nil, nil),
-        ("private", nil, nil),
-        ("precedencegroup", nil, nil),
-        ("protocol", nil, nil),
         ("Protocol", nil, nil),
-        ("public", nil, nil),
-        ("rethrows", nil, nil),
-        ("static", nil, nil),
-        ("struct", nil, nil),
-        ("subscript", nil, nil),
-        ("typealias", nil, nil),
-        ("var", nil, nil),
-        ("break", nil, nil),
-        ("case", nil, nil),
-        ("catch", nil, nil),
-        ("continue", nil, nil),
-        ("default", nil, nil),
-        ("defer", nil, nil),
-        ("do", nil, nil),
-        ("else", nil, nil),
-        ("fallthrough", nil, nil),
-        ("guard", nil, nil),
-        ("if", nil, nil),
-        ("in", nil, nil),
-        ("repeat", nil, nil),
-        ("return", nil, nil),
-        ("throw", nil, nil),
-        ("switch", nil, nil),
-        ("where", nil, nil),
-        ("while", nil, nil),
-        ("as", nil, nil),
-        ("false", nil, nil),
-        ("is", nil, nil),
-        ("nil", nil, nil),
-        ("self", nil, nil),
-        ("Self", nil, nil),
-        ("super", nil, nil),
-        ("throws", nil, nil),
-        ("true", nil, nil),
-        ("try", nil, nil),
       ],
       config: .mock(
         options: .init(conversionStrategies: .init(enumCases: .camelCase))
@@ -199,57 +149,7 @@ class EnumTemplateTests: XCTestCase {
       case upperCamelCase = "UpperCamelCase"
       case before2023 = "BEFORE2023"
       case `associatedtype` = "associatedtype"
-      case `class` = "class"
-      case `deinit` = "deinit"
-      case `enum` = "enum"
-      case `extension` = "extension"
-      case `fileprivate` = "fileprivate"
-      case `func` = "func"
-      case `import` = "import"
-      case `init` = "init"
-      case `inout` = "inout"
-      case `internal` = "internal"
-      case `let` = "let"
-      case `operator` = "operator"
-      case `private` = "private"
-      case `precedencegroup` = "precedencegroup"
-      case `protocol` = "protocol"
       case `protocol` = "Protocol"
-      case `public` = "public"
-      case `rethrows` = "rethrows"
-      case `static` = "static"
-      case `struct` = "struct"
-      case `subscript` = "subscript"
-      case `typealias` = "typealias"
-      case `var` = "var"
-      case `break` = "break"
-      case `case` = "case"
-      case `catch` = "catch"
-      case `continue` = "continue"
-      case `default` = "default"
-      case `defer` = "defer"
-      case `do` = "do"
-      case `else` = "else"
-      case `fallthrough` = "fallthrough"
-      case `guard` = "guard"
-      case `if` = "if"
-      case `in` = "in"
-      case `repeat` = "repeat"
-      case `return` = "return"
-      case `throw` = "throw"
-      case `switch` = "switch"
-      case `where` = "where"
-      case `while` = "while"
-      case `as` = "as"
-      case `false` = "false"
-      case `is` = "is"
-      case `nil` = "nil"
-      case `self` = "self"
-      case `self` = "Self"
-      case `super` = "super"
-      case `throws` = "throws"
-      case `true` = "true"
-      case `try` = "try"
     }
 
     """
@@ -280,57 +180,7 @@ class EnumTemplateTests: XCTestCase {
 
         // Escaped keywords
         ("associatedtype", nil, nil),
-        ("class", nil, nil),
-        ("deinit", nil, nil),
-        ("enum", nil, nil),
-        ("extension", nil, nil),
-        ("fileprivate", nil, nil),
-        ("func", nil, nil),
-        ("import", nil, nil),
-        ("init", nil, nil),
-        ("inout", nil, nil),
-        ("internal", nil, nil),
-        ("let", nil, nil),
-        ("operator", nil, nil),
-        ("private", nil, nil),
-        ("precedencegroup", nil, nil),
-        ("protocol", nil, nil),
         ("Protocol", nil, nil),
-        ("public", nil, nil),
-        ("rethrows", nil, nil),
-        ("static", nil, nil),
-        ("struct", nil, nil),
-        ("subscript", nil, nil),
-        ("typealias", nil, nil),
-        ("var", nil, nil),
-        ("break", nil, nil),
-        ("case", nil, nil),
-        ("catch", nil, nil),
-        ("continue", nil, nil),
-        ("default", nil, nil),
-        ("defer", nil, nil),
-        ("do", nil, nil),
-        ("else", nil, nil),
-        ("fallthrough", nil, nil),
-        ("guard", nil, nil),
-        ("if", nil, nil),
-        ("in", nil, nil),
-        ("repeat", nil, nil),
-        ("return", nil, nil),
-        ("throw", nil, nil),
-        ("switch", nil, nil),
-        ("where", nil, nil),
-        ("while", nil, nil),
-        ("as", nil, nil),
-        ("false", nil, nil),
-        ("is", nil, nil),
-        ("nil", nil, nil),
-        ("self", nil, nil),
-        ("Self", nil, nil),
-        ("super", nil, nil),
-        ("throws", nil, nil),
-        ("true", nil, nil),
-        ("try", nil, nil),
       ],
       config: .mock(
         options: .init(conversionStrategies: .init(enumCases: .none))
@@ -350,57 +200,7 @@ class EnumTemplateTests: XCTestCase {
       case UpperCamelCase
       case BEFORE2023
       case `associatedtype`
-      case `class`
-      case `deinit`
-      case `enum`
-      case `extension`
-      case `fileprivate`
-      case `func`
-      case `import`
-      case `init`
-      case `inout`
-      case `internal`
-      case `let`
-      case `operator`
-      case `private`
-      case `precedencegroup`
-      case `protocol`
       case `Protocol`
-      case `public`
-      case `rethrows`
-      case `static`
-      case `struct`
-      case `subscript`
-      case `typealias`
-      case `var`
-      case `break`
-      case `case`
-      case `catch`
-      case `continue`
-      case `default`
-      case `defer`
-      case `do`
-      case `else`
-      case `fallthrough`
-      case `guard`
-      case `if`
-      case `in`
-      case `repeat`
-      case `return`
-      case `throw`
-      case `switch`
-      case `where`
-      case `while`
-      case `as`
-      case `false`
-      case `is`
-      case `nil`
-      case `self`
-      case `Self`
-      case `super`
-      case `throws`
-      case `true`
-      case `try`
     }
     
     """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -1406,6 +1406,11 @@ class InputObjectTemplateTests: XCTestCase {
         defaultValue: nil
       ),
       GraphQLInputField.mock(
+        "for",
+        type: .nonNull(.string()),
+        defaultValue: nil
+      ),
+      GraphQLInputField.mock(
         "guard",
         type: .nonNull(.string()),
         defaultValue: nil
@@ -1533,6 +1538,7 @@ class InputObjectTemplateTests: XCTestCase {
         `do`: String,
         `else`: String,
         `fallthrough`: String,
+        `for`: String,
         `guard`: String,
         `if`: String,
         `in`: String,
@@ -1585,6 +1591,7 @@ class InputObjectTemplateTests: XCTestCase {
           "do": `do`,
           "else": `else`,
           "fallthrough": `fallthrough`,
+          "for": `for`,
           "guard": `guard`,
           "if": `if`,
           "in": `in`,
@@ -1764,6 +1771,11 @@ class InputObjectTemplateTests: XCTestCase {
       public var `fallthrough`: String {
         get { __data["`fallthrough`"] }
         set { __data["`fallthrough`"] = newValue }
+      }
+
+      public var `for`: String {
+        get { __data["`for`"] }
+        set { __data["`for`"] = newValue }
       }
 
       public var `guard`: String {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -257,6 +257,7 @@ class MockObjectTemplateTests: XCTestCase {
       "do": .mock("do", type: .nonNull(.string())),
       "else": .mock("else", type: .nonNull(.string())),
       "fallthrough": .mock("fallthrough", type: .nonNull(.string())),
+      "for": .mock("for", type: .nonNull(.string())),
       "guard": .mock("guard", type: .nonNull(.string())),
       "if": .mock("if", type: .nonNull(.string())),
       "in": .mock("in", type: .nonNull(.string())),
@@ -310,6 +311,7 @@ class MockObjectTemplateTests: XCTestCase {
         @Field<String>("fallthrough") public var `fallthrough`
         @Field<String>("false") public var `false`
         @Field<String>("fileprivate") public var `fileprivate`
+        @Field<String>("for") public var `for`
         @Field<String>("func") public var `func`
         @Field<String>("guard") public var `guard`
         @Field<String>("if") public var `if`
@@ -588,6 +590,7 @@ class MockObjectTemplateTests: XCTestCase {
       "do": .mock("do", type: .nonNull(.string())),
       "else": .mock("else", type: .nonNull(.string())),
       "fallthrough": .mock("fallthrough", type: .nonNull(.string())),
+      "for": .mock("for", type: .nonNull(.string())),
       "guard": .mock("guard", type: .nonNull(.string())),
       "if": .mock("if", type: .nonNull(.string())),
       "in": .mock("in", type: .nonNull(.string())),
@@ -644,6 +647,7 @@ class MockObjectTemplateTests: XCTestCase {
         `fallthrough`: String? = nil,
         `false`: String? = nil,
         `fileprivate`: String? = nil,
+        `for`: String? = nil,
         `func`: String? = nil,
         `guard`: String? = nil,
         `if`: String? = nil,
@@ -700,6 +704,7 @@ class MockObjectTemplateTests: XCTestCase {
         self.`fallthrough` = `fallthrough`
         self.`false` = `false`
         self.`fileprivate` = `fileprivate`
+        self.`for` = `for`
         self.`func` = `func`
         self.`guard` = `guard`
         self.`if` = `if`

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -471,6 +471,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       $fallthrough: String
       $false: String
       $fileprivate: String
+      $for: String
       $func: String
       $guard: String
       $if: String
@@ -529,6 +530,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       public var `fallthrough`: GraphQLNullable<String>
       public var `false`: GraphQLNullable<String>
       public var `fileprivate`: GraphQLNullable<String>
+      public var `for`: GraphQLNullable<String>
       public var `func`: GraphQLNullable<String>
       public var `guard`: GraphQLNullable<String>
       public var `if`: GraphQLNullable<String>
@@ -580,6 +582,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         `fallthrough`: GraphQLNullable<String>,
         `false`: GraphQLNullable<String>,
         `fileprivate`: GraphQLNullable<String>,
+        `for`: GraphQLNullable<String>,
         `func`: GraphQLNullable<String>,
         `guard`: GraphQLNullable<String>,
         `if`: GraphQLNullable<String>,
@@ -630,6 +633,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         self.`fallthrough` = `fallthrough`
         self.`false` = `false`
         self.`fileprivate` = `fileprivate`
+        self.`for` = `for`
         self.`func` = `func`
         self.`guard` = `guard`
         self.`if` = `if`
@@ -682,6 +686,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
         "fallthrough": `fallthrough`,
         "false": `false`,
         "fileprivate": `fileprivate`,
+        "for": `for`,
         "func": `func`,
         "guard": `guard`,
         "if": `if`,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -751,6 +751,7 @@ class SelectionSetTemplateTests: XCTestCase {
       do: String!
       else: String!
       fallthrough: String!
+      for: String!
       guard: String!
       if: String!
       in: String!
@@ -810,6 +811,7 @@ class SelectionSetTemplateTests: XCTestCase {
         do
         else
         fallthrough
+        for
         guard
         if
         in
@@ -869,6 +871,7 @@ class SelectionSetTemplateTests: XCTestCase {
         .field("do", String.self),
         .field("else", String.self),
         .field("fallthrough", String.self),
+        .field("for", String.self),
         .field("guard", String.self),
         .field("if", String.self),
         .field("in", String.self),
@@ -2126,6 +2129,7 @@ class SelectionSetTemplateTests: XCTestCase {
       do: String!
       else: String!
       fallthrough: String!
+      for: String!
       guard: String!
       if: String!
       in: String!
@@ -2185,6 +2189,7 @@ class SelectionSetTemplateTests: XCTestCase {
         do
         else
         fallthrough
+        for
         guard
         if
         in
@@ -2242,6 +2247,7 @@ class SelectionSetTemplateTests: XCTestCase {
       public var `do`: String { __data["do"] }
       public var `else`: String { __data["else"] }
       public var `fallthrough`: String { __data["fallthrough"] }
+      public var `for`: String { __data["for"] }
       public var `guard`: String { __data["guard"] }
       public var `if`: String { __data["if"] }
       public var `in`: String { __data["in"] }


### PR DESCRIPTION
Fixes #2765 

This PR simply adds `for` to the list of reserved keywords to escape in backticks.

_I looked through the [Apollo Tooling list](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-codegen-swift/src/language.ts#L43) and both `open` and `for` were missing from 1.0 but `open` is not an issue in the generated code._