### PR TITLE
Add asEntityRootType converter to InlineFragments

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -70,6 +70,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("species", String.self),
@@ -102,6 +103,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("humanName", String?.self),
@@ -134,6 +136,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("laysEggs", Bool.self),
@@ -170,6 +173,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("bodyTemperature", Int.self),
@@ -210,6 +214,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("wingspan", Double.self),
@@ -246,6 +251,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.PetRock }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("favoriteToy", String.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -47,6 +47,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetailsCCN
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("height", Height.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -88,6 +88,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("wingspan", Double.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -238,6 +238,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),
@@ -291,6 +292,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -374,6 +376,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -475,6 +478,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -576,6 +580,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -672,6 +677,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -721,6 +727,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -817,6 +824,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
 
         public var height: Height { __data["height"] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -238,7 +238,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -219,6 +219,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("laysEggs", Bool.self),
@@ -271,6 +272,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -354,6 +356,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -456,6 +459,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -557,6 +561,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -653,6 +658,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -732,6 +738,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -829,6 +836,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("favoriteToy", String.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -47,6 +47,10 @@ public class AllAnimalsQuery: GraphQLQuery {
             __typename
             species
             ... on WarmBlooded {
+              predators {
+                __typename
+                species
+              }
               ...WarmBloodedDetails
               laysEggs
             }
@@ -219,13 +223,15 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("predators", [Predator].self),
             .field("laysEggs", Bool.self),
             .fragment(WarmBloodedDetails.self),
           ] }
 
+          public var predators: [Predator] { __data["predators"] }
           public var laysEggs: Bool { __data["laysEggs"] }
           public var species: String { __data["species"] }
           public var bodyTemperature: Int { __data["bodyTemperature"] }
@@ -241,6 +247,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public init(
             __typename: String,
+            predators: [Predator],
             laysEggs: Bool,
             species: String,
             bodyTemperature: Int,
@@ -256,11 +263,44 @@ public class AllAnimalsQuery: GraphQLQuery {
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
+                "predators": predators._fieldData,
                 "laysEggs": laysEggs,
                 "species": species,
                 "bodyTemperature": bodyTemperature,
                 "height": height._fieldData
             ]))
+          }
+
+          /// AllAnimal.Predator.AsWarmBlooded.Predator
+          ///
+          /// Parent Type: `Animal`
+          public struct Predator: AnimalKingdomAPI.SelectionSet {
+            public let __data: DataDict
+            public init(data: DataDict) { __data = data }
+
+            public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
+            public static var __selections: [ApolloAPI.Selection] { [
+              .field("species", String.self),
+            ] }
+
+            public var species: String { __data["species"] }
+
+            public init(
+              __typename: String,
+              species: String
+            ) {
+              let objectType = ApolloAPI.Object(
+                typename: __typename,
+                implementedInterfaces: [
+                  AnimalKingdomAPI.Interfaces.Animal
+              ])
+              self.init(data: DataDict(
+                objectType: objectType,
+                data: [
+                  "__typename": objectType.typename,
+                  "species": species
+              ]))
+            }
           }
         }
       }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -85,6 +85,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
 
         public var height: ClassroomPetDetailsCCN.AsAnimal.Height { __data["height"] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -90,6 +90,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
 
         public var species: String { __data["species"] }
@@ -126,6 +127,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
 
         public var humanName: String? { __data["humanName"] }
@@ -162,6 +164,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
 
         public var species: String { __data["species"] }
@@ -202,6 +205,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
 
         public var species: String { __data["species"] }
@@ -245,6 +249,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
 
         public var species: String { __data["species"] }
@@ -285,6 +290,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.PetRock }
 
         public var humanName: String? { __data["humanName"] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -87,6 +87,7 @@ public class DogQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(DogFragment.self),

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AllAnimalsQuery.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AllAnimalsQuery.graphql
@@ -34,6 +34,9 @@ query AllAnimalsQuery {
     predators {
       species
       ... on WarmBlooded {
+        predators {
+          species
+        }
         ...WarmBloodedDetails
         laysEggs
       }

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -142,7 +142,7 @@ extension SelectionSet where Fragments: FragmentContainer {
 }
 
 extension InlineFragment {
-  public var asRootEntityType: RootEntityType {
+  @inlinable public var asRootEntityType: RootEntityType {
     RootEntityType.init(data: __data)
   }
 }

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -25,7 +25,9 @@ public protocol RootSelectionSet: SelectionSet, OutputTypeConvertible { }
 /// from the fragment's parent `RootSelectionSet` that will be selected. This includes fields from
 /// the parent selection set, as well as any other child selections sets that are compatible with
 /// the `InlineFragment`'s `__parentType` and the operation's inclusion condition.
-public protocol InlineFragment: SelectionSet { }
+public protocol InlineFragment: SelectionSet {
+  associatedtype RootEntityType: RootSelectionSet
+}
 
 // MARK: - SelectionSet
 public protocol SelectionSet: SelectionSetEntityValue, Hashable {
@@ -137,4 +139,10 @@ extension SelectionSet {
 extension SelectionSet where Fragments: FragmentContainer {
   /// Contains accessors for all of the fragments the `SelectionSet` can be converted to.
   public var fragments: Fragments { Fragments(data: __data) }
+}
+
+extension InlineFragment {
+  public var asRootEntityType: RootEntityType {
+    RootEntityType.init(data: __data)
+  }
 }

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
@@ -112,6 +112,10 @@ public class GraphQLCompositeType: GraphQLNamedType {
   public override var debugDescription: String {
     "Type - \(name)"
   }
+
+  var isRootFieldType: Bool {
+    ["Query", "Mutation", "Subscription"].contains(name)
+  }
 }
 
 protocol GraphQLInterfaceImplementingType: GraphQLCompositeType {

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -122,12 +122,13 @@ struct SelectionSetTemplate {
 
   private func RootEntityTypealias(_ selectionSet: IR.SelectionSet) -> TemplateString {
     guard !selectionSet.isEntityRoot else { return "" }
-    let rootEntityName = selectionSet
-      .entity
-      .fieldPath
-      .last
-      .value
-      .formattedSelectionSetName(with: config.pluralizer)
+    let rootEntityName = SelectionSetNameGenerator.generatedSelectionSetName(
+      from: selectionSet.scopePath.head,
+      to: selectionSet.scopePath.last.value.scopePath.head,
+      withFieldPath: selectionSet.entity.fieldPath.head,
+      removingFirst: selectionSet.scopePath.head.value.type.isRootFieldType,
+      pluralizer: config.pluralizer
+    )
     return """
     public typealias RootEntityType = \(rootEntityName)
     """
@@ -692,26 +693,38 @@ fileprivate struct SelectionSetNameGenerator {
 
   static func generatedSelectionSetName(
     from typePathNode: LinkedList<IR.ScopeDescriptor>.Node,
+    to endingNode: LinkedList<IR.ScopeCondition>.Node? = nil,
     withFieldPath fieldPathNode: IR.Entity.FieldPath.Node,
     removingFirst: Bool = false,
     pluralizer: Pluralizer
   ) -> String {
     var currentTypePathNode = Optional(typePathNode)
     var currentFieldPathNode = Optional(fieldPathNode)
-    var fieldPathIndex = 0
 
     var components: [String] = []
 
-    repeat {
+    iterateEntityScopes: repeat {
       let fieldName = currentFieldPathNode.unsafelyUnwrapped.value
         .formattedSelectionSetName(with: pluralizer)
       components.append(fieldName)
 
-      if let conditionNodes = currentTypePathNode.unsafelyUnwrapped.value.scopePath.head.next {
-        ConditionPath.add(conditionNodes, to: &components)
+      var currentConditionNode = Optional(currentTypePathNode.unsafelyUnwrapped.value.scopePath.head)
+      guard currentConditionNode !== endingNode else {
+        break iterateEntityScopes
       }
 
-      fieldPathIndex += 1
+      currentConditionNode = currentTypePathNode.unsafelyUnwrapped.value.scopePath.head.next
+      iterateConditionScopes: while currentConditionNode !== nil {
+        let node = currentConditionNode.unsafelyUnwrapped
+
+        components.append(node.value.selectionSetNameComponent)
+        guard node !== endingNode else {
+          break iterateEntityScopes
+        }
+
+        currentConditionNode = node.next
+      }
+
       currentTypePathNode = currentTypePathNode.unsafelyUnwrapped.next
       currentFieldPathNode = currentFieldPathNode.unsafelyUnwrapped.next
     } while currentTypePathNode !== nil
@@ -724,15 +737,6 @@ fileprivate struct SelectionSetNameGenerator {
   fileprivate struct ConditionPath {
     static func path(for conditions: LinkedList<IR.ScopeCondition>.Node) -> String {
       conditions.map(\.selectionSetNameComponent).joined(separator: ".")
-    }
-
-    static func add(
-      _ conditionNodes: LinkedList<IR.ScopeCondition>.Node,
-      to components: inout [String]
-    ) {
-      for condition in conditionNodes {
-        components.append(condition.selectionSetNameComponent)
-      }
     }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -95,6 +95,7 @@ struct SelectionSetTemplate {
     return """
     \(DataFieldAndInitializerTemplate())
 
+    \(RootEntityTypealias(selectionSet))
     \(ParentTypeTemplate(selectionSet.parentType))
     \(ifLet: selections.direct?.groupedByInclusionCondition, { SelectionsTemplate($0, in: scope) })
 
@@ -116,6 +117,19 @@ struct SelectionSetTemplate {
     """
     public \(isMutable ? "var" : "let") __data: DataDict
     public init(data: DataDict) { __data = data }
+    """
+  }
+
+  private func RootEntityTypealias(_ selectionSet: IR.SelectionSet) -> TemplateString {
+    guard !selectionSet.isEntityRoot else { return "" }
+    let rootEntityName = selectionSet
+      .entity
+      .fieldPath
+      .last
+      .value
+      .formattedSelectionSetName(with: config.pluralizer)
+    return """
+    public typealias RootEntityType = \(rootEntityName)
     """
   }
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
@@ -37,6 +37,7 @@ public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = AuthorDetails
     public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("id", GitHubAPI.ID.self),

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -146,6 +146,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
               public let __data: DataDict
               public init(data: DataDict) { __data = data }
 
+              public typealias RootEntityType = Author
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }
 
               /// The username of the actor.
@@ -227,6 +228,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
                   public let __data: DataDict
                   public init(data: DataDict) { __data = data }
 
+                  public typealias RootEntityType = Author
                   public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }
 
                   /// The username of the actor.

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -146,7 +146,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
               public let __data: DataDict
               public init(data: DataDict) { __data = data }
 
-              public typealias RootEntityType = Author
+              public typealias RootEntityType = Repository.Issues.Node.Author
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }
 
               /// The username of the actor.
@@ -228,7 +228,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
                   public let __data: DataDict
                   public init(data: DataDict) { __data = data }
 
-                  public typealias RootEntityType = Author
+                  public typealias RootEntityType = Repository.Issues.Node.Comments.Node.Author
                   public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }
 
                   /// The username of the actor.

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -97,7 +97,7 @@ public class RepositoryQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = IssueOrPullRequest
+          public typealias RootEntityType = Repository.IssueOrPullRequest
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Issue }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("body", String.self),
@@ -140,7 +140,7 @@ public class RepositoryQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = IssueOrPullRequest
+          public typealias RootEntityType = Repository.IssueOrPullRequest
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Reactable }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("viewerCanReact", Bool.self),
@@ -159,7 +159,7 @@ public class RepositoryQuery: GraphQLQuery {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
-            public typealias RootEntityType = IssueOrPullRequest
+            public typealias RootEntityType = Repository.IssueOrPullRequest
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Comment }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("author", Author?.self),

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -97,6 +97,7 @@ public class RepositoryQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = IssueOrPullRequest
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Issue }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("body", String.self),
@@ -139,6 +140,7 @@ public class RepositoryQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = IssueOrPullRequest
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Reactable }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("viewerCanReact", Bool.self),
@@ -157,6 +159,7 @@ public class RepositoryQuery: GraphQLQuery {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = IssueOrPullRequest
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Comment }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("author", Author?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -53,6 +53,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = CharacterNameAndDroidAppearsIn
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -57,6 +57,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = CharacterNameAndDroidPrimaryFunction
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
     public static var __selections: [ApolloAPI.Selection] { [
       .fragment(DroidPrimaryFunction.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -56,6 +56,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = CharacterNameWithInlineFragment
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("friends", [Friend?]?.self),
@@ -117,6 +118,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = CharacterNameWithInlineFragment
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
     public static var __selections: [ApolloAPI.Selection] { [
       .fragment(CharacterName.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -59,6 +59,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = HeroDetails
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("height", Double?.self),
@@ -91,6 +92,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = HeroDetails
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("primaryFunction", String?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -86,6 +86,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(DroidDetails.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -142,6 +142,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("friends", [Friend?]?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -93,6 +93,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
 
         /// The name of the character

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -89,6 +89,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("name", String.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -101,6 +101,7 @@ public class HeroDetailsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Double?.self),
@@ -133,6 +134,7 @@ public class HeroDetailsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("primaryFunction", String?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -99,6 +99,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
 
         /// The name of the character
@@ -135,6 +136,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
 
         /// The name of the character

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -130,6 +130,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("primaryFunction", String?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -130,7 +130,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Friend
+          public typealias RootEntityType = Hero.Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("primaryFunction", String?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -135,6 +135,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("name", String.self),
@@ -170,6 +171,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("primaryFunction", String?.self),
@@ -202,6 +204,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
 
           /// The name of the character

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -135,7 +135,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Friend
+          public typealias RootEntityType = Hero.Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("name", String.self),
@@ -171,7 +171,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
-            public typealias RootEntityType = Friend
+            public typealias RootEntityType = Hero.Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("primaryFunction", String?.self),
@@ -204,7 +204,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Friend
+          public typealias RootEntityType = Hero.Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
 
           /// The name of the character

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -103,6 +103,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("name", String.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -182,7 +182,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
-            public typealias RootEntityType = Friend
+            public typealias RootEntityType = Hero.AsHuman.Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("height", Double?.self, arguments: ["unit": "FOOT"]),
@@ -284,7 +284,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
-            public typealias RootEntityType = Friend
+            public typealias RootEntityType = Hero.AsDroid.Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("height", Double?.self, arguments: ["unit": "METER"]),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -115,6 +115,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("friends", [Friend?]?.self),
@@ -181,6 +182,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("height", Double?.self, arguments: ["unit": "FOOT"]),
@@ -215,6 +217,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("friends", [Friend?]?.self),
@@ -281,6 +284,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("height", Double?.self, arguments: ["unit": "METER"]),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -94,6 +94,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("homePlanet", alias: "property", String?.self),
@@ -122,6 +123,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("primaryFunction", alias: "property", String?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -102,6 +102,7 @@ public class SearchQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Search
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("id", StarWarsAPI.ID.self),
@@ -135,6 +136,7 @@ public class SearchQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Search
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("id", StarWarsAPI.ID.self),
@@ -168,6 +170,7 @@ public class SearchQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = Search
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Starship }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("id", StarWarsAPI.ID.self),

--- a/Tests/ApolloCodegenTests/AnimalKingdomAPI/AnimalKingdomIRCreationTests.swift
+++ b/Tests/ApolloCodegenTests/AnimalKingdomAPI/AnimalKingdomIRCreationTests.swift
@@ -265,6 +265,8 @@ final class AnimalKingdomIRCreationTests: XCTestCase {
 
     expected = (
       fields: [
+        .mock("predators",
+              type: .nonNull(.list(.nonNull(.entity(.mock("Animal")))))),
         .mock("laysEggs",
               type: .nonNull(.scalar(GraphQLScalarType.boolean()))),
       ],

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -1727,7 +1727,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asPet)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
   }
 
   // MARK: - Field Accessors - Scalar
@@ -2089,7 +2089,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: dog)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   // MARK: Field Accessors - Reserved Keywords + Special Names
@@ -2886,7 +2886,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(allAnimals_predator_actual).to(equalLineByLine(predator_expected, atLine: 12, ignoringExtraLines: true))
-    expect(allAnimals_predator_asPet_actual).to(equalLineByLine(predator_asPet_expected, atLine: 8, ignoringExtraLines: true))
+    expect(allAnimals_predator_asPet_actual).to(equalLineByLine(predator_asPet_expected, atLine: 9, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldMergedFromFragmentWithEntityNestedInEntityTypeCase_rendersFieldAccessor() throws {
@@ -2955,7 +2955,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(allAnimals_predator_actual).to(equalLineByLine(predator_expected, atLine: 11, ignoringExtraLines: true))
-    expect(allAnimals_predator_asPet_actual).to(equalLineByLine(predator_asPet_expected, atLine: 8, ignoringExtraLines: true))
+    expect(allAnimals_predator_asPet_actual).to(equalLineByLine(predator_asPet_expected, atLine: 9, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenTypeCaseMergedFromFragmentWithOtherMergedFields_rendersFieldAccessor() throws {
@@ -3136,7 +3136,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(predator_asPet_actual)
-      .to(equalLineByLine(predator_asPet_expected, atLine: 8, ignoringExtraLines: true))
+      .to(equalLineByLine(predator_asPet_expected, atLine: 9, ignoringExtraLines: true))
   }
 
   // MARK: Field Accessors - Merged From Parent
@@ -3187,7 +3187,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asDog)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldMergedFromSiblingTypeCase_rendersFieldAccessorWithCorrectName() throws {
@@ -3243,7 +3243,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asDog)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldNestedInEntityFieldMergedFromParent_rendersFieldAccessorWithCorrectName() throws {
@@ -3492,7 +3492,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asDog)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessor__givenNonNullFieldMergedFromParentWithIncludeConditionThatMatchesScope_rendersAsNotOptional() throws {
@@ -3533,7 +3533,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_ifA)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessor__givenNonNullFieldWithIncludeConditionThatMatchesScope_rendersAsNotOptional() throws {
@@ -4111,7 +4111,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asCat)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 
   // MARK: - Fragment Accessors - Include Skip
@@ -4303,7 +4303,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_ifA)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
   }
 
   // MARK: - Nested Selection Sets
@@ -4909,7 +4909,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(allAnimals_predator_actual)
       .to(equalLineByLine(allAnimals_predator_expected, atLine: 11, ignoringExtraLines: true))
     expect(allAnimals_predator_asWarmBlooded_actual)
-      .to(equalLineByLine(allAnimals_predator_asWarmBlooded_expected, atLine: 11, ignoringExtraLines: true))
+      .to(equalLineByLine(allAnimals_predator_asWarmBlooded_expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSets__givenDirectSelection_typeCase_rendersNestedSelectionSet() throws {
@@ -5284,6 +5284,110 @@ class SelectionSetTemplateTests: XCTestCase {
       expect(predator_actual)
         .to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
     }
+  }
+
+  // MARK: - InlineFragment RootEntityType Tests
+
+  func test__render_nestedTypeCase__rendersRootEntityType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+      predators: [Animal!]
+    }
+
+    interface Pet {
+      name: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Pet {
+          name
+        }
+      }
+    }
+    """
+
+    let expected = """
+    /// AllAnimal.AsPet
+    public struct AsPet: TestSchema.InlineFragment {
+      public let __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public typealias RootEntityType = AllAnimal
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals_AsPet = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?[as: "Pet"]
+    )
+
+    let actual = subject.render(inlineFragment: allAnimals_AsPet)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))
+  }
+
+  func test__render_doublyNestedTypeCase__rendersRootEntityType() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+      predators: [Animal!]
+    }
+
+    interface Pet {
+      name: String!
+    }
+
+    interface WarmBlooded {
+      name: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on WarmBlooded {
+          ... on Pet {
+            name
+          }
+        }
+      }
+    }
+    """
+
+    let expected = """
+    /// AllAnimal.AsWarmBlooded.AsPet
+    public struct AsPet: TestSchema.InlineFragment {
+      public let __data: DataDict
+      public init(data: DataDict) { __data = data }
+
+      public typealias RootEntityType = AllAnimal
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals_AsPet = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?[as: "WarmBlooded"]?[as: "Pet"]
+    )
+
+    let actual = subject.render(inlineFragment: allAnimals_AsPet)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 1, ignoringExtraLines: true))
   }
 
   // MARK: - Documentation Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -211,7 +211,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asPet_asWarmBlooded)
     
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
   
   // MARK: Selection Tests
@@ -677,7 +677,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_asPet)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
   }
 
   func test__render_given_mergedOnly_SelectionSet_rendersInitializer() throws {

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -83,7 +83,9 @@ open class MockFragment: MockSelectionSet, Fragment {
   open class var fragmentDefinition: StaticString { "" }
 }
 
-open class MockTypeCase: MockSelectionSet, InlineFragment { }
+open class MockTypeCase: MockSelectionSet, InlineFragment {
+  public typealias RootEntityType = MockSelectionSet
+}
 
 extension DataDict {
   public static func empty() -> DataDict {

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -845,6 +845,8 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         struct AsDroid: MockMutableInlineFragment {
           public var __data: DataDict = .empty()
+
+          public typealias RootEntityType = Hero
           static let __parentType: ParentType = Types.Droid
           init(data: DataDict) { __data = data }
 
@@ -933,6 +935,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct AsDroid: MockMutableInlineFragment {
         public var __data: DataDict = .empty()
+        public typealias RootEntityType = GivenFragment
         static let __parentType: ParentType = Types.Droid
         init(data: DataDict) { __data = data }
 
@@ -1064,6 +1067,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct AsDroid: MockMutableInlineFragment {
         public var __data: DataDict = .empty()
+        public typealias RootEntityType = GivenFragment
         static let __parentType: ParentType = Types.Droid
         init(data: DataDict) { __data = data }
 
@@ -1113,6 +1117,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         struct AsDroid: MockMutableInlineFragment {
           public var __data: DataDict = .empty()
+          public typealias RootEntityType = GivenFragment
           static let __parentType: ParentType = Types.Droid
           init(data: DataDict) { __data = data }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetails.graphql.swift
@@ -63,6 +63,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetails
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("species", String.self),
@@ -78,6 +79,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetails
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("humanName", String?.self),
@@ -93,6 +95,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetails
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("laysEggs", Bool.self),
@@ -109,6 +112,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetails
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Cat }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("bodyTemperature", Int.self),
@@ -129,6 +133,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetails
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Bird }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("wingspan", Double.self),
@@ -147,6 +152,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetails
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.PetRock }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -35,6 +35,7 @@ public extension MyGraphQLSchema {
       public let __data: DataDict
       public init(data: DataDict) { __data = data }
 
+      public typealias RootEntityType = ClassroomPetDetailsCCN
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
         .field("height", Height.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -23,6 +23,18 @@ public extension MyGraphQLSchema {
         set { __data["allAnimals"] = newValue }
       }
 
+      public init(
+        allAnimals: [AllAnimal]
+      ) {
+        let objectType = MyGraphQLSchema.Objects.Query
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "allAnimals": allAnimals._fieldData
+        ]))
+      }
+
       /// AllAnimal
       ///
       /// Parent Type: `Animal`
@@ -51,6 +63,25 @@ public extension MyGraphQLSchema {
           set { if let newData = newValue?.__data._data { __data._data = newData }}
         }
 
+        public init(
+          __typename: String,
+          species: String,
+          skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? = nil
+        ) {
+          let objectType = ApolloAPI.Object(
+            typename: __typename,
+            implementedInterfaces: [
+              MyGraphQLSchema.Interfaces.Animal
+          ])
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "species": species,
+              "skinCovering": skinCovering
+          ]))
+        }
+
         /// AllAnimal.AsBird
         ///
         /// Parent Type: `Bird`
@@ -58,6 +89,7 @@ public extension MyGraphQLSchema {
           public var __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -74,6 +106,22 @@ public extension MyGraphQLSchema {
           public var skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? {
             get { __data["skinCovering"] }
             set { __data["skinCovering"] = newValue }
+          }
+
+          public init(
+            wingspan: Double,
+            species: String,
+            skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? = nil
+          ) {
+            let objectType = MyGraphQLSchema.Objects.Bird
+            self.init(data: DataDict(
+              objectType: objectType,
+              data: [
+                "__typename": objectType.typename,
+                "wingspan": wingspan,
+                "species": species,
+                "skinCovering": skinCovering
+            ]))
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -28,6 +28,23 @@ public extension MyGraphQLSchema {
       set { __data["owner"] = newValue }
     }
 
+    public init(
+      __typename: String,
+      owner: Owner? = nil
+    ) {
+      let objectType = ApolloAPI.Object(
+        typename: __typename,
+        implementedInterfaces: [
+          MyGraphQLSchema.Interfaces.Pet
+      ])
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "owner": owner._fieldData
+      ]))
+    }
+
     /// Owner
     ///
     /// Parent Type: `Human`
@@ -43,6 +60,18 @@ public extension MyGraphQLSchema {
       public var firstName: String {
         get { __data["firstName"] }
         set { __data["firstName"] = newValue }
+      }
+
+      public init(
+        firstName: String
+      ) {
+        let objectType = MyGraphQLSchema.Objects.Human
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "firstName": firstName
+        ]))
       }
     }
   }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -40,6 +40,18 @@ public extension MyGraphQLSchema {
         set { __data["pets"] = newValue }
       }
 
+      public init(
+        pets: [Pet]
+      ) {
+        let objectType = MyGraphQLSchema.Objects.Query
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "pets": pets._fieldData
+        ]))
+      }
+
       /// Pet
       ///
       /// Parent Type: `Pet`
@@ -60,6 +72,25 @@ public extension MyGraphQLSchema {
         public var humanName: String? {
           get { __data["humanName"] }
           set { __data["humanName"] = newValue }
+        }
+
+        public init(
+          __typename: String,
+          id: MyGraphQLSchema.ID,
+          humanName: String? = nil
+        ) {
+          let objectType = ApolloAPI.Object(
+            typename: __typename,
+            implementedInterfaces: [
+              MyGraphQLSchema.Interfaces.Pet
+          ])
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "id": id,
+              "humanName": humanName
+          ]))
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -179,6 +179,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = Predator
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("species", String.self),
@@ -208,6 +209,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -249,6 +251,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("height", Height.self),
@@ -302,6 +305,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = AllAnimal
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
               .fragment(WarmBloodedDetails.self),
@@ -350,6 +354,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Cat }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("isJellicle", Bool.self),
@@ -398,6 +403,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Unions.ClassroomPet }
           public static var __selections: [ApolloAPI.Selection] { [
             .inlineFragment(AsBird.self),
@@ -424,6 +430,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = AllAnimal
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Bird }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("wingspan", Double.self),
@@ -472,6 +479,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
 
           public var height: Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -179,7 +179,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
-            public typealias RootEntityType = Predator
+            public typealias RootEntityType = AllAnimal.Predator
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("species", String.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -159,6 +159,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = Predator
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("laysEggs", Bool.self),
@@ -187,6 +188,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -228,6 +230,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("height", Height.self),
@@ -280,6 +283,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = AllAnimal
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
               .fragment(WarmBloodedDetails.self),
@@ -328,6 +332,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Cat }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("isJellicle", Bool.self),
@@ -376,6 +381,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Unions.ClassroomPet }
           public static var __selections: [ApolloAPI.Selection] { [
             .inlineFragment(AsBird.self),
@@ -416,6 +422,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
+            public typealias RootEntityType = AllAnimal
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Bird }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("wingspan", Double.self),
@@ -465,6 +472,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Dog }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -55,6 +55,10 @@ public extension MyGraphQLSchema {
               species
               ... on WarmBlooded {
                 __typename
+                predators {
+                  __typename
+                  species
+                }
                 ...WarmBloodedDetails
                 laysEggs
               }
@@ -162,10 +166,12 @@ public extension MyGraphQLSchema {
             public typealias RootEntityType = Predator
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("predators", [Predator].self),
               .field("laysEggs", Bool.self),
               .fragment(WarmBloodedDetails.self),
             ] }
 
+            public var predators: [Predator] { __data["predators"] }
             public var laysEggs: Bool { __data["laysEggs"] }
             public var species: String { __data["species"] }
             public var bodyTemperature: Int { __data["bodyTemperature"] }
@@ -177,6 +183,21 @@ public extension MyGraphQLSchema {
 
               public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
               public var heightInMeters: HeightInMeters { _toFragment() }
+            }
+
+            /// AllAnimal.Predator.AsWarmBlooded.Predator
+            ///
+            /// Parent Type: `Animal`
+            public struct Predator: MyGraphQLSchema.SelectionSet {
+              public let __data: DataDict
+              public init(data: DataDict) { __data = data }
+
+              public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
+              public static var __selections: [ApolloAPI.Selection] { [
+                .field("species", String.self),
+              ] }
+
+              public var species: String { __data["species"] }
             }
           }
         }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -163,7 +163,7 @@ public extension MyGraphQLSchema {
             public let __data: DataDict
             public init(data: DataDict) { __data = data }
 
-            public typealias RootEntityType = Predator
+            public typealias RootEntityType = AllAnimal.Predator
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
             public static var __selections: [ApolloAPI.Selection] { [
               .field("predators", [Predator].self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -60,6 +60,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
 
           public var height: ClassroomPetDetailsCCN.AsAnimal.Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -65,6 +65,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
 
           public var species: String { __data["species"] }
@@ -84,6 +85,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
 
           public var humanName: String? { __data["humanName"] }
@@ -103,6 +105,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
 
           public var species: String { __data["species"] }
@@ -123,6 +126,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Cat }
 
           public var species: String { __data["species"] }
@@ -146,6 +150,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Bird }
 
           public var species: String { __data["species"] }
@@ -168,6 +173,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = ClassroomPet
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.PetRock }
 
           public var humanName: String? { __data["humanName"] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
@@ -60,6 +60,7 @@ public extension MyGraphQLSchema {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Dog }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(DogFragment.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -179,6 +179,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),
@@ -208,6 +209,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -249,6 +251,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -302,6 +305,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -350,6 +354,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -398,6 +403,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -424,6 +430,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -472,6 +479,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
 
         public var height: Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -179,7 +179,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsLocalCacheMutation.graphql.swift
@@ -23,6 +23,18 @@ class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       set { __data["allAnimals"] = newValue }
     }
 
+    public init(
+      allAnimals: [AllAnimal]
+    ) {
+      let objectType = MySchemaModule.Objects.Query
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "allAnimals": allAnimals._fieldData
+      ]))
+    }
+
     /// AllAnimal
     ///
     /// Parent Type: `Animal`
@@ -51,6 +63,25 @@ class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         set { if let newData = newValue?.__data._data { __data._data = newData }}
       }
 
+      public init(
+        __typename: String,
+        species: String,
+        skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? = nil
+      ) {
+        let objectType = ApolloAPI.Object(
+          typename: __typename,
+          implementedInterfaces: [
+            MySchemaModule.Interfaces.Animal
+        ])
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "species": species,
+            "skinCovering": skinCovering
+        ]))
+      }
+
       /// AllAnimal.AsBird
       ///
       /// Parent Type: `Bird`
@@ -58,6 +89,7 @@ class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Bird }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("wingspan", Double.self),
@@ -74,6 +106,22 @@ class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? {
           get { __data["skinCovering"] }
           set { __data["skinCovering"] = newValue }
+        }
+
+        public init(
+          wingspan: Double,
+          species: String,
+          skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? = nil
+        ) {
+          let objectType = MySchemaModule.Objects.Bird
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "wingspan": wingspan,
+              "species": species,
+              "skinCovering": skinCovering
+          ]))
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
@@ -159,6 +159,7 @@ class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("laysEggs", Bool.self),
@@ -187,6 +188,7 @@ class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -228,6 +230,7 @@ class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -280,6 +283,7 @@ class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -328,6 +332,7 @@ class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -376,6 +381,7 @@ class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -416,6 +422,7 @@ class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -465,6 +472,7 @@ class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
@@ -159,7 +159,7 @@ class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("laysEggs", Bool.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetDetails.graphql.swift
@@ -63,6 +63,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("species", String.self),
@@ -78,6 +79,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("humanName", String?.self),
@@ -93,6 +95,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("laysEggs", Bool.self),
@@ -109,6 +112,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Cat }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("bodyTemperature", Int.self),
@@ -129,6 +133,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Bird }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("wingspan", Double.self),
@@ -147,6 +152,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.PetRock }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
@@ -65,6 +65,7 @@ class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
 
         public var species: String { __data["species"] }
@@ -84,6 +85,7 @@ class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
 
         public var humanName: String? { __data["humanName"] }
@@ -103,6 +105,7 @@ class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
 
         public var species: String { __data["species"] }
@@ -123,6 +126,7 @@ class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Cat }
 
         public var species: String { __data["species"] }
@@ -146,6 +150,7 @@ class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Bird }
 
         public var species: String { __data["species"] }
@@ -168,6 +173,7 @@ class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.PetRock }
 
         public var humanName: String? { __data["humanName"] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetailsMutation.graphql.swift
@@ -28,6 +28,23 @@ struct PetDetailsMutation: MySchemaModule.MutableSelectionSet, Fragment {
     set { __data["owner"] = newValue }
   }
 
+  public init(
+    __typename: String,
+    owner: Owner? = nil
+  ) {
+    let objectType = ApolloAPI.Object(
+      typename: __typename,
+      implementedInterfaces: [
+        MySchemaModule.Interfaces.Pet
+    ])
+    self.init(data: DataDict(
+      objectType: objectType,
+      data: [
+        "__typename": objectType.typename,
+        "owner": owner._fieldData
+    ]))
+  }
+
   /// Owner
   ///
   /// Parent Type: `Human`
@@ -43,6 +60,18 @@ struct PetDetailsMutation: MySchemaModule.MutableSelectionSet, Fragment {
     public var firstName: String {
       get { __data["firstName"] }
       set { __data["firstName"] = newValue }
+    }
+
+    public init(
+      firstName: String
+    ) {
+      let objectType = MySchemaModule.Objects.Human
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "firstName": firstName
+      ]))
     }
   }
 }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetDetailsCCN.graphql.swift
@@ -35,6 +35,7 @@ struct ClassroomPetDetailsCCN: MySchemaModule.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetailsCCN
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("height", Height.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
@@ -60,6 +60,7 @@ class ClassroomPetsCCNQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
 
         public var height: ClassroomPetDetailsCCN.AsAnimal.Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetails.graphql.swift
@@ -56,6 +56,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
     public static var __selections: [Apollo.Selection] { [
       .field("species", String.self),
@@ -71,6 +72,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
     public static var __selections: [Apollo.Selection] { [
       .field("humanName", String?.self),
@@ -86,6 +88,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
     public static var __selections: [Apollo.Selection] { [
       .field("laysEggs", Bool.self),
@@ -102,6 +105,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Cat }
     public static var __selections: [Apollo.Selection] { [
       .field("bodyTemperature", Int.self),
@@ -122,6 +126,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Bird }
     public static var __selections: [Apollo.Selection] { [
       .field("wingspan", Double.self),
@@ -140,6 +145,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.PetRock }
     public static var __selections: [Apollo.Selection] { [
       .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -33,6 +33,7 @@ public struct ClassroomPetDetailsCCN: MyCustomProject.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetailsCCN
     public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
     public static var __selections: [Apollo.Selection] { [
       .field("height", Height.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -22,6 +22,18 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       set { __data["allAnimals"] = newValue }
     }
 
+    public init(
+      allAnimals: [AllAnimal]
+    ) {
+      let objectType = MyCustomProject.Objects.Query
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "allAnimals": allAnimals._fieldData
+      ]))
+    }
+
     /// AllAnimal
     ///
     /// Parent Type: `Animal`
@@ -50,6 +62,25 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         set { if let newData = newValue?.__data._data { __data._data = newData }}
       }
 
+      public init(
+        __typename: String,
+        species: String,
+        skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? = nil
+      ) {
+        let objectType = Apollo.Object(
+          typename: __typename,
+          implementedInterfaces: [
+            MyCustomProject.Interfaces.Animal
+        ])
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "species": species,
+            "skinCovering": skinCovering
+        ]))
+      }
+
       /// AllAnimal.AsBird
       ///
       /// Parent Type: `Bird`
@@ -57,6 +88,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Bird }
         public static var __selections: [Apollo.Selection] { [
           .field("wingspan", Double.self),
@@ -73,6 +105,22 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? {
           get { __data["skinCovering"] }
           set { __data["skinCovering"] = newValue }
+        }
+
+        public init(
+          wingspan: Double,
+          species: String,
+          skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? = nil
+        ) {
+          let objectType = MyCustomProject.Objects.Bird
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "wingspan": wingspan,
+              "species": species,
+              "skinCovering": skinCovering
+          ]))
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -27,6 +27,23 @@ public struct PetDetailsMutation: MyCustomProject.MutableSelectionSet, Fragment 
     set { __data["owner"] = newValue }
   }
 
+  public init(
+    __typename: String,
+    owner: Owner? = nil
+  ) {
+    let objectType = Apollo.Object(
+      typename: __typename,
+      implementedInterfaces: [
+        MyCustomProject.Interfaces.Pet
+    ])
+    self.init(data: DataDict(
+      objectType: objectType,
+      data: [
+        "__typename": objectType.typename,
+        "owner": owner._fieldData
+    ]))
+  }
+
   /// Owner
   ///
   /// Parent Type: `Human`
@@ -42,6 +59,18 @@ public struct PetDetailsMutation: MyCustomProject.MutableSelectionSet, Fragment 
     public var firstName: String {
       get { __data["firstName"] }
       set { __data["firstName"] = newValue }
+    }
+
+    public init(
+      firstName: String
+    ) {
+      let objectType = MyCustomProject.Objects.Human
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "firstName": firstName
+      ]))
     }
   }
 }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -39,6 +39,18 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
       set { __data["pets"] = newValue }
     }
 
+    public init(
+      pets: [Pet]
+    ) {
+      let objectType = MyCustomProject.Objects.Query
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "pets": pets._fieldData
+      ]))
+    }
+
     /// Pet
     ///
     /// Parent Type: `Pet`
@@ -59,6 +71,25 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
       public var humanName: String? {
         get { __data["humanName"] }
         set { __data["humanName"] = newValue }
+      }
+
+      public init(
+        __typename: String,
+        id: MyCustomProject.ID,
+        humanName: String? = nil
+      ) {
+        let objectType = Apollo.Object(
+          typename: __typename,
+          implementedInterfaces: [
+            MyCustomProject.Interfaces.Pet
+        ])
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "id": id,
+            "humanName": humanName
+        ]))
       }
     }
   }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -172,7 +172,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
           public static var __selections: [Apollo.Selection] { [
             .field("species", String.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -172,6 +172,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
           public static var __selections: [Apollo.Selection] { [
             .field("species", String.self),
@@ -201,6 +202,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
         public static var __selections: [Apollo.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -242,6 +244,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
         public static var __selections: [Apollo.Selection] { [
           .field("height", Height.self),
@@ -295,6 +298,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
           public static var __selections: [Apollo.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -343,6 +347,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Cat }
         public static var __selections: [Apollo.Selection] { [
           .field("isJellicle", Bool.self),
@@ -391,6 +396,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Unions.ClassroomPet }
         public static var __selections: [Apollo.Selection] { [
           .inlineFragment(AsBird.self),
@@ -417,6 +423,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Bird }
           public static var __selections: [Apollo.Selection] { [
             .field("wingspan", Double.self),
@@ -465,6 +472,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
 
         public var height: Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -47,6 +47,10 @@ public class AllAnimalsQuery: GraphQLQuery {
             __typename
             species
             ... on WarmBlooded {
+              predators {
+                __typename
+                species
+              }
               ...WarmBloodedDetails
               laysEggs
             }
@@ -151,13 +155,15 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
           public static var __selections: [Apollo.Selection] { [
+            .field("predators", [Predator].self),
             .field("laysEggs", Bool.self),
             .fragment(WarmBloodedDetails.self),
           ] }
 
+          public var predators: [Predator] { __data["predators"] }
           public var laysEggs: Bool { __data["laysEggs"] }
           public var species: String { __data["species"] }
           public var bodyTemperature: Int { __data["bodyTemperature"] }
@@ -169,6 +175,21 @@ public class AllAnimalsQuery: GraphQLQuery {
 
             public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
             public var heightInMeters: HeightInMeters { _toFragment() }
+          }
+
+          /// AllAnimal.Predator.AsWarmBlooded.Predator
+          ///
+          /// Parent Type: `Animal`
+          public struct Predator: MyCustomProject.SelectionSet {
+            public let __data: DataDict
+            public init(data: DataDict) { __data = data }
+
+            public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
+            public static var __selections: [Apollo.Selection] { [
+              .field("species", String.self),
+            ] }
+
+            public var species: String { __data["species"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -151,6 +151,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
           public static var __selections: [Apollo.Selection] { [
             .field("laysEggs", Bool.self),
@@ -179,6 +180,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
         public static var __selections: [Apollo.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -220,6 +222,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
         public static var __selections: [Apollo.Selection] { [
           .field("height", Height.self),
@@ -272,6 +275,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
           public static var __selections: [Apollo.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -320,6 +324,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Cat }
         public static var __selections: [Apollo.Selection] { [
           .field("isJellicle", Bool.self),
@@ -368,6 +373,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Unions.ClassroomPet }
         public static var __selections: [Apollo.Selection] { [
           .inlineFragment(AsBird.self),
@@ -408,6 +414,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Bird }
           public static var __selections: [Apollo.Selection] { [
             .field("wingspan", Double.self),
@@ -457,6 +464,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Dog }
         public static var __selections: [Apollo.Selection] { [
           .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -59,6 +59,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
 
         public var height: ClassroomPetDetailsCCN.AsAnimal.Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -64,6 +64,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
 
         public var species: String { __data["species"] }
@@ -83,6 +84,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
 
         public var humanName: String? { __data["humanName"] }
@@ -102,6 +104,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
 
         public var species: String { __data["species"] }
@@ -122,6 +125,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Cat }
 
         public var species: String { __data["species"] }
@@ -145,6 +149,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Bird }
 
         public var species: String { __data["species"] }
@@ -167,6 +172,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.PetRock }
 
         public var humanName: String? { __data["humanName"] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
@@ -58,6 +58,7 @@ public class DogQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Dog }
         public static var __selections: [Apollo.Selection] { [
           .fragment(DogFragment.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetails.graphql.swift
@@ -62,6 +62,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("species", String.self),
@@ -77,6 +78,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("humanName", String?.self),
@@ -92,6 +94,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("laysEggs", Bool.self),
@@ -108,6 +111,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Cat }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("bodyTemperature", Int.self),
@@ -128,6 +132,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Bird }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("wingspan", Double.self),
@@ -146,6 +151,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.PetRock }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -34,6 +34,7 @@ public struct ClassroomPetDetailsCCN: GraphQLAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetailsCCN
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("height", Height.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -22,6 +22,18 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       set { __data["allAnimals"] = newValue }
     }
 
+    public init(
+      allAnimals: [AllAnimal]
+    ) {
+      let objectType = GraphQLAPI.Objects.Query
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "allAnimals": allAnimals._fieldData
+      ]))
+    }
+
     /// AllAnimal
     ///
     /// Parent Type: `Animal`
@@ -50,6 +62,25 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         set { if let newData = newValue?.__data._data { __data._data = newData }}
       }
 
+      public init(
+        __typename: String,
+        species: String,
+        skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? = nil
+      ) {
+        let objectType = ApolloAPI.Object(
+          typename: __typename,
+          implementedInterfaces: [
+            GraphQLAPI.Interfaces.Animal
+        ])
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "species": species,
+            "skinCovering": skinCovering
+        ]))
+      }
+
       /// AllAnimal.AsBird
       ///
       /// Parent Type: `Bird`
@@ -57,6 +88,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Bird }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("wingspan", Double.self),
@@ -73,6 +105,22 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? {
           get { __data["skinCovering"] }
           set { __data["skinCovering"] = newValue }
+        }
+
+        public init(
+          wingspan: Double,
+          species: String,
+          skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? = nil
+        ) {
+          let objectType = GraphQLAPI.Objects.Bird
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "wingspan": wingspan,
+              "species": species,
+              "skinCovering": skinCovering
+          ]))
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -27,6 +27,23 @@ public struct PetDetailsMutation: GraphQLAPI.MutableSelectionSet, Fragment {
     set { __data["owner"] = newValue }
   }
 
+  public init(
+    __typename: String,
+    owner: Owner? = nil
+  ) {
+    let objectType = ApolloAPI.Object(
+      typename: __typename,
+      implementedInterfaces: [
+        GraphQLAPI.Interfaces.Pet
+    ])
+    self.init(data: DataDict(
+      objectType: objectType,
+      data: [
+        "__typename": objectType.typename,
+        "owner": owner._fieldData
+    ]))
+  }
+
   /// Owner
   ///
   /// Parent Type: `Human`
@@ -42,6 +59,18 @@ public struct PetDetailsMutation: GraphQLAPI.MutableSelectionSet, Fragment {
     public var firstName: String {
       get { __data["firstName"] }
       set { __data["firstName"] = newValue }
+    }
+
+    public init(
+      firstName: String
+    ) {
+      let objectType = GraphQLAPI.Objects.Human
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "firstName": firstName
+      ]))
     }
   }
 }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -178,7 +178,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -178,6 +178,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),
@@ -207,6 +208,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -248,6 +250,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -301,6 +304,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -349,6 +353,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -397,6 +402,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -423,6 +429,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -471,6 +478,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
 
         public var height: Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -158,7 +158,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("laysEggs", Bool.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -158,6 +158,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("laysEggs", Bool.self),
@@ -186,6 +187,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -227,6 +229,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -279,6 +282,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -327,6 +331,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -375,6 +380,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -415,6 +421,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -464,6 +471,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -59,6 +59,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
 
         public var height: ClassroomPetDetailsCCN.AsAnimal.Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -64,6 +64,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
 
         public var species: String { __data["species"] }
@@ -83,6 +84,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
 
         public var humanName: String? { __data["humanName"] }
@@ -102,6 +104,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
 
         public var species: String { __data["species"] }
@@ -122,6 +125,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Cat }
 
         public var species: String { __data["species"] }
@@ -145,6 +149,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Bird }
 
         public var species: String { __data["species"] }
@@ -167,6 +172,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.PetRock }
 
         public var humanName: String? { __data["humanName"] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -62,6 +62,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("species", String.self),
@@ -77,6 +78,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("humanName", String?.self),
@@ -92,6 +94,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("laysEggs", Bool.self),
@@ -108,6 +111,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("bodyTemperature", Int.self),
@@ -128,6 +132,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("wingspan", Double.self),
@@ -146,6 +151,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.PetRock }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -34,6 +34,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
     public let __data: DataDict
     public init(data: DataDict) { __data = data }
 
+    public typealias RootEntityType = ClassroomPetDetailsCCN
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
       .field("height", Height.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -22,6 +22,18 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       set { __data["allAnimals"] = newValue }
     }
 
+    public init(
+      allAnimals: [AllAnimal]
+    ) {
+      let objectType = AnimalKingdomAPI.Objects.Query
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "allAnimals": allAnimals._fieldData
+      ]))
+    }
+
     /// AllAnimal
     ///
     /// Parent Type: `Animal`
@@ -50,6 +62,25 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         set { if let newData = newValue?.__data._data { __data._data = newData }}
       }
 
+      public init(
+        __typename: String,
+        species: String,
+        skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil
+      ) {
+        let objectType = ApolloAPI.Object(
+          typename: __typename,
+          implementedInterfaces: [
+            AnimalKingdomAPI.Interfaces.Animal
+        ])
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "species": species,
+            "skinCovering": skinCovering
+        ]))
+      }
+
       /// AllAnimal.AsBird
       ///
       /// Parent Type: `Bird`
@@ -57,6 +88,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("wingspan", Double.self),
@@ -73,6 +105,22 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
         public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? {
           get { __data["skinCovering"] }
           set { __data["skinCovering"] = newValue }
+        }
+
+        public init(
+          wingspan: Double,
+          species: String,
+          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil
+        ) {
+          let objectType = AnimalKingdomAPI.Objects.Bird
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "wingspan": wingspan,
+              "species": species,
+              "skinCovering": skinCovering
+          ]))
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -27,6 +27,23 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
     set { __data["owner"] = newValue }
   }
 
+  public init(
+    __typename: String,
+    owner: Owner? = nil
+  ) {
+    let objectType = ApolloAPI.Object(
+      typename: __typename,
+      implementedInterfaces: [
+        AnimalKingdomAPI.Interfaces.Pet
+    ])
+    self.init(data: DataDict(
+      objectType: objectType,
+      data: [
+        "__typename": objectType.typename,
+        "owner": owner._fieldData
+    ]))
+  }
+
   /// Owner
   ///
   /// Parent Type: `Human`
@@ -42,6 +59,18 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
     public var firstName: String {
       get { __data["firstName"] }
       set { __data["firstName"] = newValue }
+    }
+
+    public init(
+      firstName: String
+    ) {
+      let objectType = AnimalKingdomAPI.Objects.Human
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "firstName": firstName
+      ]))
     }
   }
 }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -39,6 +39,18 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
       set { __data["pets"] = newValue }
     }
 
+    public init(
+      pets: [Pet]
+    ) {
+      let objectType = AnimalKingdomAPI.Objects.Query
+      self.init(data: DataDict(
+        objectType: objectType,
+        data: [
+          "__typename": objectType.typename,
+          "pets": pets._fieldData
+      ]))
+    }
+
     /// Pet
     ///
     /// Parent Type: `Pet`
@@ -59,6 +71,25 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
       public var humanName: String? {
         get { __data["humanName"] }
         set { __data["humanName"] = newValue }
+      }
+
+      public init(
+        __typename: String,
+        id: AnimalKingdomAPI.ID,
+        humanName: String? = nil
+      ) {
+        let objectType = ApolloAPI.Object(
+          typename: __typename,
+          implementedInterfaces: [
+            AnimalKingdomAPI.Interfaces.Pet
+        ])
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "id": id,
+            "humanName": humanName
+        ]))
       }
     }
   }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -178,6 +178,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),
@@ -207,6 +208,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -248,6 +250,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -301,6 +304,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -349,6 +353,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -397,6 +402,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -423,6 +429,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -471,6 +478,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
 
         public var height: Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -178,7 +178,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("species", String.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -54,6 +54,10 @@ public class AllAnimalsQuery: GraphQLQuery {
             species
             ... on WarmBlooded {
               __typename
+              predators {
+                __typename
+                species
+              }
               ...WarmBloodedDetails
               laysEggs
             }
@@ -158,13 +162,15 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
-          public typealias RootEntityType = Predator
+          public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("predators", [Predator].self),
             .field("laysEggs", Bool.self),
             .fragment(WarmBloodedDetails.self),
           ] }
 
+          public var predators: [Predator] { __data["predators"] }
           public var laysEggs: Bool { __data["laysEggs"] }
           public var species: String { __data["species"] }
           public var bodyTemperature: Int { __data["bodyTemperature"] }
@@ -176,6 +182,21 @@ public class AllAnimalsQuery: GraphQLQuery {
 
             public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
             public var heightInMeters: HeightInMeters { _toFragment() }
+          }
+
+          /// AllAnimal.Predator.AsWarmBlooded.Predator
+          ///
+          /// Parent Type: `Animal`
+          public struct Predator: AnimalKingdomAPI.SelectionSet {
+            public let __data: DataDict
+            public init(data: DataDict) { __data = data }
+
+            public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
+            public static var __selections: [ApolloAPI.Selection] { [
+              .field("species", String.self),
+            ] }
+
+            public var species: String { __data["species"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -158,6 +158,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("laysEggs", Bool.self),
@@ -186,6 +187,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(WarmBloodedDetails.self),
@@ -227,6 +229,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("height", Height.self),
@@ -279,6 +282,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
           public static var __selections: [ApolloAPI.Selection] { [
             .fragment(WarmBloodedDetails.self),
@@ -327,6 +331,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("isJellicle", Bool.self),
@@ -375,6 +380,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
           .inlineFragment(AsBird.self),
@@ -415,6 +421,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           public let __data: DataDict
           public init(data: DataDict) { __data = data }
 
+          public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
           public static var __selections: [ApolloAPI.Selection] { [
             .field("wingspan", Double.self),
@@ -464,6 +471,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
           .field("favoriteToy", String.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -59,6 +59,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
 
         public var height: ClassroomPetDetailsCCN.AsAnimal.Height { __data["height"] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -64,6 +64,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
 
         public var species: String { __data["species"] }
@@ -83,6 +84,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
 
         public var humanName: String? { __data["humanName"] }
@@ -102,6 +104,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
 
         public var species: String { __data["species"] }
@@ -122,6 +125,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
 
         public var species: String { __data["species"] }
@@ -145,6 +149,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
 
         public var species: String { __data["species"] }
@@ -167,6 +172,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.PetRock }
 
         public var humanName: String? { __data["humanName"] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -59,6 +59,7 @@ public class DogQuery: GraphQLQuery {
         public let __data: DataDict
         public init(data: DataDict) { __data = data }
 
+        public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
         public static var __selections: [ApolloAPI.Selection] { [
           .fragment(DogFragment.self),


### PR DESCRIPTION
This adds a new property `.asEntityRootType` to all generated inline fragment selection sets. This allows you to convert them back to the root selection set model of the entity directly. This means you never have to hold on to a reference to the parent. It also is necessary for initializing type condition models and passing them as the values to entity fields when using generated initializers for the models.