### PR TITLE
Refactor EntitySelectionTree

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -146,7 +146,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public var feet: Int { __data["feet"] }
         public var inches: Int? { __data["inches"] }
-        public var meters: Int { __data["meters"] }
       }
 
       /// AllAnimal.Predator
@@ -287,7 +286,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var centimeters: Double? { __data["centimeters"] }
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsPet.AsWarmBlooded
@@ -331,9 +329,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }
@@ -380,9 +378,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -410,20 +408,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-        }
-
-        /// AllAnimal.AsClassroomPet.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: AnimalKingdomAPI.SelectionSet {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsClassroomPet.AsBird
@@ -468,9 +452,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -213,8 +213,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-        public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -235,44 +233,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
           public var meters: Int { __data["meters"] }
-        }
-
-        /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-        ///
-        /// Parent Type: `WarmBlooded`
-        public struct IfGetWarmBlooded: AnimalKingdomAPI.InlineFragment {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-            public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: AnimalKingdomAPI.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
-          }
         }
       }
 

--- a/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
@@ -357,7 +357,7 @@ extension IR {
     var debugDescription: String {
       """
       Fields: \(fields.values.elements)
-      Fragments: \(fragments.values.elements.map(\.definition.name))
+      Fragments: \(fragments.values.elements.debugDescription)
       """
     }
   }
