### PR TITLE
Change code generation of conditionally included named fragments

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -120,9 +120,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         .inlineFragment(AsPet.self),
         .inlineFragment(AsClassroomPet.self),
         .include(if: "includeSpecies", .field("species", String.self)),
+        .include(if: !"skipHeightInMeters", .inlineFragment(IfNotSkipHeightInMeters.self)),
         .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         .include(if: "getCat", .inlineFragment(AsCat.self)),
-        .include(if: !"skipHeightInMeters", .fragment(HeightInMeters.self)),
       ] }
 
       public var height: Height { __data["height"] }
@@ -130,11 +130,11 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
+      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }
       public var asClassroomPet: AsClassroomPet? { _asInlineFragment() }
-      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -269,6 +269,83 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 ObjectIdentifier(AllAnimal.Predator.self),
                 ObjectIdentifier(WarmBloodedDetails.self),
                 ObjectIdentifier(HeightInMeters.self)
+              ])
+            ]))
+          }
+        }
+      }
+
+      /// AllAnimal.IfNotSkipHeightInMeters
+      ///
+      /// Parent Type: `Animal`
+      public struct IfNotSkipHeightInMeters: AnimalKingdomAPI.InlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = AllAnimal
+        public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .fragment(HeightInMeters.self),
+        ] }
+
+        public var height: Height { __data["height"] }
+        public var species: String? { __data["species"] }
+        public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
+        public var predators: [Predator] { __data["predators"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var heightInMeters: HeightInMeters { _toFragment() }
+        }
+
+        public init(
+          __typename: String,
+          height: Height,
+          species: String,
+          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
+          predators: [Predator]
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": __typename,
+            "height": height._fieldData,
+            "species": species,
+            "skinCovering": skinCovering,
+            "predators": predators._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self),
+              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(HeightInMeters.self)
+            ])
+          ]))
+        }
+
+        /// AllAnimal.IfNotSkipHeightInMeters.Height
+        ///
+        /// Parent Type: `Height`
+        public struct Height: AnimalKingdomAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
+
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
+
+          public init(
+            feet: Int,
+            inches: Int? = nil,
+            meters: Int
+          ) {
+            self.init(_dataDict: DataDict(data: [
+              "__typename": AnimalKingdomAPI.Objects.Height.typename,
+              "feet": feet,
+              "inches": inches,
+              "meters": meters,
+              "__fulfilled": Set([
+                ObjectIdentifier(Self.self)
               ])
             ]))
           }
@@ -804,79 +881,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 ])
               ]))
             }
-          }
-        }
-      }
-      /// AllAnimal.IfNotSkipHeightInMeters
-      ///
-      /// Parent Type: `Animal`
-      public struct IfNotSkipHeightInMeters: AnimalKingdomAPI.InlineFragment {
-        public let __data: DataDict
-        public init(_dataDict: DataDict) { __data = _dataDict }
-
-        public typealias RootEntityType = AllAnimal
-        public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
-
-        public var height: Height { __data["height"] }
-        public var species: String? { __data["species"] }
-        public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
-        public var predators: [Predator] { __data["predators"] }
-
-        public struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public var heightInMeters: HeightInMeters { _toFragment() }
-        }
-
-        public init(
-          __typename: String,
-          height: Height,
-          species: String,
-          skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
-          predators: [Predator]
-        ) {
-          self.init(_dataDict: DataDict(data: [
-            "__typename": __typename,
-            "height": height._fieldData,
-            "species": species,
-            "skinCovering": skinCovering,
-            "predators": predators._fieldData,
-            "__fulfilled": Set([
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
-              ObjectIdentifier(HeightInMeters.self)
-            ])
-          ]))
-        }
-
-        /// AllAnimal.IfNotSkipHeightInMeters.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: AnimalKingdomAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
-
-          public init(
-            feet: Int,
-            inches: Int? = nil,
-            meters: Int
-          ) {
-            self.init(_dataDict: DataDict(data: [
-              "__typename": AnimalKingdomAPI.Objects.Height.typename,
-              "feet": feet,
-              "inches": inches,
-              "meters": meters,
-              "__fulfilled": Set([
-                ObjectIdentifier(Self.self)
-              ])
-            ]))
           }
         }
       }

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -195,8 +195,9 @@ extension IR {
           guard let typeCondition = scope.type else { return true }
           return selectionSetScope.matches(typeCondition)
         }
