### PR TITLE
Added `jsonObject` associated value to ResponseCodeError to aid usability

### DIFF
--- a/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
+++ b/Tests/ApolloTests/Cache/CacheDependentInterceptorTests.swift
@@ -124,7 +124,7 @@ class CacheDependentInterceptorTests: XCTestCase, CacheDependentTesting {
         return
       }
       switch handledError {
-      case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _):
+      case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(let response, _, _):
         XCTAssertEqual(response?.statusCode, 401)
       default:
         XCTFail("Unexpected error on the additional error handler: \(handledError)")

--- a/Tests/ApolloTests/Interceptors/ResponseCodeInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/ResponseCodeInterceptorTests.swift
@@ -96,7 +96,7 @@ class ResponseCodeInterceptorTests: XCTestCase {
         XCTFail("This should not have succeeded")
       case .failure(let error):
         switch error {
-        case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(response: let response, let rawData):
+        case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(response: let response, let rawData, _):
           XCTAssertEqual(response?.statusCode, 401)
 
           guard

--- a/Tests/ApolloTests/Interceptors/ResponseCodeInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/ResponseCodeInterceptorTests.swift
@@ -96,7 +96,7 @@ class ResponseCodeInterceptorTests: XCTestCase {
         XCTFail("This should not have succeeded")
       case .failure(let error):
         switch error {
-        case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(response: let response, let rawData, _):
+        case ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(response: let response, let rawData, let jsonObject):
           XCTAssertEqual(response?.statusCode, 401)
 
           guard
@@ -107,6 +107,10 @@ class ResponseCodeInterceptorTests: XCTestCase {
           }
 
           XCTAssertEqual(dataString, "{\"data\":{\"hero\":{\"__typename\":\"Human\",\"name\":\"Luke Skywalker\"}}}")
+          XCTAssertEqual(
+            jsonObject,
+            ["data": ["hero": ["__typename": "Human","name": "Luke Skywalker"]]]
+          )
         default:
           XCTFail("Unexpected error type: \(error.localizedDescription)")
         }


### PR DESCRIPTION
Added optional `jsonObject` associated value to `ResponseCodeError` enum to allow consumers to parse and display user-facing errors. Attempted fix for #2426.