@@ -635,11 +635,10 @@ extension IR.EntitySelectionTree: CustomDebugStringConvertible {
 extension IR.EntitySelectionTree.EnclosingEntityNode: CustomDebugStringConvertible {
   var debugDescription: String {
     TemplateString("""
-    {
-      child:
-        \(child?.debugDescription ?? "nil")
+    Entity Node: {
+      child: \(child?.debugDescription ?? "nil")
       conditionalScopes:
-        \(scopeConditions?.debugDescription ?? "[]")
+      \(scopeConditions?.description ?? "[]")
     }
     """).description
   }
@@ -648,11 +647,11 @@ extension IR.EntitySelectionTree.EnclosingEntityNode: CustomDebugStringConvertib
 extension IR.EntitySelectionTree.FieldScopeNode: CustomDebugStringConvertible {
   var debugDescription: String {
     TemplateString("""
-    {
-      selections:
-        \(selections.debugDescription)
+    Field Node: {
+      \(scope.debugDescription)
+      selections: \(selections.description)
       conditionalScopes:
-        \(scopeConditions?.debugDescription ?? "[]")
+      \(scopeConditions?.description ?? "[]")
     }
     """).description
   }

--- a/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
@@ -252,20 +252,6 @@ extension IR {
         }
       }
 
-//      fileprivate func childAsFieldScopeNode(scope: ScopeCondition) -> FieldScopeNode {
-//        guard let child = child else {
-//          let node = FieldScopeNode(scope: scope)
-//          self.child = .fieldScope(node)
-//          return node
-//        }
-//
-//        guard case let .fieldScope(child) = child, child.scope == scope else {
-//          fatalError()
-//        }
-//
-//        return child
-//      }
-
       fileprivate func scopeConditionNode(for condition: ScopeCondition) -> EnclosingEntityNode {
         let nodeCondition = ScopeCondition(
           type: condition.type == self.type ? nil : condition.type,
@@ -384,7 +370,6 @@ extension IR.EntitySelectionTree {
       otherTree,
       from: fragment,
       with: fragment.inclusionConditions,
-      withNodeRootType: rootEntityToStartMerge.type,
       using: entityStorage
     )    
   }
@@ -408,7 +393,6 @@ extension IR.EntitySelectionTree.EnclosingEntityNode {
     _ fragmentTree: IR.EntitySelectionTree,
     from fragment: IR.FragmentSpread,
     with inclusionConditions: AnyOf<IR.InclusionConditions>?,
-    withNodeRootType nodeRootType: GraphQLCompositeType, // TODO: Remove this param?
     using entityStorage: IR.RootFieldEntityStorage
   ) {
     let rootNodeToStartMerge = findOrCreate(
@@ -445,74 +429,7 @@ extension IR.EntitySelectionTree.EnclosingEntityNode {
         using: entityStorage
       )
     }
-
-//    default:
-//      self.mergeIn(
-//        fragmentTree,
-//        from: fragment,
-//        withNodeRootType: nodeRootType,
-//        using: entityStorage
-//      )
-//    }
   }
-//
-//  fileprivate func mergeIn(
-//    _ otherTree: IR.EntitySelectionTree,
-//    from fragment: IR.FragmentSpread,
-//    withNodeRootType nodeRootType: GraphQLCompositeType,
-//    using entityStorage: IR.RootFieldEntityStorage
-//  ) {
-//    let rootNode = otherTree.rootNode
-//    self.mergeIn(
-//      rootNode: rootNode,
-//      from: fragment,
-//      withNodeRootType: nodeRootType,
-//      using: entityStorage
-//    )
-//  }
-
-//  fileprivate func mergeIn(
-//    rootNode: IR.EntitySelectionTree.EnclosingEntityNode,
-//    from fragment: IR.FragmentSpread,
-//    withNodeRootType nodeRootType: GraphQLCompositeType,
-//    using entityStorage: IR.RootFieldEntityStorage
-//  ) {
-//    let fragmentType = fragment.typeInfo.parentType
-//    let rootTypesMatch = nodeRootType == fragmentType
-//    let nextEntityNode = rootTypesMatch ?
-//    self : self.scopeConditionNode(for: IR.ScopeCondition(type: fragmentType))
-//
-//    switch rootNode.child {
-//    case let .enclosingEntity(otherNextNode):
-//      let nextNode = nextEntityNode.childAsEnclosingEntityNode()
-//
-//      nextNode.mergeIn(
-//        otherNextNode,
-//        from: fragment,
-//        using: entityStorage
-//      )
-//
-//    case let .selections(treeSelections):
-//      let fieldNode = nextEntityNode.childAsFieldScopeNode(scope: IR.ScopeCondition(type: nodeRootType))
-//
-//      fieldNode.mergeIn(
-//        fragmentRootFieldNode: otherNextNode,
-//        from: fragment,
-//        withScopePath: fragment.typeInfo.scopePath.last.value.scopePath.head,
-//        using: entityStorage
-//      )
-//
-//    case .none:
-//      break
-//    }
-//
-//    if let otherConditions = rootNode.scopeConditions {
-//      for (otherCondition, otherNode) in otherConditions {
-//        let conditionNode = nextEntityNode.scopeConditionNode(for: otherCondition)
-//        conditionNode.mergeIn(otherNode, from: fragment, using: entityStorage)
-//      }
-//    }
-//  }
 
   fileprivate func mergeIn(
     _ otherNode: IR.EntitySelectionTree.EnclosingEntityNode,
@@ -529,8 +446,6 @@ extension IR.EntitySelectionTree.EnclosingEntityNode {
       )
 
     case let .selections(otherNodeSelections):
-//      let nextNode = self.childAsFieldScopeNode(scope: otherNode.scope)
-
       self.mergeIn(
         otherNodeSelections,
         from: fragment,
@@ -606,103 +521,9 @@ extension IR.EntitySelectionTree.EnclosingEntityNode {
         from: newSource
       )
     }
-
-//    if let otherConditions = otherNode.scopeConditions {
-//      for (otherCondition, otherNode) in otherConditions {
-//        let conditionNode = self.scopeConditionNode(for: otherCondition)
-//        conditionNode.mergeIn(otherNode, from: fragment, using: entityStorage)
-//      }
-//    }
   }
 
 }
-
-//extension IR.EntitySelectionTree.FieldScopeNode {
-//
-//  fileprivate func mergeIn(
-//    fragmentRootFieldNode otherNode: IR.EntitySelectionTree.FieldScopeNode,
-//    from fragment: IR.FragmentSpread,
-//    withScopePath fragmentScopePath: LinkedList<IR.ScopeCondition>.Node,
-//    using entityStorage: IR.RootFieldEntityStorage
-//  ) {
-//    guard let nextFragmentScope = fragmentScopePath.next else {
-//      // Merge fragment entity tree in at current scope.
-//      mergeIn(
-//        otherNode,
-//        from: fragment,
-//        using: entityStorage
-//      )
-//      return
-//    }
-//
-//    let nextFieldNode = self.scopeConditionNode(for: nextFragmentScope.value)
-//    nextFieldNode.mergeIn(
-//      fragmentRootFieldNode: otherNode,
-//      from: fragment,
-//      withScopePath: nextFragmentScope,
-//      using: entityStorage
-//    )
-//  }
-//
-//  fileprivate func mergeIn(
-//    _ otherNode: IR.EntitySelectionTree.FieldScopeNode,
-//    from fragment: IR.FragmentSpread,
-//    using entityStorage: IR.RootFieldEntityStorage
-//  ) {
-//    for (source, selections) in otherNode.selections {
-//      let newSource = source.fragment != nil ?
-//      source :
-//      IR.MergedSelections.MergedSource(
-//        typeInfo: source.typeInfo, fragment: fragment.fragment
-//      )
-//
-//      let fields = selections.fields.mapValues { oldField -> IR.Field in
-//        if let oldField = oldField as? IR.EntityField {
-//          let entity = entityStorage.entity(
-//            for: oldField.entity,
-//            inFragmentSpreadAtTypePath: fragment.typeInfo
-//          )
-//
-//          return IR.EntityField(
-//            oldField.underlyingField,
-//            inclusionConditions: oldField.inclusionConditions,
-//            selectionSet: IR.SelectionSet(
-//              entity: entity,
-//              scopePath: oldField.selectionSet.scopePath,
-//              mergedSelectionsOnly: true)
-//          )
-//
-//        } else {
-//          return oldField
-//        }
-//      }
-//
-//      let fragments = selections.fragments.mapValues { oldFragment -> IR.FragmentSpread in
-//        let entity = entityStorage.entity(
-//          for: oldFragment.typeInfo.entity,
-//          inFragmentSpreadAtTypePath: fragment.typeInfo
-//        )
-//        return IR.FragmentSpread(
-//          fragment: oldFragment.fragment,
-//          typeInfo: IR.SelectionSet.TypeInfo(
-//            entity: entity,
-//            scopePath: oldFragment.typeInfo.scopePath
-//          ),
-//          inclusionConditions: oldFragment.inclusionConditions
-//        )
-//      }
-//      self.selections[newSource] = IR.EntityTreeScopeSelections(fields: fields, fragments: fragments)
-//    }
-//
-//    if let otherConditions = otherNode.scopeConditions {
-//      for (otherCondition, otherNode) in otherConditions {
-//        let conditionNode = self.scopeConditionNode(for: otherCondition)
-//        conditionNode.mergeIn(otherNode, from: fragment, using: entityStorage)
-//      }
-//    }
-//  }
-//
-//}
 
 // MARK: - CustomDebugStringConvertible
 

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -132,7 +132,7 @@ extension IR {
       addSelections(from: selectionSet, to: target, atTypePath: typeInfo)
 
       typeInfo.entity.selectionTree.mergeIn(
-        selections: target,
+        selections: target.readOnlyView,
         with: typeInfo
       )
     }

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -7,13 +7,7 @@ extension IR {
     let type: GraphQLCompositeType?
     let conditions: InclusionConditions?
 
-    init(type: GraphQLCompositeType, conditions: InclusionConditions? = nil) {
-      self.type = type
-      self.conditions = conditions
-    }
-
-    @_disfavoredOverload
-    init(type: GraphQLCompositeType? = nil, conditions: InclusionConditions) {
+    init(type: GraphQLCompositeType? = nil, conditions: InclusionConditions? = nil) {
       self.type = type
       self.conditions = conditions
     }

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -7,7 +7,13 @@ extension IR {
     let type: GraphQLCompositeType?
     let conditions: InclusionConditions?
 
-    init(type: GraphQLCompositeType? = nil, conditions: InclusionConditions? = nil) {
+    init(type: GraphQLCompositeType, conditions: InclusionConditions? = nil) {
+      self.type = type
+      self.conditions = conditions
+    }
+
+    @_disfavoredOverload
+    init(type: GraphQLCompositeType? = nil, conditions: InclusionConditions) {
       self.type = type
       self.conditions = conditions
     }
@@ -49,7 +55,7 @@ extension IR {
     ///   }
     /// }
     /// ```
-    /// The typePath for the `SelectionSet` that includes field `fieldOnABC` would be:
+    /// The scopePath for the `SelectionSet` that includes field `fieldOnABC` would be:
     /// `[A, B, C]`.
     let scopePath: LinkedList<ScopeCondition>
 

--- a/Sources/ApolloCodegenLib/IR/SortedSelections.swift
+++ b/Sources/ApolloCodegenLib/IR/SortedSelections.swift
@@ -271,7 +271,7 @@ extension IR {
       typeInfo: SelectionSet.TypeInfo
     ) {
       self.directSelections = directSelections
-      self.typeInfo = typeInfo      
+      self.typeInfo = typeInfo
     }
 
     func mergeIn(_ selections: EntityTreeScopeSelections, from source: MergedSource) {

--- a/Sources/ApolloCodegenLib/IR/SortedSelections.swift
+++ b/Sources/ApolloCodegenLib/IR/SortedSelections.swift
@@ -274,20 +274,6 @@ extension IR {
       self.typeInfo = typeInfo      
     }
 
-    private func createConditionalSelectionSetsForConditionalFragmentSpreads(
-      in directSelections: DirectSelections.ReadOnly?
-    ) {
-      directSelections?.fragments.values.forEach { fragment in
-        if let anyOfConditions = fragment.inclusionConditions {
-          for conditions in anyOfConditions.elements {
-            createShallowlyMergedInlineFragmentIfNeeded(
-              with: ScopeCondition(conditions: conditions)
-            )
-          }
-        }
-      }
-    }
-
     func mergeIn(_ selections: EntityTreeScopeSelections, from source: MergedSource) {
       @IsEverTrue var didMergeAnySelections: Bool
 

--- a/Sources/ApolloCodegenLib/IR/SortedSelections.swift
+++ b/Sources/ApolloCodegenLib/IR/SortedSelections.swift
@@ -271,9 +271,7 @@ extension IR {
       typeInfo: SelectionSet.TypeInfo
     ) {
       self.directSelections = directSelections
-      self.typeInfo = typeInfo
-
-      createConditionalSelectionSetsForConditionalFragmentSpreads(in: directSelections)
+      self.typeInfo = typeInfo      
     }
 
     private func createConditionalSelectionSetsForConditionalFragmentSpreads(

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -63,8 +63,6 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
 
       /// The movies this character appears in
       public var appearsIn: [GraphQLEnum<StarWarsAPI.Episode>?] { __data["appearsIn"] }
-      /// The name of the character
-      public var name: String { __data["name"] }
     }
   }
 

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
@@ -2536,6 +2536,8 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
       allAnimals[field: "child"] as? IR.EntityField
     )
 
+    let allAnimals_asWarmBloodedIfC = allAnimals[as: "WarmBlooded", if: "c"]
+
     let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
     let Interface_WarmBlooded = try XCTUnwrap(schema[interface: "WarmBlooded"])
     let Object_Child = try XCTUnwrap(schema[object: "Child"])
@@ -2639,7 +2641,7 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
     expect(allAnimals[if: !"b"]).to(shallowlyMatch(expected_allAnimals_ifB))
     expect(allAnimals[if: !"b"]?[field: "child"]?.selectionSet)
       .to(shallowlyMatch(expected_allAnimals_ifB_child))
-    expect(allAnimals[as: "WarmBlooded", if: "c"]).to(shallowlyMatch(expected_allAnimals_ifWarmBloodedAndC))
+    expect(allAnimals_asWarmBloodedIfC).to(shallowlyMatch(expected_allAnimals_ifWarmBloodedAndC))
     expect(allAnimals[as: "WarmBlooded", if: "c"]?[field: "child"]?.selectionSet)
       .to(shallowlyMatch(expected_allAnimals_ifWarmBloodedAndC_child))
   }

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
@@ -2537,30 +2537,29 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
     )
 
     let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
+    let Interface_WarmBlooded = try XCTUnwrap(schema[interface: "WarmBlooded"])
     let Object_Child = try XCTUnwrap(schema[object: "Child"])
     let ChildFragment = try XCTUnwrap(allAnimals[fragment: "ChildFragment"])
     let FragmentContainingChildFragment = try XCTUnwrap(
       allAnimals[as: "WarmBlooded", if: "c"]?[fragment: "FragmentContainingChildFragment"]
     )
 
-//    let expected_allAnimals = SelectionSetMatcher(
-//      parentType: Interface_Animal,
-//      inclusionConditions: nil,
-//      directSelections: [
-//        .field("child", type: .nonNull(.entity(Object_Child))),
-//        .fragmentSpread(ChildFragment.definition,
-//                        inclusionConditions: [.skip(if: "b")]),
-//        .fragmentSpread(FragmentContainingChildFragment.definition,
-//                        inclusionConditions: [.include(if: "c")])
-//      ],
-//      mergedSelections: [
-//        .inlineFragment(parentType: Interface_Animal,
-//                        inclusionConditions: [.skip(if: "b")]),
-//        .inlineFragment(parentType: Interface_Animal,
-//                        inclusionConditions: [.include(if: "c")])
-//      ],
-//      mergedSources: []
-//    )
+    let expected_allAnimals = SelectionSetMatcher(
+      parentType: Interface_Animal,
+      inclusionConditions: nil,
+      directSelections: [
+        .field("child", type: .nonNull(.entity(Object_Child))),
+        .inlineFragment(parentType: Interface_WarmBlooded,
+                        inclusionConditions: [.include(if: "c")]),
+        .fragmentSpread(ChildFragment.definition,
+                        inclusionConditions: [.skip(if: "b")]),
+      ],
+      mergedSelections: [
+        .inlineFragment(parentType: Interface_Animal,
+                        inclusionConditions: [.skip(if: "b")]),
+      ],
+      mergedSources: []
+    )
 
     let expected_allAnimals_child = SelectionSetMatcher(
       parentType: Object_Child,
@@ -2572,83 +2571,77 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
       mergedSources: []
     )
 
-//    let expected_allAnimals_ifB = try SelectionSetMatcher(
-//      parentType: Interface_Animal,
-//      inclusionConditions: [.skip(if: "b")],
-//      directSelections: nil,
-//      mergedSelections: [
-//        .field("child", type: .nonNull(.entity(Object_Child))),
-//        .fragmentSpread(ChildFragment.definition,
-//                        inclusionConditions: [.skip(if: "b")]),
-//        .fragmentSpread(FragmentContainingChildFragment.definition,
-//                        inclusionConditions: [.include(if: "c")])
-//      ],
-//      mergedSources: [
-//        .mock(allAnimals),
-//        .mock(for: ChildFragment.fragment.rootField,
-//              from: ChildFragment),
-//      ]
-//    )
-//
-//    let expected_allAnimals_ifB_child = try SelectionSetMatcher(
-//      parentType: Object_Child,
-//      inclusionConditions: nil,
-//      directSelections: nil,
-//      mergedSelections: [
-//        .field("a", type: .nonNull(.scalar(.string()))),
-//        .field("b", type: .nonNull(.scalar(.string()))),
-//      ],
-//      mergedSources: [
-//        .mock(allAnimals[field: "child"]),
-//        .mock(for: ChildFragment.fragment[field: "child"],
-//              from: ChildFragment),
-//      ]
-//    )
-//
-//
-//    let expected_allAnimals_ifC = try SelectionSetMatcher(
-//      parentType: Interface_Animal,
-//      inclusionConditions: [.include(if: "c")],
-//      directSelections: nil,
-//      mergedSelections: [
-//        .field("child", type: .nonNull(.entity(Object_Child))),
-//        .fragmentSpread(ChildFragment.definition),
-//        .fragmentSpread(FragmentContainingChildFragment.definition,
-//                        inclusionConditions: [.include(if: "c")]),
-//      ],
-//      mergedSources: [
-//        .mock(allAnimals),
-//        .mock(for: FragmentContainingChildFragment.fragment.rootField,
-//              from: FragmentContainingChildFragment),
-//        .mock(for: ChildFragment.fragment.rootField,
-//              from: ChildFragment),
-//      ]
-//    )
-//
-//    let expected_allAnimals_ifC_child = try SelectionSetMatcher(
-//      parentType: Object_Child,
-//      inclusionConditions: nil,
-//      directSelections: nil,
-//      mergedSelections: [
-//        .field("a", type: .nonNull(.scalar(.string()))),
-//        .field("b", type: .nonNull(.scalar(.string()))),
-//      ],
-//      mergedSources: [
-//        .mock(allAnimals[field: "child"]),
-//        .mock(for: ChildFragment.fragment[field: "child"],
-//              from: ChildFragment),
-//      ]
-//    )
+    let expected_allAnimals_ifB = try SelectionSetMatcher(
+      parentType: Interface_Animal,
+      inclusionConditions: [.skip(if: "b")],
+      directSelections: nil,
+      mergedSelections: [
+        .field("child", type: .nonNull(.entity(Object_Child))),
+        .fragmentSpread(ChildFragment.definition,
+                        inclusionConditions: [.skip(if: "b")])
+      ],
+      mergedSources: [
+        .mock(allAnimals),
+        .mock(for: ChildFragment.fragment.rootField,
+              from: ChildFragment),
+      ]
+    )
+
+    let expected_allAnimals_ifB_child = try SelectionSetMatcher(
+      parentType: Object_Child,
+      inclusionConditions: nil,
+      directSelections: nil,
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+        .field("b", type: .nonNull(.scalar(.string()))),
+      ],
+      mergedSources: [
+        .mock(allAnimals[field: "child"]),
+        .mock(for: ChildFragment.fragment[field: "child"],
+              from: ChildFragment),
+      ]
+    )
+
+    let expected_allAnimals_ifWarmBloodedAndC = try SelectionSetMatcher(
+      parentType: Interface_WarmBlooded,
+      inclusionConditions: [.include(if: "c")],
+      directSelections: [
+        .fragmentSpread(FragmentContainingChildFragment.definition,
+                        inclusionConditions: [.include(if: "c")]),
+      ],
+      mergedSelections: [
+        .field("child", type: .nonNull(.entity(Object_Child))),
+        .fragmentSpread(ChildFragment.definition, inclusionConditions: [.skip(if: "b")]),
+      ],
+      mergedSources: [
+        .mock(allAnimals)
+      ]
+    )
+
+    let expected_allAnimals_ifWarmBloodedAndC_child = try SelectionSetMatcher(
+      parentType: Object_Child,
+      inclusionConditions: nil,
+      directSelections: nil,
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+        .field("b", type: .nonNull(.scalar(.string()))),
+      ],
+      mergedSources: [
+        .mock(allAnimals[field: "child"]),
+        .mock(for: ChildFragment.fragment[field: "child"],
+              from: ChildFragment),
+      ]
+    )
 
     // then
-//    expect(allAnimals.selectionSet).to(shallowlyMatch(expected_allAnimals))
+    expect(allAnimals.selectionSet).to(shallowlyMatch(expected_allAnimals))
     expect(allAnimals_child.selectionSet).to(shallowlyMatch(expected_allAnimals_child))
-//    expect(allAnimals[if: !"b"]).to(shallowlyMatch(expected_allAnimals_ifB))
-//    expect(allAnimals[if: !"b"]?[field: "child"]?.selectionSet)
-//      .to(shallowlyMatch(expected_allAnimals_ifB_child))
-//    expect(allAnimals[if: "c"]).to(shallowlyMatch(expected_allAnimals_ifC))
-//    expect(allAnimals[if: "c"]?[field: "child"]?.selectionSet)
-//      .to(shallowlyMatch(expected_allAnimals_ifC_child))
+    expect(allAnimals[if: !"b"]).to(shallowlyMatch(expected_allAnimals_ifB))
+    expect(allAnimals[if: !"b"]?[field: "child"]?.selectionSet)
+      .to(shallowlyMatch(expected_allAnimals_ifB_child))
+    expect(allAnimals[as: "WarmBlooded", if: "c"]).to(shallowlyMatch(expected_allAnimals_ifWarmBloodedAndC))
+    expect(allAnimals[as: "WarmBlooded", if: "c"]?[field: "child"]?.selectionSet)
+      .to(shallowlyMatch(expected_allAnimals_ifWarmBloodedAndC_child))
   }
 
   // MARK: - Group By Inclusion Conditions

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -4210,7 +4210,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
   }
 
   func test__render_fragmentAccessor__givenFragmentOnSameTypeWithInclusionConditionThatPartiallyMatchesScope_rendersFragmentAccessorAsOptionalWithConditions() throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -4210,7 +4210,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
   }
 
   func test__render_fragmentAccessor__givenFragmentOnSameTypeWithInclusionConditionThatPartiallyMatchesScope_rendersFragmentAccessorAsOptionalWithConditions() throws {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -153,7 +153,6 @@ public extension MyGraphQLSchema {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.Predator
@@ -220,8 +219,6 @@ public extension MyGraphQLSchema {
           public var predators: [Predator] { __data["predators"] }
           public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-          public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
@@ -242,44 +239,6 @@ public extension MyGraphQLSchema {
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
             public var meters: Int { __data["meters"] }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-          ///
-          /// Parent Type: `WarmBlooded`
-          public struct IfGetWarmBlooded: MyGraphQLSchema.InlineFragment {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
-
-            public var height: Height { __data["height"] }
-            public var species: String? { __data["species"] }
-            public var skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? { __data["skinCovering"] }
-            public var predators: [Predator] { __data["predators"] }
-            public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-            public struct Fragments: FragmentContainer {
-              public let __data: DataDict
-              public init(data: DataDict) { __data = data }
-
-              public var heightInMeters: HeightInMeters { _toFragment() }
-              public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-            }
-
-            /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-            ///
-            /// Parent Type: `Height`
-            public struct Height: MyGraphQLSchema.SelectionSet {
-              public let __data: DataDict
-              public init(data: DataDict) { __data = data }
-
-              public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
-
-              public var feet: Int { __data["feet"] }
-              public var inches: Int? { __data["inches"] }
-              public var meters: Int { __data["meters"] }
-            }
           }
         }
 
@@ -334,7 +293,6 @@ public extension MyGraphQLSchema {
             public var centimeters: Double? { __data["centimeters"] }
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
           }
 
           /// AllAnimal.AsPet.AsWarmBlooded
@@ -378,9 +336,9 @@ public extension MyGraphQLSchema {
 
               public var feet: Int { __data["feet"] }
               public var inches: Int? { __data["inches"] }
-              public var meters: Int { __data["meters"] }
               public var relativeSize: GraphQLEnum<MyGraphQLSchema.RelativeSize>? { __data["relativeSize"] }
               public var centimeters: Double? { __data["centimeters"] }
+              public var meters: Int { __data["meters"] }
             }
           }
         }
@@ -427,9 +385,9 @@ public extension MyGraphQLSchema {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<MyGraphQLSchema.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
 
@@ -457,20 +415,6 @@ public extension MyGraphQLSchema {
             public init(data: DataDict) { __data = data }
 
             public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-          }
-
-          /// AllAnimal.AsClassroomPet.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: MyGraphQLSchema.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
           }
 
           /// AllAnimal.AsClassroomPet.AsBird
@@ -515,9 +459,9 @@ public extension MyGraphQLSchema {
 
               public var feet: Int { __data["feet"] }
               public var inches: Int? { __data["inches"] }
-              public var meters: Int { __data["meters"] }
               public var relativeSize: GraphQLEnum<MyGraphQLSchema.RelativeSize>? { __data["relativeSize"] }
               public var centimeters: Double? { __data["centimeters"] }
+              public var meters: Int { __data["meters"] }
             }
           }
         }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -153,7 +153,6 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public var feet: Int { __data["feet"] }
         public var inches: Int? { __data["inches"] }
