### PR TITLE
Update documentation sample with new format

### DIFF
--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -556,7 +556,10 @@ The properties you will need to configure are:
 		}
 	},
 	"downloadTimeout": 60,
-	"headers": [],
+	"headers": {
+		"Accept-Encoding" : "gzip",
+		"Authorization" : "Bearer <token>"
+	},
 	"outputPath": "./graphql/"
 }
 ```
@@ -570,7 +573,10 @@ let configuration = ApolloCodegenConfiguration(
       graphID: "your-graphid",
       variant: "current")),
     timeout: 60.0,
-    headers: [],
+    headers: [
+      .init(key: "Accept-Encoding", value: "gzip"),
+      .init(key: "Authorization", value: "Bearer <token>")
+    ],
     outputPath: "./graphql/")
 )
 ```


### PR DESCRIPTION
This PR updates the documentation samples for the HTTP header fields. It's layered on top of #2811 because it changes docs and they're deployed once the PR is merged but the fix would only go out with `1.0.7`.

tl;dr - I'll rebase and merge this PR into the patch release PR once it's created.