### PR TITLE
fix: ApolloSchemaDownloadConfiguration HTTP headers json

### DIFF
--- a/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
@@ -74,7 +74,7 @@ class ApolloSchemaDownloadConfigurationCodableTests: XCTestCase {
     expect(actual).to(equal(expected))
   }
 
-  func test__decodeApolloSchemaDownloadConfiguration__givenAllParameters_withHTTPHeadersAsArrayOfDictionaries_shouldReturnStruct() throws {
+  func test__decodeApolloSchemaDownloadConfiguration__givenAllParameters_withHTTPHeadersAsArrayOfStructs_shouldReturnStruct() throws {
     // given
     let subject = """
       {

--- a/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
@@ -21,22 +21,27 @@ class ApolloSchemaDownloadConfigurationCodableTests: XCTestCase {
 
   // MARK: - ApolloSchemaDownloadConfiguration Tests
 
-  enum MockApolloSchemaDownloadConfiguration {
-    static var decodedStruct: ApolloSchemaDownloadConfiguration {
-      .init(
-        using: .introspection(
-          endpointURL: URL(string: "http://server.com")!,
-          httpMethod: .POST,
-          outputFormat: .SDL,
-          includeDeprecatedInputValues: true),
-        timeout: 120,
-        headers: [],
-        outputPath: "ServerSchema.graphqls"
-      )
-    }
+  func test__encodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnJSON_withHTTPHeadersAsArrayOfDictionaries() throws {
+    // given
+    let subject = ApolloSchemaDownloadConfiguration(
+      using: .introspection(
+        endpointURL: URL(string: "http://server.com")!,
+        httpMethod: .POST,
+        outputFormat: .SDL,
+        includeDeprecatedInputValues: true),
+      timeout: 120,
+      headers: [
+        .init(key: "Accept-Encoding", value: "gzip"),
+        .init(key: "Authorization", value: "Bearer <token>")
+      ],
+      outputPath: "ServerSchema.graphqls"
+    )
 
-    static var encodedJSON: String {
-      """
+    // when
+    let encodedJSON = try testJSONEncoder.encode(subject)
+    let actual = encodedJSON.asString
+
+    let expected = """
       {
         "downloadMethod" : {
           "introspection" : {
@@ -52,35 +57,125 @@ class ApolloSchemaDownloadConfigurationCodableTests: XCTestCase {
         },
         "downloadTimeout" : 120,
         "headers" : [
-
+          {
+            "key" : "Accept-Encoding",
+            "value" : "gzip"
+          },
+          {
+            "key" : "Authorization",
+            "value" : "Bearer <token>"
+          }
         ],
         "outputPath" : "ServerSchema.graphqls"
       }
       """
-    }
-  }
-
-  func test__encodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnJSON() throws {
-    // given
-    let subject = MockApolloSchemaDownloadConfiguration.decodedStruct
-
-    // when
-    let encodedJSON = try testJSONEncoder.encode(subject)
-    let actual = encodedJSON.asString
 
     // then
-    expect(actual).to(equal(MockApolloSchemaDownloadConfiguration.encodedJSON))
+    expect(actual).to(equal(expected))
   }
 