+        let matchesScope = selectionSetScope.matches(scope)
 
-        if matchesType {
+        if matchesScope {
           let irFragmentSpread = buildFragmentSpread(
             fromFragment: fragmentSpread,
             with: scope,
@@ -215,6 +216,13 @@ extension IR {
           )
 
           target.mergeIn(irTypeCaseEnclosingFragment)
+
+          if matchesType {
+            typeInfo.entity.selectionTree.mergeIn(
+              selections: irTypeCaseEnclosingFragment.selections.direct.unsafelyUnwrapped.readOnlyView,
+              with: typeInfo
+            )
+          }
         }
       }
     }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -59,7 +59,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
-        .include(if: "includeDetails", .fragment(HeroDetails.self)),
+        .include(if: "includeDetails", .inlineFragment(IfIncludeDetails.self)),
       ] }
 
       public var ifIncludeDetails: IfIncludeDetails? { _asInlineFragment() }
@@ -91,6 +91,9 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
 
         public typealias RootEntityType = Hero
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .fragment(HeroDetails.self),
+        ] }
 
         /// The name of the character
         public var name: String { __data["name"] }

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
@@ -1773,30 +1773,32 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
 
     let allAnimals = self.subject[field: "allAnimals"]
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
+        .inlineFragment(parentType: Interface_Animal,
+                        inclusionConditions: [.include(if: "a")]),
       ],
       mergedSelections: [
-        .inlineFragment(parentType: Interface_Animal,
-                              inclusionConditions: [.include(if: "a")]),
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")])
       ],
-      mergedSources: []
+      mergedSources: [
+        .mock(allAnimals)
+      ]
     )
 
     let expected_allAnimal_ifA = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "a")],
-      directSelections: nil,
-      mergedSelections: [
-        .field("a", type: .nonNull(.scalar(.string()))),
+      directSelections: [
         .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
       ],
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+      ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentA"]),
       ]
     )
 
@@ -1911,30 +1913,32 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
 
     let allAnimals = self.subject[field: "allAnimals"]
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
+        .inlineFragment(parentType: Interface_Animal,
+                        inclusionConditions: [.include(if: "a")]),
       ],
       mergedSelections: [
-        .inlineFragment(parentType: Interface_Animal,
-                              inclusionConditions: [.include(if: "a")]),
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
       ],
-      mergedSources: []
+      mergedSources: [
+        .mock(allAnimals)
+      ]
     )
 
     let expected_allAnimal_ifA = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "a")],
-      directSelections: nil,
-      mergedSelections: [
-        .field("a", type: .nonNull(.scalar(.string()))),
+      directSelections: [
         .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
       ],
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+      ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentA"]),
       ]
     )
 
@@ -1977,53 +1981,49 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
     let FragmentA = try XCTUnwrap(ir.compilationResult[fragment: "FragmentA"])
 
     let allAnimals = self.subject[field: "allAnimals"]
-    let fragmentASpread: ShallowSelectionMatcher = .fragmentSpread(
-      FragmentA,
-      inclusionConditions: AnyOf([
-        .init(.include(if: "a")),
-        .init(.include(if: "b"))
-      ]))
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        fragmentASpread
-      ],
-      mergedSelections: [
         .inlineFragment(parentType: Interface_Animal,
                         inclusionConditions: [.include(if: "a")]),
         .inlineFragment(parentType: Interface_Animal,
                         inclusionConditions: [.include(if: "b")]),
       ],
-      mergedSources: []
+      mergedSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "b")])
+      ],
+      mergedSources: [
+        .mock(allAnimals),
+      ]
     )
 
     let expected_allAnimal_ifA = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "a")],
