### PR TITLE
fix: Removes links to underscored properties and functions

### DIFF
--- a/Sources/Apollo/Atomic.swift
+++ b/Sources/Apollo/Atomic.swift
@@ -41,7 +41,7 @@ public class Atomic<T> {
 
 public extension Atomic where T : Numeric {
 
-  /// Increments the wrapped `Int` atomically, adding +1 to the ``value``.
+  /// Increments the wrapped `Int` atomically, adding +1 to the value.
   @discardableResult
   func increment() -> T {
     lock.lock()

--- a/Sources/ApolloAPI/InputValue.swift
+++ b/Sources/ApolloAPI/InputValue.swift
@@ -9,12 +9,12 @@ public indirect enum InputValue {
   /// For enum input values, the enum cases's `rawValue` as a `String` should be used.
   case scalar(any ScalarType)
 
-  /// A variable input value to be evaluated using the operation's
-  /// ``GraphQLOperation/variables-swift.property-4o32c`` dictionary at runtime.
+  /// A variable input value to be evaluated using the operation's variables dictionary at runtime.
+  /// See ``GraphQLOperation``.
   ///
   /// `.variable` should only be used as the value for an argument in a ``Selection/Field``.
-  /// A `.variable` value should not be included in an operation's
-  /// ``GraphQLOperation/variables-swift.property-4o32c`` dictionary.
+  /// A `.variable` value should not be included in an operation's variables dictionary. See
+  /// ``GraphQLOperation``.
   case variable(String)
 
   /// A GraphQL "`List`" input value.

--- a/Sources/ApolloAPI/JSONDecodingError.swift
+++ b/Sources/ApolloAPI/JSONDecodingError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// An error thrown while decoding `JSON`.
 ///
-/// This error should be thrown when a ``JSONDecodable/init(jsonValue:)`` fails.
+/// This error should be thrown when a ``JSONDecodable`` initialization fails.
 /// `GraphQLExecutor` and `ApolloStore` may also throw this error when decoding a `JSON` fails.
 public enum JSONDecodingError: Error, LocalizedError, Hashable {
   /// A value that is expected to be present is missing from the ``JSONObject``.
@@ -14,7 +14,7 @@ public enum JSONDecodingError: Error, LocalizedError, Hashable {
   case wrongType
   /// The `value` could not be converted to the expected type.
   ///
-  /// This error is thrown when the ``JSONDecodable/init(jsonValue:)`` fails for the expected type.
+  /// This error is thrown when a ``JSONDecodable`` initialization fails for the expected type.
   case couldNotConvert(value: AnyHashable, to: Any.Type)
 
   public var errorDescription: String? {


### PR DESCRIPTION
Fixes #2766 

The reason these documentation links have broken is because the properties they link to were changed to be 'private' by using the `_` prefix in their names. This change was largely done between `1.0.0-beta.4` and `1.0.0-rc.1`; _if you build the documentation between these two versions you'll notice there are many more when building for `1.0.0-rc.1`_.

It looks like Swift `5.7` simply doesn't emit the hidden signatures so docc can never consume them, but [coming in Swift `5.8`](https://forums.swift.org/t/nodoc-attribute-for-hiding-symbols-from-the-symbol-graph/59227/53) there might be the ability to [annotate the hidden signatures](https://forums.swift.org/t/nodoc-attribute-for-hiding-symbols-from-the-symbol-graph/59227/48) as `public`/`internal`/`private`.

To fix this now I've simply reworded the documentation to link to the related part that is public.