-        public var meters: Int { __data["meters"] }
       }
 
       /// AllAnimal.Predator
@@ -220,8 +219,6 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-        public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -242,44 +239,6 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
           public var meters: Int { __data["meters"] }
-        }
-
-        /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-        ///
-        /// Parent Type: `WarmBlooded`
-        public struct IfGetWarmBlooded: MySchemaModule.InlineFragment {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-            public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: MySchemaModule.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
-          }
         }
       }
 
@@ -334,7 +293,6 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var centimeters: Double? { __data["centimeters"] }
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsPet.AsWarmBlooded
@@ -378,9 +336,9 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<MySchemaModule.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }
@@ -427,9 +385,9 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<MySchemaModule.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -457,20 +415,6 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-        }
-
-        /// AllAnimal.AsClassroomPet.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: MySchemaModule.SelectionSet {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsClassroomPet.AsBird
@@ -515,9 +459,9 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<MySchemaModule.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -146,7 +146,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public var feet: Int { __data["feet"] }
         public var inches: Int? { __data["inches"] }
-        public var meters: Int { __data["meters"] }
       }
 
       /// AllAnimal.Predator
@@ -213,8 +212,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-        public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -235,44 +232,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
           public var meters: Int { __data["meters"] }
-        }
-
-        /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-        ///
-        /// Parent Type: `WarmBlooded`
-        public struct IfGetWarmBlooded: MyCustomProject.InlineFragment {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-            public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: MyCustomProject.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
-          }
         }
       }
 
