### PR TITLE
Fix selection set value serialization when writing to cache

### DIFF
--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -306,7 +306,7 @@ public class ApolloStore {
       withKey key: CacheKey,
       variables: GraphQLOperation.Variables? = nil
     ) throws {
-      let normalizer = GraphQLResultNormalizer()
+      let normalizer = ResultNormalizerFactory.selectionSetDataNormalizer()
       let executor = GraphQLExecutor { object, info in
         return object[info.responseKeyForField]
       }

--- a/Sources/Apollo/GraphQLDependencyTracker.swift
+++ b/Sources/Apollo/GraphQLDependencyTracker.swift
@@ -9,6 +9,10 @@ final class GraphQLDependencyTracker: GraphQLResultAccumulator {
     dependentKeys.insert(info.cachePath.joined)
   }
 
+  func accept(customScalar: JSONValue, info: FieldExecutionInfo) {
+    dependentKeys.insert(info.cachePath.joined)
+  }
+
   func acceptNullValue(info: FieldExecutionInfo) {
     dependentKeys.insert(info.cachePath.joined)
   }

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -362,8 +362,11 @@ final class GraphQLExecutor {
                       asType: innerType,
                       accumulator: accumulator)
 
-    case .scalar, .customScalar:
+    case .scalar:
       return PossiblyDeferred { try accumulator.accept(scalar: value, info: fieldInfo) }
+
+    case .customScalar:
+      return PossiblyDeferred { try accumulator.accept(customScalar: value, info: fieldInfo) }
 
     case .list(let innerType):
       guard let array = value as? [JSONValue] else {

--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -23,7 +23,7 @@ public final class GraphQLResponse<Data: RootSelectionSet> {
   public func parseResult() throws -> (GraphQLResult<Data>, RecordSet?) {
     let accumulator = zip(
       GraphQLSelectionSetMapper<Data>(),
-      GraphQLResultNormalizer(),
+      ResultNormalizerFactory.networkResponseDataNormalizer(),
       GraphQLDependencyTracker()
     )
 

--- a/Sources/Apollo/GraphQLResultAccumulator.swift
+++ b/Sources/Apollo/GraphQLResultAccumulator.swift
@@ -9,6 +9,7 @@ protocol GraphQLResultAccumulator: AnyObject {
   associatedtype FinalResult
 
   func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult
+  func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult
   func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult
   func acceptMissingValue(info: FieldExecutionInfo) throws -> PartialResult
   func accept(list: [PartialResult], info: FieldExecutionInfo) throws -> PartialResult
@@ -45,6 +46,11 @@ final class Zip2Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2
   func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
     return (try accumulator1.accept(scalar: scalar, info: info),
             try accumulator2.accept(scalar: scalar, info: info))
+  }
+
+  func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
+    return (try accumulator1.accept(customScalar: customScalar, info: info),
+            try accumulator2.accept(customScalar: customScalar, info: info))
   }
 
   func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult {
@@ -108,6 +114,12 @@ final class Zip3Accumulator<Accumulator1: GraphQLResultAccumulator, Accumulator2
     return (try accumulator1.accept(scalar: scalar, info: info),
             try accumulator2.accept(scalar: scalar, info: info),
             try accumulator3.accept(scalar: scalar, info: info))
+  }
+
+  func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> PartialResult {
+    return (try accumulator1.accept(customScalar: customScalar, info: info),
+            try accumulator2.accept(customScalar: customScalar, info: info),
+            try accumulator3.accept(customScalar: customScalar, info: info))
   }
 
   func acceptNullValue(info: FieldExecutionInfo) throws -> PartialResult {

--- a/Sources/Apollo/GraphQLResultNormalizer.swift
+++ b/Sources/Apollo/GraphQLResultNormalizer.swift
@@ -3,35 +3,53 @@ import Foundation
 import ApolloAPI
 #endif
 
-final class GraphQLResultNormalizer: GraphQLResultAccumulator {
+struct ResultNormalizerFactory {
+  private init() {}
+
+  static func selectionSetDataNormalizer() -> SelectionSetDataResultNormalizer {
+    SelectionSetDataResultNormalizer()
+  }
+
+  static func networkResponseDataNormalizer() -> RawJSONResultNormalizer {
+    RawJSONResultNormalizer()
+  }
+}
+
+class BaseGraphQLResultNormalizer: GraphQLResultAccumulator {
   private var records: RecordSet = [:]
 
-  func accept(scalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
+  fileprivate init() {}
+
+  final func accept(scalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
     return scalar
   }
 
-  func acceptNullValue(info: FieldExecutionInfo) -> JSONValue? {
+  func accept(customScalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
+    return customScalar
+  }
+
+  final func acceptNullValue(info: FieldExecutionInfo) -> JSONValue? {
     return NSNull()
   }
 
-  func acceptMissingValue(info: FieldExecutionInfo) -> JSONValue? {
+  final func acceptMissingValue(info: FieldExecutionInfo) -> JSONValue? {
     return nil
   }
 
-  func accept(list: [JSONValue?], info: FieldExecutionInfo) -> JSONValue? {
+  final func accept(list: [JSONValue?], info: FieldExecutionInfo) -> JSONValue? {
     return list
   }
 
-  func accept(childObject: CacheReference, info: FieldExecutionInfo) -> JSONValue? {
+  final func accept(childObject: CacheReference, info: FieldExecutionInfo) -> JSONValue? {
     return childObject
   }
 
-  func accept(fieldEntry: JSONValue?, info: FieldExecutionInfo) -> (key: String, value: JSONValue)? {
+  final func accept(fieldEntry: JSONValue?, info: FieldExecutionInfo) -> (key: String, value: JSONValue)? {
     guard let fieldEntry else { return nil }
     return (info.cacheKeyForField, fieldEntry)
   }
 
-  func accept(
+  final func accept(
     fieldEntries: [(key: String, value: JSONValue)],
     info: ObjectExecutionInfo
   ) throws -> CacheReference {
@@ -39,11 +57,22 @@ final class GraphQLResultNormalizer: GraphQLResultAccumulator {
 
     let object = JSONObject(fieldEntries, uniquingKeysWith: { (_, last) in last })
     records.merge(record: Record(key: cachePath, object))
-    
+
     return CacheReference(cachePath)
   }
 
-  func finish(rootValue: CacheReference, info: ObjectExecutionInfo) throws -> RecordSet {
+  final func finish(rootValue: CacheReference, info: ObjectExecutionInfo) throws -> RecordSet {
     return records
+  }
+}
+
+final class RawJSONResultNormalizer: BaseGraphQLResultNormalizer {}
+
+final class SelectionSetDataResultNormalizer: BaseGraphQLResultNormalizer {
+  override final func accept(customScalar: JSONValue, info: FieldExecutionInfo) -> JSONValue? {
+    if let customScalar = customScalar as? JSONEncodable {
+      return customScalar._jsonValue
+    }
+    return customScalar
   }
 }

--- a/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -20,11 +20,21 @@ final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLRes
 
   func accept(scalar: JSONValue, info: FieldExecutionInfo) throws -> JSONValue? {
     switch info.field.type.namedType {
-    case let .scalar(decodable as any JSONDecodable.Type),
-      let .customScalar(decodable as any JSONDecodable.Type):
+    case let .scalar(decodable as any JSONDecodable.Type):
       // This will convert a JSON value to the expected value type,
       // which could be a custom scalar or an enum.
       return try decodable.init(_jsonValue: scalar)._asAnyHashable
+    default:
+      preconditionFailure()
+    }
+  }
+
+  func accept(customScalar: JSONValue, info: FieldExecutionInfo) throws -> JSONValue? {
+    switch info.field.type.namedType {
+    case let .customScalar(decodable as any JSONDecodable.Type):
+      // This will convert a JSON value to the expected value type,
+      // which could be a custom scalar or an enum.
+      return try decodable.init(_jsonValue: customScalar)._asAnyHashable
     default:
       preconditionFailure()
     }

--- a/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
@@ -26,7 +26,7 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
       on: object,
       withRootCacheReference: CacheReference.RootQuery,
       variables: variables,
-      accumulator: GraphQLResultNormalizer()
+      accumulator: ResultNormalizerFactory.networkResponseDataNormalizer()
     )
   }
 


### PR DESCRIPTION
Fixes #2775

When writing a SelectionSets data back into the cache, custom scalars need to re-encoded into their `_jsonValue`. Since we don't want to have to do this when writing network response data (which is already properly serialized JSON) we created a new normalizer and a factory to return the proper normalizer based on the data source.