-      directSelections: nil,
+      directSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")])
+      ],
       mergedSelections: [
         .field("a", type: .nonNull(.scalar(.string()))),
-        fragmentASpread
       ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentA"]),
       ]
     )
 
     let expected_allAnimal_ifB = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "b")],
-      directSelections: nil,
+      directSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "b")])
+      ],
       mergedSelections: [
         .field("a", type: .nonNull(.scalar(.string()))),
-        fragmentASpread
       ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "b"]?[fragment: "FragmentA"]),
       ]
     )
 
@@ -2066,54 +2066,49 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
     let FragmentA = try XCTUnwrap(ir.compilationResult[fragment: "FragmentA"])
 
     let allAnimals = self.subject[field: "allAnimals"]
-    let fragmentASpread: ShallowSelectionMatcher = .fragmentSpread(
-      FragmentA,
-      inclusionConditions: AnyOf([
-        try .allOf([IR.InclusionCondition.include(if: "a"),
-                    IR.InclusionCondition.include(if: "b")]).conditions.xctUnwrapped(),
-        .init(.include(if: "c"))
-      ]))
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        fragmentASpread
-      ],
-      mergedSelections: [
         .inlineFragment(parentType: Interface_Animal,
                         inclusionConditions: [.include(if: "a"), .include(if: "b")]),
         .inlineFragment(parentType: Interface_Animal,
                         inclusionConditions: [.include(if: "c")]),
       ],
-      mergedSources: []
+      mergedSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "c")])
+      ],
+      mergedSources: [
+        .mock(allAnimals),
+      ]
     )
 
     let expected_allAnimal_ifAAndB = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "a"), .include(if: "b")],
-      directSelections: nil,
+      directSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a"), .include(if: "b")])
+      ],
       mergedSelections: [
         .field("a", type: .nonNull(.scalar(.string()))),
-        fragmentASpread
       ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "a" && "b"]?[fragment: "FragmentA"]),
       ]
     )
 
     let expected_allAnimal_ifC = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "c")],
-      directSelections: nil,
+      directSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "c")])
+      ],
       mergedSelections: [
         .field("a", type: .nonNull(.scalar(.string()))),
-        fragmentASpread
       ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "c"]?[fragment: "FragmentA"]),
       ]
     )
 
@@ -2163,34 +2158,36 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
 
     let allAnimals = self.subject[field: "allAnimals"]
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
-        .fragmentSpread(FragmentB, inclusionConditions: [.include(if: "a")]),
-      ],
-      mergedSelections: [
         .inlineFragment(parentType: Interface_Animal,
                               inclusionConditions: [.include(if: "a")]),
       ],
-      mergedSources: []
-    )
-
-    let expected_allAnimal_ifA = try SelectionSetMatcher(
-      parentType: Interface_Animal,
-      inclusionConditions: [.include(if: "a")],
-      directSelections: nil,
       mergedSelections: [
-        .field("a", type: .nonNull(.scalar(.string()))),
-        .field("b", type: .nonNull(.scalar(.string()))),
         .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
         .fragmentSpread(FragmentB, inclusionConditions: [.include(if: "a")]),
       ],
       mergedSources: [
         .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
-        .mock(allAnimals?[fragment: "FragmentB"]),
+      ]
+    )
+
+    let expected_allAnimal_ifA = try SelectionSetMatcher(
+      parentType: Interface_Animal,
+      inclusionConditions: [.include(if: "a")],
+      directSelections: [
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
+        .fragmentSpread(FragmentB, inclusionConditions: [.include(if: "a")]),
+      ],
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+        .field("b", type: .nonNull(.scalar(.string()))),
+      ],
+      mergedSources: [
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentB"]),
       ]
     )
 
@@ -2242,30 +2239,33 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
 
     let allAnimals = self.subject[field: "allAnimals"]
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
+        .inlineFragment(parentType: Interface_Animal,
+                        inclusionConditions: [.include(if: "a")]),
         .inlineFragment(parentType: Interface_Pet),
       ],
       mergedSelections: [
-        .inlineFragment(parentType: Interface_Animal,
-                        inclusionConditions: [.include(if: "a")]),],
-      mergedSources: []
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
+      ],
+      mergedSources: [
+        .mock(allAnimals),
+      ]
     )
 
     let expected_allAnimal_ifA = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "a")],
