### PR TITLE
Add more tests and documentation for generated selection set initializers

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -1320,7 +1320,6 @@
 		DE09F9BC27024FEA00795949 /* InputObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputObject.swift; sourceTree = "<group>"; };
 		DE09F9C0270269E800795949 /* MockJavaScriptObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockJavaScriptObject.swift; sourceTree = "<group>"; };
 		DE09F9C5270269F800795949 /* OperationDefinitionTemplate_DocumentType_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationDefinitionTemplate_DocumentType_Tests.swift; sourceTree = "<group>"; };
-		DE09F9C727026E0B00795949 /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
 		DE0D38EF282ECA6D00AFCC84 /* MockObjectFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockObjectFileGenerator.swift; sourceTree = "<group>"; };
 		DE0D38F1282ECF9700AFCC84 /* MockObjectFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockObjectFileGeneratorTests.swift; sourceTree = "<group>"; };
 		DE100B17287F3FB100BE11C2 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
@@ -1356,12 +1355,6 @@
 		DE2FCF2426E8083A0057EA67 /* Interface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interface.swift; sourceTree = "<group>"; };
 		DE2FCF2526E8083A0057EA67 /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		DE2FCF2626E8083A0057EA67 /* Field.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Field.swift; sourceTree = "<group>"; };
-		DE2FCF3626E809BB0057EA67 /* PetDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PetDetails.swift; sourceTree = "<group>"; };
-		DE2FCF3726E809BB0057EA67 /* HeightInMeters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeightInMeters.swift; sourceTree = "<group>"; };
-		DE2FCF3826E809BB0057EA67 /* ClassroomPetDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassroomPetDetails.swift; sourceTree = "<group>"; };
-		DE2FCF3926E809BB0057EA67 /* WarmBloodedDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WarmBloodedDetails.swift; sourceTree = "<group>"; };
-		DE2FCF3B26E809BB0057EA67 /* ClassroomPetsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClassroomPetsQuery.swift; sourceTree = "<group>"; };
-		DE2FCF3C26E809BB0057EA67 /* AllAnimalsQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllAnimalsQuery.swift; sourceTree = "<group>"; };
 		DE2FCF4826E94D150057EA67 /* TestMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMockTests.swift; sourceTree = "<group>"; };
 		DE3484612746FF8F0065B77E /* IR+OperationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+OperationBuilder.swift"; sourceTree = "<group>"; };
 		DE363CB227640FBA001EC05B /* GraphQLJSFrontend+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLJSFrontend+TestHelpers.swift"; sourceTree = "<group>"; };
@@ -2798,13 +2791,6 @@
 			path = CodeGeneration;
 			sourceTree = "<group>";
 		};
-		DE09F9C827026EFD00795949 /* SchemaTypes */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SchemaTypes;
-			sourceTree = "<group>";
-		};
 		DE223C3227221116004A0148 /* TestHelpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -2850,41 +2836,9 @@
 		DE2FCF3326E809A30057EA67 /* AnimalKingdomAPI */ = {
 			isa = PBXGroup;
 			children = (
-				DE2FCF3426E809BB0057EA67 /* ExpectedGeneratedOutput */,
 				DE223C1B271F3288004A0148 /* AnimalKingdomIRCreationTests.swift */,
 			);
 			path = AnimalKingdomAPI;
-			sourceTree = "<group>";
-		};
-		DE2FCF3426E809BB0057EA67 /* ExpectedGeneratedOutput */ = {
-			isa = PBXGroup;
-			children = (
-				DE09F9C827026EFD00795949 /* SchemaTypes */,
-				DE2FCF3526E809BB0057EA67 /* Fragments */,
-				DE2FCF3A26E809BB0057EA67 /* Queries */,
-				DE09F9C727026E0B00795949 /* Schema.swift */,
-			);
-			path = ExpectedGeneratedOutput;
-			sourceTree = "<group>";
-		};
-		DE2FCF3526E809BB0057EA67 /* Fragments */ = {
-			isa = PBXGroup;
-			children = (
-				DE2FCF3626E809BB0057EA67 /* PetDetails.swift */,
-				DE2FCF3726E809BB0057EA67 /* HeightInMeters.swift */,
-				DE2FCF3826E809BB0057EA67 /* ClassroomPetDetails.swift */,
-				DE2FCF3926E809BB0057EA67 /* WarmBloodedDetails.swift */,
-			);
-			path = Fragments;
-			sourceTree = "<group>";
-		};
-		DE2FCF3A26E809BB0057EA67 /* Queries */ = {
-			isa = PBXGroup;
-			children = (
-				DE2FCF3B26E809BB0057EA67 /* ClassroomPetsQuery.swift */,
-				DE2FCF3C26E809BB0057EA67 /* AllAnimalsQuery.swift */,
-			);
-			path = Queries;
 			sourceTree = "<group>";
 		};
 		DE31A437276A78140020DC44 /* Templates */ = {

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -74,7 +74,7 @@ public protocol SelectionSetEntityValue {
   var _fieldData: AnyHashable { get }
 }
 
-extension SelectionSet {
+extension RootSelectionSet {
   /// - Warning: This function is not supported for external use.
   /// Unsupported usage may result in unintended consequences including crashes.
   @inlinable public init(_fieldData data: AnyHashable?) {

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -45,12 +45,16 @@ public protocol SelectionSet: Hashable {
   /// This may be a concrete type (`Object`) or an abstract type (`Interface`, or `Union`).
   static var __parentType: ParentType { get }
 
-  /// The data of the underlying GraphQL object represented by generated selection set.
+  /// The data of the underlying GraphQL object represented by the generated selection set.
   var __data: DataDict { get }
 
   /// Designated Initializer
   ///
-  /// - Parameter data: The data of the underlying GraphQL object represented by generated
+  /// - Warning: This initializer is not supported for public use. It should only be used by the
+  /// `GraphQLSelectionSetMapper`, which is guaranteed by the GraphQL compiler to be safe.
+  /// Unsupported usage may result in unintended consequences including crashes.
+  ///
+  /// - Parameter data: The data of the underlying GraphQL object represented by the generated
   /// selection set.
   init(_dataDict: DataDict)
 }

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -12,7 +12,7 @@
 /// This is why only a `RootSelectionSet` can be executed by a `GraphQLExecutor`. Executing a
 /// non-root selection set would result in fields from the root selection set not being collected
 /// into the `ResponseDict` for the `SelectionSet`'s data.
-public protocol RootSelectionSet: SelectionSet, OutputTypeConvertible { }
+public protocol RootSelectionSet: SelectionSet, SelectionSetEntityValue, OutputTypeConvertible { }
 
 /// A selection set that represents an inline fragment nested inside a `RootSelectionSet`.
 ///
@@ -30,7 +30,7 @@ public protocol InlineFragment: SelectionSet {
 }
 
 // MARK: - SelectionSet
-public protocol SelectionSet: SelectionSetEntityValue, Hashable {
+public protocol SelectionSet: Hashable {
   associatedtype Schema: SchemaMetadata
 
   /// A type representing all of the fragments the `SelectionSet` can be converted to.

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -1345,4 +1345,64 @@ class SelectionSetTests: XCTestCase {
     // then
     expect(actual.ifA?.name).to(equal("Han Solo"))
   }
+
+  // MARK: Initializer - Optional Field Tests
+
+  func test__selectionInitializer_givenOptionalField__fieldIsPresentWithOptionalNilValue() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Hero: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("name", String?.self)
+      ]}
+
+      var name: String? { __data["name"] }
+
+      convenience init(
+        name: String? = nil
+      ) {
+        let objectType = Types.Human
+        self.init(_dataDict: DataDict(
+          objectType: objectType,
+          data: [
+            "__typename": objectType.typename,
+            "name": name
+          ]
+        ))
+      }
+    }
+
+    // when
+    let actual = Hero(name: nil)
+
+    // then
+    expect(actual.name).to(beNil())
+    expect(actual.__data._data.keys.contains("name")).to(beTrue())
+
+    guard let nameValue = actual.__data._data["name"] else {
+      fail("name should be Optional.some(Optional.none), got nil.")
+      return
+    }
+    expect(nameValue).to(beNil())
+
+    guard let nameValue = nameValue as? String? else {
+      fail()
+      return
+    }
+    expect(nameValue).to(beNil())
+  }
+
 }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -1393,13 +1393,13 @@ class SelectionSetTests: XCTestCase {
     expect(actual.__data._data.keys.contains("name")).to(beTrue())
 
     guard let nameValue = actual.__data._data["name"] else {
-      fail("name should be Optional.some(Optional.none), got nil.")
+      fail("name should be Optional.some(Optional.none)")
       return
     }
     expect(nameValue).to(beNil())
 
     guard let nameValue = nameValue as? String? else {
-      fail()
+      fail("name should be Optional.some(Optional.none).")
       return
     }
     expect(nameValue).to(beNil())


### PR DESCRIPTION
I thought I was going to need to change the implementation of `DataDict` and the generated initializers, but they actually already work exactly as we want them to! This adds tests to verify, adds some missing documentation, and cleans up some minor things.