### PR TITLE
Enable ApolloPerformanceTests

### DIFF
--- a/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
+++ b/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
@@ -1,53 +1,52 @@
 import XCTest
 @testable import Apollo
 import ApolloInternalTestHelpers
-//import GitHubAPI
+import GitHubAPI
 
-#warning("TODO: Fix these and test them against old metrics!")
-//class ParsingPerformanceTests: XCTestCase {
-//
-//  func testParseResult() throws {
-//    let query = IssuesAndCommentsForRepositoryQuery()
-//
-//    let response = try loadResponse(for: query)
-//
-//    measure {
-//      whileRecordingErrors {
-//        let (result, _) = try response.parseResult()
-//
-//        let data = try XCTUnwrap(result.data)
-//        XCTAssertEqual(data.repository?.name, "apollo-ios")
-//      }
-//    }
-//  }
-//
-//  func testParseResultFast() throws {
-//    let query = IssuesAndCommentsForRepositoryQuery()
-//
-//    let response = try loadResponse(for: query)
-//
-//    measure {
-//      whileRecordingErrors {
-//        let result = try response.parseResultFast()
-//
-//        let data = try XCTUnwrap(result.data)
-//        XCTAssertEqual(data.repository?.name, "apollo-ios")
-//      }
-//    }
-//  }
-//
-//  // MARK - Helpers
-//
-//  func loadResponse<Query: GraphQLQuery>(for query: Query, file: StaticString = #file, line: UInt = #line) throws -> GraphQLResponse<Query.Data> {
-//    let bundle = Bundle(for: type(of: self))
-//
-//    guard let url = bundle.url(forResource: query.operationName, withExtension: "json") else {
-//      throw XCTFailure("Missing response file for query: \(query.operationName)", file: file, line: line)
-//    }
-//
-//    let data = try Data(contentsOf: url)
-//    let body = try JSONSerialization.jsonObject(with: data, options: []) as! JSONObject
-//
-//    return GraphQLResponse(operation: query, body: body)
-//  }
-//}
+class ParsingPerformanceTests: XCTestCase {
+
+  func testParseResult() throws {
+    let query = IssuesAndCommentsForRepositoryQuery()
+
+    let response = try loadResponse(for: query)
+
+    measure {
+      whileRecordingErrors {
+        let (result, _) = try response.parseResult()
+
+        let data = try XCTUnwrap(result.data)
+        XCTAssertEqual(data.repository?.name, "apollo-ios")
+      }
+    }
+  }
+
+  func testParseResultFast() throws {
+    let query = IssuesAndCommentsForRepositoryQuery()
+
+    let response = try loadResponse(for: query)
+
+    measure {
+      whileRecordingErrors {
+        let result = try response.parseResultFast()
+
+        let data = try XCTUnwrap(result.data)
+        XCTAssertEqual(data.repository?.name, "apollo-ios")
+      }
+    }
+  }
+
+  // MARK - Helpers
+
+  func loadResponse<Query: GraphQLQuery>(for query: Query, file: StaticString = #file, line: UInt = #line) throws -> GraphQLResponse<Query.Data> {
+    let bundle = Bundle(for: type(of: self))
+
+    guard let url = bundle.url(forResource: Query.operationName, withExtension: "json") else {
+      throw XCTFailure("Missing response file for query: \(Query.operationName)", file: file, line: line)
+    }
+
+    let data = try Data(contentsOf: url)
+    let body = try JSONSerialization.jsonObject(with: data, options: []) as! JSONObject
+
+    return GraphQLResponse(operation: query, body: body)
+  }
+}


### PR DESCRIPTION
Closes #2387

The issue mentioned that re-enabling the tests was waiting on #2386 (Update internal testing APIs to use 1.0 code generation). Since that was already completed I uncommented the tests to see if they would run, and they do run with no issues.

I only ran into one compile error in which I had to update `query.operationName` to `Query.operationName` due to the following error: `Static member 'operationName' cannot be used on instance of type 'Query'`

![Screen Shot 2023-03-21 at 10 47 25 PM](https://user-images.githubusercontent.com/202240/226805601-7df38653-3d32-4d9f-a59b-4965ae7975cb.png)