@@ -327,7 +286,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var centimeters: Double? { __data["centimeters"] }
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsPet.AsWarmBlooded
@@ -371,9 +329,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<MyCustomProject.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }
@@ -420,9 +378,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<MyCustomProject.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -450,20 +408,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-        }
-
-        /// AllAnimal.AsClassroomPet.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: MyCustomProject.SelectionSet {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsClassroomPet.AsBird
@@ -508,9 +452,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<MyCustomProject.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -152,7 +152,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public var feet: Int { __data["feet"] }
         public var inches: Int? { __data["inches"] }
-        public var meters: Int { __data["meters"] }
       }
 
       /// AllAnimal.Predator
@@ -219,8 +218,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-        public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -241,44 +238,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
           public var meters: Int { __data["meters"] }
-        }
-
-        /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-        ///
-        /// Parent Type: `WarmBlooded`
-        public struct IfGetWarmBlooded: GraphQLAPI.InlineFragment {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-            public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: GraphQLAPI.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
-          }
         }
       }
 
@@ -333,7 +292,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var centimeters: Double? { __data["centimeters"] }
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsPet.AsWarmBlooded
@@ -377,9 +335,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<GraphQLAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }
@@ -426,9 +384,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<GraphQLAPI.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -456,20 +414,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-        }
-
-        /// AllAnimal.AsClassroomPet.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: GraphQLAPI.SelectionSet {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsClassroomPet.AsBird
@@ -514,9 +458,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<GraphQLAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -152,7 +152,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public var feet: Int { __data["feet"] }
         public var inches: Int? { __data["inches"] }
