### PR TITLE
fix: `DataDict` subscript crash on iOS <= `14.4`

### DIFF
--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -76,7 +76,7 @@ extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue 
     guard let fieldData = fieldData as? [AnyHashable?] else {
       fatalError("\(Self.self) expected list of data for entity.")
     }
-    self = fieldData.map { Element.init(fieldData:$0, variables: variables) }
+    self = fieldData.map { Element.init(fieldData:$0?.base as? AnyHashable, variables: variables) }
   }
 
   @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -13,7 +13,7 @@ public struct DataDict: Hashable {
   }
 
   @inlinable public subscript<T: AnyScalarType & Hashable>(_ key: String) -> T {
-    get { _data[key] as! T }
+    get { _data[key]?.base as! T }
     set { _data[key] = newValue }
     _modify {
       var value = _data[key] as! T

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -43,23 +43,23 @@ class JSONTests: XCTestCase {
   
   func testJSONDictionaryEncodingAndDecoding() throws {
     let jsonString = """
-{
-  "a_dict": {
-    "a_bool": true,
-    "another_dict" : {
-      "a_double": 23.1,
-      "an_int": 8,
-      "a_string": "LOL wat"
-    },
-    "an_array": [
-      "one",
-      "two",
-      "three"
-    ],
-    "a_null": null
-  }
-}
-"""
+      {
+        "a_dict": {
+          "a_bool": true,
+          "another_dict" : {
+            "a_double": 23.1,
+            "an_int": 8,
+            "a_string": "LOL wat"
+          },
+          "an_array": [
+            "one",
+            "two",
+            "three"
+          ],
+          "a_null": null
+        }
+      }
+      """
     let data = try XCTUnwrap(jsonString.data(using: .utf8))
     let json = try JSONSerializationFormat.deserialize(data: data)
     XCTAssertNotNil(json)
@@ -72,12 +72,12 @@ class JSONTests: XCTestCase {
     
     let stringFromReserialized = try XCTUnwrap(String(bytes: reserialized, encoding: .utf8))
     XCTAssertEqual(stringFromReserialized, """
-{"a_dict":{"a_bool":true,"a_null":null,"an_array":["one","two","three"],"another_dict":{"a_double":23.100000000000001,"a_string":"LOL wat","an_int":8}}}
-""")
+      {"a_dict":{"a_bool":true,"a_null":null,"an_array":["one","two","three"],"another_dict":{"a_double":23.100000000000001,"a_string":"LOL wat","an_int":8}}}
+      """)
   }
 
   func testEncodingNSNullDoesNotCrash() throws {
-    let nsNull = ["aWeirdNull": NSNull()]
+    let nsNull: JSONObject = ["aWeirdNull": NSNull()]
     let serialized = try JSONSerializationFormat.serialize(value: nsNull)
     let stringFromSerialized = try XCTUnwrap(String(data: serialized, encoding: .utf8))
 

--- a/Tests/ApolloTests/JSONTests.swift
+++ b/Tests/ApolloTests/JSONTests.swift
@@ -85,7 +85,7 @@ class JSONTests: XCTestCase {
   }
 
   func testEncodingOptionalNSNullDoesNotCrash() throws {
-    let optionalNSNull = ["aWeirdNull": Optional.some(NSNull())]
+    let optionalNSNull: JSONObject = ["aWeirdNull": Optional.some(NSNull())]
     let serialized = try JSONSerializationFormat.serialize(value: optionalNSNull as JSONObject)
     let stringFromSerialized = try XCTUnwrap(String(data: serialized, encoding: .utf8))
 
@@ -93,7 +93,7 @@ class JSONTests: XCTestCase {
   }
 
   func testEncodingDoubleOptionalsDoesNotCrash() throws {
-    let doubleOptional = ["aWeirdNull": Optional.some(Optional<Int>.none)]
+    let doubleOptional: JSONObject = ["aWeirdNull": Optional.some(Optional<Int>.none)]
     let serialized = try JSONSerializationFormat.serialize(value: doubleOptional as JSONObject)
     let stringFromSerialized = try XCTUnwrap(String(data: serialized, encoding: .utf8))
 

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -31,7 +31,7 @@ class SelectionSetTests: XCTestCase {
     expect(actual.name).to(equal("Johnny Tsunami"))
   }
 
-  func test__selection_givenOptionalField_givenNilValue__returnsNil() {
+  func test__selection_givenOptionalField_missingValue__returnsNil() {
     // given
     class Hero: MockSelectionSet, SelectionSet {
       typealias Schema = MockSchemaMetadata
@@ -46,6 +46,31 @@ class SelectionSetTests: XCTestCase {
 
     let object: JSONObject = [
       "__typename": "Human"
+    ]
+
+    // when
+    let actual = Hero(data: DataDict(object, variables: nil))
+
+    // then
+    expect(actual.name).to(beNil())
+  }
+
+  func test__selection_givenOptionalField_givenNilValue__returnsNil() {
+    // given
+    class Hero: MockSelectionSet, SelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __selections: [Selection] {[
+        .field("__typename", String.self),
+        .field("name", String?.self)
+      ]}
+
+      var name: String? { __data["name"] }
+    }
+
+    let object: JSONObject = [
+      "__typename": "Human",
+      "name": String?.none
     ]
 
     // when


### PR DESCRIPTION
Fixes #2668 

It seems that additional type checking was added in Swift `5.4` (correlated with Xcode `12.5` and iOS `14.5`) which handled the base type conversions/checks of `AnyHashable` for us. On iOS <= `14.4` accessing `DataDict` properties where the `AnyHashable` value is `nil` causes a crash. This change adds checks on the base type to prevent the crash.

I don't think there are any automated CI checks we can add to test this because of the [CircleCI supported environments](https://circleci.com/docs/testing-ios/#supported-xcode-versions):
* The [`14.2.0` image](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v10821/manifest.txt), which [we use](https://github.com/apollographql/apollo-ios/blob/main/.circleci/config.yml#L4) only has the iOS `15.5` and `16.1` runtimes. We would need to download the simulator before being able to run any tests and that will drastically increase CI times.
* The [`12.5.1` image](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v5775/index.html) does have iOS runtimes that would work (13.7 and 14.5) but our code would not compile on the older versions of Xcode and Swift.