-      directSelections: nil,
-      mergedSelections: [
-        .field("a", type: .nonNull(.scalar(.string()))),
+      directSelections: [
         .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
       ],
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+      ],
       mergedSources: [
-        .mock(allAnimals?[fragment: "FragmentA"]),
-        .mock(allAnimals),
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentA"]),
       ]
     )
 
@@ -2325,30 +2325,32 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
 
     let allAnimals = self.subject[field: "allAnimals"]
 
-    let expected_allAnimal = SelectionSetMatcher(
+    let expected_allAnimal = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
-        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
+        .inlineFragment(parentType: Interface_Animal,
+                        inclusionConditions: [.include(if: "a")]),
       ],
       mergedSelections: [
-        .inlineFragment(parentType: Interface_Animal,
-                              inclusionConditions: [.include(if: "a")]),
+        .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
       ],
-      mergedSources: []
+      mergedSources: [
+        .mock(allAnimals),
+      ]
     )
 
     let expected_allAnimal_ifA = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.include(if: "a")],
-      directSelections: nil,
-      mergedSelections: [
-        .field("a", type: .nonNull(.scalar(.string()))),
+      directSelections: [
         .fragmentSpread(FragmentA, inclusionConditions: [.include(if: "a")]),
       ],
+      mergedSelections: [
+        .field("a", type: .nonNull(.scalar(.string()))),
+      ],
       mergedSources: [
-        .mock(allAnimals),
-        .mock(allAnimals?[fragment: "FragmentA"]),
+        .mock(allAnimals?[if: "a"]?[fragment: "FragmentA"]),
       ]
     )
 
@@ -2546,21 +2548,23 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
       allAnimals[as: "WarmBlooded", if: "c"]?[fragment: "FragmentContainingChildFragment"]
     )
 