-        public var meters: Int { __data["meters"] }
       }
 
       /// AllAnimal.Predator
@@ -219,8 +218,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-        public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -241,44 +238,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
           public var meters: Int { __data["meters"] }
-        }
-
-        /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-        ///
-        /// Parent Type: `WarmBlooded`
-        public struct IfGetWarmBlooded: AnimalKingdomAPI.InlineFragment {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-            public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: AnimalKingdomAPI.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
-          }
         }
       }
 
@@ -333,7 +292,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var centimeters: Double? { __data["centimeters"] }
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsPet.AsWarmBlooded
@@ -377,9 +335,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }
@@ -426,9 +384,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -456,20 +414,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-        }
-
-        /// AllAnimal.AsClassroomPet.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: AnimalKingdomAPI.SelectionSet {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsClassroomPet.AsBird
@@ -514,9 +458,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<AnimalKingdomAPI.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/SwiftPackageManager/Packages/GraphQLSchemaName/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SwiftPackageManager/Packages/GraphQLSchemaName/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -152,7 +152,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public var feet: Int { __data["feet"] }
         public var inches: Int? { __data["inches"] }
-        public var meters: Int { __data["meters"] }
       }
 
       /// AllAnimal.Predator
@@ -219,8 +218,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-        public var ifGetWarmBlooded: IfGetWarmBlooded? { _asInlineFragment(if: "getWarmBlooded") }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -241,44 +238,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
           public var meters: Int { __data["meters"] }
