### PR TITLE
docs: Updates code generation intro

### DIFF
--- a/docs/source/code-generation/introduction.mdx
+++ b/docs/source/code-generation/introduction.mdx
@@ -38,11 +38,13 @@ Apollo iOS combines the type information from your schema with your operation de
 
 The Apollo iOS Code Generation Engine parses your schema and operations and ensures that your operations are valid to be performed against the schema provided. It generates models that include all of the necessary information to create type-safe operations, send those operations as network requests, and parse the response data onto the type-safe response models.
 
-The most basic way to think about this is the following equation:
+There are many choices to made about the shape of the generated models and how they are packaged to be used in your project. You specify this through a [code generation configuration](./codegen-configuration).
 
-**Schema + Operations = Code**
+The most basic way to think about these is with the following equation:
 
-If you don't have any operations, our code generator won't know what information you want to fetch, so it can't generate the code to send a request or parse a result. If you don't provide a schema, our code generator won't know if your operations are valid or what types any of the fields you want to fetch will return, so it can't generate type-safe models. If you have both, the appropriate checks can be made and type-safe code can be generated.
+**Schema + Operations + Configuration = Code**
+
+If you don't have any operations, our code generator won't know what information you want to fetch, so it can't generate the code to send a request or parse a result. If you don't provide a schema, our code generator won't know if your operations are valid or what types any of the fields you want to fetch will return, so it can't generate type-safe models. If you don't provide a configuration our code generator can only make general assumptions about the generated code which may not be the best choice for your needs. If you have all three, the appropriate checks can be made and type-safe code can be generated, in a precise way for your project.
 
 ## Running code generation
 

--- a/docs/source/code-generation/introduction.mdx
+++ b/docs/source/code-generation/introduction.mdx
@@ -38,7 +38,7 @@ Apollo iOS combines the type information from your schema with your operation de
 
 The Apollo iOS Code Generation Engine parses your schema and operations and ensures that your operations are valid to be performed against the schema provided. It generates models that include all of the necessary information to create type-safe operations, send those operations as network requests, and parse the response data onto the type-safe response models.
 
-There are many choices to made about the shape of the generated models and how they are packaged to be used in your project. You specify this through a [code generation configuration](./codegen-configuration).
+There are many choices to be made about the shape of the generated models and how they are packaged to be used in your project. You specify this through a [code generation configuration](./codegen-configuration).
 
 The most basic way to think about these is with the following equation:
 


### PR DESCRIPTION
Closes #2829 

This stems from a docs feedback comment about why code generation couldn't just work with the two input sources. We have in the past always stated that `schema + operations = code` which is correct when using the most basic assumptions for the generated code but that's not the case in practical usage. This simply updates the codegen intro to state that configuration is part of the equation.