-    let expected_allAnimals = SelectionSetMatcher(
+    let expected_allAnimals = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: nil,
       directSelections: [
         .field("child", type: .nonNull(.entity(Object_Child))),
+        .inlineFragment(parentType: Interface_Animal,
+                        inclusionConditions: [.skip(if: "b")]),
         .inlineFragment(parentType: Interface_WarmBlooded,
                         inclusionConditions: [.include(if: "c")]),
+      ],
+      mergedSelections: [
         .fragmentSpread(ChildFragment.definition,
                         inclusionConditions: [.skip(if: "b")]),
       ],
-      mergedSelections: [
-        .inlineFragment(parentType: Interface_Animal,
-                        inclusionConditions: [.skip(if: "b")]),
-      ],
-      mergedSources: []
+      mergedSources: [
+        .mock(allAnimals),
+      ]
     )
 
     let expected_allAnimals_child = SelectionSetMatcher(
@@ -2576,11 +2580,12 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
     let expected_allAnimals_ifB = try SelectionSetMatcher(
       parentType: Interface_Animal,
       inclusionConditions: [.skip(if: "b")],
-      directSelections: nil,
-      mergedSelections: [
-        .field("child", type: .nonNull(.entity(Object_Child))),
+      directSelections: [
         .fragmentSpread(ChildFragment.definition,
                         inclusionConditions: [.skip(if: "b")])
+      ],
+      mergedSelections: [
+        .field("child", type: .nonNull(.entity(Object_Child))),
       ],
       mergedSources: [
         .mock(allAnimals),
@@ -2889,8 +2894,8 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
     // when
     try buildSubjectRootField()
 
+    let Interface_Animal = try XCTUnwrap(schema[interface: "Animal"])
     let Interface_Pet = try XCTUnwrap(schema[interface: "Pet"])
-    let FragmentB = try XCTUnwrap(ir.compilationResult[fragment: "FragB"])
     let FragmentG = try XCTUnwrap(ir.compilationResult[fragment: "FragG"])
     let allAnimals = self.subject[field: "allAnimals"]
 
@@ -2924,10 +2929,10 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
           .mock("a", type: .string(), inclusionConditions: AnyOf(.include(if: "a"))),
         ],
         typeCases: [
+          .mock(parentType: Interface_Animal, inclusionConditions: [.include(if: "a")]),
           .mock(parentType: Interface_Pet, inclusionConditions: [.include(if: "a")])
         ],
         fragments: [
-          .mock(FragmentB, inclusionConditions: AnyOf(.include(if: "a")))
         ]),
       AnyOf(.include(if: "c")): (
         fields: [

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -1573,7 +1573,7 @@ class SelectionSetTemplateTests: XCTestCase {
           .field("fieldA", String.self),
           .field("fieldB", String.self),
           .inlineFragment(AsPet.self),
-          .fragment(FragmentA.self),
+          .inlineFragment(IfA.self),
         ]),
       ] }
     """
@@ -4151,8 +4151,8 @@ class SelectionSetTemplateTests: XCTestCase {
         public let __data: DataDict
         public init(_dataDict: DataDict) { __data = _dataDict }
 
-        public var fragmentA: FragmentA? { _toFragment() }
         public var lowercaseFragment: LowercaseFragment { _toFragment() }
+        public var fragmentA: FragmentA? { _toFragment() }
       }
     """
 
@@ -4303,7 +4303,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(inlineFragment: allAnimals_ifA)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   // MARK: - Nested Selection Sets

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -1379,6 +1379,6 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     expect(allAnimals_actual).to(equalLineByLine(
       allAnimals_expected, atLine: 22, ignoringExtraLines: true))
     expect(allAnimals_ifA_actual).to(equalLineByLine(
-      allAnimals_ifA_expected, atLine: 20, ignoringExtraLines: true))
+      allAnimals_ifA_expected, atLine: 23, ignoringExtraLines: true))
   }
 }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -115,9 +115,9 @@ public extension MyGraphQLSchema {
           .inlineFragment(AsPet.self),
           .inlineFragment(AsClassroomPet.self),
           .include(if: "includeSpecies", .field("species", String.self)),
+          .include(if: !"skipHeightInMeters", .inlineFragment(IfNotSkipHeightInMeters.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
           .include(if: "getCat", .inlineFragment(AsCat.self)),
-          .include(if: !"skipHeightInMeters", .fragment(HeightInMeters.self)),
         ] }
 
         public var height: Height { __data["height"] }
@@ -125,11 +125,11 @@ public extension MyGraphQLSchema {
         public var skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? { __data["skinCovering"] }
         public var predators: [Predator] { __data["predators"] }
 
+        public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
         public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
         public var asPet: AsPet? { _asInlineFragment() }
         public var asCat: AsCat? { _asInlineFragment() }
         public var asClassroomPet: AsClassroomPet? { _asInlineFragment() }
-        public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
 
         public struct Fragments: FragmentContainer {
           public let __data: DataDict
@@ -199,6 +199,46 @@ public extension MyGraphQLSchema {
               public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
               public var heightInMeters: HeightInMeters { _toFragment() }
             }
+          }
+        }
+
+        /// AllAnimal.IfNotSkipHeightInMeters
+        ///
+        /// Parent Type: `Animal`
+        public struct IfNotSkipHeightInMeters: MyGraphQLSchema.InlineFragment {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public typealias RootEntityType = AllAnimal
+          public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
+          public static var __selections: [ApolloAPI.Selection] { [
+            .fragment(HeightInMeters.self),
+          ] }
+
+          public var height: Height { __data["height"] }
+          public var species: String? { __data["species"] }
+          public var skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? { __data["skinCovering"] }
+          public var predators: [Predator] { __data["predators"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var heightInMeters: HeightInMeters { _toFragment() }
+          }
+
+          /// AllAnimal.IfNotSkipHeightInMeters.Height
+          ///
+          /// Parent Type: `Height`
+          public struct Height: MyGraphQLSchema.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
+
+            public var feet: Int { __data["feet"] }
+            public var inches: Int? { __data["inches"] }
+            public var meters: Int { __data["meters"] }
           }
         }
 
@@ -470,42 +510,6 @@ public extension MyGraphQLSchema {
               public var centimeters: Double? { __data["centimeters"] }
               public var meters: Int { __data["meters"] }
             }
-          }
-        }
-        /// AllAnimal.IfNotSkipHeightInMeters
-        ///
-        /// Parent Type: `Animal`
-        public struct IfNotSkipHeightInMeters: MyGraphQLSchema.InlineFragment {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public typealias RootEntityType = AllAnimal
-          public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
-
-          public var height: Height { __data["height"] }
-          public var species: String? { __data["species"] }
-          public var skinCovering: GraphQLEnum<MyGraphQLSchema.SkinCovering>? { __data["skinCovering"] }
-          public var predators: [Predator] { __data["predators"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var heightInMeters: HeightInMeters { _toFragment() }
-          }
-
-          /// AllAnimal.IfNotSkipHeightInMeters.Height
-          ///
-          /// Parent Type: `Height`
-          public struct Height: MyGraphQLSchema.SelectionSet {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
-
-            public var feet: Int { __data["feet"] }
-            public var inches: Int? { __data["inches"] }
-            public var meters: Int { __data["meters"] }
           }
         }
       }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -115,9 +115,9 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         .inlineFragment(AsPet.self),
         .inlineFragment(AsClassroomPet.self),
         .include(if: "includeSpecies", .field("species", String.self)),