-  func test__decodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnStruct() throws {
+  func test__decodeApolloSchemaDownloadConfiguration__givenAllParameters_withHTTPHeadersAsArrayOfDictionaries_shouldReturnStruct() throws {
     // given
-    let subject = MockApolloSchemaDownloadConfiguration.encodedJSON.asData
+    let subject = """
+      {
+        "downloadMethod" : {
+          "introspection" : {
+            "endpointURL" : "http://server.com",
+            "httpMethod" : {
+              "POST" : {
+
+              }
+            },
+            "includeDeprecatedInputValues" : true,
+            "outputFormat" : "SDL"
+          }
+        },
+        "downloadTimeout" : 120,
+        "headers" : [
+          {
+            "key" : "Accept-Encoding",
+            "value" : "gzip"
+          },
+          {
+            "key" : "Authorization",
+            "value" : "Bearer <token>"
+          }
+        ],
+        "outputPath" : "ServerSchema.graphqls"
+      }
+      """
 
     // when
-    let actual = try JSONDecoder().decode(ApolloSchemaDownloadConfiguration.self, from: subject)
+    let actual = try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.self,
+      from: subject.asData
+    )
+
+    let expected = ApolloSchemaDownloadConfiguration(
+      using: .introspection(
+        endpointURL: URL(string: "http://server.com")!,
+        httpMethod: .POST,
+        outputFormat: .SDL,
+        includeDeprecatedInputValues: true),
+      timeout: 120,
+      headers: [
+        .init(key: "Accept-Encoding", value: "gzip"),
+        .init(key: "Authorization", value: "Bearer <token>")
+      ],
+      outputPath: "ServerSchema.graphqls"
+    )
 
     // then
-    expect(actual).to(equal(MockApolloSchemaDownloadConfiguration.decodedStruct))
+    expect(actual).to(equal(expected))
+  }
+
+  func test__decodeApolloSchemaDownloadConfiguration__givenAllParameters_withHTTPHeadersAsDictionary_shouldReturnStruct() throws {
+    // given
+    let subject = """
+      {
+        "downloadMethod" : {
+          "introspection" : {
+            "endpointURL" : "http://server.com",
+            "httpMethod" : {
+              "POST" : {
+
+              }
+            },
+            "includeDeprecatedInputValues" : true,
+            "outputFormat" : "SDL"
+          }
+        },
+        "downloadTimeout" : 120,
+        "headers" : {
+          "Accept-Encoding" : "gzip",
+          "Authorization" : "Bearer <token>"
+        },
+        "outputPath" : "ServerSchema.graphqls"
+      }
+      """
+
+    // when
+    let actual = try JSONDecoder().decode(
+      ApolloSchemaDownloadConfiguration.self,
+      from: subject.asData
+    )
+
+    let expected = ApolloSchemaDownloadConfiguration(
+      using: .introspection(
+        endpointURL: URL(string: "http://server.com")!,
+        httpMethod: .POST,
+        outputFormat: .SDL,
+        includeDeprecatedInputValues: true),
+      timeout: 120,
+      headers: [
+        .init(key: "Accept-Encoding", value: "gzip"),
+        .init(key: "Authorization", value: "Bearer <token>")
+      ],
+      outputPath: "ServerSchema.graphqls"
+    )
+
+    // then
+    expect(actual).to(equal(expected))
   }
 
   func test__decodeApolloSchemaDownloadConfiguration__givenOnlyRequiredParameters_shouldReturnStruct() throws {

--- a/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloSchemaDownloadConfigurationCodableTests.swift
@@ -21,7 +21,7 @@ class ApolloSchemaDownloadConfigurationCodableTests: XCTestCase {
 
   // MARK: - ApolloSchemaDownloadConfiguration Tests
 
-  func test__encodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnJSON_withHTTPHeadersAsArrayOfDictionaries() throws {
+  func test__encodeApolloSchemaDownloadConfiguration__givenAllParameters_shouldReturnJSON_withHTTPHeadersAsArrayOfStructs() throws {
     // given
     let subject = ApolloSchemaDownloadConfiguration(
       using: .introspection(


### PR DESCRIPTION
Fixes #2661 

This PR enables the HTTP headers, `"headers"` property within the `"ApolloSchemaDownloadConfiguration"` section of the JSON configuration file, to be written and parsed in a more intuitive format.

An example of the current format is `[{ "key": "Authorization", "value": "<token>"}]` where the new format would allow `{ "Authorization": "<token>"}`.

* The logic allows parsing of both formats.
* The property type has not changed because that would be a breaking change and I didn't want to do that in a patch release. _The config file format needs to be refactored at some point, this property change can happen then._
* The encoding format has not changed either because there might be projects that build the configuration in code, serialize it to JSON and use it in outside tooling which would break if the encoding format changed now too. Adding the ability to simply parse the new format is the least intrusive change here.
* PR #2812 is layered on top of this that updates the documentation to promote use of the new format.