### PR TITLE
Remove unused module import (Foundation)

### DIFF
--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
 


### PR DESCRIPTION
Remove the import statement since the Foundation code is not used in InMemoryNormalizedCache.