+        .include(if: !"skipHeightInMeters", .inlineFragment(IfNotSkipHeightInMeters.self)),
         .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         .include(if: "getCat", .inlineFragment(AsCat.self)),
-        .include(if: !"skipHeightInMeters", .fragment(HeightInMeters.self)),
       ] }
 
       public var height: Height { __data["height"] }
@@ -125,11 +125,11 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
+      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }
       public var asClassroomPet: AsClassroomPet? { _asInlineFragment() }
-      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -199,6 +199,46 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
             public var heightInMeters: HeightInMeters { _toFragment() }
           }
+        }
+      }
+
+      /// AllAnimal.IfNotSkipHeightInMeters
+      ///
+      /// Parent Type: `Animal`
+      public struct IfNotSkipHeightInMeters: MySchemaModule.InlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = AllAnimal
+        public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .fragment(HeightInMeters.self),
+        ] }
+
+        public var height: Height { __data["height"] }
+        public var species: String? { __data["species"] }
+        public var skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? { __data["skinCovering"] }
+        public var predators: [Predator] { __data["predators"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var heightInMeters: HeightInMeters { _toFragment() }
+        }
+
+        /// AllAnimal.IfNotSkipHeightInMeters.Height
+        ///
+        /// Parent Type: `Height`
+        public struct Height: MySchemaModule.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
+
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -470,42 +510,6 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var centimeters: Double? { __data["centimeters"] }
             public var meters: Int { __data["meters"] }
           }
-        }
-      }
-      /// AllAnimal.IfNotSkipHeightInMeters
-      ///
-      /// Parent Type: `Animal`
-      public struct IfNotSkipHeightInMeters: MySchemaModule.InlineFragment {
-        public let __data: DataDict
-        public init(_dataDict: DataDict) { __data = _dataDict }
-
-        public typealias RootEntityType = AllAnimal
-        public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
-
-        public var height: Height { __data["height"] }
-        public var species: String? { __data["species"] }
-        public var skinCovering: GraphQLEnum<MySchemaModule.SkinCovering>? { __data["skinCovering"] }
-        public var predators: [Predator] { __data["predators"] }
-
-        public struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public var heightInMeters: HeightInMeters { _toFragment() }
-        }
-
-        /// AllAnimal.IfNotSkipHeightInMeters.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: MySchemaModule.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -108,9 +108,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         .inlineFragment(AsPet.self),
         .inlineFragment(AsClassroomPet.self),
         .include(if: "includeSpecies", .field("species", String.self)),
+        .include(if: !"skipHeightInMeters", .inlineFragment(IfNotSkipHeightInMeters.self)),
         .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         .include(if: "getCat", .inlineFragment(AsCat.self)),
-        .include(if: !"skipHeightInMeters", .fragment(HeightInMeters.self)),
       ] }
 
       public var height: Height { __data["height"] }
