### PR TITLE
Support Include/Skip in generated selection set initializers

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -618,6 +618,7 @@
 		DE7C183C272A12EB00727031 /* ScopeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7C183B272A12EB00727031 /* ScopeDescriptor.swift */; };
 		DE7C183E272A154400727031 /* IR.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7C183D272A154400727031 /* IR.swift */; };
 		DE80003428B5608E00C827BD /* SchemaMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE80003328B5608E00C827BD /* SchemaMetadata.swift */; };
+		DE903E1329B7E6D300A74415 /* SelectionSet+JSONInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE903E1229B7E6D300A74415 /* SelectionSet+JSONInitializer.swift */; };
 		DE90FDBA27FE405F0084CC79 /* Selection+Conditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE90FDB927FE405F0084CC79 /* Selection+Conditions.swift */; };
 		DE9C04AC26EAAE4400EC35E7 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC4B91F1D2A6F8D0046A641 /* JSON.swift */; };
 		DE9C04AD26EAAE5400EC35E7 /* JSONStandardTypeConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F27D4631D40379500715680 /* JSONStandardTypeConversions.swift */; };
@@ -1794,6 +1795,7 @@
 		DE7C183B272A12EB00727031 /* ScopeDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeDescriptor.swift; sourceTree = "<group>"; };
 		DE7C183D272A154400727031 /* IR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IR.swift; sourceTree = "<group>"; };
 		DE80003328B5608E00C827BD /* SchemaMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaMetadata.swift; sourceTree = "<group>"; };
+		DE903E1229B7E6D300A74415 /* SelectionSet+JSONInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SelectionSet+JSONInitializer.swift"; sourceTree = "<group>"; };
 		DE90FDB927FE405F0084CC79 /* Selection+Conditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Selection+Conditions.swift"; sourceTree = "<group>"; };
 		DE9C04AE26EAAEE800EC35E7 /* CacheReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheReference.swift; sourceTree = "<group>"; };
 		DE9C04B026EAAFF900EC35E7 /* JSONDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingError.swift; sourceTree = "<group>"; };
@@ -2520,6 +2522,7 @@
 				9FA6F3671E65DF4700BF8D73 /* GraphQLResultAccumulator.swift */,
 				DE0586322669948500265760 /* InputValue+Evaluation.swift */,
 				9F7BA89822927A3700999B3B /* ResponsePath.swift */,
+				DE903E1229B7E6D300A74415 /* SelectionSet+JSONInitializer.swift */,
 			);
 			name = Execution;
 			sourceTree = "<group>";
@@ -5387,6 +5390,7 @@
 				9FC9A9BF1E2C27FB0023C4D5 /* GraphQLResult.swift in Sources */,
 				9FEB050D1DB5732300DA3B44 /* JSONSerializationFormat.swift in Sources */,
 				9B260BEB245A020300562176 /* ApolloInterceptor.swift in Sources */,
+				DE903E1329B7E6D300A74415 /* SelectionSet+JSONInitializer.swift in Sources */,
 				54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */,
 				9B554CC4247DC29A002F452A /* TaskData.swift in Sources */,
 				9B9BBAF524DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift in Sources */,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -30,7 +30,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -56,7 +56,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
       typename: __typename,
       implementedInterfaces: [
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -68,7 +68,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Animal`
   public struct AsAnimal: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
@@ -87,7 +87,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
         implementedInterfaces: [
           AnimalKingdomAPI.Interfaces.Animal
       ])
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -101,7 +101,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Pet`
   public struct AsPet: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
@@ -120,7 +120,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
         implementedInterfaces: [
           AnimalKingdomAPI.Interfaces.Pet
       ])
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -134,7 +134,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `WarmBlooded`
   public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -156,7 +156,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           AnimalKingdomAPI.Interfaces.WarmBlooded,
           AnimalKingdomAPI.Interfaces.Animal
       ])
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -171,7 +171,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Cat`
   public struct AsCat: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
@@ -194,7 +194,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
       laysEggs: Bool
     ) {
       let objectType = AnimalKingdomAPI.Objects.Cat
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -212,7 +212,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Bird`
   public struct AsBird: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
