### PR TITLE
Update docs to remove the leading period from the `.embeddedInTarget` command line option

### DIFF
--- a/docs/shared/setup-codegen/single-panel.mdx
+++ b/docs/shared/setup-codegen/single-panel.mdx
@@ -28,8 +28,8 @@ From your project's root directory, run the following command with your customiz
 - `${ModuleType}` configures how your generated schema types are included in your project.
   > This is a crucial decision to make **before configuring code generation**. To determine the right option for your project, see [Project Configuration](/ios/project-configuration).
   >
-  > To get started quickly, you can use the `.embeddedInTarget` option.
-  > Using `.embeddedInTarget`, you must supply a target name using the `--target-name` command line option.
+  > To get started quickly, you can use the `embeddedInTarget` option.
+  > Using `embeddedInTarget`, you must supply a target name using the `--target-name` command line option.
 
 Running this command creates an `apollo-codegen-config.json` file.
 


### PR DESCRIPTION
I initially ran the `apollo-ios-cli init` command with `--module-type .embeddedInTarget` but got an error indicating that I shouldn't include the period:

```
Error: The value '.embeddedInTarget' is invalid for '--module-type <module-type>'. Please provide one of 'embeddedInTarget', 'swiftPackageManager' or 'other'.
```

(I follow that this is because the enum member that it maps to is `ModuleType.embeddedInTarget` but the user doesn't really know that yet.)