### PR TITLE
Fix creating of TestMocks to compute fulfilledFragments

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -623,6 +623,7 @@
 		DE903E1D29CA23B200A74415 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = DE903E1C29CA23B200A74415 /* Nimble */; };
 		DE903E1E29CA25A600A74415 /* AnimalKingdomAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE3C7A11260A6B9800D2F4FF /* AnimalKingdomAPI.framework */; };
 		DE903E2229CA622E00A74415 /* SelectionSetInitializerPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE903E2129CA622E00A74415 /* SelectionSetInitializerPerformanceTests.swift */; };
+		DE903E2529CE59C000A74415 /* Apollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FC750441D2A532C00458D91 /* Apollo.framework */; };
 		DE90FDBA27FE405F0084CC79 /* Selection+Conditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE90FDB927FE405F0084CC79 /* Selection+Conditions.swift */; };
 		DE9C04AC26EAAE4400EC35E7 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC4B91F1D2A6F8D0046A641 /* JSON.swift */; };
 		DE9C04AD26EAAE5400EC35E7 /* JSONStandardTypeConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F27D4631D40379500715680 /* JSONStandardTypeConversions.swift */; };
@@ -933,6 +934,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = DE3C7A00260A6B9800D2F4FF;
 			remoteInfo = AnimalKingdomAPI;
+		};
+		DE903E2329CE59BD00A74415 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9FC7503B1D2A532C00458D91 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9FC750431D2A532C00458D91;
+			remoteInfo = Apollo;
 		};
 		DE90FCE627FCC71E0084CC79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2100,6 +2108,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DE903E2529CE59C000A74415 /* Apollo.framework in Frameworks */,
 				DE9CEAE42829A01C00959AF9 /* ApolloAPI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4468,6 +4477,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DE903E2429CE59BD00A74415 /* PBXTargetDependency */,
 				DE9CEAE32829A01A00959AF9 /* PBXTargetDependency */,
 			);
 			name = ApolloTestSupport;
@@ -5823,6 +5833,11 @@
 			isa = PBXTargetDependency;
 			target = DE3C7A00260A6B9800D2F4FF /* AnimalKingdomAPI */;
 			targetProxy = DE903E1F29CA25AA00A74415 /* PBXContainerItemProxy */;
