### PR TITLE
internal: Update `schemaName` to `schemaNamespace` in tests and test support

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SchemaMetadataTemplate.swift
@@ -35,7 +35,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
       \(embeddedAccessControlModifier)\
       typealias MutableInlineFragment = \(schemaNamespace)_MutableInlineFragment
       """),
-    else: protocolDefinition(prefix: nil, schemaName: schemaNamespace))
+    else: protocolDefinition(prefix: nil, schemaNamespace: schemaNamespace))
 
     \(documentation: schema.documentation, config: config)
     \(embeddedAccessControlModifier)\
@@ -72,7 +72,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
   var detachedTemplate: TemplateString? {
     guard !config.output.schemaTypes.isInModule else { return nil }
 
-    return protocolDefinition(prefix: "\(schemaNamespace)_", schemaName: schemaNamespace)
+    return protocolDefinition(prefix: "\(schemaNamespace)_", schemaNamespace: schemaNamespace)
   }
 
   init(schema: IR.Schema, config: ApolloCodegen.ConfigurationContext) {
@@ -81,7 +81,7 @@ struct SchemaMetadataTemplate: TemplateRenderer {
     self.config = config
   }
 
-  private func protocolDefinition(prefix: String?, schemaName: String) -> TemplateString {
+  private func protocolDefinition(prefix: String?, schemaNamespace: String) -> TemplateString {
     return TemplateString("""
       public protocol \(prefix ?? "")SelectionSet: \(config.ApolloAPITargetName).SelectionSet & \(config.ApolloAPITargetName).RootSelectionSet
       where Schema == \(schemaNamespace).SchemaMetadata {}