@@ -118,11 +118,11 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
+      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }
       public var asClassroomPet: AsClassroomPet? { _asInlineFragment() }
-      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -192,6 +192,46 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
             public var heightInMeters: HeightInMeters { _toFragment() }
           }
+        }
+      }
+
+      /// AllAnimal.IfNotSkipHeightInMeters
+      ///
+      /// Parent Type: `Animal`
+      public struct IfNotSkipHeightInMeters: MyCustomProject.InlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = AllAnimal
+        public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
+        public static var __selections: [Apollo.Selection] { [
+          .fragment(HeightInMeters.self),
+        ] }
+
+        public var height: Height { __data["height"] }
+        public var species: String? { __data["species"] }
+        public var skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? { __data["skinCovering"] }
+        public var predators: [Predator] { __data["predators"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var heightInMeters: HeightInMeters { _toFragment() }
+        }
+
+        /// AllAnimal.IfNotSkipHeightInMeters.Height
+        ///
+        /// Parent Type: `Height`
+        public struct Height: MyCustomProject.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
+
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -463,42 +503,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var centimeters: Double? { __data["centimeters"] }
             public var meters: Int { __data["meters"] }
           }
-        }
-      }
-      /// AllAnimal.IfNotSkipHeightInMeters
-      ///
-      /// Parent Type: `Animal`
-      public struct IfNotSkipHeightInMeters: MyCustomProject.InlineFragment {
-        public let __data: DataDict
-        public init(_dataDict: DataDict) { __data = _dataDict }
-
-        public typealias RootEntityType = AllAnimal
-        public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
-
-        public var height: Height { __data["height"] }
-        public var species: String? { __data["species"] }
-        public var skinCovering: GraphQLEnum<MyCustomProject.SkinCovering>? { __data["skinCovering"] }
-        public var predators: [Predator] { __data["predators"] }
-
-        public struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public var heightInMeters: HeightInMeters { _toFragment() }
-        }
-
-        /// AllAnimal.IfNotSkipHeightInMeters.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: MyCustomProject.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -114,9 +114,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         .inlineFragment(AsPet.self),
         .inlineFragment(AsClassroomPet.self),
         .include(if: "includeSpecies", .field("species", String.self)),
+        .include(if: !"skipHeightInMeters", .inlineFragment(IfNotSkipHeightInMeters.self)),
         .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         .include(if: "getCat", .inlineFragment(AsCat.self)),
-        .include(if: !"skipHeightInMeters", .fragment(HeightInMeters.self)),
       ] }
 
       public var height: Height { __data["height"] }
@@ -124,11 +124,11 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
+      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }
       public var asClassroomPet: AsClassroomPet? { _asInlineFragment() }
-      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -198,6 +198,46 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
             public var heightInMeters: HeightInMeters { _toFragment() }
           }
+        }
+      }
+
+      /// AllAnimal.IfNotSkipHeightInMeters
+      ///
+      /// Parent Type: `Animal`
+      public struct IfNotSkipHeightInMeters: GraphQLAPI.InlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = AllAnimal
+        public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .fragment(HeightInMeters.self),
+        ] }
+
+        public var height: Height { __data["height"] }
+        public var species: String? { __data["species"] }
+        public var skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? { __data["skinCovering"] }
+        public var predators: [Predator] { __data["predators"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var heightInMeters: HeightInMeters { _toFragment() }
+        }
+
+        /// AllAnimal.IfNotSkipHeightInMeters.Height
+        ///
+        /// Parent Type: `Height`
+        public struct Height: GraphQLAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
+
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -469,42 +509,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var centimeters: Double? { __data["centimeters"] }
             public var meters: Int { __data["meters"] }
           }