+		};
+		DE903E2429CE59BD00A74415 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9FC750431D2A532C00458D91 /* Apollo */;
+			targetProxy = DE903E2329CE59BD00A74415 /* PBXContainerItemProxy */;
 		};
 		DE90FCE727FCC71E0084CC79 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,7 @@ let package = Package(
     .target(
       name: "ApolloTestSupport",
       dependencies: [
+        "Apollo",
         "ApolloAPI"
       ],
       exclude: [

--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -284,7 +284,7 @@ public class ApolloStore {
         variables: variables,
         accumulator: GraphQLSelectionSetMapper<SelectionSet>(
           stripNullValues: false,
-          allowMissingValuesForOptionalFields: true
+          handleMissingValues: .allowForOptionalFields
         )
       )
 

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -245,6 +245,7 @@ final class GraphQLExecutor<FieldCollector: FieldSelectionCollector> {
   ) throws -> FieldSelectionGrouping {
     var grouping = FieldSelectionGrouping(info: info)
 
+    #warning("TODO: When executing on a selection set that isn't operation root. This will be wrong.")
     // Add __typename field to all selection sets other than the root of the operation.
     if !info.responsePath.isEmpty {
       grouping.append(field: .init("__typename", type: .scalar(String.self)), withInfo: info)

--- a/Sources/Apollo/SelectionSet+JSONInitializer.swift
+++ b/Sources/Apollo/SelectionSet+JSONInitializer.swift
@@ -21,7 +21,7 @@ extension RootSelectionSet {
     variables: GraphQLOperation.Variables? = nil
   ) throws {
     let accumulator = GraphQLSelectionSetMapper<Self>(
-      allowMissingValuesForOptionalFields: true
+      handleMissingValues: .allowForOptionalFields
     )
     let executor = GraphQLExecutor { object, info in
       return object[info.responseKeyForField]

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -86,7 +86,7 @@ TODO: Test missing values for required fields
     withVariables variables: GraphQLOperation.Variables? = nil
   ) -> Self {
     let accumulator = GraphQLSelectionSetMapper<Self>(
-      allowMissingValuesForOptionalFields: true
+      handleMissingValues: .allowForAllFields
     )
     let executor = GraphQLExecutor { object, info in
       return object[info.responseKeyForField]

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -78,9 +78,6 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
 // MARK: - Selection Set Conversion
 
 public extension RootSelectionSet {
-#warning("""
-TODO: Test missing values for required fields
-""")
   static func from<O: MockObject>(
     _ mock: Mock<O>,
     withVariables variables: GraphQLOperation.Variables? = nil

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -44,11 +44,10 @@ open class MockSubscription<SelectionSet: RootSelectionSet>: MockOperation<Selec
 // MARK: - MockSelectionSets
 
 @dynamicMemberLookup
-open class AbstractMockSelectionSet<F>: RootSelectionSet, Hashable {
-  public typealias Schema = MockSchemaMetadata
+open class AbstractMockSelectionSet<F, S: SchemaMetadata>: RootSelectionSet, Hashable {
+  public typealias Schema = S
   public typealias Fragments = F
 
-  open class var __schema: SchemaMetadata.Type { MockSchemaMetadata.self }
   open class var __selections: [Selection] { [] }
   open class var __parentType: ParentType { Object.mock }
 
@@ -75,7 +74,7 @@ open class AbstractMockSelectionSet<F>: RootSelectionSet, Hashable {
   }
 }
 
-public typealias MockSelectionSet = AbstractMockSelectionSet<NoFragments>
+public typealias MockSelectionSet = AbstractMockSelectionSet<NoFragments, MockSchemaMetadata>
 
 open class MockFragment: MockSelectionSet, Fragment {
   public typealias Schema = MockSchemaMetadata

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -893,9 +893,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
       }
     }
 
-    class GivenSelectionSet: AbstractMockSelectionSet<GivenSelectionSet.Fragments> {
-      typealias Schema = MockSchemaMetadata
-
+    class GivenSelectionSet: AbstractMockSelectionSet<GivenSelectionSet.Fragments, MockSchemaMetadata> {
       override class var __parentType: ParentType { Types.MockChildObject }
       override class var __selections: [Selection] {[
         .fragment(GivenFragment.self)

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -867,9 +867,7 @@ class SelectionSetTests: XCTestCase {
     // given
     class GivenFragment: MockFragment { }
 
-    class Hero: AbstractMockSelectionSet<Hero.Fragments> {
-      typealias Schema = MockSchemaMetadata
-
+    class Hero: AbstractMockSelectionSet<Hero.Fragments, MockSchemaMetadata> {
       override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .include(if: "includeFragment", .fragment(GivenFragment.self))
@@ -899,9 +897,7 @@ class SelectionSetTests: XCTestCase {
     // given
     class GivenFragment: MockFragment { }
 
-    class Hero: AbstractMockSelectionSet<Hero.Fragments> {
-      typealias Schema = MockSchemaMetadata
-
+    class Hero: AbstractMockSelectionSet<Hero.Fragments, MockSchemaMetadata> {
       override class var __selections: [Selection] {[
         .field("__typename", String.self),
         .include(if: "includeFragment", .fragment(GivenFragment.self))

--- a/Tests/ApolloTests/TestMockTests.swift
+++ b/Tests/ApolloTests/TestMockTests.swift
@@ -322,7 +322,7 @@ class TestMockTests: XCTestCase {
 
   // MARK: - Selection Set Conversion Tests
 
-  func test__givenSelectionSetWithVariableForInclusionCondition_isTrue_canAccessConditionalField() throws {
+  func test__convertToSelectionSet_givenSelectionSetWithVariableForInclusionCondition_isTrue_canAccessConditionalField() throws {
     // given
     class Animal: TestMockSchema.MockSelectionSet {
       override class var __parentType: ParentType { TestMockSchema.Interfaces.Animal }
@@ -332,7 +332,7 @@ class TestMockTests: XCTestCase {
 
       var ifA: IfA? { _asInlineFragment() }
 
-      class IfA: TestMockSchema.ConcreteMockTypeCase<Animal> {        
+      class IfA: TestMockSchema.ConcreteMockTypeCase<Animal> {
         override class var __parentType: ParentType { TestMockSchema.Interfaces.Animal }
         override class var __selections: [Selection] {[
           .field("species", String.self),
@@ -352,7 +352,7 @@ class TestMockTests: XCTestCase {
     expect(selectionSet.ifA?.species).to(equal("Canine"))
   }
 
-  func test__givenSelectionSetWithVariableForInclusionCondition_isFalse_canNotAccessConditionalField() throws {
+  func test__convertToSelectionSet_givenSelectionSetWithVariableForInclusionCondition_isFalse_canNotAccessConditionalField() throws {
     // given
     class Animal: TestMockSchema.MockSelectionSet {
       override class var __parentType: ParentType { TestMockSchema.Interfaces.Animal }
@@ -382,7 +382,7 @@ class TestMockTests: XCTestCase {
     expect(selectionSet.ifA).to(beNil())
   }
 
-  func test__givenSelectionSetWithTypeCondition_canConvert_canAccessConditionalField() throws {
+  func test__convertToSelectionSet_givenSelectionSetWithTypeCondition_canConvert_canAccessConditionalField() throws {
     // given
     class Animal: TestMockSchema.MockSelectionSet {
       override class var __parentType: ParentType { TestMockSchema.Interfaces.Animal }
@@ -412,7 +412,7 @@ class TestMockTests: XCTestCase {
     expect(selectionSet.asDog?.species).to(equal("Canine"))
   }
 
-  func test__givenSelectionSetWithTypeCondition_canNotConvert_canNotAccessConditionalField() throws {
+  func test__convertToSelectionSet_givenSelectionSetWithTypeCondition_canNotConvert_canNotAccessConditionalField() throws {
     // given
     class Animal: TestMockSchema.MockSelectionSet {
       override class var __parentType: ParentType { TestMockSchema.Interfaces.Animal }
@@ -440,6 +440,26 @@ class TestMockTests: XCTestCase {
 
     // then
     expect(selectionSet.asDog).to(beNil())
+  }
+
+  func test__convertToSelectionSet_givenRequiredFieldNotInitialized_doesNotThrow() throws {
+    // given
+    class Animal: TestMockSchema.MockSelectionSet {
+      override class var __parentType: ParentType { TestMockSchema.Interfaces.Animal }
+      override class var __selections: [Selection] {[
+        .field("species", String.self),
+      ]}
+
+      var species: String { __data["species"] }
+    }
+
+    // when
+    let dog = Mock<Dog>()
+
+    let selectionSet = Animal.from(dog)
+
+    // then
+    expect(selectionSet.__data._data["species"]).to(beNil())
   }
 }
 


### PR DESCRIPTION
Test Mocks need to compute the fulfilledFragments when converting to SelectionSets now. This means they need to go through the executor.

This configures an executor that will allow missing values for use with test mocks.