-        }
-
-        /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded
-        ///
-        /// Parent Type: `WarmBlooded`
-        public struct IfGetWarmBlooded: GraphQLSchemaName.InlineFragment {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphQLSchemaName.Interfaces.WarmBlooded }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<GraphQLSchemaName.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-          public var bodyTemperature: Int { __data["bodyTemperature"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-            public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
-          }
-
-          /// AllAnimal.AsWarmBlooded.IfGetWarmBlooded.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: GraphQLSchemaName.SelectionSet {
-            public let __data: DataDict
-            public init(data: DataDict) { __data = data }
-
-            public static var __parentType: ApolloAPI.ParentType { GraphQLSchemaName.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
-          }
         }
       }
 
@@ -333,7 +292,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public var centimeters: Double? { __data["centimeters"] }
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsPet.AsWarmBlooded
@@ -377,9 +335,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<GraphQLSchemaName.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }
@@ -426,9 +384,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public var feet: Int { __data["feet"] }
           public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
           public var relativeSize: GraphQLEnum<GraphQLSchemaName.RelativeSize>? { __data["relativeSize"] }
           public var centimeters: Double? { __data["centimeters"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -456,20 +414,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public init(data: DataDict) { __data = data }
 
           public var heightInMeters: HeightInMeters? { _toFragment(if: !"skipHeightInMeters") }
-        }
-
-        /// AllAnimal.AsClassroomPet.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: GraphQLSchemaName.SelectionSet {
-          public let __data: DataDict
-          public init(data: DataDict) { __data = data }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphQLSchemaName.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
 
         /// AllAnimal.AsClassroomPet.AsBird
@@ -514,9 +458,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
             public var feet: Int { __data["feet"] }
             public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
             public var relativeSize: GraphQLEnum<GraphQLSchemaName.RelativeSize>? { __data["relativeSize"] }
             public var centimeters: Double? { __data["centimeters"] }
+            public var meters: Int { __data["meters"] }
           }
         }
       }


### PR DESCRIPTION
This was a major refactoring of the EntitySelectionTree. It's slimmer and easier to reason about and debug now.

There were a few bugs resolved by this PR, specifically surrounding computation of merged fields when merging named fragment spreads with inclusion conditions.