--- a/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
@@ -46,7 +46,7 @@ extension IR {
   }
 
   public static func mock(
-    schemaName: String = "TestSchema",
+    schemaNamespace: String = "TestSchema",
     compilationResult: CompilationResult
   ) -> IR {
     return IR(compilationResult: compilationResult)

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -2,7 +2,7 @@
 
 extension ApolloCodegenConfiguration {
   public static func mock(
-    schemaName: String = "TestSchema",
+    schemaNamespace: String = "TestSchema",
     input: FileInput = .init(
       schemaPath: "**/*.graphqls",
       operationSearchPaths: []
@@ -17,7 +17,7 @@ extension ApolloCodegenConfiguration {
     experimentalFeatures: ExperimentalFeatures = .init()
   ) -> Self {
     .init(
-      schemaNamespace: schemaName,
+      schemaNamespace: schemaNamespace,
       input: input,
       output: output,
       options: options,
@@ -28,11 +28,11 @@ extension ApolloCodegenConfiguration {
   public static func mock(
     _ moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
     options: ApolloCodegenConfiguration.OutputOptions = .init(),
-    schemaName: String = "TestSchema",
+    schemaNamespace: String = "TestSchema",
     to path: String = "MockModulePath"
   ) -> Self {
     .init(
-      schemaNamespace: schemaName,
+      schemaNamespace: schemaNamespace,
       input: .init(
         schemaPath: "schema.graphqls",
         operationSearchPaths: ["*.graphql"]

--- a/Tests/ApolloCodegenInternalTestHelpers/MockValidationOptions.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockValidationOptions.swift
@@ -3,9 +3,9 @@ import Foundation
 
 extension ValidationOptions {
 
-  public static func mock(schemaName: String = "TestSchema") -> Self {
+  public static func mock(schemaNamespace: String = "TestSchema") -> Self {
     let context = ApolloCodegen.ConfigurationContext(
-      config: ApolloCodegenConfiguration.mock(schemaName: schemaName))
+      config: ApolloCodegenConfiguration.mock(schemaNamespace: schemaNamespace))
 
     return ValidationOptions(config: context)
   }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -587,7 +587,7 @@ class ApolloCodegenTests: XCTestCase {
       .appendingPathComponent("*.graphql").path
 
     let config = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
-      schemaName: "AnimalKingdomAPI",
+      schemaNamespace: "AnimalKingdomAPI",
       input: .init(
         schemaPath: schemaPath,
         operationSearchPaths: [operationsPath]
@@ -688,7 +688,7 @@ class ApolloCodegenTests: XCTestCase {
     let operationsOutputURL = directoryURL.appendingPathComponent("AbsoluteSources")
 
     let config = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
-      schemaName: "AnimalKingdomAPI",
+      schemaNamespace: "AnimalKingdomAPI",
       input: .init(
         schemaPath: schemaPath,
         operationSearchPaths: [operationsPath]
@@ -950,7 +950,7 @@ class ApolloCodegenTests: XCTestCase {
       .appendingPathComponent("*.graphql").path
 
     let config = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
-      schemaName: "AnimalKingdomAPI",
+      schemaNamespace: "AnimalKingdomAPI",
       input: .init(
         schemaPath: schemaPath,
         operationSearchPaths: [operationsPath]
@@ -1049,7 +1049,7 @@ class ApolloCodegenTests: XCTestCase {
       .appendingPathComponent("*.graphql").path
 
     let config = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
-      schemaName: "AnimalKingdomAPI",
+      schemaNamespace: "AnimalKingdomAPI",
       input: .init(
         schemaPath: schemaPath,
         operationSearchPaths: [operationsPath]
@@ -1846,7 +1846,7 @@ class ApolloCodegenTests: XCTestCase {
 
     // when
     let config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       input: .init(
         schemaSearchPaths: ["schema*.graphqls"],
         operationSearchPaths: ["*.graphql"]
@@ -1904,7 +1904,7 @@ class ApolloCodegenTests: XCTestCase {
 
     // when
     let config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       input: .init(
         schemaSearchPaths: ["schema*.graphqls"],
         operationSearchPaths: ["*.graphql"]
@@ -2026,7 +2026,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2044,7 +2044,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2062,7 +2062,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2080,7 +2080,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2098,7 +2098,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2116,7 +2116,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2136,7 +2136,7 @@ class ApolloCodegenTests: XCTestCase {
     // then
     for name in conflictingSchemaNames {
       let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-        schemaName: name
+        schemaNamespace: name
       ), rootURL: nil)
 
       expect(try ApolloCodegen.validate(configContext, with: compilationResult))
@@ -2150,7 +2150,7 @@ class ApolloCodegenTests: XCTestCase {
 
     // when
     for name in disallowedNames {
-      let config = ApolloCodegenConfiguration.mock(schemaName: name)
+      let config = ApolloCodegenConfiguration.mock(schemaNamespace: name)
 
       // then
       expect(try ApolloCodegen._validate(config: config))
@@ -2159,7 +2159,7 @@ class ApolloCodegenTests: XCTestCase {
   }
 
   func test__validation__givenEmptySchemaName_shouldThrow() throws {
-    let config = ApolloCodegenConfiguration.mock(schemaName: "")
+    let config = ApolloCodegenConfiguration.mock(schemaNamespace: "")
 
     // then
     expect(try ApolloCodegen._validate(config: config))
@@ -2167,7 +2167,7 @@ class ApolloCodegenTests: XCTestCase {
   }
 
   func test__validation__givenWhitespaceOnlySchemaName_shouldThrow() throws {
-    let config = ApolloCodegenConfiguration.mock(schemaName: " ")
+    let config = ApolloCodegenConfiguration.mock(schemaNamespace: " ")
 
     // then
     expect(try ApolloCodegen._validate(config: config))
@@ -2175,7 +2175,7 @@ class ApolloCodegenTests: XCTestCase {
   }
 
   func test__validation__givenSchemaNameContainingWhitespace_shouldThrow() throws {
-    let config = ApolloCodegenConfiguration.mock(schemaName: "My Schema")
+    let config = ApolloCodegenConfiguration.mock(schemaNamespace: "My Schema")
 
     // then
     expect(try ApolloCodegen._validate(config: config))
@@ -2207,7 +2207,7 @@ class ApolloCodegenTests: XCTestCase {
 
     // then
     let configContext = ApolloCodegen.ConfigurationContext(config: .mock(
-      schemaName: "MySchema"
+      schemaNamespace: "MySchema"
     ), rootURL: nil)
 
     expect(try ApolloCodegen.validate(configContext, with: compilationResult))

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/SchemaModuleFileGeneratorTests.swift
@@ -44,7 +44,7 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
 
     let configuration = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
       .embeddedInTarget(name: "MockApplication"),
-      schemaName: "schema",
+      schemaNamespace: "schema",
       to: rootURL.path
     ))
 
@@ -68,7 +68,7 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
 
     let configuration = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
       .embeddedInTarget(name: "MockApplication"),
-      schemaName: "SCHEMA",
+      schemaNamespace: "SCHEMA",
       to: rootURL.path
     ))
 
@@ -92,7 +92,7 @@ class SchemaModuleFileGeneratorTests: XCTestCase {
 
     let configuration = ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
       .embeddedInTarget(name: "MockApplication"),
-      schemaName: "MySchema",
+      schemaNamespace: "MySchema",
       to: rootURL.path
     ))
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -617,7 +617,7 @@ class FragmentTemplateTests: XCTestCase {
 
   func test__casing__givenLowercasedSchemaName_generatesWithFirstUppercasedNamespace() throws {
     // given
-    try buildSubjectAndFragment(config: .mock(schemaName: "mySchema"))
+    try buildSubjectAndFragment(config: .mock(schemaNamespace: "mySchema"))
 
     // then
     let expected = """
@@ -631,7 +631,7 @@ class FragmentTemplateTests: XCTestCase {
 
   func test__casing__givenUppercasedSchemaName_generatesWithUppercasedNamespace() throws {
     // given
-    try buildSubjectAndFragment(config: .mock(schemaName: "MY_SCHEMA"))
+    try buildSubjectAndFragment(config: .mock(schemaNamespace: "MY_SCHEMA"))
 
     // then
     let expected = """
@@ -645,7 +645,7 @@ class FragmentTemplateTests: XCTestCase {
 
   func test__casing__givenCapitalizedSchemaName_generatesWithCapitalizedNamespace() throws {
     // given
-    try buildSubjectAndFragment(config: .mock(schemaName: "MySchema"))
+    try buildSubjectAndFragment(config: .mock(schemaNamespace: "MySchema"))
 
     // then
     let expected = """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/InputObjectTemplateTests.swift
@@ -251,7 +251,7 @@ class InputObjectTemplateTests: XCTestCase {
         type: .list(.scalar(.string())),
         defaultValue: nil
       )
-    ], config: .mock(schemaName: "TestSchema"))
+    ], config: .mock(schemaNamespace: "TestSchema"))
 
     let expected = """
       public init(
@@ -1507,7 +1507,7 @@ class InputObjectTemplateTests: XCTestCase {
       ),
     ]
 
-    buildSubject(fields: fields, config: .mock(schemaName: "TestSchema"))
+    buildSubject(fields: fields, config: .mock(schemaNamespace: "TestSchema"))
 
     let expected = """
       public init(
@@ -1912,7 +1912,7 @@ class InputObjectTemplateTests: XCTestCase {
 
     buildSubject(
       fields: fields,
-      config: .mock(schemaName: "testschema", output: .mock(
+      config: .mock(schemaNamespace: "testschema", output: .mock(
         moduleType: .swiftPackageManager,
         operations: .relative(subpath: nil)))
     )
@@ -1968,7 +1968,7 @@ class InputObjectTemplateTests: XCTestCase {
 
     buildSubject(
       fields: fields,
-      config: .mock(schemaName: "TESTSCHEMA", output: .mock(
+      config: .mock(schemaNamespace: "TESTSCHEMA", output: .mock(
         moduleType: .swiftPackageManager,
         operations: .relative(subpath: nil)))
     )
@@ -2024,7 +2024,7 @@ class InputObjectTemplateTests: XCTestCase {
 
     buildSubject(
       fields: fields,
-      config: .mock(schemaName: "TestSchema", output: .mock(
+      config: .mock(schemaNamespace: "TestSchema", output: .mock(
         moduleType: .swiftPackageManager,
         operations: .relative(subpath: nil)))
     )
@@ -2066,7 +2066,7 @@ class InputObjectTemplateTests: XCTestCase {
         type: .list(.enum(.mock(name: "EnumValue"))),
         defaultValue: nil)],
       config: .mock(
-        schemaName: "testschema",
+        schemaNamespace: "testschema",
         output: .mock(operations: .relative(subpath: nil))
       )
     )
@@ -2098,7 +2098,7 @@ class InputObjectTemplateTests: XCTestCase {
         type: .list(.enum(.mock(name: "EnumValue"))),
         defaultValue: nil)],
       config: .mock(
-        schemaName: "TESTSCHEMA",
+        schemaNamespace: "TESTSCHEMA",
         output: .mock(operations: .relative(subpath: nil))
       )
     )
@@ -2130,7 +2130,7 @@ class InputObjectTemplateTests: XCTestCase {
         type: .list(.enum(.mock(name: "EnumValue"))),
         defaultValue: nil)],
       config: .mock(
-        schemaName: "TestSchema",
+        schemaNamespace: "TestSchema",
         output: .mock(operations: .relative(subpath: nil))
       )
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -454,7 +454,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     """
 
     config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       options: .init(
         selectionSetInitializers: [.localCacheMutations]
       )
@@ -497,7 +497,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     """
 
     config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       options: .init(
         selectionSetInitializers: [.operation(named: "TestOperation")]
       )
@@ -534,7 +534,7 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     """
 
     config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       options: .init(
         selectionSetInitializers: [.namedFragments]
       )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -20,14 +20,14 @@ class MockObjectTemplateTests: XCTestCase {
   private func buildSubject(
     name: String = "Dog",
     interfaces: [GraphQLInterfaceType] = [],
-    schemaName: String = "TestSchema",
+    schemaNamespace: String = "TestSchema",
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude
   ) {
     let config = ApolloCodegenConfiguration.mock(
       moduleType,
       options: .init(warningsOnDeprecatedUsage: warningsOnDeprecatedUsage),
-      schemaName: schemaName
+      schemaNamespace: schemaNamespace
     )
     ir = IR.mock(compilationResult: .mock())
 
@@ -100,7 +100,7 @@ class MockObjectTemplateTests: XCTestCase {
 
   func test_render_givenLowercasedSchemaName_generatesFirstUppercasedSchemaNameReferences() {
     // given
-    buildSubject(schemaName: "lowercased")
+    buildSubject(schemaNamespace: "lowercased")
 
     let expected = """
       public static let objectType: Object = Lowercased.Objects.Dog
@@ -115,7 +115,7 @@ class MockObjectTemplateTests: XCTestCase {
 
   func test_render_givenUppercasedSchemaName_generatesCapitalizedSchemaNameReferences() {
     // given
-    buildSubject(schemaName: "UPPER")
+    buildSubject(schemaNamespace: "UPPER")
 
     let expected = """
       public static let objectType: Object = UPPER.Objects.Dog
@@ -130,7 +130,7 @@ class MockObjectTemplateTests: XCTestCase {
 
   func test_render_givenCapitalizedSchemaName_generatesCapitalizedSchemaNameReferences() {
     // given
-    buildSubject(schemaName: "MySchema")
+    buildSubject(schemaNamespace: "MySchema")
 
     let expected = """
       public static let objectType: Object = MySchema.Objects.Dog

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaMetadataTemplateTests.swift
@@ -88,7 +88,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     buildSubject(
       config: .mock(
         .embeddedInTarget(name: "CustomTarget"),
-        schemaName: "aName"
+        schemaNamespace: "aName"
       )
     )
 
@@ -133,7 +133,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     buildSubject(
       config: .mock(
         .swiftPackageManager,
-        schemaName: "aName"
+        schemaNamespace: "aName"
       )
     )
 
@@ -167,7 +167,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
     buildSubject(
       config: .mock(
         .other,
-        schemaName: "aName"
+        schemaNamespace: "aName"
       )
     )
 
@@ -202,7 +202,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
       config: .mock(
         .other,
         options: .init(cocoapodsCompatibleImportStatements: true),
-        schemaName: "aName"
+        schemaNamespace: "aName"
       )
     )
 
@@ -305,7 +305,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
         GraphQLObjectType.mock("objB"),
         GraphQLObjectType.mock("objC"),
       ]),
-      config: .mock(schemaName: "objectSchema")
+      config: .mock(schemaNamespace: "objectSchema")
     )
 
     let expected = """
@@ -339,7 +339,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
         GraphQLEnumType.mock(name: "EnumE"),
         GraphQLInputObjectType.mock("InputObjectC"),
       ]),
-      config: .mock(schemaName: "ObjectSchema")
+      config: .mock(schemaNamespace: "ObjectSchema")
     )
 
     let expected = """
@@ -371,7 +371,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
         GraphQLEnumType.mock(name: "EnumE"),
         GraphQLInputObjectType.mock("InputObjectC"),
       ]),
-      config: .mock(schemaName: "ObjectSchema")
+      config: .mock(schemaNamespace: "ObjectSchema")
     )
 
     let expected = """
@@ -401,7 +401,7 @@ class SchemaMetadataTemplateTests: XCTestCase {
       ]),
       config: .mock(
         .swiftPackageManager,
-        schemaName: "ObjectSchema"
+        schemaNamespace: "ObjectSchema"
       )
     )
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SchemaModuleNamespaceTemplateTests.swift
@@ -16,7 +16,7 @@ class SchemaModuleNamespaceTemplateTests: XCTestCase {
 
     // when
     let subject = SchemaModuleNamespaceTemplate(
-      config: .init(config: .mock(schemaName: "schema"))
+      config: .init(config: .mock(schemaNamespace: "schema"))
     )
     let actual = subject.template.description
 
@@ -33,7 +33,7 @@ class SchemaModuleNamespaceTemplateTests: XCTestCase {
 
     // when
     let subject = SchemaModuleNamespaceTemplate(
-      config: .init(config: .mock(schemaName: "SCHEMA"))
+      config: .init(config: .mock(schemaNamespace: "SCHEMA"))
     )
     let actual = subject.template.description
 
@@ -50,7 +50,7 @@ class SchemaModuleNamespaceTemplateTests: XCTestCase {
 
     // when
     let subject = SchemaModuleNamespaceTemplate(
-      config: .init(config: .mock(schemaName: "MySchema"))
+      config: .init(config: .mock(schemaNamespace: "MySchema"))
     )
     let actual = subject.template.description
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -38,7 +38,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
     let config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       output: configOutput,
       options: .init(
         additionalInflectionRules: inflectionRules,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -33,7 +33,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let operationDefinition = try XCTUnwrap(ir.compilationResult[operation: operationName])
     operation = ir.build(operation: operationDefinition)
     let config = ApolloCodegenConfiguration.mock(
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       options: .init()
     )
     subject = SelectionSetTemplate(

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -27,7 +27,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
   // MARK: - Helpers
 
   func buildSubjectAndOperation(
-    schemaName: String = "TestSchema",
+    schemaNamespace: String = "TestSchema",
     named operationName: String = "TestOperation"
   ) throws {
     ir = try .mock(schema: schemaSDL, document: document)
@@ -36,7 +36,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     subject = SelectionSetTemplate(
       mutable: true,
       generateInitializers: false,
-      config: .init(config: .mock(schemaName: schemaName))
+      config: .init(config: .mock(schemaNamespace: schemaNamespace))
     )
   }
 
@@ -437,7 +437,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(schemaName: "myschema")
+    try buildSubjectAndOperation(schemaNamespace: "myschema")
     let actual = subject.render(for: operation)
 
     // then
@@ -469,7 +469,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(schemaName: "MYSCHEMA")
+    try buildSubjectAndOperation(schemaNamespace: "MYSCHEMA")
     let actual = subject.render(for: operation)
 
     // then
@@ -501,7 +501,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(schemaName: "MySchema")
+    try buildSubjectAndOperation(schemaNamespace: "MySchema")
     let actual = subject.render(for: operation)
 
     // then
@@ -539,7 +539,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(schemaName: "myschema")
+    try buildSubjectAndOperation(schemaNamespace: "myschema")
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )
@@ -581,7 +581,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(schemaName: "MYSCHEMA")
+    try buildSubjectAndOperation(schemaNamespace: "MYSCHEMA")
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )
@@ -623,7 +623,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(schemaName: "MySchema")
+    try buildSubjectAndOperation(schemaNamespace: "MySchema")
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SwiftPackageManagerModuleTemplateTests.swift
@@ -14,7 +14,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   private func buildSubject(
     testMockConfig: ApolloCodegenConfiguration.TestMockFileOutput = .none,
-    config: ApolloCodegenConfiguration = .mock(schemaName: "TestModule")
+    config: ApolloCodegenConfiguration = .mock(schemaNamespace: "TestModule")
   ) {
     subject = .init(
       testMockConfig: testMockConfig,
@@ -62,7 +62,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenLowercaseSchemaName_generatesPackageDefinitionWithCapitalizedName() {
     // given
-    buildSubject(config: .mock(schemaName: "module"))
+    buildSubject(config: .mock(schemaNamespace: "module"))
 
     let expected = """
     let package = Package(
@@ -78,7 +78,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenUppercaseSchemaName_generatesPackageDefinitionWithUppercasedName() {
     // given
-    buildSubject(config: .mock(schemaName: "MODULE"))
+    buildSubject(config: .mock(schemaNamespace: "MODULE"))
 
     let expected = """
     let package = Package(
@@ -94,7 +94,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenCapitalizedSchemaName_generatesPackageDefinitionWithCapitalizedName() {
     // given
-    buildSubject(config: .mock(schemaName: "NewModule"))
+    buildSubject(config: .mock(schemaNamespace: "NewModule"))
 
     let expected = """
     let package = Package(
@@ -130,7 +130,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenLowercasedSchemaName_generatesProductWithCapitalizedName() {
     // given
-    buildSubject(config: .mock(schemaName: "newmodule"))
+    buildSubject(config: .mock(schemaNamespace: "newmodule"))
 
     let expected = """
       products: [
@@ -147,7 +147,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenUppercasedSchemaName_generatesProductWithUppercasedName() {
     // given
-    buildSubject(config: .mock(schemaName: "NEWMODULE"))
+    buildSubject(config: .mock(schemaNamespace: "NEWMODULE"))
 
     let expected = """
       products: [
@@ -164,7 +164,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenCapitalizedSchemaName_generatesProductWithCapitalizedName() {
     // given
-    buildSubject(config: .mock(schemaName: "NewModule"))
+    buildSubject(config: .mock(schemaNamespace: "NewModule"))
 
     let expected = """
       products: [
@@ -197,7 +197,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfigNone_withLowercaseSchemaName_generatesTargetWithCapitalizedName() {
     // given
-    buildSubject(config: .mock(schemaName: "testmodule"))
+    buildSubject(config: .mock(schemaNamespace: "testmodule"))
 
     let expected = """
       targets: [
@@ -220,7 +220,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfigNone_withUppercaseSchemaName_generatesTargetWithUppercasedName() {
     // given
-    buildSubject(config: .mock(schemaName: "TEST"))
+    buildSubject(config: .mock(schemaNamespace: "TEST"))
 
     let expected = """
       targets: [
@@ -243,7 +243,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
 
   func test__packageDescription__givenTestMockConfigNone_withCapitalizedSchemaName_generatesTargetWithCapitalizedName() {
     // given
-    buildSubject(config: .mock(schemaName: "TestModule"))
+    buildSubject(config: .mock(schemaNamespace: "TestModule"))
 
     let expected = """
       targets: [
@@ -390,7 +390,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     // given
     buildSubject(
       testMockConfig: .swiftPackage(targetName: "CustomMocks"),
-      config: .mock(schemaName: "testmodule"))
+      config: .mock(schemaNamespace: "testmodule"))
 
     let expected = """
             .target(name: "Testmodule"),
@@ -407,7 +407,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     // given
     buildSubject(
       testMockConfig: .swiftPackage(targetName: "CustomMocks"),
-      config: .mock(schemaName: "MODULE"))
+      config: .mock(schemaNamespace: "MODULE"))
 
     let expected = """
             .target(name: "MODULE"),
@@ -424,7 +424,7 @@ class SwiftPackageManagerModuleTemplateTests: XCTestCase {
     // given
     buildSubject(
       testMockConfig: .swiftPackage(targetName: "CustomMocks"),
-      config: .mock(schemaName: "MyModule"))
+      config: .mock(schemaNamespace: "MyModule"))
 
     let expected = """
             .target(name: "MyModule"),

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_OperationFile_Tests.swift
@@ -9,12 +9,12 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
   private func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
-    schemaName: String = "testSchema",
+    schemaNamespace: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput,
     cocoapodsCompatibleImportStatements: Bool = false
   ) -> ApolloCodegenConfiguration {
     ApolloCodegenConfiguration.mock(
-      schemaName: schemaName,
+      schemaNamespace: schemaNamespace,
       input: .init(schemaPath: "MockInputPath", operationSearchPaths: []),
       output: .mock(moduleType: moduleType, operations: operations),
       options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements)
@@ -329,7 +329,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "testschema",
+      schemaNamespace: "testschema",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config)
@@ -350,7 +350,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "TESTSCHEMA",
+      schemaNamespace: "TESTSCHEMA",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config)
@@ -371,7 +371,7 @@ class TemplateRenderer_OperationFile_Tests: XCTestCase {
 
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_SchemaFile_Tests.swift
@@ -9,12 +9,12 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
 
   private func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
-    schemaName: String = "testSchema",
+    schemaNamespace: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput,
     cocoapodsCompatibleImportStatements: Bool = false
   ) -> ApolloCodegenConfiguration {
     ApolloCodegenConfiguration.mock(
-      schemaName: schemaName,
+      schemaNamespace: schemaNamespace,
       input: .init(schemaPath: "MockInputPath", operationSearchPaths: []),
       output: .mock(moduleType: moduleType, operations: operations),
       options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements)
@@ -968,7 +968,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "testschema",
+      schemaNamespace: "testschema",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config, targetFileType: .union)
@@ -988,7 +988,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "TESTSCHEMA",
+      schemaNamespace: "TESTSCHEMA",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config, targetFileType: .union)
@@ -1008,7 +1008,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config, targetFileType: .union)
@@ -1028,7 +1028,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "testschema",
+      schemaNamespace: "testschema",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config, targetFileType: .customScalar)
@@ -1048,7 +1048,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "TESTSCHEMA",
+      schemaNamespace: "TESTSCHEMA",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config, targetFileType: .customScalar)
@@ -1068,7 +1068,7 @@ class TemplateRenderer_SchemaFile_Tests: XCTestCase {
     // given
     let config = buildConfig(
       moduleType: .embeddedInTarget(name: "MockApplication"),
-      schemaName: "TestSchema",
+      schemaNamespace: "TestSchema",
       operations: .inSchemaModule)
 
     let subject = buildSubject(config: config, targetFileType: .customScalar)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/TemplateRenderer_TestMockFile_Tests.swift
@@ -9,12 +9,12 @@ class TemplateRenderer_TestMockFile_Tests: XCTestCase {
 
   private func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType,
-    schemaName: String = "testSchema",
+    schemaNamespace: String = "testSchema",
     operations: ApolloCodegenConfiguration.OperationsFileOutput,
     cocoapodsCompatibleImportStatements: Bool = false
   ) -> ApolloCodegenConfiguration {
     ApolloCodegenConfiguration.mock(
-      schemaName: schemaName,
+      schemaNamespace: schemaNamespace,
       input: .init(schemaPath: "MockInputPath", operationSearchPaths: []),
       output: .mock(moduleType: moduleType, operations: operations),
       options: .init(cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/UnionTemplateTests.swift
@@ -55,7 +55,7 @@ class UnionTemplateTests: XCTestCase {
 
   func test_render_givenLowercaseSchemaName_generatesUsingCapitalizedSchemaName() throws {
     // given
-    buildSubject(config: .mock(schemaName: "lowercased"))
+    buildSubject(config: .mock(schemaNamespace: "lowercased"))
 
     let expected = """
       possibleTypes: [
@@ -75,7 +75,7 @@ class UnionTemplateTests: XCTestCase {
 
   func test_render_givenUppercaseSchemaName_generatesUsingUppercaseSchemaName() throws {
     // given
-    buildSubject(config: .mock(schemaName: "UPPER"))
+    buildSubject(config: .mock(schemaNamespace: "UPPER"))
 
     let expected = """
       possibleTypes: [
@@ -95,7 +95,7 @@ class UnionTemplateTests: XCTestCase {
 
   func test_render_givenCapitalizedSchemaName_generatesUsingCapitalizedSchemaName() throws {
     // given
-    buildSubject(config: .mock(schemaName: "MySchema"))
+    buildSubject(config: .mock(schemaNamespace: "MySchema"))
 
     let expected = """
       possibleTypes: [

--- a/Tests/ApolloCodegenTests/Frontend/CompilationTests.swift
+++ b/Tests/ApolloCodegenTests/Frontend/CompilationTests.swift
@@ -32,12 +32,12 @@ class CompilationTests: XCTestCase {
   }
 
   func compileFrontend(
-    schemaName: String = "TestSchema",
+    schemaNamespace: String = "TestSchema",
     enableCCN: Bool = false
   ) throws -> CompilationResult {
     let frontend = try GraphQLJSFrontend()
     let config = ApolloCodegen.ConfigurationContext(config: .mock(
-      schemaName: schemaName,
+      schemaNamespace: schemaNamespace,
       experimentalFeatures: .init(clientControlledNullability: enableCCN)
     ))
 
@@ -312,7 +312,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertNoThrow(try compileFrontend(schemaName: "MySchema"))
+    XCTAssertNoThrow(try compileFrontend(schemaNamespace: "MySchema"))
   }
 
   func test__compile__givenSchemaName_matchingScalarFieldAndInputValueName_shouldNotThrow() throws {
@@ -344,7 +344,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertNoThrow(try compileFrontend(schemaName: "species"))
+    XCTAssertNoThrow(try compileFrontend(schemaNamespace: "species"))
   }
 
   func test__compile__givenSchemaName_matchingEntityFieldName_shouldThrow() throws {
@@ -379,7 +379,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertThrowsError(try compileFrontend(schemaName: "height")) { error in
+    XCTAssertThrowsError(try compileFrontend(schemaNamespace: "height")) { error in
       XCTAssertTrue((error as! ApolloCodegenLib.JavaScriptError).description.contains("""
         Schema name "height" conflicts with name of a generated object API. \
         Please choose a different schema name.
@@ -420,7 +420,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertThrowsError(try compileFrontend(schemaName: "predator")) { error in
+    XCTAssertThrowsError(try compileFrontend(schemaNamespace: "predator")) { error in
       XCTAssertTrue((error as! ApolloCodegenLib.JavaScriptError).description.contains("""
         Schema name "predator" conflicts with name of a generated object API. \
         Please choose a different schema name.
@@ -461,7 +461,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertThrowsError(try compileFrontend(schemaName: "predator")) { error in
+    XCTAssertThrowsError(try compileFrontend(schemaNamespace: "predator")) { error in
       XCTAssertTrue((error as! ApolloCodegenLib.JavaScriptError).description.contains("""
         Schema name "predator" conflicts with name of a generated object API. \
         Please choose a different schema name.
@@ -502,7 +502,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertNoThrow(try compileFrontend(schemaName: "predators"))
+    XCTAssertNoThrow(try compileFrontend(schemaNamespace: "predators"))
   }
 
   func test__compile__givenPluralizedSchemaName_matchingPluralizedNonNullListFieldName_shouldNotThrow() throws {
@@ -537,7 +537,7 @@ class CompilationTests: XCTestCase {
     """
 
     // then
-    XCTAssertNoThrow(try compileFrontend(schemaName: "predators"))
+    XCTAssertNoThrow(try compileFrontend(schemaNamespace: "predators"))
   }
 
 }

--- a/Tests/ApolloCodegenTests/Frontend/DocumentParsingAndValidationTests.swift
+++ b/Tests/ApolloCodegenTests/Frontend/DocumentParsingAndValidationTests.swift
@@ -290,7 +290,7 @@ class DocumentParsingAndValidationTests: XCTestCase {
       let validationErrors = try codegenFrontend.validateDocument(
         schema: schema,
         document: document,
-        validationOptions: .mock(schemaName: "AnimalKingdomAPI")
+        validationOptions: .mock(schemaNamespace: "AnimalKingdomAPI")
       )
 
       XCTAssertEqual(validationErrors.map(\.message), [


### PR DESCRIPTION
This layers into #2877 and can be merged into that once both are reviewed. It has changes that are largely internal-only but gets rid of the reference term `schemaName` for `schemaNamespace` to remove any confusion about what it means to those without the historical context of this change.