### PR TITLE
Move Object Type to DataDict

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -96,16 +96,6 @@ public class AllAnimalsQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
-//      init(
-//        __typename: String,
-//        height: Height,
-//        species: String,
-//        skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>?,
-//        predators: [Predator]
-//      ) {
-//
-//      }
-
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -96,6 +96,16 @@ public class AllAnimalsQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
+//      init(
+//        __typename: String,
+//        height: Height,
+//        species: String,
+//        skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>?,
+//        predators: [Predator]
+//      ) {
+//
+//      }
+
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }
@@ -189,6 +199,23 @@ public class AllAnimalsQuery: GraphQLQuery {
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
+
+//        init(
+//          __typename: String,
+//          height: Height,
+//          species: String,
+//          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>?,
+//          predators: [Predator],
+//          bodyTemperature: Int
+//        ) {
+//          let object = Object(
+//            typename: __typename,
+//            implementedInterfaces: [
+//              AnimalKingdomAPI.Interfaces.Animal,
+//              AnimalKingdomAPI.Interfaces.WarmBlooded
+//            ]
+//          )
+//        }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
@@ -334,6 +361,15 @@ public class AllAnimalsQuery: GraphQLQuery {
         public var humanName: String? { __data["humanName"] }
         public var favoriteToy: String { __data["favoriteToy"] }
         public var owner: PetDetails.Owner? { __data["owner"] }
+
+//        init(
+//          height: Height,
+//          species: String,
+//          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>?,
+//          predators: [Predator]
+//        ) {
+//
+//        }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -200,23 +200,6 @@ public class AllAnimalsQuery: GraphQLQuery {
         public var predators: [Predator] { __data["predators"] }
         public var bodyTemperature: Int { __data["bodyTemperature"] }
 
-//        init(
-//          __typename: String,
-//          height: Height,
-//          species: String,
-//          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>?,
-//          predators: [Predator],
-//          bodyTemperature: Int
-//        ) {
-//          let object = Object(
-//            typename: __typename,
-//            implementedInterfaces: [
-//              AnimalKingdomAPI.Interfaces.Animal,
-//              AnimalKingdomAPI.Interfaces.WarmBlooded
-//            ]
-//          )
-//        }
-
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
@@ -361,15 +344,6 @@ public class AllAnimalsQuery: GraphQLQuery {
         public var humanName: String? { __data["humanName"] }
         public var favoriteToy: String { __data["favoriteToy"] }
         public var owner: PetDetails.Owner? { __data["owner"] }
-
-//        init(
-//          height: Height,
-//          species: String,
-//          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>?,
-//          predators: [Predator]
-//        ) {
-//
-//        }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -181,7 +181,7 @@ final class GraphQLExecutor {
     accumulator: Accumulator
   ) throws -> Accumulator.FinalResult {
     let info = ObjectExecutionInfo(variables: variables,
-                                   schema: selectionSet.__schema,
+                                   schema: SelectionSet.Schema.self,
                                    withRootCacheReference: root)
 
     let rootValue = execute(selections: selectionSet.__selections,

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -170,8 +170,11 @@ final class GraphQLExecutor {
 
   // MARK: - Execution
 
-  func execute<Accumulator: GraphQLResultAccumulator>(
-    selectionSet: RootSelectionSet.Type,
+  func execute<
+    Accumulator: GraphQLResultAccumulator,
+    SelectionSet: RootSelectionSet
+  >(
+    selectionSet: SelectionSet.Type,
     on data: JSONObject,
     withRootCacheReference root: CacheReference? = nil,
     variables: GraphQLOperation.Variables? = nil,

--- a/Sources/Apollo/GraphQLSelectionSetMapper.swift
+++ b/Sources/Apollo/GraphQLSelectionSetMapper.swift
@@ -5,7 +5,7 @@ import ApolloAPI
 import Foundation
 
 /// An accumulator that converts executed data to the correct values to create a `SelectionSet`.
-final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLResultAccumulator {
+final class GraphQLSelectionSetMapper<T: SelectionSet>: GraphQLResultAccumulator {
 
   let stripNullValues: Bool
   let allowMissingValuesForOptionalFields: Bool
@@ -71,7 +71,7 @@ final class GraphQLSelectionSetMapper<SelectionSet: AnySelectionSet>: GraphQLRes
     return .init(fieldEntries, uniquingKeysWith: { (_, last) in last })
   }
 
-  func finish(rootValue: JSONObject, info: ObjectExecutionInfo) -> SelectionSet {
-    return SelectionSet.init(data: DataDict(rootValue, variables: info.variables))
+  func finish(rootValue: JSONObject, info: ObjectExecutionInfo) -> T {
+    return T.init(unsafeData: rootValue, variables: info.variables)
   }
 }

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -2,13 +2,17 @@
 public struct DataDict: Hashable {
 
   public var _data: JSONObject
+  public let _objectType: Object?
   public let _variables: GraphQLOperation.Variables?
 
+  #warning("TODO try making init internal")
   public init(
     _ data: JSONObject,
+    objectType: Object?,
     variables: GraphQLOperation.Variables?
   ) {
     self._data = data
+    self._objectType = objectType
     self._variables = variables
   }
 
@@ -23,10 +27,10 @@ public struct DataDict: Hashable {
   }
   
   @inlinable public subscript<T: SelectionSetEntityValue>(_ key: String) -> T {
-    get { T.init(fieldData: _data[key], variables: _variables) }
+    get { T.init(_fieldData: _data[key], variables: _variables) }
     set { _data[key] = newValue._fieldData }
     _modify {
-      var value = T.init(fieldData: _data[key], variables: _variables)
+      var value = T.init(_fieldData: _data[key], variables: _variables)
       defer { _data[key] = value._fieldData }
       yield &value
     }
@@ -44,39 +48,48 @@ public struct DataDict: Hashable {
 }
 
 public protocol SelectionSetEntityValue {
-  init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?)
+  /// - Warning: This function is not supported for external use.
+  /// Unsupported usage may result in unintended consequences including crashes.
+  init(_fieldData: AnyHashable?, variables: GraphQLOperation.Variables?)
   var _fieldData: AnyHashable { get }
 }
 
-extension AnySelectionSet {
-  @inlinable public init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?) {
-    guard let fieldData = fieldData as? JSONObject else {
+extension SelectionSet {
+  /// - Warning: This function is not supported for external use.
+  /// Unsupported usage may result in unintended consequences including crashes.
+  @inlinable public init(_fieldData data: AnyHashable?, variables: GraphQLOperation.Variables?) {
+    guard let data = data as? JSONObject else {
       fatalError("\(Self.self) expected data for entity.")
     }
-    self.init(data: DataDict(fieldData, variables: variables))
+
+    self.init(unsafeData: data, variables: variables)
   }
 
   @inlinable public var _fieldData: AnyHashable { __data._data }
 }
 
 extension Optional: SelectionSetEntityValue where Wrapped: SelectionSetEntityValue {
-  @inlinable public init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?) {
-    guard case let .some(fieldData) = fieldData else {
+  /// - Warning: This function is not supported for external use.
+  /// Unsupported usage may result in unintended consequences including crashes.
+  @inlinable public init(_fieldData data: AnyHashable?, variables: GraphQLOperation.Variables?) {
+    guard case let .some(data) = data else {
       self = .none
       return
     }
-    self = .some(Wrapped.init(fieldData: fieldData, variables: variables))
+    self = .some(Wrapped.init(_fieldData: data, variables: variables))
   }
 
   @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }
 }
 
 extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue {
-  @inlinable public init(fieldData: AnyHashable?, variables: GraphQLOperation.Variables?) {
-    guard let fieldData = fieldData as? [AnyHashable?] else {
+  /// - Warning: This function is not supported for external use.
+  /// Unsupported usage may result in unintended consequences including crashes.
+  @inlinable public init(_fieldData data: AnyHashable?, variables: GraphQLOperation.Variables?) {
+    guard let data = data as? [AnyHashable?] else {
       fatalError("\(Self.self) expected list of data for entity.")
     }
-    self = fieldData.map { Element.init(fieldData:$0?.base as? AnyHashable, variables: variables) }
+    self = data.map { Element.init(_fieldData:$0?.base as? AnyHashable, variables: variables) }
   }
 
   @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -5,8 +5,7 @@ public struct DataDict: Hashable {
   public let _objectType: Object?
   public let _variables: GraphQLOperation.Variables?
 
-  #warning("TODO try making init internal")
-  public init(
+  @usableFromInline init(
     _ data: JSONObject,
     objectType: Object?,
     variables: GraphQLOperation.Variables?

--- a/Sources/ApolloAPI/FragmentProtocols.swift
+++ b/Sources/ApolloAPI/FragmentProtocols.swift
@@ -4,7 +4,7 @@
 ///
 /// A ``SelectionSet`` can be converted to any ``Fragment`` included in it's
 /// `Fragments` object via its ``SelectionSet/fragments-swift.property`` property.
-public protocol Fragment: AnySelectionSet {
+public protocol Fragment: SelectionSet {
   /// The definition of the fragment in GraphQL syntax.
   static var fragmentDefinition: StaticString { get }
 }

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -45,9 +45,9 @@ public enum DocumentType {
 /// - See: [GraphQLSpec - Document](https://spec.graphql.org/draft/#Document)
 public struct OperationDefinition {
   let operationDefinition: String
-  let fragments: [Fragment.Type]?
+  let fragments: [any Fragment.Type]?
 
-  public init(_ definition: String, fragments: [Fragment.Type]? = nil) {
+  public init(_ definition: String, fragments: [any Fragment.Type]? = nil) {
     self.operationDefinition = definition
     self.fragments = fragments
   }

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -4,9 +4,9 @@ public enum Selection {
   /// A single field selection.
   case field(Field)
   /// A fragment spread of a named fragment definition.
-  case fragment(Fragment.Type)
+  case fragment(any Fragment.Type)
   /// An inline fragment with a child selection set nested in a parent selection set.
-  case inlineFragment(InlineFragment.Type)
+  case inlineFragment(any InlineFragment.Type)
   /// A group of selections that have `@include/@skip` directives.
   case conditional(Conditions, [Selection])
 

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -35,7 +35,7 @@ public enum Selection {
     public indirect enum OutputType {
       case scalar(any ScalarType.Type)
       case customScalar(any CustomScalarType.Type)
-      case object(RootSelectionSet.Type)
+      case object(any RootSelectionSet.Type)
       case nonNull(OutputType)
       case list(OutputType)
 

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -1,6 +1,6 @@
 // MARK: - Type Erased SelectionSets
 
-public protocol AnySelectionSet: SelectionSetEntityValue {
+public protocol AnySelectionSet {
   static var __schema: SchemaMetadata.Type { get }
 
   static var __selections: [Selection] { get }
@@ -38,7 +38,7 @@ public extension AnySelectionSet {
 /// This is why only a `RootSelectionSet` can be executed by a `GraphQLExecutor`. Executing a
 /// non-root selection set would result in fields from the root selection set not being collected
 /// into the `ResponseDict` for the `SelectionSet`'s data.
-public protocol RootSelectionSet: AnySelectionSet, OutputTypeConvertible { }
+public protocol RootSelectionSet: SelectionSet, OutputTypeConvertible { }
 
 /// A selection set that represents an inline fragment nested inside a `RootSelectionSet`.
 ///
@@ -54,7 +54,7 @@ public protocol RootSelectionSet: AnySelectionSet, OutputTypeConvertible { }
 public protocol InlineFragment: AnySelectionSet { }
 
 // MARK: - SelectionSet
-public protocol SelectionSet: AnySelectionSet, Hashable {
+public protocol SelectionSet: AnySelectionSet, SelectionSetEntityValue, Hashable {
   associatedtype Schema: SchemaMetadata
 
   /// A type representing all of the fragments the `SelectionSet` can be converted to.
@@ -67,7 +67,7 @@ extension SelectionSet {
 
   @inlinable public static var __schema: SchemaMetadata.Type { Schema.self }
 
-  @usableFromInline var __objectType: Object? { Schema.objectType(forTypename: __typename) }
+  @inlinable public var __objectType: Object? { __data._objectType }
 
   @inlinable public var __typename: String { __data["__typename"] }
 
@@ -104,6 +104,35 @@ extension SelectionSet {
     if condition: Selection.Condition
   ) -> T? where T.Schema == Schema {
     _asInlineFragment(if: Selection.Conditions(condition))
+  }
+
+  /// Initializes the `SelectionSet` **unsafely** with an unsafe result data dictionary.
+  ///
+  /// - Warning: This method is unsafe and improper use may result in unintended consequences
+  /// including crashes. The `unsafeData` should mirror the result data returned by a
+  /// `GraphQLSelectionSetMapper` after completion of GraphQL Execution.
+  ///
+  /// This is not identical to the JSON response from a GraphQL network request. The data should be
+  /// normalized and custom scalars should be converted to their concrete types.
+  ///
+  /// To create a `SelectionSet` from data representing a JSON format GraphQL network response
+  /// directly, create a `GraphQLResponse` object and call `parseResultFast()`.
+  @inlinable public init(
+    unsafeData data: [String: AnyHashable],
+    variables: GraphQLOperation.Variables? = nil
+  ) {
+    let objectType: Object?
+    if let typename = data["__typename"] as? String {
+      objectType = Schema.objectType(forTypename: typename)
+    } else {
+      objectType = nil
+    }
+
+    self.init(data: DataDict(
+      data,
+      objectType: objectType,
+      variables: variables
+    ))
   }
 
   @inlinable public func hash(into hasher: inout Hasher) {

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -1,29 +1,3 @@
-// MARK: - Type Erased SelectionSets
-
-public protocol AnySelectionSet {
-  static var __schema: SchemaMetadata.Type { get }
-
-  static var __selections: [Selection] { get }
-
-  /// The GraphQL type for the `SelectionSet`.
-  ///
-  /// This may be a concrete type (`Object`) or an abstract type (`Interface`, or `Union`).
-  static var __parentType: ParentType { get }
-
-  /// The data of the underlying GraphQL object represented by generated selection set.
-  var __data: DataDict { get }
-
-  /// Designated Initializer
-  /// 
-  /// - Parameter data: The data of the underlying GraphQL object represented by generated
-  /// selection set.
-  init(data: DataDict)
-}
-
-public extension AnySelectionSet {
-  static var __selections: [Selection] { [] }
-}
-
 /// A selection set that represents the root selections on its `__parentType`. Nested selection
 /// sets for type cases are not `RootSelectionSet`s.
 ///
@@ -51,21 +25,37 @@ public protocol RootSelectionSet: SelectionSet, OutputTypeConvertible { }
 /// from the fragment's parent `RootSelectionSet` that will be selected. This includes fields from
 /// the parent selection set, as well as any other child selections sets that are compatible with
 /// the `InlineFragment`'s `__parentType` and the operation's inclusion condition.
-public protocol InlineFragment: AnySelectionSet { }
+public protocol InlineFragment: SelectionSet { }
 
 // MARK: - SelectionSet
-public protocol SelectionSet: AnySelectionSet, SelectionSetEntityValue, Hashable {
+public protocol SelectionSet: SelectionSetEntityValue, Hashable {
   associatedtype Schema: SchemaMetadata
 
   /// A type representing all of the fragments the `SelectionSet` can be converted to.
   /// Defaults to a stub type with no fragments.
   /// A `SelectionSet` with fragments should provide a type that conforms to `FragmentContainer`
   associatedtype Fragments = NoFragments
+
+  static var __selections: [Selection] { get }
+
+  /// The GraphQL type for the `SelectionSet`.
+  ///
+  /// This may be a concrete type (`Object`) or an abstract type (`Interface`, or `Union`).
+  static var __parentType: ParentType { get }
+
+  /// The data of the underlying GraphQL object represented by generated selection set.
+  var __data: DataDict { get }
+
+  /// Designated Initializer
+  ///
+  /// - Parameter data: The data of the underlying GraphQL object represented by generated
+  /// selection set.
+  init(data: DataDict)
 }
 
-extension SelectionSet {
+extension SelectionSet {  
 
-  @inlinable public static var __schema: SchemaMetadata.Type { Schema.self }
+  @inlinable public static var __selections: [Selection] { [] }
 
   @inlinable public var __objectType: Object? { __data._objectType }
 

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -1,5 +1,5 @@
 #if !COCOAPODS
-@_exported import ApolloAPI
+@_exported @testable import ApolloAPI
 #endif
 import Foundation
 

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -77,11 +77,15 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
 // MARK: - Selection Set Conversion
 
 public extension SelectionSet {
-  static func from(
-    _ mock: AnyMock,
+  static func from<O: MockObject>(
+    _ mock: Mock<O>,
     withVariables variables: GraphQLOperation.Variables? = nil
   ) -> Self {
-    Self.init(data: DataDict(mock._selectionSetMockData, variables: variables))
+    Self.init(data: DataDict(
+      mock._selectionSetMockData,
+      objectType: O.objectType,
+      variables: variables)
+    )
   }
 }
 

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -29,7 +29,7 @@ public extension MockMutableRootSelectionSet {
   static var __parentType: ParentType { Object.mock }
 
   init() {
-    self.init(data: DataDict([:], variables: nil))
+    self.init(data: .empty())
   }
 }
 

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -44,12 +44,15 @@ open class MockSubscription<SelectionSet: RootSelectionSet>: MockOperation<Selec
 // MARK: - MockSelectionSets
 
 @dynamicMemberLookup
-open class AbstractMockSelectionSet: AnySelectionSet {
+open class AbstractMockSelectionSet<F>: RootSelectionSet, Hashable {
+  public typealias Schema = MockSchemaMetadata
+  public typealias Fragments = F
+
   open class var __schema: SchemaMetadata.Type { MockSchemaMetadata.self }
   open class var __selections: [Selection] { [] }
   open class var __parentType: ParentType { Object.mock }
 
-  public var __data: DataDict = DataDict([:], variables: nil)
+  public var __data: DataDict = .empty()
 
   public required init(data: DataDict) {
     self.__data = data
@@ -62,10 +65,7 @@ open class AbstractMockSelectionSet: AnySelectionSet {
   public subscript<T: MockSelectionSet>(dynamicMember key: String) -> T? {
     __data[key]
   }
-  
-}
 
-open class MockSelectionSet: AbstractMockSelectionSet, RootSelectionSet, Hashable {
   public static func == (lhs: MockSelectionSet, rhs: MockSelectionSet) -> Bool {
     lhs.__data == rhs.__data
   }
@@ -75,8 +75,18 @@ open class MockSelectionSet: AbstractMockSelectionSet, RootSelectionSet, Hashabl
   }
 }
 
-open class MockFragment: AbstractMockSelectionSet, RootSelectionSet, Fragment {
+public typealias MockSelectionSet = AbstractMockSelectionSet<NoFragments>
+
+open class MockFragment: MockSelectionSet, Fragment {
+  public typealias Schema = MockSchemaMetadata
+
   open class var fragmentDefinition: StaticString { "" }
 }
 
-open class MockTypeCase: AbstractMockSelectionSet, InlineFragment { }
+open class MockTypeCase: MockSelectionSet, InlineFragment { }
+
+extension DataDict {
+  public static func empty() -> DataDict {
+    DataDict([:], objectType: nil, variables: nil)
+  }
+}

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -263,7 +263,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     }
 
-    class GivenSelectionSet: MockFragment, SelectionSet {
+    class GivenSelectionSet: MockFragment {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] { [
@@ -274,7 +274,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       var asDroid: AsDroid? { _asInlineFragment() }
 
-      class AsDroid: MockTypeCase, SelectionSet {
+      class AsDroid: MockTypeCase {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: ParentType { Types.Droid }
 
@@ -319,7 +319,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
     }
 
-    class GivenSelectionSet: MockFragment, SelectionSet {
+    class GivenSelectionSet: MockFragment {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] { [
@@ -330,7 +330,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       var asDroid: AsDroid? { _asInlineFragment() }
 
-      class AsDroid: MockTypeCase, SelectionSet {
+      class AsDroid: MockTypeCase {
         typealias Schema = MockSchemaMetadata
         override class var __parentType: ParentType { Types.Droid }
 
@@ -371,7 +371,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateCacheMutation_updateNestedField_updatesObjects() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -384,7 +384,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -436,7 +436,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateCacheMutationWithOptionalField_containingNull_updateNestedField_updatesObjectsMaintainingNullValue() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -449,7 +449,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -513,7 +513,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateCacheMutationWithOptionalField_omittingOptionalField_updateNestedField_updatesObjectsMaintainingNilValue_throwsMissingValueErrorOnRead() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -526,7 +526,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -578,7 +578,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateCacheMutationWithNonNullField_withNilValue_updateNestedField_throwsMissingValueOnInitialReadForUpdate() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -591,7 +591,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -637,7 +637,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateCacheMutation_givenMutationOperation_updateNestedField_updatesObjectAtMutationRoot() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -650,7 +650,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -707,7 +707,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -720,7 +720,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -811,7 +811,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -824,7 +824,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -844,7 +844,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         }
 
         struct AsDroid: MockMutableInlineFragment {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           static let __parentType: ParentType = Types.Droid
           init(data: DataDict) { __data = data }
 
@@ -912,7 +912,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       typealias Schema = MockSchemaMetadata
       static let fragmentDefinition: StaticString = ""
 
-      var __data: DataDict = DataDict([:], variables: nil)
+      var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -932,7 +932,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct AsDroid: MockMutableInlineFragment {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         static let __parentType: ParentType = Types.Droid
         init(data: DataDict) { __data = data }
 
@@ -948,7 +948,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -961,7 +961,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1043,7 +1043,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       typealias Schema = MockSchemaMetadata
       static let fragmentDefinition: StaticString = ""
 
-      var __data: DataDict = DataDict([:], variables: nil)
+      var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1063,7 +1063,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct AsDroid: MockMutableInlineFragment {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         static let __parentType: ParentType = Types.Droid
         init(data: DataDict) { __data = data }
 
@@ -1079,7 +1079,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1092,7 +1092,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1112,7 +1112,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         }
 
         struct AsDroid: MockMutableInlineFragment {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           static let __parentType: ParentType = Types.Droid
           init(data: DataDict) { __data = data }
 
@@ -1180,7 +1180,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateCacheMutation_givenAddNewReferencedEntity_entityIsIncludedOnRead() throws {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1193,7 +1193,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1213,7 +1213,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] { [
@@ -1301,7 +1301,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     }
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1314,7 +1314,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1366,7 +1366,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_writeDataForCacheMutation_givenMutationOperation_updateNestedField_updatesObjectAtMutationRoot() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1379,7 +1379,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1397,12 +1397,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       let updateCompletedExpectation = expectation(description: "Update completed")
 
       store.withinReadWriteTransaction({ transaction in
-        let data = GivenSelectionSet(data: DataDict(
+        let data = GivenSelectionSet(unsafeData:
           ["hero": [
             "__typename": "Droid",
             "name": "Artoo"
           ]],
-          variables: nil)
+          variables: nil
         )
         let cacheMutation = MockLocalCacheMutationFromMutation<GivenSelectionSet>()
 
@@ -1432,7 +1432,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_writeDataForCacheMutation_givenInvalidData_throwsError() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1445,7 +1445,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1463,7 +1463,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let writeCompletedExpectation = expectation(description: "Write completed")
 
     store.withinReadWriteTransaction({ transaction in
-      let data = GivenSelectionSet(data: DataDict(["hero": "name"], variables: nil))
+      let data = GivenSelectionSet(unsafeData: ["hero": "name"], variables: nil)
       let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
       try transaction.write(data: data, for: cacheMutation)
     }, completion: { result in
@@ -1487,7 +1487,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     struct GivenFragment: MockMutableRootSelectionSet, Fragment {
       static var fragmentDefinition: StaticString { "" }
 
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1500,7 +1500,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1518,12 +1518,12 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       let updateCompletedExpectation = expectation(description: "Update completed")
 
       store.withinReadWriteTransaction({ transaction in
-        let fragment = GivenFragment(data: DataDict(
+        let fragment = GivenFragment(unsafeData:
           ["hero": [
             "__typename": "Droid",
             "name": "Artoo"
           ]],
-          variables: nil)
+          variables: nil
         )
 
         try transaction.write(selectionSet: fragment, withKey: CacheReference.RootQuery.key)
@@ -1552,7 +1552,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_updateObjectWithKey_readAfterUpdateWithinSameTransaction_hasUpdatedValue() throws {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1565,7 +1565,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1614,7 +1614,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     struct GivenFragment: MockMutableRootSelectionSet, Fragment {
       static var fragmentDefinition: StaticString { "" }
 
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1628,7 +1628,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Friend: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1732,7 +1732,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
   func test_removeObject_givenReferencedByOtherRecord_thenReadQueryReferencingRemovedRecord_throwsError() throws {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -1745,7 +1745,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -1765,7 +1765,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] { [

--- a/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
+++ b/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
@@ -142,7 +142,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
   func testConcurrentUpdatesInitiatedFromMainThread() throws {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -155,7 +155,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -180,7 +180,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] { [
@@ -266,7 +266,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
   func testConcurrentUpdatesInitiatedFromBackgroundThreads() throws {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] { [
@@ -279,7 +279,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] { [
@@ -304,7 +304,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] { [

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -828,7 +828,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
   func testWatchedQueryGetsUpdatedWhenObjectIsChangedByDirectStoreUpdate() throws {
     struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] {[
@@ -841,7 +841,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] {[
@@ -861,7 +861,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] {[
@@ -955,7 +955,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   func testWatchedQuery_givenCachePolicyReturnCacheDataDontFetch_doesNotRefetchFromServerAfterOtherQueryUpdatesListWithIncompleteObject() throws {
     // given
     struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] {[
@@ -968,7 +968,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] {[
@@ -994,7 +994,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] {[
@@ -1017,7 +1017,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     }
 
     struct HeroAndFriendsIDsOnlySelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] {[
@@ -1030,7 +1030,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] {[
@@ -1050,7 +1050,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] {[
@@ -1080,7 +1080,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
       client.store.withinReadWriteTransaction({ transaction in
         let data = HeroAndFriendsNamesSelectionSet(
-          data: DataDict(
+          unsafeData:
             [
               "hero": [
                 "id": "2001",
@@ -1094,7 +1094,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
               ]
             ],
             variables: nil
-          ))
+          )
 
         let cacheMutation = MockLocalCacheMutation<HeroAndFriendsNamesSelectionSet>()
         try transaction.write(data: data, for: cacheMutation)
@@ -1366,7 +1366,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   func testWatchedQueryDependentKeysAreUpdatedAfterDirectStoreUpdate() {
     // given
     struct HeroAndFriendsNamesWithIDsSelectionSet: MockMutableRootSelectionSet {
-      public var __data: DataDict = DataDict([:], variables: nil)
+      public var __data: DataDict = .empty()
       init(data: DataDict) { __data = data }
 
       static var __selections: [Selection] {[
@@ -1379,7 +1379,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       }
 
       struct Hero: MockMutableRootSelectionSet {
-        public var __data: DataDict = DataDict([:], variables: nil)
+        public var __data: DataDict = .empty()
         init(data: DataDict) { __data = data }
 
         static var __selections: [Selection] {[
@@ -1405,7 +1405,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
         }
 
         struct Friend: MockMutableRootSelectionSet {
-          public var __data: DataDict = DataDict([:], variables: nil)
+          public var __data: DataDict = .empty()
           init(data: DataDict) { __data = data }
 
           static var __selections: [Selection] {[

--- a/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_ResultNormalizer_FromResponse_Tests.swift
@@ -16,8 +16,8 @@ class GraphQLExecutor_ResultNormalizer_FromResponse_Tests: XCTestCase {
     return executor
   }()
 
-  private func normalizeRecords(
-    _ selectionSet: RootSelectionSet.Type,
+  private func normalizeRecords<S: RootSelectionSet>(
+    _ selectionSet: S.Type,
     with variables: GraphQLOperation.Variables? = nil,
     from object: JSONObject
   ) throws -> RecordSet {

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -823,14 +823,14 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       static let MockChildObject = Object(typename: "MockChildObject", implementedInterfaces: [])
     }
 
-    class GivenSelectionSet: MockSelectionSet, SelectionSet {
+    class GivenSelectionSet: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
       override class var __parentType: ParentType { Object.mock }
       override class var __selections: [Selection] {[
         .field("child", Child.self),
       ]}
 
-      class Child: MockSelectionSet, SelectionSet {
+      class Child: MockSelectionSet {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.MockChildObject }
@@ -893,7 +893,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       }
     }
 
-    class GivenSelectionSet: MockSelectionSet, SelectionSet {
+    class GivenSelectionSet: AbstractMockSelectionSet<GivenSelectionSet.Fragments> {
       typealias Schema = MockSchemaMetadata
 
       override class var __parentType: ParentType { Types.MockChildObject }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -8,7 +8,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection_givenOptionalField_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -25,7 +25,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.name).to(equal("Johnny Tsunami"))
@@ -33,7 +33,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection_givenOptionalField_missingValue__returnsNil() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -49,7 +49,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.name).to(beNil())
@@ -57,7 +57,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection_givenOptionalField_givenNilValue__returnsNil() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -74,7 +74,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.name).to(beNil())
@@ -84,7 +84,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__nestedArrayOfScalar_nonNull_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -101,7 +101,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.nestedList).to(equal([["A"]]))
@@ -111,7 +111,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection_givenRequiredEntityField_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -121,7 +121,7 @@ class SelectionSetTests: XCTestCase {
 
       var friend: Friend { __data["friend"] }
 
-      class Friend: MockSelectionSet, SelectionSet {
+      class Friend: MockSelectionSet {
         typealias Schema = MockSchemaMetadata
 
         override class var __selections: [Selection] {[
@@ -137,10 +137,10 @@ class SelectionSetTests: XCTestCase {
       "friend": friendData
     ]
 
-    let expected = Hero.Friend(data: DataDict(friendData, variables: nil))
+    let expected = Hero.Friend(unsafeData: friendData)
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friend).to(equal(expected))
@@ -148,7 +148,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection_givenOptionalEntityField_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -166,10 +166,10 @@ class SelectionSetTests: XCTestCase {
       "friend": friendData
     ]
 
-    let expected = Hero(data: DataDict(friendData, variables: nil))
+    let expected = Hero(unsafeData: friendData, variables: nil)
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friend).to(equal(expected))
@@ -177,7 +177,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection_givenOptionalEntityField_givenNilValue__returnsNil() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -193,7 +193,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friend).to(beNil())
@@ -203,7 +203,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__arrayOfEntity_nonNull_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -224,16 +224,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "friends": []
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friends).to(equal([expected]))
@@ -241,7 +241,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__arrayOfEntity_nullableEntity_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -262,16 +262,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "friends": []
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friends).to(equal([expected]))
@@ -279,7 +279,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__arrayOfEntity_nullableEntity_givenNilValueInList__returnsArrayWithNil() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -299,16 +299,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "friends": []
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friends).to(equal([Hero?.none, expected, Hero?.none]))
@@ -316,7 +316,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__arrayOfEntity_nullableList_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -337,16 +337,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "friends": []
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friends).to(equal([expected]))
@@ -354,7 +354,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__arrayOfEntity_nullableList_givenNoListValue__returnsNil() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -370,7 +370,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.friends).to(beNil())
@@ -380,7 +380,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__nestedArrayOfEntity_nonNull_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -401,16 +401,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "nestedList": [[]]
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -418,7 +418,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__nestedArrayOfEntity_nullableInnerList_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -439,16 +439,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "nestedList": [[]]
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -456,7 +456,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__nestedArrayOfEntity_nullableInnerList_givenNilValues__returnsListWithNils() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -481,10 +481,10 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expectedItem = Hero(data: DataDict(nestedObjectData, variables: nil))
+    let expectedItem = Hero(unsafeData: nestedObjectData, variables: nil)
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.nestedList).to(equal([[Hero]?.none, [expectedItem], [Hero]?.none]))
@@ -492,7 +492,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__nestedArrayOfEntity_nullableEntity_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -513,16 +513,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "nestedList": [[]]
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -530,7 +530,7 @@ class SelectionSetTests: XCTestCase {
 
   func test__selection__nestedArrayOfEntity_nullableOuterList_givenValue__returnsValue() {
     // given
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -551,16 +551,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(data: DataDict(
+    let expected = Hero(unsafeData:
       [
         "__typename": "Human",
         "nestedList": [[]]
       ],
       variables: nil
-    ))
+    )
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -583,7 +583,7 @@ class SelectionSetTests: XCTestCase {
       }
     }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -595,7 +595,7 @@ class SelectionSetTests: XCTestCase {
       var asHuman: AsHuman? { _asInlineFragment() }
       var asDroid: AsDroid? { _asInlineFragment() }
 
-      class AsHuman: MockTypeCase, SelectionSet {
+      class AsHuman: MockTypeCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Human }
@@ -604,7 +604,7 @@ class SelectionSetTests: XCTestCase {
         ]}
       }
 
-      class AsDroid: MockTypeCase, SelectionSet {
+      class AsDroid: MockTypeCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Droid }
@@ -620,7 +620,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.asHuman).to(beNil())
@@ -641,7 +641,7 @@ class SelectionSetTests: XCTestCase {
       }
     }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -651,7 +651,7 @@ class SelectionSetTests: XCTestCase {
 
       var asHumanoid: AsHumanoid? { _asInlineFragment() }
 
-      class AsHumanoid: MockTypeCase, SelectionSet {
+      class AsHumanoid: MockTypeCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Humanoid }
@@ -668,7 +668,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.asHumanoid).toNot(beNil())
@@ -688,7 +688,7 @@ class SelectionSetTests: XCTestCase {
       }
     }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -698,7 +698,7 @@ class SelectionSetTests: XCTestCase {
 
       var asHumanoid: AsHumanoid? { _asInlineFragment() }
 
-      class AsHumanoid: MockTypeCase, SelectionSet {
+      class AsHumanoid: MockTypeCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Humanoid }
@@ -715,7 +715,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.asHumanoid).to(beNil())
@@ -735,7 +735,7 @@ class SelectionSetTests: XCTestCase {
       }
     }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -745,7 +745,7 @@ class SelectionSetTests: XCTestCase {
 
       var asCharacter: AsCharacter? { _asInlineFragment() }
 
-      class AsCharacter: MockTypeCase, SelectionSet {
+      class AsCharacter: MockTypeCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Character }
@@ -761,7 +761,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.asCharacter).toNot(beNil())
@@ -781,7 +781,7 @@ class SelectionSetTests: XCTestCase {
       }
     }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: MockSelectionSet {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -791,7 +791,7 @@ class SelectionSetTests: XCTestCase {
 
       var asCharacter: AsCharacter? { _asInlineFragment() }
 
-      class AsCharacter: MockTypeCase, SelectionSet {
+      class AsCharacter: MockTypeCase {
         typealias Schema = MockSchemaMetadata
 
         override class var __parentType: ParentType { Types.Character }
@@ -807,7 +807,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: nil))
+    let actual = Hero(unsafeData: object)
 
     // then
     expect(actual.asCharacter).to(beNil())
@@ -819,7 +819,7 @@ class SelectionSetTests: XCTestCase {
     // given
     class GivenFragment: MockFragment { }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: AbstractMockSelectionSet<Hero.Fragments> {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -841,7 +841,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: ["includeFragment": true]))
+    let actual = Hero(unsafeData: object, variables: ["includeFragment": true])
 
     // then
     expect(actual.fragments.givenFragment).toNot(beNil())
@@ -851,7 +851,7 @@ class SelectionSetTests: XCTestCase {
     // given
     class GivenFragment: MockFragment { }
 
-    class Hero: MockSelectionSet, SelectionSet {
+    class Hero: AbstractMockSelectionSet<Hero.Fragments> {
       typealias Schema = MockSchemaMetadata
 
       override class var __selections: [Selection] {[
@@ -873,7 +873,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(data: DataDict(object, variables: ["includeFragment": false]))
+    let actual = Hero(unsafeData: object, variables: ["includeFragment": false])
 
     // then
     expect(actual.fragments.givenFragment).to(beNil())


### PR DESCRIPTION
This PR moves the `_objectType` field from the `SelectionSet` protocol to the `DataDict.` This is in preparation for #2551, which will require the object type to be manually set by the generated initializers (instead of computed from the Schema config and `__typename`).

This PR also includes some refactoring of other API surfaces that will introduce minor breaking changes (mostly around APIs that are intended to be `internal`, but must be `public` for generated code consumption). Those changes are:

- Get rid of `AnySelectionSet` completely
  - Since Swift unlocked existential types its not necessary anymore.
- Introduce a new initializer for `SelectionSet.init(unsafeData: variables)`.
- Make `DataDict` initializer `internal`
  - It's use case is being replaced by the new initializer above.