-        }
-      }
-      /// AllAnimal.IfNotSkipHeightInMeters
-      ///
-      /// Parent Type: `Animal`
-      public struct IfNotSkipHeightInMeters: GraphQLAPI.InlineFragment {
-        public let __data: DataDict
-        public init(_dataDict: DataDict) { __data = _dataDict }
-
-        public typealias RootEntityType = AllAnimal
-        public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
-
-        public var height: Height { __data["height"] }
-        public var species: String? { __data["species"] }
-        public var skinCovering: GraphQLEnum<GraphQLAPI.SkinCovering>? { __data["skinCovering"] }
-        public var predators: [Predator] { __data["predators"] }
-
-        public struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public var heightInMeters: HeightInMeters { _toFragment() }
-        }
-
-        /// AllAnimal.IfNotSkipHeightInMeters.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: GraphQLAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
       }
     }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -114,9 +114,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
         .inlineFragment(AsPet.self),
         .inlineFragment(AsClassroomPet.self),
         .include(if: "includeSpecies", .field("species", String.self)),
+        .include(if: !"skipHeightInMeters", .inlineFragment(IfNotSkipHeightInMeters.self)),
         .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         .include(if: "getCat", .inlineFragment(AsCat.self)),
-        .include(if: !"skipHeightInMeters", .fragment(HeightInMeters.self)),
       ] }
 
       public var height: Height { __data["height"] }
@@ -124,11 +124,11 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
       public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
       public var predators: [Predator] { __data["predators"] }
 
+      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
       public var asWarmBlooded: AsWarmBlooded? { _asInlineFragment() }
       public var asPet: AsPet? { _asInlineFragment() }
       public var asCat: AsCat? { _asInlineFragment() }
       public var asClassroomPet: AsClassroomPet? { _asInlineFragment() }
-      public var ifNotSkipHeightInMeters: IfNotSkipHeightInMeters? { _asInlineFragment() }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -198,6 +198,46 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var warmBloodedDetails: WarmBloodedDetails { _toFragment() }
             public var heightInMeters: HeightInMeters { _toFragment() }
           }
+        }
+      }
+
+      /// AllAnimal.IfNotSkipHeightInMeters
+      ///
+      /// Parent Type: `Animal`
+      public struct IfNotSkipHeightInMeters: AnimalKingdomAPI.InlineFragment {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public typealias RootEntityType = AllAnimal
+        public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .fragment(HeightInMeters.self),
+        ] }
+
+        public var height: Height { __data["height"] }
+        public var species: String? { __data["species"] }
+        public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
+        public var predators: [Predator] { __data["predators"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var heightInMeters: HeightInMeters { _toFragment() }
+        }
+
+        /// AllAnimal.IfNotSkipHeightInMeters.Height
+        ///
+        /// Parent Type: `Height`
+        public struct Height: AnimalKingdomAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
+
+          public var feet: Int { __data["feet"] }
+          public var inches: Int? { __data["inches"] }
+          public var meters: Int { __data["meters"] }
         }
       }
 
@@ -469,42 +509,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             public var centimeters: Double? { __data["centimeters"] }
             public var meters: Int { __data["meters"] }
           }
-        }
-      }
-      /// AllAnimal.IfNotSkipHeightInMeters
-      ///
-      /// Parent Type: `Animal`
-      public struct IfNotSkipHeightInMeters: AnimalKingdomAPI.InlineFragment {
-        public let __data: DataDict
-        public init(_dataDict: DataDict) { __data = _dataDict }
-
-        public typealias RootEntityType = AllAnimal
-        public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
-
-        public var height: Height { __data["height"] }
-        public var species: String? { __data["species"] }
-        public var skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? { __data["skinCovering"] }
-        public var predators: [Predator] { __data["predators"] }
-
-        public struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public var heightInMeters: HeightInMeters { _toFragment() }
-        }
-
-        /// AllAnimal.IfNotSkipHeightInMeters.Height
-        ///
-        /// Parent Type: `Height`
-        public struct Height: AnimalKingdomAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
-
-          public var feet: Int { __data["feet"] }
-          public var inches: Int? { __data["inches"] }
-          public var meters: Int { __data["meters"] }
         }
       }
     }


### PR DESCRIPTION
In order for the executor to properly calculate fulfilled fragments, we need to remove a shortcut I had created earlier.

The fragment selection should be inside of the selection set for the inclusion condition.