@@ -232,7 +232,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
       laysEggs: Bool
     ) {
       let objectType = AnimalKingdomAPI.Objects.Bird
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -249,7 +249,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `PetRock`
   public struct AsPetRock: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetails
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.PetRock }
@@ -265,7 +265,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
       humanName: String? = nil
     ) {
       let objectType = AnimalKingdomAPI.Objects.PetRock
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -17,7 +17,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -33,7 +33,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
       typename: __typename,
       implementedInterfaces: [
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -45,7 +45,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Animal`
   public struct AsAnimal: AnimalKingdomAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = ClassroomPetDetailsCCN
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
@@ -64,7 +64,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
         implementedInterfaces: [
           AnimalKingdomAPI.Interfaces.Animal
       ])
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -77,7 +77,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
     /// Parent Type: `Height`
     public struct Height: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -90,7 +90,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
         inches: Int
       ) {
         let objectType = AnimalKingdomAPI.Objects.Height
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
@@ -12,7 +12,7 @@ public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -25,7 +25,7 @@ public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
     species: String
   ) {
     let objectType = AnimalKingdomAPI.Objects.Dog
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -15,7 +15,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -33,7 +33,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         AnimalKingdomAPI.Interfaces.Animal
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -46,7 +46,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Height`
   public struct Height: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -59,7 +59,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
       meters: Int
     ) {
       let objectType = AnimalKingdomAPI.Objects.Height
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
@@ -17,7 +17,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -41,7 +41,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         AnimalKingdomAPI.Interfaces.Pet
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
   /// Parent Type: `Human`
   public struct Owner: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -69,7 +69,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
       firstName: String
     ) {
       let objectType = AnimalKingdomAPI.Objects.Human
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -13,7 +13,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
         AnimalKingdomAPI.Interfaces.WarmBlooded,
         AnimalKingdomAPI.Interfaces.Animal
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -10,7 +10,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
 
   public struct Data: AnimalKingdomAPI.MutableSelectionSet {
     public var __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -26,7 +26,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       allAnimals: [AllAnimal]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -39,7 +39,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
     /// Parent Type: `Animal`
     public struct AllAnimal: AnimalKingdomAPI.MutableSelectionSet {
       public var __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -72,7 +72,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Animal
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -86,7 +86,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
       /// Parent Type: `Bird`
       public struct AsBird: AnimalKingdomAPI.MutableInlineFragment {
         public var __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
@@ -113,7 +113,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
           skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil
         ) {
           let objectType = AnimalKingdomAPI.Objects.Bird
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -15,7 +15,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
     """ }
 
   public var __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -36,7 +36,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
       implementedInterfaces: [
         AnimalKingdomAPI.Interfaces.Pet
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -49,7 +49,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
   /// Parent Type: `Human`
   public struct Owner: AnimalKingdomAPI.MutableSelectionSet {
     public var __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -65,7 +65,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
       firstName: String
     ) {
       let objectType = AnimalKingdomAPI.Objects.Human
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -27,7 +27,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
 
   public struct Data: AnimalKingdomAPI.MutableSelectionSet {
     public var __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -43,7 +43,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
       pets: [Pet]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
     /// Parent Type: `Pet`
     public struct Pet: AnimalKingdomAPI.MutableSelectionSet {
       public var __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -83,7 +83,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Pet
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -28,7 +28,7 @@ public class PetAdoptionMutation: GraphQLMutation {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -41,7 +41,7 @@ public class PetAdoptionMutation: GraphQLMutation {
       adoptPet: AdoptPet
     ) {
       let objectType = AnimalKingdomAPI.Objects.Mutation
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -54,7 +54,7 @@ public class PetAdoptionMutation: GraphQLMutation {
     /// Parent Type: `Pet`
     public struct AdoptPet: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -75,7 +75,7 @@ public class PetAdoptionMutation: GraphQLMutation {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Pet
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -25,7 +25,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -38,7 +38,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
       allAnimals: [AllAnimal]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -51,7 +51,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
     /// Parent Type: `Animal`
     public struct AllAnimal: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -69,7 +69,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Animal
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -82,7 +82,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
       /// Parent Type: `Height`
       public struct Height: AnimalKingdomAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -98,7 +98,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
           inches: Int
         ) {
           let objectType = AnimalKingdomAPI.Objects.Height
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -84,7 +84,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -97,7 +97,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       allAnimals: [AllAnimal]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -110,7 +110,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
     /// Parent Type: `Animal`
     public struct AllAnimal: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -155,7 +155,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Animal
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -171,7 +171,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `Height`
       public struct Height: AnimalKingdomAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -187,7 +187,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           inches: Int? = nil
         ) {
           let objectType = AnimalKingdomAPI.Objects.Height
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -202,7 +202,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `Animal`
       public struct Predator: AnimalKingdomAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -223,7 +223,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -236,7 +236,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `WarmBlooded`
         public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -272,7 +272,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 AnimalKingdomAPI.Interfaces.Animal,
                 AnimalKingdomAPI.Interfaces.WarmBlooded
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -290,7 +290,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `WarmBlooded`
       public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -326,7 +326,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               AnimalKingdomAPI.Interfaces.Animal,
               AnimalKingdomAPI.Interfaces.WarmBlooded
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -343,7 +343,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -357,7 +357,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             meters: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -374,7 +374,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `Pet`
       public struct AsPet: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
@@ -418,7 +418,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               AnimalKingdomAPI.Interfaces.Animal,
               AnimalKingdomAPI.Interfaces.Pet
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -437,7 +437,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -459,7 +459,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             inches: Int? = nil
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -476,7 +476,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `WarmBlooded`
         public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -520,7 +520,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 AnimalKingdomAPI.Interfaces.Pet,
                 AnimalKingdomAPI.Interfaces.WarmBlooded
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -540,7 +540,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           /// Parent Type: `Height`
           public struct Height: AnimalKingdomAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -558,7 +558,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               meters: Int
             ) {
               let objectType = AnimalKingdomAPI.Objects.Height
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -578,7 +578,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `Cat`
       public struct AsCat: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
@@ -617,7 +617,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           bodyTemperature: Int
         ) {
           let objectType = AnimalKingdomAPI.Objects.Cat
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -638,7 +638,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -656,7 +656,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             meters: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -675,7 +675,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `ClassroomPet`
       public struct AsClassroomPet: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
@@ -709,7 +709,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -725,7 +725,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `Bird`
         public struct AsBird: AnimalKingdomAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
@@ -764,7 +764,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             bodyTemperature: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Bird
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -785,7 +785,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           /// Parent Type: `Height`
           public struct Height: AnimalKingdomAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -803,7 +803,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               meters: Int
             ) {
               let objectType = AnimalKingdomAPI.Objects.Height
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -822,7 +822,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       /// Parent Type: `Animal`
       public struct IfNotSkipHeightInMeters: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
@@ -851,7 +851,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -867,7 +867,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -881,7 +881,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             meters: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -65,7 +65,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -78,7 +78,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       allAnimals: [AllAnimal]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -91,7 +91,7 @@ public class AllAnimalsQuery: GraphQLQuery {
     /// Parent Type: `Animal`
     public struct AllAnimal: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -137,7 +137,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Animal
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -153,7 +153,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `Height`
       public struct Height: AnimalKingdomAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -171,7 +171,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           meters: Int
         ) {
           let objectType = AnimalKingdomAPI.Objects.Height
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -187,7 +187,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `Animal`
       public struct Predator: AnimalKingdomAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -208,7 +208,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -221,7 +221,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `WarmBlooded`
         public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = AllAnimal.Predator
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -259,7 +259,7 @@ public class AllAnimalsQuery: GraphQLQuery {
                 AnimalKingdomAPI.Interfaces.Animal,
                 AnimalKingdomAPI.Interfaces.WarmBlooded
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -276,7 +276,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           /// Parent Type: `Animal`
           public struct Predator: AnimalKingdomAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
             public static var __selections: [ApolloAPI.Selection] { [
@@ -294,7 +294,7 @@ public class AllAnimalsQuery: GraphQLQuery {
                 implementedInterfaces: [
                   AnimalKingdomAPI.Interfaces.Animal
               ])
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -310,7 +310,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `WarmBlooded`
       public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -346,7 +346,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               AnimalKingdomAPI.Interfaces.Animal,
               AnimalKingdomAPI.Interfaces.WarmBlooded
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -363,7 +363,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -377,7 +377,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             meters: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -394,7 +394,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `Pet`
       public struct AsPet: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
@@ -438,7 +438,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               AnimalKingdomAPI.Interfaces.Animal,
               AnimalKingdomAPI.Interfaces.Pet
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -457,7 +457,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -479,7 +479,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             meters: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -497,7 +497,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `WarmBlooded`
         public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -541,7 +541,7 @@ public class AllAnimalsQuery: GraphQLQuery {
                 AnimalKingdomAPI.Interfaces.Pet,
                 AnimalKingdomAPI.Interfaces.WarmBlooded
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -561,7 +561,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           /// Parent Type: `Height`
           public struct Height: AnimalKingdomAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -579,7 +579,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               centimeters: Double
             ) {
               let objectType = AnimalKingdomAPI.Objects.Height
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -599,7 +599,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `Cat`
       public struct AsCat: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
@@ -638,7 +638,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           owner: PetDetails.Owner? = nil
         ) {
           let objectType = AnimalKingdomAPI.Objects.Cat
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -659,7 +659,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -677,7 +677,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             centimeters: Double
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -696,7 +696,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `ClassroomPet`
       public struct AsClassroomPet: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
@@ -730,7 +730,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -746,7 +746,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -760,7 +760,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             meters: Int
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -776,7 +776,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `Bird`
         public struct AsBird: AnimalKingdomAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = AllAnimal
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
@@ -815,7 +815,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             owner: PetDetails.Owner? = nil
           ) {
             let objectType = AnimalKingdomAPI.Objects.Bird
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -836,7 +836,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           /// Parent Type: `Height`
           public struct Height: AnimalKingdomAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -854,7 +854,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               centimeters: Double
             ) {
               let objectType = AnimalKingdomAPI.Objects.Height
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -874,7 +874,7 @@ public class AllAnimalsQuery: GraphQLQuery {
       /// Parent Type: `Dog`
       public struct AsDog: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
@@ -914,7 +914,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           owner: PetDetails.Owner? = nil
         ) {
           let objectType = AnimalKingdomAPI.Objects.Dog
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -935,7 +935,7 @@ public class AllAnimalsQuery: GraphQLQuery {
         /// Parent Type: `Height`
         public struct Height: AnimalKingdomAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
 
@@ -953,7 +953,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             centimeters: Double
           ) {
             let objectType = AnimalKingdomAPI.Objects.Height
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -22,7 +22,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -35,7 +35,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
       classroomPets: [ClassroomPet]? = nil
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -48,7 +48,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
     /// Parent Type: `ClassroomPet`
     public struct ClassroomPet: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -71,7 +71,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
           typename: __typename,
           implementedInterfaces: [
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -83,7 +83,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
       /// Parent Type: `Animal`
       public struct AsAnimal: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
@@ -106,7 +106,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -22,7 +22,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -35,7 +35,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       classroomPets: [ClassroomPet?]? = nil
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -48,7 +48,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
     /// Parent Type: `ClassroomPet`
     public struct ClassroomPet: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -76,7 +76,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
           typename: __typename,
           implementedInterfaces: [
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -88,7 +88,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       /// Parent Type: `Animal`
       public struct AsAnimal: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
@@ -111,7 +111,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -125,7 +125,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       /// Parent Type: `Pet`
       public struct AsPet: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
@@ -148,7 +148,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
             implementedInterfaces: [
               AnimalKingdomAPI.Interfaces.Pet
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -162,7 +162,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       /// Parent Type: `WarmBlooded`
       public struct AsWarmBlooded: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
@@ -188,7 +188,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
               AnimalKingdomAPI.Interfaces.WarmBlooded,
               AnimalKingdomAPI.Interfaces.Animal
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -203,7 +203,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       /// Parent Type: `Cat`
       public struct AsCat: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Cat }
@@ -229,7 +229,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
           isJellicle: Bool
         ) {
           let objectType = AnimalKingdomAPI.Objects.Cat
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -247,7 +247,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       /// Parent Type: `Bird`
       public struct AsBird: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Bird }
@@ -271,7 +271,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
           wingspan: Double
         ) {
           let objectType = AnimalKingdomAPI.Objects.Bird
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -288,7 +288,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
       /// Parent Type: `PetRock`
       public struct AsPetRock: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = ClassroomPet
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.PetRock }
@@ -308,7 +308,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
           favoriteToy: String
         ) {
           let objectType = AnimalKingdomAPI.Objects.PetRock
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -25,7 +25,7 @@ public class DogQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -38,7 +38,7 @@ public class DogQuery: GraphQLQuery {
       allAnimals: [AllAnimal]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -51,7 +51,7 @@ public class DogQuery: GraphQLQuery {
     /// Parent Type: `Animal`
     public struct AllAnimal: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -72,7 +72,7 @@ public class DogQuery: GraphQLQuery {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Animal
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -85,7 +85,7 @@ public class DogQuery: GraphQLQuery {
       /// Parent Type: `Dog`
       public struct AsDog: AnimalKingdomAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = AllAnimal
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
@@ -108,7 +108,7 @@ public class DogQuery: GraphQLQuery {
           species: String
         ) {
           let objectType = AnimalKingdomAPI.Objects.Dog
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -39,7 +39,7 @@ public class PetSearchQuery: GraphQLQuery {
 
   public struct Data: AnimalKingdomAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -52,7 +52,7 @@ public class PetSearchQuery: GraphQLQuery {
       pets: [Pet]
     ) {
       let objectType = AnimalKingdomAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -65,7 +65,7 @@ public class PetSearchQuery: GraphQLQuery {
     /// Parent Type: `Pet`
     public struct Pet: AnimalKingdomAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -86,7 +86,7 @@ public class PetSearchQuery: GraphQLQuery {
           implementedInterfaces: [
             AnimalKingdomAPI.Interfaces.Pet
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -164,10 +164,6 @@ final class GraphQLExecutor {
     self.resolveReference = resolveReference
   }
 
-  private func runtimeType(of object: JSONObject) -> String? {
-    return object["__typename"] as? String
-  }
-
   // MARK: - Execution
 
   func execute<
@@ -418,6 +414,11 @@ final class GraphQLExecutor {
                         asType: returnType,
                         accumulator: accumulator)
         }
+
+      case let dataDict as ApolloAPI.DataDict:
+        return executeChildSelections(forObjectTypeFields: fieldInfo,
+                                      onChildObject: dataDict._data,
+                                      accumulator: accumulator)
 
       case let object as JSONObject:
         return executeChildSelections(forObjectTypeFields: fieldInfo,

--- a/Sources/Apollo/SelectionSet+JSONInitializer.swift
+++ b/Sources/Apollo/SelectionSet+JSONInitializer.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+#if !COCOAPODS
+import ApolloAPI
+#endif
+
+extension RootSelectionSet {
+
+#warning("TODO: Update documentation here")
+  /// Initializes the `SelectionSet` **unsafely** with an unsafe result data dictionary.
+  ///
+  /// - Warning: This method is unsafe and improper use may result in unintended consequences
+  /// including crashes. The `unsafeData` should mirror the result data returned by a
+  /// `GraphQLSelectionSetMapper` after completion of GraphQL Execution.
+  ///
+  /// This is not identical to the JSON response from a GraphQL network request. The data should be
+  /// normalized and custom scalars should be converted to their concrete types.
+  ///
+  /// To create a `SelectionSet` from data representing a JSON format GraphQL network response
+  /// directly, create a `GraphQLResponse` object and call `parseResultFast()`.
+  public init(
+    data: JSONObject,
+    variables: GraphQLOperation.Variables? = nil
+  ) throws {
+    let accumulator = GraphQLSelectionSetMapper<Self>(
+      allowMissingValuesForOptionalFields: true
+    )
+    let executor = GraphQLExecutor { object, info in
+      return object[info.responseKeyForField]
+    }
+    executor.shouldComputeCachePath = false
+
+    self = try executor.execute(
+      selectionSet: Self.self,
+      on: data,
+      variables: variables,
+      accumulator: accumulator
+    )
+  }
+
+}

--- a/Sources/Apollo/SelectionSet+JSONInitializer.swift
+++ b/Sources/Apollo/SelectionSet+JSONInitializer.swift
@@ -6,18 +6,16 @@ import ApolloAPI
 
 extension RootSelectionSet {
 
-#warning("TODO: Update documentation here")
-  /// Initializes the `SelectionSet` **unsafely** with an unsafe result data dictionary.
+  /// Initializes a `SelectionSet` with a raw JSON response object.
   ///
-  /// - Warning: This method is unsafe and improper use may result in unintended consequences
-  /// including crashes. The `unsafeData` should mirror the result data returned by a
-  /// `GraphQLSelectionSetMapper` after completion of GraphQL Execution.
+  /// The process of converting a JSON response into `SelectionSetData` is done by using a
+  /// `GraphQLExecutor` with a`GraphQLSelectionSetMapper` to parse, validate, and transform
+  /// the JSON response data into the format expected by `SelectionSet`.
   ///
-  /// This is not identical to the JSON response from a GraphQL network request. The data should be
-  /// normalized and custom scalars should be converted to their concrete types.
-  ///
-  /// To create a `SelectionSet` from data representing a JSON format GraphQL network response
-  /// directly, create a `GraphQLResponse` object and call `parseResultFast()`.
+  /// - Parameters:
+  ///   - data: A dictionary representing a JSON response object for a GraphQL object.
+  ///   - variables: [Optional] The operation variables that would be used to obtain
+  ///                the given JSON response data.
   public init(
     data: JSONObject,
     variables: GraphQLOperation.Variables? = nil

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -1,17 +1,21 @@
 /// A structure that wraps the underlying data used by ``SelectionSet``s.
-public struct DataDict: Hashable {
-  #warning("TODO: Finish documentation here")
+public struct DataDict: Hashable {  
   /// A type representing the underlying data for a `SelectionSet`.
   ///
   /// - Warning: This is not identical to the JSON response from a GraphQL network request.
   /// The data should be normalized for consumption by a ``SelectionSet``. This means:
-  ///   1. Values for entity fields are represented by ``DataDict`` values
-  ///   2. Custom scalars are serialized and converted to their concrete types.
-  ///   3. Inclusion conditions and type conditions **TODO**
+  ///
+  /// * Values for entity fields are represented by ``DataDict`` values
+  /// * Custom scalars are serialized and converted to their concrete types.
+  /// * The `implementedInterfaces` used for fulfilling type conditions are
+  ///   on the `_objectType` of the `DataDict`.
+  /// * The variables used for fulfilling inclusion conditions are included
+  ///   in the `_variables` of the `DataDict`.
   ///
   /// The process of converting a JSON response into ``SelectionSetData`` is done by using a
   /// `GraphQLExecutor` with a`GraphQLSelectionSetMapper`. This can be performed manually
-  /// by using **TODO**.
+  /// by using `SelectionSet.init(data: JSONObject, variables: GraphQLOperation.Variables?)` in
+  /// the `Apollo` library.
   public typealias SelectionSetData = [String: AnyHashable]
 
   public let _objectType: Object?

--- a/Sources/ApolloAPI/FragmentProtocols.swift
+++ b/Sources/ApolloAPI/FragmentProtocols.swift
@@ -72,7 +72,7 @@ extension FragmentContainer {
   }
 
   @usableFromInline func _convertToFragment<T: Fragment>()-> T {
-    return T.init(data: __data)
+    return T.init(_dataDict: __data)
   }
 
   /// Converts a ``SelectionSet`` to a ``Fragment`` given a generic fragment type if the given

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -52,7 +52,7 @@ public protocol SelectionSet: SelectionSetEntityValue, Hashable {
   ///
   /// - Parameter data: The data of the underlying GraphQL object represented by generated
   /// selection set.
-  init(data: DataDict)
+  init(_dataDict: DataDict)
 }
 
 extension SelectionSet {  
@@ -72,18 +72,20 @@ extension SelectionSet {
   @inlinable public func _asInlineFragment<T: SelectionSet>(
     if conditions: Selection.Conditions? = nil
   ) -> T? where T.Schema == Schema {
+    let child: T? = _asType()
+
     guard let conditions = conditions else {
-      return _asType()
+      return child
     }
 
-    return conditions.evaluate(with: __data._variables) ? _asType() : nil
+    return conditions.evaluate(with: child?.__data._variables) ? child : nil
   }
 
   @usableFromInline func _asType<T: SelectionSet>() -> T? where T.Schema == Schema {
     guard let __objectType = __objectType,
           T.__parentType.canBeConverted(from: __objectType) else { return nil }
 
-    return T.init(data: __data)
+    return T.init(_dataDict: __data)
   }
 
   @inlinable public func _asInlineFragment<T: SelectionSet>(
@@ -120,7 +122,7 @@ extension SelectionSet {
       objectType = nil
     }
 
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: data,
       variables: variables
@@ -143,6 +145,6 @@ extension SelectionSet where Fragments: FragmentContainer {
 
 extension InlineFragment {
   @inlinable public var asRootEntityType: RootEntityType {
-    RootEntityType.init(data: __data)
+    RootEntityType.init(_dataDict: __data)
   }
 }

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -100,35 +100,6 @@ extension SelectionSet {
     _asInlineFragment(if: Selection.Conditions(condition))
   }
 
-  /// Initializes the `SelectionSet` **unsafely** with an unsafe result data dictionary.
-  ///
-  /// - Warning: This method is unsafe and improper use may result in unintended consequences
-  /// including crashes. The `unsafeData` should mirror the result data returned by a
-  /// `GraphQLSelectionSetMapper` after completion of GraphQL Execution.
-  ///
-  /// This is not identical to the JSON response from a GraphQL network request. The data should be
-  /// normalized and custom scalars should be converted to their concrete types.
-  ///
-  /// To create a `SelectionSet` from data representing a JSON format GraphQL network response
-  /// directly, create a `GraphQLResponse` object and call `parseResultFast()`.
-  @inlinable public init(
-    unsafeData data: [String: AnyHashable],
-    variables: GraphQLOperation.Variables? = nil
-  ) {
-    let objectType: Object?
-    if let typename = data["__typename"] as? String {
-      objectType = Schema.objectType(forTypename: typename)
-    } else {
-      objectType = nil
-    }
-
-    self.init(_dataDict: DataDict(
-      objectType: objectType,
-      data: data,
-      variables: variables
-    ))
-  }
-
   @inlinable public func hash(into hasher: inout Hasher) {
     hasher.combine(__data)
   }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -422,6 +422,12 @@ struct SelectionSetTemplate {
         objectType: objectType,
         data: [
           \(InitializerDataDictTemplate(selectionSet.selections))
+        \(ifLet: selectionSet.typeInfo.scope.matchingConditions, { conditions in
+        """
+        ],
+        variables: [
+          \(conditions.map { "\"\($0.variable)\": \((!$0.isInverted).description)"})
+        """})
       ]))
     }
     """

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -81,7 +81,7 @@ public extension SelectionSet {
     _ mock: Mock<O>,
     withVariables variables: GraphQLOperation.Variables? = nil
   ) -> Self {
-    Self.init(data: DataDict(
+    Self.init(_dataDict: DataDict(
       objectType: O.objectType,
       data: mock._selectionSetMockData,
       variables: variables)

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
@@ -17,7 +17,7 @@ public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -35,7 +35,7 @@ public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
   /// Parent Type: `User`
   public struct AsUser: GitHubAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = AuthorDetails
     public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -45,7 +45,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
   public struct Data: GitHubAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -63,7 +63,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
     /// Parent Type: `Repository`
     public struct Repository: GitHubAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Repository }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -81,7 +81,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
       /// Parent Type: `IssueConnection`
       public struct Issues: GitHubAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.IssueConnection }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -96,7 +96,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
         /// Parent Type: `Issue`
         public struct Node: GitHubAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Issue }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -120,7 +120,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
           /// Parent Type: `Actor`
           public struct Author: GitHubAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
             public static var __selections: [ApolloAPI.Selection] { [
@@ -144,7 +144,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
             /// Parent Type: `User`
             public struct AsUser: GitHubAPI.InlineFragment {
               public let __data: DataDict
-              public init(data: DataDict) { __data = data }
+              public init(_dataDict: DataDict) { __data = _dataDict }
 
               public typealias RootEntityType = Repository.Issues.Node.Author
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }
@@ -169,7 +169,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
           /// Parent Type: `IssueCommentConnection`
           public struct Comments: GitHubAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.IssueCommentConnection }
             public static var __selections: [ApolloAPI.Selection] { [
@@ -184,7 +184,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
             /// Parent Type: `IssueComment`
             public struct Node: GitHubAPI.SelectionSet {
               public let __data: DataDict
-              public init(data: DataDict) { __data = data }
+              public init(_dataDict: DataDict) { __data = _dataDict }
 
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.IssueComment }
               public static var __selections: [ApolloAPI.Selection] { [
@@ -202,7 +202,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
               /// Parent Type: `Actor`
               public struct Author: GitHubAPI.SelectionSet {
                 public let __data: DataDict
-                public init(data: DataDict) { __data = data }
+                public init(_dataDict: DataDict) { __data = _dataDict }
 
                 public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
                 public static var __selections: [ApolloAPI.Selection] { [
@@ -226,7 +226,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
                 /// Parent Type: `User`
                 public struct AsUser: GitHubAPI.InlineFragment {
                   public let __data: DataDict
-                  public init(data: DataDict) { __data = data }
+                  public init(_dataDict: DataDict) { __data = _dataDict }
 
                   public typealias RootEntityType = Repository.Issues.Node.Comments.Node.Author
                   public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.User }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
@@ -21,7 +21,7 @@ public class RepoURLQuery: GraphQLQuery {
 
   public struct Data: GitHubAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -39,7 +39,7 @@ public class RepoURLQuery: GraphQLQuery {
     /// Parent Type: `Repository`
     public struct Repository: GitHubAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Repository }
       public static var __selections: [ApolloAPI.Selection] { [

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -46,7 +46,7 @@ public class RepositoryQuery: GraphQLQuery {
 
   public struct Data: GitHubAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -64,7 +64,7 @@ public class RepositoryQuery: GraphQLQuery {
     /// Parent Type: `Repository`
     public struct Repository: GitHubAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Repository }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -79,7 +79,7 @@ public class RepositoryQuery: GraphQLQuery {
       /// Parent Type: `IssueOrPullRequest`
       public struct IssueOrPullRequest: GitHubAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Unions.IssueOrPullRequest }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -95,7 +95,7 @@ public class RepositoryQuery: GraphQLQuery {
         /// Parent Type: `Issue`
         public struct AsIssue: GitHubAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = Repository.IssueOrPullRequest
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Issue }
@@ -119,7 +119,7 @@ public class RepositoryQuery: GraphQLQuery {
           /// Parent Type: `Actor`
           public struct Author: GitHubAPI.SelectionSet {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
             public static var __selections: [ApolloAPI.Selection] { [
@@ -138,7 +138,7 @@ public class RepositoryQuery: GraphQLQuery {
         /// Parent Type: `Reactable`
         public struct AsReactable: GitHubAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = Repository.IssueOrPullRequest
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Reactable }
@@ -157,7 +157,7 @@ public class RepositoryQuery: GraphQLQuery {
           /// Parent Type: `Comment`
           public struct AsComment: GitHubAPI.InlineFragment {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public typealias RootEntityType = Repository.IssueOrPullRequest
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Comment }
@@ -175,7 +175,7 @@ public class RepositoryQuery: GraphQLQuery {
             /// Parent Type: `Actor`
             public struct Author: GitHubAPI.SelectionSet {
               public let __data: DataDict
-              public init(data: DataDict) { __data = data }
+              public init(_dataDict: DataDict) { __data = _dataDict }
 
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
               public static var __selections: [ApolloAPI.Selection] { [

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
@@ -12,7 +12,7 @@ public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -31,7 +31,7 @@ public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
@@ -12,7 +12,7 @@ public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -31,7 +31,7 @@ public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
@@ -13,7 +13,7 @@ public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -36,7 +36,7 @@ public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
@@ -12,7 +12,7 @@ public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.Selectio
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.Selectio
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -16,7 +16,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -38,7 +38,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -51,7 +51,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
   /// Parent Type: `Droid`
   public struct AsDroid: StarWarsAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = CharacterNameAndDroidAppearsIn
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -69,7 +69,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
       name: String
     ) {
       let objectType = StarWarsAPI.Objects.Droid
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -13,7 +13,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
   /// Parent Type: `Droid`
   public struct AsDroid: StarWarsAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = CharacterNameAndDroidPrimaryFunction
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -81,7 +81,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
       primaryFunction: String? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Droid
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -23,7 +23,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -54,7 +54,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
   /// Parent Type: `Human`
   public struct AsHuman: StarWarsAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = CharacterNameWithInlineFragment
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -69,7 +69,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
       friends: [Friend?]? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Human
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -82,7 +82,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
     /// Parent Type: `Character`
     public struct Friend: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -101,7 +101,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -116,7 +116,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
   /// Parent Type: `Droid`
   public struct AsDroid: StarWarsAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = CharacterNameWithInlineFragment
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -143,7 +143,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
       friends: [FriendsNames.Friend?]? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Droid
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
@@ -13,7 +13,7 @@ public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -43,7 +43,7 @@ public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
@@ -13,7 +13,7 @@ public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -31,7 +31,7 @@ public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
     primaryFunction: String? = nil
   ) {
     let objectType = StarWarsAPI.Objects.Droid
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
@@ -12,7 +12,7 @@ public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -26,7 +26,7 @@ public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
     name: String
   ) {
     let objectType = StarWarsAPI.Objects.Droid
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
@@ -13,7 +13,7 @@ public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -39,7 +39,7 @@ public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
     name: String
   ) {
     let objectType = StarWarsAPI.Objects.Droid
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
@@ -12,7 +12,7 @@ public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -26,7 +26,7 @@ public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
     primaryFunction: String? = nil
   ) {
     let objectType = StarWarsAPI.Objects.Droid
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
@@ -15,7 +15,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -34,7 +34,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -47,7 +47,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
   /// Parent Type: `Character`
   public struct Friend: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -66,7 +66,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
         implementedInterfaces: [
           StarWarsAPI.Interfaces.Character
       ])
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -20,7 +20,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -44,7 +44,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
       implementedInterfaces: [
         StarWarsAPI.Interfaces.Character
     ])
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,
@@ -57,7 +57,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
   /// Parent Type: `Human`
   public struct AsHuman: StarWarsAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = HeroDetails
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -75,7 +75,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
       name: String
     ) {
       let objectType = StarWarsAPI.Objects.Human
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -90,7 +90,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
   /// Parent Type: `Droid`
   public struct AsDroid: StarWarsAPI.InlineFragment {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public typealias RootEntityType = HeroDetails
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -108,7 +108,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
       name: String
     ) {
       let objectType = StarWarsAPI.Objects.Droid
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
@@ -12,7 +12,7 @@ public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
     """ }
 
   public let __data: DataDict
-  public init(data: DataDict) { __data = data }
+  public init(_dataDict: DataDict) { __data = _dataDict }
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
   public static var __selections: [ApolloAPI.Selection] { [
@@ -26,7 +26,7 @@ public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
     height: Double? = nil
   ) {
     let objectType = StarWarsAPI.Objects.Human
-    self.init(data: DataDict(
+    self.init(_dataDict: DataDict(
       objectType: objectType,
       data: [
         "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -23,7 +23,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
       createReview: CreateReview? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Mutation
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
     /// Parent Type: `Review`
     public struct CreateReview: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -73,7 +73,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
         commentary: String? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Review
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -37,7 +37,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -53,7 +53,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
       createReview: CreateReview? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Mutation
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -66,7 +66,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
     /// Parent Type: `Review`
     public struct CreateReview: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -84,7 +84,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
         commentary: String? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Review
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -23,7 +23,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
       createReview: CreateReview? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Mutation
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
     /// Parent Type: `Review`
     public struct CreateReview: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -73,7 +73,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
         commentary: String? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Review
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -29,7 +29,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -72,7 +72,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -84,7 +84,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -109,7 +109,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
           primaryFunction: String? = nil
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -46,7 +46,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -59,7 +59,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -86,7 +86,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -101,7 +101,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -120,7 +120,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -32,7 +32,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -45,7 +45,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -58,7 +58,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -81,7 +81,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -95,7 +95,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -114,7 +114,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -30,7 +30,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -43,7 +43,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -86,7 +86,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -39,7 +39,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -52,7 +52,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -65,7 +65,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -87,7 +87,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -100,7 +100,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -126,7 +126,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -140,7 +140,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -155,7 +155,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
           friends: [Friend?]? = nil
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -168,7 +168,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
         /// Parent Type: `Character`
         public struct Friend: StarWarsAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -194,7 +194,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
               implementedInterfaces: [
                 StarWarsAPI.Interfaces.Character
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -33,7 +33,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -46,7 +46,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -59,7 +59,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -86,7 +86,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -101,7 +101,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -120,7 +120,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -34,7 +34,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -47,7 +47,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -60,7 +60,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -87,7 +87,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -102,7 +102,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -125,7 +125,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -22,7 +22,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -35,7 +35,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -48,7 +48,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -67,7 +67,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -81,7 +81,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -79,7 +79,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -91,7 +91,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct IfIncludeDetails: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
@@ -115,7 +115,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -32,7 +32,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -45,7 +45,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -58,7 +58,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -75,7 +75,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -87,7 +87,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct IfIncludeDetails: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
@@ -111,7 +111,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -36,7 +36,7 @@ public class HeroDetailsQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -49,7 +49,7 @@ public class HeroDetailsQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -62,7 +62,7 @@ public class HeroDetailsQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -86,7 +86,7 @@ public class HeroDetailsQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -99,7 +99,7 @@ public class HeroDetailsQuery: GraphQLQuery {
       /// Parent Type: `Human`
       public struct AsHuman: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -117,7 +117,7 @@ public class HeroDetailsQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -132,7 +132,7 @@ public class HeroDetailsQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -150,7 +150,7 @@ public class HeroDetailsQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -84,7 +84,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -97,7 +97,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
       /// Parent Type: `Human`
       public struct AsHuman: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -119,7 +119,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
           height: Double? = nil
         ) {
           let objectType = StarWarsAPI.Objects.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -134,7 +134,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -156,7 +156,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
           primaryFunction: String? = nil
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -48,7 +48,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -61,7 +61,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -80,7 +80,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -93,7 +93,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -115,7 +115,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -128,7 +128,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
         /// Parent Type: `Droid`
         public struct AsDroid: StarWarsAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = Hero.Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -146,7 +146,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
             name: String
           ) {
             let objectType = StarWarsAPI.Objects.Droid
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -39,7 +39,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -52,7 +52,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -65,7 +65,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -84,7 +84,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -97,7 +97,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -120,7 +120,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -133,7 +133,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
         /// Parent Type: `Character`
         public struct IfIncludeFriendsDetails: StarWarsAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = Hero.Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
@@ -156,7 +156,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
               implementedInterfaces: [
                 StarWarsAPI.Interfaces.Character
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -169,7 +169,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           /// Parent Type: `Droid`
           public struct AsDroid: StarWarsAPI.InlineFragment {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public typealias RootEntityType = Hero.Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -187,7 +187,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
               name: String
             ) {
               let objectType = StarWarsAPI.Objects.Droid
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -202,7 +202,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
         /// Parent Type: `Droid`
         public struct AsDroid: StarWarsAPI.InlineFragment {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public typealias RootEntityType = Hero.Friend
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -217,7 +217,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
             primaryFunction: String? = nil
           ) {
             let objectType = StarWarsAPI.Objects.Droid
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -48,7 +48,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -61,7 +61,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -80,7 +80,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -93,7 +93,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
       /// Parent Type: `Character`
       public struct Friend: StarWarsAPI.SelectionSet {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
@@ -116,7 +116,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
             implementedInterfaces: [
               StarWarsAPI.Interfaces.Character
           ])
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -130,7 +130,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
         /// Parent Type: `Character`
         public struct Friend: StarWarsAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -149,7 +149,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
               implementedInterfaces: [
                 StarWarsAPI.Interfaces.Character
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -78,7 +78,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -84,7 +84,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -36,7 +36,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -49,7 +49,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -62,7 +62,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -81,7 +81,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -37,7 +37,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -50,7 +50,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -63,7 +63,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -82,7 +82,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -41,7 +41,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -54,7 +54,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -73,7 +73,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -41,7 +41,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -54,7 +54,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -73,7 +73,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -28,7 +28,7 @@ public class HeroNameQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -41,7 +41,7 @@ public class HeroNameQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -54,7 +54,7 @@ public class HeroNameQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -73,7 +73,7 @@ public class HeroNameQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -40,7 +40,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -53,7 +53,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -66,7 +66,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -88,7 +88,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -101,7 +101,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -116,7 +116,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -30,7 +30,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -43,7 +43,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -86,7 +86,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -81,7 +81,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -78,7 +78,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -50,7 +50,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -63,7 +63,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -76,7 +76,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -100,7 +100,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -113,7 +113,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
       /// Parent Type: `Human`
       public struct AsHuman: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -131,7 +131,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -145,7 +145,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         /// Parent Type: `Character`
         public struct Friend: StarWarsAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -167,7 +167,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               implementedInterfaces: [
                 StarWarsAPI.Interfaces.Character
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -180,7 +180,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           /// Parent Type: `Human`
           public struct AsHuman: StarWarsAPI.InlineFragment {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public typealias RootEntityType = Hero.AsHuman.Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -198,7 +198,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               name: String
             ) {
               let objectType = StarWarsAPI.Objects.Human
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,
@@ -215,7 +215,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -233,7 +233,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -247,7 +247,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
         /// Parent Type: `Character`
         public struct Friend: StarWarsAPI.SelectionSet {
           public let __data: DataDict
-          public init(data: DataDict) { __data = data }
+          public init(_dataDict: DataDict) { __data = _dataDict }
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
@@ -269,7 +269,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               implementedInterfaces: [
                 StarWarsAPI.Interfaces.Character
             ])
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -282,7 +282,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           /// Parent Type: `Human`
           public struct AsHuman: StarWarsAPI.InlineFragment {
             public let __data: DataDict
-            public init(data: DataDict) { __data = data }
+            public init(_dataDict: DataDict) { __data = _dataDict }
 
             public typealias RootEntityType = Hero.AsDroid.Friend
             public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -300,7 +300,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               name: String
             ) {
               let objectType = StarWarsAPI.Objects.Human
-              self.init(data: DataDict(
+              self.init(_dataDict: DataDict(
                 objectType: objectType,
                 data: [
                   "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -35,7 +35,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -48,7 +48,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
       hero: Hero? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -61,7 +61,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -80,7 +80,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -92,7 +92,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
       /// Parent Type: `Human`
       public struct AsHuman: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -107,7 +107,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
           property: String? = nil
         ) {
           let objectType = StarWarsAPI.Objects.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -121,7 +121,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -136,7 +136,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
           property: String? = nil
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -29,7 +29,7 @@ public class HumanQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class HumanQuery: GraphQLQuery {
       human: Human? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -55,7 +55,7 @@ public class HumanQuery: GraphQLQuery {
     /// Parent Type: `Human`
     public struct Human: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -73,7 +73,7 @@ public class HumanQuery: GraphQLQuery {
         mass: Double? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Human
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -26,7 +26,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
       r2: R2? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Hero: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -75,7 +75,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -89,7 +89,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct R2: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -108,7 +108,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -42,7 +42,7 @@ public class SearchQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -55,7 +55,7 @@ public class SearchQuery: GraphQLQuery {
       search: [Search?]? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -68,7 +68,7 @@ public class SearchQuery: GraphQLQuery {
     /// Parent Type: `SearchResult`
     public struct Search: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Unions.SearchResult }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -88,7 +88,7 @@ public class SearchQuery: GraphQLQuery {
           typename: __typename,
           implementedInterfaces: [
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -100,7 +100,7 @@ public class SearchQuery: GraphQLQuery {
       /// Parent Type: `Human`
       public struct AsHuman: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Search
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
@@ -119,7 +119,7 @@ public class SearchQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -134,7 +134,7 @@ public class SearchQuery: GraphQLQuery {
       /// Parent Type: `Droid`
       public struct AsDroid: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Search
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
@@ -153,7 +153,7 @@ public class SearchQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Droid
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -168,7 +168,7 @@ public class SearchQuery: GraphQLQuery {
       /// Parent Type: `Starship`
       public struct AsStarship: StarWarsAPI.InlineFragment {
         public let __data: DataDict
-        public init(data: DataDict) { __data = data }
+        public init(_dataDict: DataDict) { __data = _dataDict }
 
         public typealias RootEntityType = Search
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Starship }
@@ -187,7 +187,7 @@ public class SearchQuery: GraphQLQuery {
           name: String
         ) {
           let objectType = StarWarsAPI.Objects.Starship
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -30,7 +30,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -43,7 +43,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
       starshipCoordinates: StarshipCoordinates? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
     /// Parent Type: `Starship`
     public struct StarshipCoordinates: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Starship }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -77,7 +77,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
         length: Double? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Starship
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -23,7 +23,7 @@ public class StarshipQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -36,7 +36,7 @@ public class StarshipQuery: GraphQLQuery {
       starship: Starship? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -49,7 +49,7 @@ public class StarshipQuery: GraphQLQuery {
     /// Parent Type: `Starship`
     public struct Starship: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Starship }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -66,7 +66,7 @@ public class StarshipQuery: GraphQLQuery {
         coordinates: [[Double]]? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Starship
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -26,7 +26,7 @@ public class TwoHeroesQuery: GraphQLQuery {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -42,7 +42,7 @@ public class TwoHeroesQuery: GraphQLQuery {
       luke: Luke? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Query
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class TwoHeroesQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct R2: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -75,7 +75,7 @@ public class TwoHeroesQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -89,7 +89,7 @@ public class TwoHeroesQuery: GraphQLQuery {
     /// Parent Type: `Character`
     public struct Luke: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -108,7 +108,7 @@ public class TwoHeroesQuery: GraphQLQuery {
           implementedInterfaces: [
             StarWarsAPI.Interfaces.Character
         ])
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -30,7 +30,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
 
   public struct Data: StarWarsAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Subscription }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -43,7 +43,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
       reviewAdded: ReviewAdded? = nil
     ) {
       let objectType = StarWarsAPI.Objects.Subscription
-      self.init(data: DataDict(
+      self.init(_dataDict: DataDict(
         objectType: objectType,
         data: [
           "__typename": objectType.typename,
@@ -56,7 +56,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
     /// Parent Type: `Review`
     public struct ReviewAdded: StarWarsAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
@@ -78,7 +78,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
         commentary: String? = nil
       ) {
         let objectType = StarWarsAPI.Objects.Review
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
@@ -18,7 +18,7 @@ public class IncrementingSubscription: GraphQLSubscription {
 
   public struct Data: SubscriptionAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { SubscriptionAPI.Objects.Subscription }
     public static var __selections: [ApolloAPI.Selection] { [

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -38,7 +38,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -55,7 +55,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
     /// Parent Type: `File`
     public struct MultipleParameterUpload: UploadAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.File }
       public static var __selections: [ApolloAPI.Selection] { [

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -30,7 +30,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -44,7 +44,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
     /// Parent Type: `File`
     public struct MultipleUpload: UploadAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.File }
       public static var __selections: [ApolloAPI.Selection] { [

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -30,7 +30,7 @@ public class UploadOneFileMutation: GraphQLMutation {
 
   public struct Data: UploadAPI.SelectionSet {
     public let __data: DataDict
-    public init(data: DataDict) { __data = data }
+    public init(_dataDict: DataDict) { __data = _dataDict }
 
     public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.Mutation }
     public static var __selections: [ApolloAPI.Selection] { [
@@ -44,7 +44,7 @@ public class UploadOneFileMutation: GraphQLMutation {
     /// Parent Type: `File`
     public struct SingleUpload: UploadAPI.SelectionSet {
       public let __data: DataDict
-      public init(data: DataDict) { __data = data }
+      public init(_dataDict: DataDict) { __data = _dataDict }
 
       public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.File }
       public static var __selections: [ApolloAPI.Selection] { [

--- a/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockLocalCacheMutation.swift
@@ -29,7 +29,7 @@ public extension MockMutableRootSelectionSet {
   static var __parentType: ParentType { Object.mock }
 
   init() {
-    self.init(data: .empty())
+    self.init(_dataDict: .empty())
   }
 }
 

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -87,6 +87,10 @@ open class MockTypeCase: MockSelectionSet, InlineFragment {
   public typealias RootEntityType = MockSelectionSet
 }
 
+open class ConcreteMockTypeCase<T: MockSelectionSet>: MockSelectionSet, InlineFragment {
+  public typealias RootEntityType = T
+}
+
 extension DataDict {
   public static func empty() -> DataDict {
     DataDict(objectType: nil, data: [:], variables: nil)

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -54,8 +54,8 @@ open class AbstractMockSelectionSet<F>: RootSelectionSet, Hashable {
 
   public var __data: DataDict = .empty()
 
-  public required init(data: DataDict) {
-    self.__data = data
+  public required init(_dataDict: DataDict) {
+    self.__data = _dataDict
   }
 
   public subscript<T: AnyScalarType & Hashable>(dynamicMember key: String) -> T? {

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -1402,7 +1402,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       let updateCompletedExpectation = expectation(description: "Update completed")
 
       store.withinReadWriteTransaction({ transaction in
-        let data = GivenSelectionSet(unsafeData:
+        let data = try! GivenSelectionSet(data:
           ["hero": [
             "__typename": "Droid",
             "name": "Artoo"
@@ -1468,7 +1468,11 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     let writeCompletedExpectation = expectation(description: "Write completed")
 
     store.withinReadWriteTransaction({ transaction in
-      let data = GivenSelectionSet(unsafeData: ["hero": "name"], variables: nil)
+      let data = GivenSelectionSet(
+        _dataDict: .init(
+          objectType: Object(typename: "Hero", implementedInterfaces: []),
+          data: ["hero": "name"]
+        ))
       let cacheMutation = MockLocalCacheMutation<GivenSelectionSet>()
       try transaction.write(data: data, for: cacheMutation)
     }, completion: { result in
@@ -1523,7 +1527,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       let updateCompletedExpectation = expectation(description: "Update completed")
 
       store.withinReadWriteTransaction({ transaction in
-        let fragment = GivenFragment(unsafeData:
+        let fragment = try! GivenFragment(data:
           ["hero": [
             "__typename": "Droid",
             "name": "Artoo"

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -372,7 +372,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -385,7 +385,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self)
@@ -437,7 +437,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -450,7 +450,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self),
@@ -514,7 +514,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -527,7 +527,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self),
@@ -579,7 +579,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -592,7 +592,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self),
@@ -638,7 +638,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -651,7 +651,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self)
@@ -708,7 +708,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self, arguments: ["episode": .variable("episode")])
@@ -721,7 +721,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self)
@@ -812,7 +812,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -825,7 +825,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("__typename", String.self),
@@ -848,7 +848,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
           public typealias RootEntityType = Hero
           static let __parentType: ParentType = Types.Droid
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] { [
             .field("primaryFunction", String.self),
@@ -915,7 +915,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       static let fragmentDefinition: StaticString = ""
 
       var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("__typename", String.self),
@@ -937,7 +937,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = .empty()
         public typealias RootEntityType = GivenFragment
         static let __parentType: ParentType = Types.Droid
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("primaryFunction", String.self),
@@ -952,7 +952,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -965,7 +965,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("__typename", String.self),
@@ -1047,7 +1047,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       static let fragmentDefinition: StaticString = ""
 
       var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("__typename", String.self),
@@ -1069,7 +1069,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         public var __data: DataDict = .empty()
         public typealias RootEntityType = GivenFragment
         static let __parentType: ParentType = Types.Droid
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("primaryFunction", String.self),
@@ -1084,7 +1084,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1097,7 +1097,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("__typename", String.self),
@@ -1119,7 +1119,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
           public var __data: DataDict = .empty()
           public typealias RootEntityType = GivenFragment
           static let __parentType: ParentType = Types.Droid
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] { [
             .field("primaryFunction", String.self),
@@ -1186,7 +1186,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1199,7 +1199,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("id", String.self),
@@ -1219,7 +1219,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] { [
             .field("id", String.self),
@@ -1307,7 +1307,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1320,7 +1320,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("type", GraphQLEnum<HeroType>.self)
@@ -1372,7 +1372,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1385,7 +1385,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self)
@@ -1438,7 +1438,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1451,7 +1451,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String?.self)
@@ -1493,7 +1493,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       static var fragmentDefinition: StaticString { "" }
 
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1506,7 +1506,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self)
@@ -1558,7 +1558,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     // given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1571,7 +1571,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("name", String.self)
@@ -1620,7 +1620,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       static var fragmentDefinition: StaticString { "" }
 
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("id", String.self),
@@ -1634,7 +1634,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Friend: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("id", String.self),
@@ -1738,7 +1738,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -1751,7 +1751,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("id", String.self),
@@ -1771,7 +1771,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] { [
             .field("id", String.self),

--- a/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
+++ b/Tests/ApolloTests/Cache/StoreConcurrencyTests.swift
@@ -143,7 +143,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -156,7 +156,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("id", String.self),
@@ -181,7 +181,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] { [
             .field("id", String.self),
@@ -267,7 +267,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
     /// given
     struct GivenSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
         .field("hero", Hero.self)
@@ -280,7 +280,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
           .field("id", String.self),
@@ -305,7 +305,7 @@ class StoreConcurrencyTests: XCTestCase, CacheDependentTesting {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] { [
             .field("id", String.self),

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -829,7 +829,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
   func testWatchedQueryGetsUpdatedWhenObjectIsChangedByDirectStoreUpdate() throws {
     struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] {[
         .field("hero", Hero?.self)
@@ -842,7 +842,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] {[
           .field("__typename", String.self),
@@ -862,7 +862,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] {[
             .field("__typename", String.self),
@@ -956,7 +956,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     // given
     struct HeroAndFriendsNamesSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] {[
         .field("hero", Hero.self)
@@ -969,7 +969,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] {[
           .field("__typename", String.self),
@@ -995,7 +995,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] {[
             .field("__typename", String.self),
@@ -1018,7 +1018,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
     struct HeroAndFriendsIDsOnlySelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] {[
         .field("hero", Hero.self)
@@ -1031,7 +1031,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] {[
           .field("__typename", String.self),
@@ -1051,7 +1051,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] {[
             .field("__typename", String.self),
@@ -1367,7 +1367,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
     // given
     struct HeroAndFriendsNamesWithIDsSelectionSet: MockMutableRootSelectionSet {
       public var __data: DataDict = .empty()
-      init(data: DataDict) { __data = data }
+      init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] {[
         .field("hero", Hero.self)
@@ -1380,7 +1380,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
       struct Hero: MockMutableRootSelectionSet {
         public var __data: DataDict = .empty()
-        init(data: DataDict) { __data = data }
+        init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] {[
           .field("__typename", String.self),
@@ -1406,7 +1406,7 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
 
         struct Friend: MockMutableRootSelectionSet {
           public var __data: DataDict = .empty()
-          init(data: DataDict) { __data = data }
+          init(_dataDict: DataDict) { __data = _dataDict }
 
           static var __selections: [Selection] {[
             .field("__typename", String.self),

--- a/Tests/ApolloTests/Cache/WatchQueryTests.swift
+++ b/Tests/ApolloTests/Cache/WatchQueryTests.swift
@@ -1079,8 +1079,8 @@ class WatchQueryTests: XCTestCase, CacheDependentTesting {
       let writeToStoreExpectation = expectation(description: "Initial Data written to store")
 
       client.store.withinReadWriteTransaction({ transaction in
-        let data = HeroAndFriendsNamesSelectionSet(
-          unsafeData:
+        let data = try! HeroAndFriendsNamesSelectionSet(
+          data:
             [
               "hero": [
                 "id": "2001",

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -25,7 +25,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.name).to(equal("Johnny Tsunami"))
@@ -49,7 +49,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.name).to(beNil())
@@ -74,7 +74,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.name).to(beNil())
@@ -101,7 +101,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.nestedList).to(equal([["A"]]))
@@ -137,10 +137,10 @@ class SelectionSetTests: XCTestCase {
       "friend": friendData
     ]
 
-    let expected = Hero.Friend(unsafeData: friendData)
+    let expected = try! Hero.Friend(data: friendData)
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friend).to(equal(expected))
@@ -166,10 +166,10 @@ class SelectionSetTests: XCTestCase {
       "friend": friendData
     ]
 
-    let expected = Hero(unsafeData: friendData, variables: nil)
+    let expected = try! Hero(data: friendData, variables: nil)
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friend).to(equal(expected))
@@ -193,7 +193,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friend).to(beNil())
@@ -224,8 +224,8 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(
-      unsafeData: [
+    let expected = try! Hero(
+      data: [
         "__typename": "Human",
         "friends": []
       ],
@@ -233,7 +233,7 @@ class SelectionSetTests: XCTestCase {
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friends).to(equal([expected]))
@@ -262,16 +262,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "friends": []
-                          ],
-                        variables: nil
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "friends": []
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friends).to(equal([expected]))
@@ -299,16 +299,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "friends": []
-                          ],
-                        variables: nil
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "friends": []
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friends).to(equal([Hero?.none, expected, Hero?.none]))
@@ -337,16 +337,16 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "friends": []
-                          ],
-                        variables: nil
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "friends": []
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friends).to(equal([expected]))
@@ -370,7 +370,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.friends).to(beNil())
@@ -401,16 +401,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "nestedList": [[]]
-                          ],
-                        variables: nil
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "nestedList": [[]]
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -439,16 +439,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "nestedList": [[]]
-                          ],
-                        variables: nil
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "nestedList": [[]]
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -481,10 +481,10 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expectedItem = Hero(unsafeData: nestedObjectData, variables: nil)
+    let expectedItem = try! Hero(data: nestedObjectData, variables: nil)
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.nestedList).to(equal([[Hero]?.none, [expectedItem], [Hero]?.none]))
@@ -512,17 +512,17 @@ class SelectionSetTests: XCTestCase {
         ]
       ]]
     ]
-
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "nestedList": [[]]
-                          ],
-                        variables: nil
+    
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "nestedList": [[]]
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -551,16 +551,16 @@ class SelectionSetTests: XCTestCase {
       ]]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "nestedList": [[]]
-                          ],
-                        variables: nil
+    let expected = try! Hero(
+      data: [
+        "__typename": "Human",
+        "nestedList": [[]]
+      ],
+      variables: nil
     )
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
@@ -600,7 +600,7 @@ class SelectionSetTests: XCTestCase {
 
         override class var __parentType: ParentType { Types.Human }
         override class var __selections: [Selection] {[
-          .field("name", String.self)
+          .field("name", String?.self)
         ]}
       }
 
@@ -609,7 +609,7 @@ class SelectionSetTests: XCTestCase {
 
         override class var __parentType: ParentType { Types.Droid }
         override class var __selections: [Selection] {[
-          .field("primaryFunction", String.self)
+          .field("primaryFunction", String?.self)
         ]}
       }
     }
@@ -620,7 +620,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.asHuman).to(beNil())
@@ -668,7 +668,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.asHumanoid).toNot(beNil())
@@ -715,7 +715,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.asHumanoid).to(beNil())
@@ -761,7 +761,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.asCharacter).toNot(beNil())
@@ -807,7 +807,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object)
+    let actual = try! Hero(data: object)
 
     // then
     expect(actual.asCharacter).to(beNil())
@@ -841,7 +841,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object, variables: ["includeFragment": true])
+    let actual = try! Hero(data: object, variables: ["includeFragment": true])
 
     // then
     expect(actual.fragments.givenFragment).toNot(beNil())
@@ -873,7 +873,7 @@ class SelectionSetTests: XCTestCase {
     ]
 
     // when
-    let actual = Hero(unsafeData: object, variables: ["includeFragment": false])
+    let actual = try! Hero(data: object, variables: ["includeFragment": false])
 
     // then
     expect(actual.fragments.givenFragment).to(beNil())

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -224,12 +224,12 @@ class SelectionSetTests: XCTestCase {
       ]
     ]
 
-    let expected = Hero(unsafeData:
-                          [
-                            "__typename": "Human",
-                            "friends": []
-                          ],
-                        variables: nil
+    let expected = Hero(
+      unsafeData: [
+        "__typename": "Human",
+        "friends": []
+      ],
+      variables: nil
     )
 
     // when
@@ -922,7 +922,7 @@ class SelectionSetTests: XCTestCase {
             typename: __typename,
             implementedInterfaces: [Types.Animal]
           )
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -970,7 +970,7 @@ class SelectionSetTests: XCTestCase {
         hero: Hero
       ) {
         let objectType = Types.Query
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -1006,7 +1006,7 @@ class SelectionSetTests: XCTestCase {
               typename: __typename,
               implementedInterfaces: [Types.Animal]
             )
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -1064,7 +1064,7 @@ class SelectionSetTests: XCTestCase {
           name: String
         ) {
           let objectType = Types.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -1121,7 +1121,7 @@ class SelectionSetTests: XCTestCase {
           name: String
         ) {
           let objectType = Types.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,
@@ -1175,7 +1175,7 @@ class SelectionSetTests: XCTestCase {
         hero: Hero
       ) {
         let objectType = Types.Query
-        self.init(data: DataDict(
+        self.init(_dataDict: DataDict(
           objectType: objectType,
           data: [
             "__typename": objectType.typename,
@@ -1208,7 +1208,7 @@ class SelectionSetTests: XCTestCase {
             name: String
           ) {
             let objectType = Types.Human
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename,
@@ -1226,7 +1226,7 @@ class SelectionSetTests: XCTestCase {
           ]}
           convenience init() {
             let objectType = Types.Human
-            self.init(data: DataDict(
+            self.init(_dataDict: DataDict(
               objectType: objectType,
               data: [
                 "__typename": objectType.typename
@@ -1242,8 +1242,8 @@ class SelectionSetTests: XCTestCase {
     let actual = Data(hero: .IfA(name: "Han Solo").asRootEntityType)
 
     // then
-    expect(actual.ifA).toNot(beNil())
-    expect(actual.ifB).to(beNil())
+    expect(actual.hero.ifA).toNot(beNil())
+    expect(actual.hero.ifB).to(beNil())
   }
 
   func test__selectionInitializer_givenInitMultipleTypesWithConflictingInclusionConditions__canConvertToAllConditionalTypes() {
@@ -1281,7 +1281,7 @@ class SelectionSetTests: XCTestCase {
           name: String
         ) {
           let objectType = Types.Human
-          self.init(data: DataDict(
+          self.init(_dataDict: DataDict(
             objectType: objectType,
             data: [
               "__typename": objectType.typename,

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -225,11 +225,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "friends": []
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "friends": []
+                          ],
+                        variables: nil
     )
 
     // when
@@ -263,11 +263,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "friends": []
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "friends": []
+                          ],
+                        variables: nil
     )
 
     // when
@@ -300,11 +300,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "friends": []
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "friends": []
+                          ],
+                        variables: nil
     )
 
     // when
@@ -338,11 +338,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "friends": []
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "friends": []
+                          ],
+                        variables: nil
     )
 
     // when
@@ -402,11 +402,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "nestedList": [[]]
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "nestedList": [[]]
+                          ],
+                        variables: nil
     )
 
     // when
@@ -440,11 +440,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "nestedList": [[]]
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "nestedList": [[]]
+                          ],
+                        variables: nil
     )
 
     // when
@@ -514,11 +514,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "nestedList": [[]]
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "nestedList": [[]]
+                          ],
+                        variables: nil
     )
 
     // when
@@ -552,11 +552,11 @@ class SelectionSetTests: XCTestCase {
     ]
 
     let expected = Hero(unsafeData:
-      [
-        "__typename": "Human",
-        "nestedList": [[]]
-      ],
-      variables: nil
+                          [
+                            "__typename": "Human",
+                            "nestedList": [[]]
+                          ],
+                        variables: nil
     )
 
     // when
@@ -564,7 +564,7 @@ class SelectionSetTests: XCTestCase {
 
     // then
     expect(actual.nestedList).to(equal([[expected]]))
-  }  
+  }
 
   // MARK: TypeCase Conversion Tests
 
@@ -879,4 +879,285 @@ class SelectionSetTests: XCTestCase {
     expect(actual.fragments.givenFragment).to(beNil())
   }
 
+  // MARK: - Initializer Tests
+
+  func test__selectionInitializer_givenInitTypeWithInclusionCondition__canConvertToConditionalType() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Hero: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .include(if: "a", .inlineFragment(IfA.self))
+      ]}
+
+      var ifA: IfA? { _asInlineFragment(if: "a") }
+
+      class IfA: MockTypeCase {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: ParentType { Types.Human }
+        override class var __selections: [Selection] {[
+          .field("name", String.self)
+        ]}
+        public var asEntityRootType: Hero { _asInlineFragment()! }
+        var name: String { __data["name"] }
+
+        convenience init(
+          name: String
+        ) {
+          let objectType = Types.Human
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "name": name
+            ],
+            variables: ["a": true]
+          ))
+        }
+      }
+
+    }
+
+    // when
+    let actual = Hero.IfA(name: "Han Solo").asEntityRootType
+
+    // then
+    expect(actual.ifA?.name).to(equal("Han Solo"))
+  }
+
+  func test__selectionInitializer_givenInitTypeWithInclusionCondition__cannotConvertToOtherConditionalType() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Hero: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .include(if: "a", .inlineFragment(IfA.self)),
+        .include(if: "b", .inlineFragment(IfB.self))
+      ]}
+
+      var ifA: IfA? { _asInlineFragment(if: "a") }
+      var ifB: IfB? { _asInlineFragment(if: "b") }
+
+      class IfA: MockTypeCase {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: ParentType { Types.Human }
+        override class var __selections: [Selection] {[
+          .field("name", String.self)
+        ]}
+        public var asEntityRootType: Hero { _asInlineFragment()! }
+        var name: String { __data["name"] }
+
+        convenience init(
+          name: String
+        ) {
+          let objectType = Types.Human
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "name": name
+            ],
+            variables: ["a": true]
+          ))
+        }
+      }
+      class IfB: MockTypeCase {
+        typealias Schema = MockSchemaMetadata
+        override class var __parentType: ParentType { Types.Human }
+        override class var __selections: [Selection] {[
+        ]}
+      }
+    }
+
+    // when
+    let actual = Hero.IfA(name: "Han Solo").asEntityRootType
+
+    // then
+    expect(actual.ifA).toNot(beNil())
+    expect(actual.ifB).to(beNil())
+  }
+
+  func test__selectionInitializer_givenInitNestedTypeWithInclusionCondition__cannotConvertToOtherConditionalType() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+      static let Query = Object(typename: "Query", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Data: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Query }
+      override class var __selections: [Selection] {[
+        .field("hero", Hero.self)
+      ]}
+
+      public var hero: Hero { __data["hero"] }
+
+      convenience init(
+        hero: Hero
+      ) {
+        let objectType = Types.Query
+        self.init(data: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "hero": hero._fieldData
+          ]
+        ))
+      }
+
+      class Hero: MockSelectionSet {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: ParentType { Types.Human }
+        override class var __selections: [Selection] {[
+          .include(if: "a", .inlineFragment(IfA.self)),
+          .include(if: "b", .inlineFragment(IfB.self))
+        ]}
+
+        var ifA: IfA? { _asInlineFragment(if: "a") }
+        var ifB: IfB? { _asInlineFragment(if: "b") }
+
+        class IfA: MockTypeCase {
+          typealias Schema = MockSchemaMetadata
+
+          override class var __parentType: ParentType { Types.Human }
+          override class var __selections: [Selection] {[
+            .field("name", String.self)
+          ]}
+          public var asEntityRootType: Hero { _asInlineFragment()! }
+          var name: String { __data["name"] }
+
+          convenience init(
+            name: String
+          ) {
+            let objectType = Types.Human
+            self.init(data: DataDict(
+              objectType: objectType,
+              data: [
+                "__typename": objectType.typename,
+                "name": name
+              ],
+              variables: ["a": true]
+            ))
+          }
+        }
+
+        class IfB: MockTypeCase {
+          typealias Schema = MockSchemaMetadata
+          override class var __parentType: ParentType { Types.Human }
+          override class var __selections: [Selection] {[
+          ]}
+          convenience init() {
+            let objectType = Types.Human
+            self.init(data: DataDict(
+              objectType: objectType,
+              data: [
+                "__typename": objectType.typename
+              ],
+              variables: ["b": true]
+            ))
+          }
+        }
+      }
+    }
+
+    // when
+    let actual = Data(hero: .IfA(name: "Han Solo").asEntityRootType)
+
+    // then
+    expect(actual.ifA).toNot(beNil())
+    expect(actual.ifB).to(beNil())
+  }
+
+  func test__selectionInitializer_givenInitMultipleTypesWithConflictingInclusionConditions__canConvertToAllConditionalTypes() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Hero: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .include(if: "a", .inlineFragment(IfA.self))
+      ]}
+
+      var ifA: IfA? { _asInlineFragment(if: "a") }
+
+      class IfA: MockTypeCase {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: ParentType { Types.Human }
+        override class var __selections: [Selection] {[
+          .field("name", String.self)
+        ]}
+        public var asEntityRootType: Hero { _asInlineFragment()! }
+        var name: String { __data["name"] }
+
+        convenience init(
+          name: String
+        ) {
+          let objectType = Types.Human
+          self.init(data: DataDict(
+            objectType: objectType,
+            data: [
+              "__typename": objectType.typename,
+              "name": name
+            ],
+            variables: ["a": true]
+          ))
+        }
+      }
+
+    }
+
+    // when
+    let actual = Hero.IfA(name: "Han Solo").asEntityRootType
+
+    // then
+    expect(actual.ifA?.name).to(equal("Han Solo"))
+  }
 }


### PR DESCRIPTION
This required a significant change to the way we hold the data for `SelectionSet`s in memory. During GraphQL Execution, we now create the `DataDict` for each individual entity. This includes their object type and variables. 

Now, the variables on each nested entity are used to evaluate if their fields conditions are fulfilled, rather than looking at the global variables for each operation. This allows us to generate initializers for nested entities that override the inclusion condition values.

The same concept also applies to the object type and the `implementedInterfaces` that are used to determine type conversions.

This means that you cannot just initialize a `SelectionSet` with raw JSON anymore. The data needs to be transformed. There is now a `SelectionSet.init(data: JSONObject, variables: GraphQLOperation.Variables?) throws` function that runs a bare bones version of the `GraphQLExecutor` applying the needed transformations and validating that the data is correct. This means the function is no longer unsafe, as it throws on invalid data.