### PR TITLE
Generate typename selection

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -34,6 +34,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
     .inlineFragment(AsPet.self),
     .inlineFragment(AsWarmBlooded.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -21,6 +21,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
   ] }
 
@@ -75,6 +76,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("inches", Int.self),
       ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
@@ -16,6 +16,7 @@ public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("species", String.self),
   ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -19,6 +19,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("height", Height.self),
   ] }
 
@@ -46,6 +47,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("meters", Int.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
@@ -21,6 +21,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("humanName", String?.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner?.self),
@@ -56,6 +57,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -17,6 +17,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
         .inlineFragment(AsBird.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -19,6 +19,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("owner", Owner?.self),
   ] }
 
@@ -49,6 +50,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -60,6 +60,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -58,6 +58,7 @@ public class PetAdoptionMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -55,6 +55,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height?.self),
       ] }
 
@@ -82,6 +83,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int?.self),
           .field("inches", Int.self),
         ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -114,6 +114,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
         .field("predators", [Predator].self),
@@ -171,6 +172,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -202,6 +204,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .include(if: "includeSpecies", .field("species", String.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         ] }
@@ -503,6 +506,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .include(if: "varA", [
               .field("relativeSize", GraphQLEnum<AnimalKingdomAPI.RelativeSize>.self),
               .field("centimeters", Double.self),

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -95,6 +95,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
@@ -154,6 +155,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -188,6 +190,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("species", String.self),
           .inlineFragment(AsWarmBlooded.self),
         ] }
@@ -271,6 +274,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .field("species", String.self),
             ] }
 
@@ -444,6 +448,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("relativeSize", GraphQLEnum<AnimalKingdomAPI.RelativeSize>.self),
             .field("centimeters", Double.self),
           ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -52,6 +52,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetailsCCN.self),
       ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -52,6 +52,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetails.self),
       ] }
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -55,6 +55,7 @@ public class DogQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .inlineFragment(AsDog.self),
       ] }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -69,6 +69,7 @@ public class PetSearchQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -49,10 +49,10 @@ struct ObjectExecutionInfo {
     for json: JSONObject
   ) -> Object? {
     guard let __typename = json["__typename"] as? String else {
-      if responsePath.isEmpty {
-        return schema.objectType(forTypename: rootType.__parentType.__typename)
+      guard let objectType = rootType.__parentType as? Object else {
+        return nil
       }
-      return nil
+      return schema.objectType(forTypename: objectType.typename)
     }
     return schema.objectType(forTypename: __typename)
   }
@@ -245,11 +245,6 @@ final class GraphQLExecutor<FieldCollector: FieldSelectionCollector> {
   ) throws -> FieldSelectionGrouping {
     var grouping = FieldSelectionGrouping(info: info)
 
-    #warning("TODO: When executing on a selection set that isn't operation root. This will be wrong.")
-    // Add __typename field to all selection sets other than the root of the operation.
-    if !info.responsePath.isEmpty {
-      grouping.append(field: .init("__typename", type: .scalar(String.self)), withInfo: info)
-    }
     try fieldCollector.collectFields(from: selections,
                                      into: &grouping,
                                      for: object,

--- a/Sources/ApolloAPI/LocalCacheMutation.swift
+++ b/Sources/ApolloAPI/LocalCacheMutation.swift
@@ -27,7 +27,7 @@ public protocol MutableSelectionSet: SelectionSet {
 }
 
 public extension MutableSelectionSet {
-  @inlinable var __typename: String {
+  @inlinable var __typename: String? {
     get { __data["__typename"] }
     set { __data["__typename"] = newValue }
   }

--- a/Sources/ApolloAPI/SelectionSet.swift
+++ b/Sources/ApolloAPI/SelectionSet.swift
@@ -63,9 +63,12 @@ extension SelectionSet {
 
   @inlinable public static var __selections: [Selection] { [] }
 
-  @inlinable public var __objectType: Object? { Schema.objectType(forTypename: __typename) }
+  @inlinable public var __objectType: Object? {
+    guard let __typename else { return nil }
+    return Schema.objectType(forTypename: __typename)
+  }
 
-  @inlinable public var __typename: String { __data["__typename"] }
+  @inlinable public var __typename: String? { __data["__typename"] }
 
   /// Verifies if a `SelectionSet` may be converted to an `InlineFragment` and performs
   /// the conversion.

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -40,7 +40,7 @@ extension IR {
     ///
     /// For example, given the set of nested selections sets:
     /// ```
-    /// object {
+    /// object { // object field is of type "Object"
     ///  ... on A {
     ///   ... on B {
     ///     ... on C {
@@ -50,7 +50,7 @@ extension IR {
     /// }
     /// ```
     /// The scopePath for the `SelectionSet` that includes field `fieldOnABC` would be:
-    /// `[A, B, C]`.
+    /// `[Object, A, B, C]`.
     let scopePath: LinkedList<ScopeCondition>
 
     /// All of the types that the `SelectionSet` implements. That is, all of the types in the

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -445,9 +445,16 @@ struct SelectionSetTemplate {
   private func InitializerDataDictFieldTemplate(
     _ field: IR.Field
   ) -> TemplateString {
-    """
+    let isEntityField: Bool = {
+      switch field.type.innerType {
+      case .entity: return true
+      default: return false
+      }
+    }()
+
+    return """
     "\(field.responseKey)": \(field.responseKey.asInputParameterName)\
-    \(if: field is IR.EntityField, "._fieldData")
+    \(if: isEntityField, "._fieldData")
     """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -157,6 +157,7 @@ struct SelectionSetTemplate {
 
     let selectionsTemplate = TemplateString("""
     public static var __selections: [\(config.ApolloAPITargetName).Selection] { [
+      \(if: shouldIncludeTypenameSelection(for: scope), ".field(\"__typename\", String.self),")
       \(renderedSelections(groupedSelections.unconditionalSelections, &deprecatedArguments), terminator: ",")
       \(groupedSelections.inclusionConditionGroups.map {
         renderedConditionalSelectionGroup($0, $1, in: scope, &deprecatedArguments)
@@ -172,6 +173,10 @@ struct SelectionSetTemplate {
       """)
     \(selectionsTemplate)
     """
+  }
+
+  private func shouldIncludeTypenameSelection(for scope: IR.ScopeDescriptor) -> Bool {
+    return scope.scopePath.count == 1 && !scope.type.isRootFieldType
   }
 
   private func renderedSelections(

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
@@ -21,6 +21,7 @@ public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("login", String.self),
     .inlineFragment(AsUser.self),
   ] }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -67,6 +67,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Repository }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .field("issues", Issues.self, arguments: ["last": 100]),
       ] }
@@ -85,6 +86,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.IssueConnection }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("nodes", [Node?]?.self),
         ] }
 
@@ -100,6 +102,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Issue }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("title", String.self),
             .field("author", Author?.self),
             .field("body", String.self),
@@ -124,6 +127,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .fragment(AuthorDetails.self),
             ] }
 
@@ -173,6 +177,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.IssueCommentConnection }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .field("nodes", [Node?]?.self),
             ] }
 
@@ -188,6 +193,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.IssueComment }
               public static var __selections: [ApolloAPI.Selection] { [
+                .field("__typename", String.self),
                 .field("body", String.self),
                 .field("author", Author?.self),
               ] }
@@ -206,6 +212,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
 
                 public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
                 public static var __selections: [ApolloAPI.Selection] { [
+                  .field("__typename", String.self),
                   .fragment(AuthorDetails.self),
                 ] }
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
@@ -43,6 +43,7 @@ public class RepoURLQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Repository }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("url", GitHubAPI.URI.self),
       ] }
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -68,6 +68,7 @@ public class RepositoryQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Objects.Repository }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("issueOrPullRequest", IssueOrPullRequest?.self, arguments: ["number": 13]),
       ] }
 
@@ -83,6 +84,7 @@ public class RepositoryQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Unions.IssueOrPullRequest }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .inlineFragment(AsIssue.self),
           .inlineFragment(AsReactable.self),
         ] }
@@ -123,6 +125,7 @@ public class RepositoryQuery: GraphQLQuery {
 
             public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .field("avatarUrl", GitHubAPI.URI.self),
             ] }
 
@@ -179,6 +182,7 @@ public class RepositoryQuery: GraphQLQuery {
 
               public static var __parentType: ApolloAPI.ParentType { GitHubAPI.Interfaces.Actor }
               public static var __selections: [ApolloAPI.Selection] { [
+                .field("__typename", String.self),
                 .field("login", String.self),
               ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
@@ -16,6 +16,7 @@ public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
@@ -16,6 +16,7 @@ public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
@@ -17,6 +17,7 @@ public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
     .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
@@ -16,6 +16,7 @@ public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.Selectio
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .fragment(CharacterNameWithNestedAppearsInFragment.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -20,6 +20,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
     .inlineFragment(AsDroid.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -17,6 +17,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsDroid.self),
     .fragment(CharacterName.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -27,6 +27,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsHuman.self),
     .inlineFragment(AsDroid.self),
   ] }
@@ -83,6 +84,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
@@ -17,6 +17,7 @@ public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
     .fragment(CharacterAppearsIn.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
@@ -17,6 +17,7 @@ public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
     .field("primaryFunction", String?.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
@@ -16,6 +16,7 @@ public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
@@ -17,6 +17,7 @@ public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .fragment(CharacterName.self),
     .fragment(DroidPrimaryFunction.self),
   ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
@@ -16,6 +16,7 @@ public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Droid }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("primaryFunction", String?.self),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
@@ -19,6 +19,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("friends", [Friend?]?.self),
   ] }
 
@@ -47,6 +48,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("name", String.self),
     ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -24,6 +24,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("name", String.self),
     .inlineFragment(AsHuman.self),
     .inlineFragment(AsDroid.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
@@ -16,6 +16,7 @@ public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("height", Double?.self, arguments: ["unit": .variable("heightUnit")]),
   ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -59,6 +59,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -70,6 +70,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -59,6 +59,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("stars", Int.self),
         .field("commentary", String?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -59,6 +59,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .inlineFragment(AsDroid.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -63,6 +63,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", StarWarsAPI.ID.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
@@ -101,6 +102,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", StarWarsAPI.ID.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -62,6 +62,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
       ] }
@@ -95,6 +96,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("name", String.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -60,6 +60,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .fragment(FriendsNames.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -69,6 +69,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friends", [Friend?]?.self),
         .inlineFragment(AsDroid.self),
       ] }
@@ -100,6 +101,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .fragment(CharacterName.self),
         ] }
 
@@ -166,6 +168,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .fragment(CharacterName.self),
           ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -63,6 +63,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", StarWarsAPI.ID.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
@@ -101,6 +102,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("name", String.self),
         ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -64,6 +64,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", StarWarsAPI.ID.self),
         .field("name", String.self),
         .field("friends", [Friend?]?.self),
@@ -102,6 +103,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", StarWarsAPI.ID.self),
           .field("name", String.self),
         ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -52,6 +52,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(CharacterAppearsIn.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "includeDetails", .inlineFragment(IfIncludeDetails.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -62,6 +62,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "includeDetails", .inlineFragment(IfIncludeDetails.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -66,6 +66,7 @@ public class HeroDetailsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(HeroDetails.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -65,6 +65,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "includeFriendsDetails", .field("friends", [Friend?]?.self)),
       ] }
 
@@ -93,6 +94,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("name", String.self),
           .inlineFragment(AsDroid.self),
         ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -69,6 +69,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friends", [Friend?]?.self),
       ] }
 
@@ -97,6 +98,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("name", String.self),
           .include(if: "includeFriendsDetails", .inlineFragment(IfIncludeFriendsDetails.self)),
         ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -65,6 +65,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friends", [Friend?]?.self),
       ] }
 
@@ -93,6 +94,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", StarWarsAPI.ID.self),
           .field("friends", [Friend?]?.self),
         ] }
@@ -126,6 +128,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("name", String.self),
           ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(CharacterNameAndAppearsIn.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -66,6 +66,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: !"skipName" && "includeName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -67,6 +67,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: !"skipName" || "includeName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -58,6 +58,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: !"skipName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -58,6 +58,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "includeName", .field("name", String.self)),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -58,6 +58,7 @@ public class HeroNameQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -70,6 +70,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .inlineFragment(AsDroid.self),
         .include(if: "includeName", .field("name", String.self)),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -60,6 +60,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", StarWarsAPI.ID.self),
         .fragment(CharacterName.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(CharacterName.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", StarWarsAPI.ID.self),
         .field("name", String.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -80,6 +80,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
@@ -146,6 +147,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("name", String.self),
             .inlineFragment(AsHuman.self),
           ] }
@@ -246,6 +248,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("name", String.self),
             .inlineFragment(AsHuman.self),
           ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -65,6 +65,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -59,6 +59,7 @@ public class HumanQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Human }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .field("mass", Double?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -60,6 +60,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
       ] }
 
@@ -89,6 +90,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("appearsIn", [GraphQLEnum<StarWarsAPI.Episode>?].self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -72,6 +72,7 @@ public class SearchQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Unions.SearchResult }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .inlineFragment(AsHuman.self),
         .inlineFragment(AsDroid.self),
         .inlineFragment(AsStarship.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -60,6 +60,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Starship }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .field("coordinates", [[Double]]?.self),
         .field("length", Double?.self),

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -53,6 +53,7 @@ public class StarshipQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Starship }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
         .field("coordinates", [[Double]]?.self),
       ] }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -60,6 +60,7 @@ public class TwoHeroesQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
       ] }
 
@@ -89,6 +90,7 @@ public class TwoHeroesQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Interfaces.Character }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("name", String.self),
       ] }
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -60,6 +60,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
 
       public static var __parentType: ApolloAPI.ParentType { StarWarsAPI.Objects.Review }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("episode", GraphQLEnum<StarWarsAPI.Episode>?.self),
         .field("stars", Int.self),
         .field("commentary", String?.self),

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -59,6 +59,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.File }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", UploadAPI.ID.self),
         .field("path", String.self),
         .field("filename", String.self),

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -48,6 +48,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.File }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", UploadAPI.ID.self),
         .field("path", String.self),
         .field("filename", String.self),

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -48,6 +48,7 @@ public class UploadOneFileMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { UploadAPI.Objects.File }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", UploadAPI.ID.self),
         .field("path", String.self),
         .field("filename", String.self),

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -286,7 +286,42 @@ class FragmentTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
-  func test__render__givenFragmentWithOnlyTypenameField_generatesFragmentDefinition_withNoSelections() throws {
+  func test__render__givenFragmentOnRootOperationTypeWithOnlyTypenameField_generatesFragmentDefinition_withNoSelections() throws {
+    // given
+    document = """
+    fragment TestFragment on Query {
+      __typename
+    }
+    """
+
+    try buildSubjectAndFragment()
+
+    let expected = """
+    struct TestFragment: TestSchema.SelectionSet, Fragment {
+      public static var fragmentDefinition: StaticString { ""\"
+        fragment TestFragment on Query {
+          __typename
+        }
+        ""\" }
+
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { TestSchema.Objects.Query }
+      public static var __selections: [ApolloAPI.Selection] { [
+      ] }
+    }
+
+    """
+
+    // when
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected))
+  }
+
+  func test__render__givenFragmentWithOnlyTypenameField_generatesFragmentDefinition_withTypeNameSelection() throws {
     // given
     document = """
     fragment TestFragment on Animal {
@@ -309,6 +344,7 @@ class FragmentTemplateTests: XCTestCase {
 
       public static var __parentType: ApolloAPI.ParentType { TestSchema.Objects.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
       ] }
     }
 
@@ -365,7 +401,7 @@ class FragmentTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
   }
 
   func test__render_givenNamedFragment_configIncludesSpecificFragment_rendersInitializer() throws {
@@ -410,7 +446,7 @@ class FragmentTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 19, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
   }
 
   func test__render_givenNamedFragment_configDoesNotIncludeNamedFragments_doesNotRenderInitializer() throws {
@@ -440,7 +476,7 @@ class FragmentTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine("}", atLine: 18, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine("}", atLine: 19, ignoringExtraLines: true))
   }
 
   func test__render_givenNamedFragments_configIncludeSpecificFragmentWithOtherName_doesNotRenderInitializer() throws {
@@ -470,7 +506,7 @@ class FragmentTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine("}", atLine: 18, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine("}", atLine: 19, ignoringExtraLines: true))
   }
 
   func test__render_givenNamedFragments_asLocalCacheMutation_configIncludeLocalCacheMutations_rendersInitializer() throws {
@@ -515,7 +551,7 @@ class FragmentTemplateTests: XCTestCase {
     let actual = renderSubject()
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 22, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 23, ignoringExtraLines: true))
   }
 
   // MARK: - Local Cache Mutation Tests

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -307,7 +307,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       let actual = renderSubject()
 
       // then
-      expect(actual).to(equalLineByLine(expected, atLine: 54, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 55, ignoringExtraLines: true))
     }
 
     func test__generate_givenOperationSelectionSet_configIncludesSpecificOperation_rendersInitializer() throws {
@@ -355,7 +355,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       let actual = renderSubject()
 
       // then
-      expect(actual).to(equalLineByLine(expected, atLine: 54, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 55, ignoringExtraLines: true))
     }
 
     func test__render_givenOperationSelectionSet_configDoesNotIncludeOperations_doesNotRenderInitializer() throws {
@@ -386,7 +386,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       let actual = renderSubject()
 
       // then
-      expect(actual).to(equalLineByLine("    }", atLine: 41, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine("    }", atLine: 42, ignoringExtraLines: true))
     }
 
     func test__render_givenOperationSelectionSet_configIncludeSpecificOperationWithOtherName_doesNotRenderInitializer() throws {
@@ -419,7 +419,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       let actual = renderSubject()
 
       // then
-      expect(actual).to(equalLineByLine("    }", atLine: 41, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine("    }", atLine: 42, ignoringExtraLines: true))
     }
 
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -267,6 +267,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("FieldName", String.self),
       ] }
     """
@@ -407,6 +408,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("string", String.self),
         .field("string_optional", String?.self),
         .field("int", Int.self),
@@ -479,6 +481,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("custom", TestSchema.Custom.self),
         .field("custom_optional", TestSchema.Custom?.self),
         .field("custom_required_list", [TestSchema.Custom].self),
@@ -551,6 +554,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("testEnum", GraphQLEnum<TestSchema.TestEnum>.self),
         .field("testEnumOptional", GraphQLEnum<TestSchema.TestEnumOptional>?.self),
         .field("lowercaseEnum", GraphQLEnum<TestSchema.LowercaseEnum>.self),
@@ -605,6 +609,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("FieldName", String.self),
       ] }
     """
@@ -643,6 +648,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("string", alias: "aliased", String.self),
       ] }
     """
@@ -692,6 +698,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("predator", Predator.self),
         .field("lowercaseType", LowercaseType.self),
       ] }
@@ -839,6 +846,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("associatedtype", String.self),
         .field("class", String.self),
         .field("deinit", String.self),
@@ -937,6 +945,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("_oneUnderscore", _OneUnderscore.self),
         .field("__twoUnderscore", __TwoUnderscore.self),
       ] }
@@ -1043,6 +1052,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("self", Self_SelectionSet.self),
         .field("parentType", ParentType_SelectionSet.self),
         .field("dataDict", DataDict_SelectionSet.self),
@@ -1099,6 +1109,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("string", alias: "aliased", String.self, arguments: ["variable": 3]),
       ] }
     """
@@ -1137,6 +1148,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("string", alias: "aliased", String.self, arguments: ["variable": .null]),
       ] }
     """
@@ -1175,6 +1187,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("string", alias: "aliased", String.self, arguments: ["variable": .variable("var")]),
       ] }
     """
@@ -1244,6 +1257,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("string", alias: "aliased", String.self, arguments: ["input": [
           "string": "ABCD",
           "int": 3,
@@ -1308,6 +1322,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .inlineFragment(AsPet.self),
         .inlineFragment(AsLowercaseInterface.self),
       ] }
@@ -1359,6 +1374,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(FragmentA.self),
         .fragment(LowercaseFragment.self),
       ] }
@@ -1400,6 +1416,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "a", .field("fieldName", String.self)),
       ] }
     """
@@ -1438,6 +1455,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: !"b", .field("fieldName", String.self)),
       ] }
     """
@@ -1476,6 +1494,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: !"b" && "a", .field("fieldName", String.self)),
       ] }
     """
@@ -1517,6 +1536,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: (!"b" && "a") || !"c" || ("d" && !"e") || "f", .field("fieldName", String.self)),
       ] }
     """
@@ -1569,6 +1589,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "a", [
           .field("fieldA", String.self),
           .field("fieldB", String.self),
@@ -1622,6 +1643,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "a", .inlineFragment(AsPet.self)),
       ] }
     """
@@ -1666,6 +1688,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .include(if: "a", .inlineFragment(IfA.self)),
       ] }
     """
@@ -1728,6 +1751,129 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  // MARK: Selections - __typename Selection
+
+  func test__render_selections__givenEntityRootSelectionSet_rendersTypenameSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      fieldName: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        fieldName
+      }
+    }
+    """
+
+    let expected = """
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("fieldName", String.self),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
+  }
+
+  func test__render_selections__givenInlineFragment_doesNotRenderTypenameSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      fieldName: String!
+    }
+
+    interface Pet {
+      fieldName: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Pet {
+          fieldName
+        }
+      }
+    }
+    """
+
+    let expected = """
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("fieldName", String.self),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let allAnimals_asPet = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"]?[as: "Pet"]
+    )
+
+    let actual = subject.render(inlineFragment: allAnimals_asPet)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__render_selections__givenOperationRootSelectionSet_doesNotRenderTypenameSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]!
+    }
+
+    type Animal {
+      fieldName: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        fieldName
+      }
+    }
+    """
+
+    let expected = """
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("allAnimals", [AllAnimal].self),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let queryRoot = try XCTUnwrap(
+      operation[field: "query"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: queryRoot)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
   // MARK: - Field Accessors - Scalar
@@ -1836,7 +1982,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 34, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 35, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenCustomScalarFields_rendersFieldAccessorsWithNamespaceWhenRequiredInAllConfigurations() throws {
@@ -1900,7 +2046,7 @@ class SelectionSetTemplateTests: XCTestCase {
       let actual = subject.render(field: allAnimals)
 
       // then
-      expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
     }
   }
 
@@ -1968,7 +2114,7 @@ class SelectionSetTemplateTests: XCTestCase {
       let actual = subject.render(field: allAnimals)
 
       // then
-      expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+      expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
     }
   }
 
@@ -2007,7 +2153,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenFieldWithAlias_rendersAllFieldAccessors() throws {
@@ -2045,7 +2191,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenMergedScalarField_rendersFieldAccessor() throws {
@@ -2286,7 +2432,7 @@ class SelectionSetTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(
       expected,
-      atLine: 10 + allAnimals.selectionSet.selections.direct!.fields.count,
+      atLine: 11 + allAnimals.selectionSet.selections.direct!.fields.count,
       ignoringExtraLines: true)
     )
   }
@@ -2334,7 +2480,7 @@ class SelectionSetTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(
       expected,
-      atLine: 10 + allAnimals.selectionSet.selections.direct!.fields.count,
+      atLine: 11 + allAnimals.selectionSet.selections.direct!.fields.count,
       ignoringExtraLines: true)
     )
   }
@@ -2447,7 +2593,7 @@ class SelectionSetTemplateTests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(
       expected,
-      atLine: 10 + allAnimals.selectionSet.selections.direct!.fields.count,
+      atLine: 11 + allAnimals.selectionSet.selections.direct!.fields.count,
       ignoringExtraLines: true)
     )
   }
@@ -2499,7 +2645,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenDirectEntityFieldWithAlias_rendersFieldAccessor() throws {
@@ -2538,7 +2684,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenDirectEntityFieldAsOptional_rendersFieldAccessor() throws {
@@ -2577,7 +2723,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenDirectEntityFieldAsList_rendersFieldAccessor() throws {
@@ -2616,7 +2762,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldWithDirectSelectionsAndMergedFromFragment_rendersFieldAccessor() throws {
@@ -2663,7 +2809,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
   }
 
   // MARK: Field Accessors - Merged Fragment
@@ -2708,7 +2854,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldMergedFromFragmentEntityNestedInEntity_rendersFieldAccessor() throws {
@@ -2762,7 +2908,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_predator)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldMergedFromFragmentInTypeCaseWithEntityNestedInEntity_rendersFieldAccessor() throws {
@@ -2885,7 +3031,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let allAnimals_predator_asPet_actual = subject.render(inlineFragment: allAnimals_predator_asPet)
 
     // then
-    expect(allAnimals_predator_actual).to(equalLineByLine(predator_expected, atLine: 12, ignoringExtraLines: true))
+    expect(allAnimals_predator_actual).to(equalLineByLine(predator_expected, atLine: 13, ignoringExtraLines: true))
     expect(allAnimals_predator_asPet_actual).to(equalLineByLine(predator_asPet_expected, atLine: 9, ignoringExtraLines: true))
   }
 
@@ -2954,7 +3100,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let allAnimals_predator_asPet_actual = subject.render(inlineFragment: allAnimals_predator_asPet)
 
     // then
-    expect(allAnimals_predator_actual).to(equalLineByLine(predator_expected, atLine: 11, ignoringExtraLines: true))
+    expect(allAnimals_predator_actual).to(equalLineByLine(predator_expected, atLine: 12, ignoringExtraLines: true))
     expect(allAnimals_predator_asPet_actual).to(equalLineByLine(predator_asPet_expected, atLine: 9, ignoringExtraLines: true))
   }
 
@@ -3016,7 +3162,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(predator_actual)
-      .to(equalLineByLine(predator_expected, atLine: 14, ignoringExtraLines: true))
+      .to(equalLineByLine(predator_expected, atLine: 15, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenTypeCaseMergedFromFragmentWithNoOtherMergedFields_rendersFieldAccessor() throws {
@@ -3076,7 +3222,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(predator_actual)
-      .to(equalLineByLine(predator_expected, atLine: 11, ignoringExtraLines: true))
+      .to(equalLineByLine(predator_expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldMergedAsRootOfNestedFragment_rendersFieldAccessor() throws {
@@ -3302,7 +3448,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_asDog_predator)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldNestedInEntityFieldInMatchingTypeCaseMergedFromParent_rendersFieldAccessorWithCorrectName() throws {
@@ -3369,7 +3515,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_asDog_predator)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   // MARK: Field Accessors - Include/Skip
@@ -3407,7 +3553,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessor__givenNonNullFieldWithSkipCondition_rendersAsOptional() throws {
@@ -3443,7 +3589,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenEntityFieldMergedFromParentWithInclusionCondition_rendersFieldAccessorAsOptional() throws {
@@ -3569,7 +3715,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessor__givenNonNullFieldMergedFromNestedEntityInNamedFragmentWithIncludeCondition_doesNotRenderField() throws {
@@ -3619,7 +3765,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_child)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessor__givenNonNullFieldMergedFromNestedEntityInNamedFragmentWithIncludeCondition_inConditionalFragment_rendersFieldAsNonOptional() throws {
@@ -3728,7 +3874,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__render_inlineFragmentAccessors__givenMergedTypeCasesFromSingleMergedTypeCaseSource_rendersTypeCaseAccessorWithCorrectName() throws {
@@ -3788,7 +3934,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_asDog_predator)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   // MARK: Inline Fragment Accessors - Include/Skip
@@ -3832,7 +3978,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_inlineFragmentAccessors__givenInlineFragmentOnDifferentTypeWithSkipCondition_renders() throws {
@@ -3874,7 +4020,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_inlineFragmentAccessors__givenInlineFragmentOnDifferentTypeWithMultipleConditions_renders() throws {
@@ -3916,7 +4062,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_inlineFragmentAccessors__givenInlineFragmentOnSameTypeWithMultipleConditions_renders() throws {
@@ -3958,7 +4104,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_inlineFragmentAccessor__givenNamedFragmentOnSameTypeWithInclusionCondition_renders() throws {
@@ -3999,7 +4145,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   // MARK: - Fragment Accessors
@@ -4053,7 +4199,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__render_fragmentAccessor__givenInheritedFragmentFromParent_rendersFragmentAccessor() throws {
@@ -4165,7 +4311,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
   }
 
   func test__render_fragmentAccessor__givenFragmentOnSameTypeWithInclusionConditionThatMatchesScope_rendersFragmentAccessorAsNotOptional() throws {
@@ -4211,7 +4357,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fragmentAccessor__givenFragmentOnSameTypeWithInclusionConditionThatPartiallyMatchesScope_rendersFragmentAccessorAsOptional() throws {
@@ -4257,7 +4403,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   func test__render_fragmentAccessor__givenFragmentMergedFromParent_withInclusionConditionThatMatchesScope_rendersFragmentAccessorAsNotOptional() throws {
@@ -4347,7 +4493,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSets__givenDirectEntityFieldAsList_withIrregularPluralizationRule_rendersNestedSelectionSetWithCorrectSingularName() throws {
@@ -4389,7 +4535,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSets__givenDirectEntityFieldAsNonNullList_withIrregularPluralizationRule_rendersNestedSelectionSetWithCorrectSingularName() throws {
@@ -4431,7 +4577,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSets__givenDirectEntityFieldAsList_withCustomIrregularPluralizationRule_rendersNestedSelectionSetWithCorrectSingularName() throws {
@@ -4476,7 +4622,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   /// Explicit test for edge case surfaced in issue
@@ -4520,6 +4666,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
         public static var __parentType: ApolloAPI.ParentType { TestSchema.Objects.Badge }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("a", String?.self),
         ] }
 
@@ -4533,6 +4680,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
         public static var __parentType: ApolloAPI.ParentType { TestSchema.Objects.ProductBadge }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("b", String?.self),
         ] }
 
@@ -4594,6 +4742,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
         public static var __parentType: ApolloAPI.ParentType { TestSchema.Objects.Badge }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("a", String?.self),
         ] }
 
@@ -4607,6 +4756,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
         public static var __parentType: ApolloAPI.ParentType { TestSchema.Objects.ProductBadge }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("b", String?.self),
         ] }
 
@@ -4708,7 +4858,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_asDog_predator)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenEntityFieldMergedFromFragment_doesNotRendersSelectionSet() throws {
@@ -4759,7 +4909,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenEntityFieldMergedFromFragmentWithLowercaseName_rendersFragmentNestedSelctionSetNameCorrectlyCased() throws {
@@ -4810,7 +4960,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenEntityFieldMergedFromNestedFragmentInTypeCase_withNoOtherMergedFields_doesNotRendersSelectionSet() throws {
@@ -4905,9 +5055,9 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(allAnimals_actual)
-      .to(equalLineByLine(allAnimals_expected, atLine: 11, ignoringExtraLines: true))
+      .to(equalLineByLine(allAnimals_expected, atLine: 12, ignoringExtraLines: true))
     expect(allAnimals_predator_actual)
-      .to(equalLineByLine(allAnimals_predator_expected, atLine: 11, ignoringExtraLines: true))
+      .to(equalLineByLine(allAnimals_predator_expected, atLine: 12, ignoringExtraLines: true))
     expect(allAnimals_predator_asWarmBlooded_actual)
       .to(equalLineByLine(allAnimals_predator_asWarmBlooded_expected, atLine: 12, ignoringExtraLines: true))
   }
@@ -4964,7 +5114,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenMergedTypeCasesFromSingleMergedTypeCaseSource_rendersTypeCaseSelectionSet() throws {
@@ -5027,7 +5177,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals_asDog_predator)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenInlineFragmentOnSameTypeWithMultipleConditions_renders() throws {
@@ -5072,7 +5222,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenNamedFragmentOnSameTypeWithInclusionCondition_rendersConditionalSelectionSet() throws {
@@ -5114,7 +5264,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 21, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenTypeCaseMergedFromFragmentWithOtherMergedFields_rendersTypeCase() throws {
@@ -5176,7 +5326,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(predator_actual)
-      .to(equalLineByLine(predator_expected, atLine: 23, ignoringExtraLines: true))
+      .to(equalLineByLine(predator_expected, atLine: 24, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet__givenTypeCaseMergedFromFragmentWithNoOtherMergedFields_rendersTypeCase() throws {
@@ -5237,7 +5387,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(predator_actual)
-      .to(equalLineByLine(predator_expected, atLine: 20, ignoringExtraLines: true))
+      .to(equalLineByLine(predator_expected, atLine: 21, ignoringExtraLines: true))
   }
 
   // MARK: Nested Selection Sets - Reserved Keywords + Special Names
@@ -5282,7 +5432,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
       // then
       expect(predator_actual)
-        .to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+        .to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
     }
   }
 
@@ -5486,7 +5636,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   func test__render_nestedSelectionSet_givenSchemaDocumentation_exclude_hasDocumentation_shouldNotGenerateDocumentationComment() throws {
@@ -5528,7 +5678,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenSchemaDocumentation_include_hasDocumentation_shouldGenerateDocumentationComment() throws {
@@ -5568,7 +5718,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenSchemaDocumentation_exclude_hasDocumentation_shouldNotGenerateDocumentationComment() throws {
@@ -5607,7 +5757,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   // MARK: - Deprecation Warnings
@@ -5651,7 +5801,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
 
@@ -5698,7 +5848,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenWarningsOnDeprecatedUsage_include_hasDeprecatedField_withMultilineDocumentation_includingEmptyLine_shouldGenerateWarningBelowDocumentationWithMultilineLiteral() throws {
@@ -5745,7 +5895,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 13, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__givenWarningsOnDeprecatedUsage_exclude_hasDeprecatedField_shouldNotGenerateWarning() throws {
@@ -5781,7 +5931,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_selections__givenWarningsOnDeprecatedUsage_include_usesDeprecatedArgument__shouldGenerateWarning() throws {
@@ -5810,6 +5960,7 @@ class SelectionSetTemplateTests: XCTestCase {
     let expected = """
       #warning("Argument 'species' of field 'friend' is deprecated. Reason: 'Who cares?'")
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friend", Friend?.self, arguments: [
           "name": .variable("name"),
           "species": .variable("species")
@@ -5856,6 +6007,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friend", Friend?.self, arguments: [
           "name": .variable("name"),
           "species": .variable("species")
@@ -5907,6 +6059,7 @@ class SelectionSetTemplateTests: XCTestCase {
       #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'"),
       #warning("Argument 'species' of field 'friend' is deprecated. Reason: 'Who cares?'")
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friend", Friend?.self, arguments: [
           "name": .variable("name"),
           "species": .variable("species")
@@ -5956,6 +6109,7 @@ class SelectionSetTemplateTests: XCTestCase {
       #warning("Argument 'name' of field 'friend' is deprecated. Reason: 'Someone broke it.'"),
       #warning("Argument 'species' of field 'species' is deprecated. Reason: 'Redundant'")
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("friend", Friend?.self, arguments: ["name": .variable("name")]),
         .field("species", String?.self, arguments: ["species": .variable("species")]),
       ] }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -91,7 +91,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
     
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
   
   func test__render_givenSelectionSetOnInterfaceType_parametersIncludeTypenameField() throws {
@@ -140,7 +140,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
     
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__render_givenSelectionSetOnUnionType_parametersIncludeFulfilledFragmentsWithUnion() throws {
@@ -413,7 +413,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
     
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 61, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 62, ignoringExtraLines: true))
   }
 
   func test__render_given_fieldWithAlias_rendersInitializer() throws {
@@ -460,7 +460,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
   
   func test__render_given_entityFieldSelection_rendersInitializer() throws {
@@ -510,7 +510,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__render_given_abstractEntityFieldSelectionWithNoFields_rendersInitializer() throws {
@@ -566,7 +566,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__render_given_entityFieldListSelection_rendersInitializer() throws {
@@ -616,7 +616,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
   func test__render_given_entityFieldSelection_nullable_rendersInitializer() throws {
@@ -666,7 +666,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 15, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
 
 
@@ -859,7 +859,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 22, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 23, ignoringExtraLines: true))
   }
 
   func test__render_givenNamedFragmentSelectionNestedInNamedFragment_fulfilledFragmentsIncludesNamedFragment() throws {
@@ -922,7 +922,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 24, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 25, ignoringExtraLines: true))
   }
 
   func test__render_givenTypeCaseWithNamedFragmentMergedFromParent_fulfilledFragmentsIncludesNamedFragment() throws {
@@ -1059,7 +1059,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
 
     // then
     expect(allAnimals_actual).to(equalLineByLine(
-      allAnimals_expected, atLine: 15, ignoringExtraLines: true))
+      allAnimals_expected, atLine: 16, ignoringExtraLines: true))
 
     expect(allAnimals_asPet_actual).to(equalLineByLine(
       allAnimals_asPet_expected, atLine: 23, ignoringExtraLines: true))
@@ -1377,7 +1377,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
 
     // then
     expect(allAnimals_actual).to(equalLineByLine(
-      allAnimals_expected, atLine: 22, ignoringExtraLines: true))
+      allAnimals_expected, atLine: 23, ignoringExtraLines: true))
     expect(allAnimals_ifA_actual).to(equalLineByLine(
       allAnimals_ifA_expected, atLine: 23, ignoringExtraLines: true))
   }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -462,6 +462,156 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
   }
+
+  func test__render_given_listField_rendersInitializerWithListFieldTransformedToFieldData() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+      friends: [Animal!]!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        friends {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+        public init(
+          friends: [Friend]
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": TestSchema.Objects.Animal.typename,
+            "friends": friends._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self)
+            ])
+          ]))
+        }
+      """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+  }
+
+  func test__render_given_optionalListField_rendersInitializerWithListFieldTransformedToFieldData() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+      friends: [Animal!]
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        friends {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+        public init(
+          friends: [Friend]? = nil
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": TestSchema.Objects.Animal.typename,
+            "friends": friends._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self)
+            ])
+          ]))
+        }
+      """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+  }
+
+  func test__render_given_optionalListOfOptionalsField_rendersInitializerWithListFieldTransformedToFieldData() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    type Animal {
+      species: String!
+      friends: [Animal]
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        friends {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+        public init(
+          friends: [Friend?]? = nil
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": TestSchema.Objects.Animal.typename,
+            "friends": friends._fieldData,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self)
+            ])
+          ]))
+        }
+      """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+  }
   
   func test__render_given_entityFieldSelection_rendersInitializer() throws {
     // given

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_LocalCacheMutation_Tests.swift
@@ -155,7 +155,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
   }
 
   // MARK: - Accessor Tests
@@ -237,7 +237,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 16, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
   }
 
   func test__render_fieldAccessors__rendersFieldAccessorWithGetterAndSetter() throws {
@@ -276,7 +276,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_inlineFragmentAccessors__rendersAccessorWithGetterAndSetter() throws {
@@ -321,7 +321,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 11, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
   func test__render_namedFragmentAccessors__givenFragmentWithNoConditions_rendersAccessorWithGetterModifierAndSetterUnavailable() throws {
@@ -366,7 +366,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 21, ignoringExtraLines: true))
   }
 
   func test__render_namedFragmentAccessors__givenFragmentWithConditions_rendersAccessorAsOptionalWithGetterAndSetter() throws {
@@ -411,7 +411,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
     let actual = subject.render(field: allAnimals)
 
     // then
-    expect(actual).to(equalLineByLine(expected, atLine: 20, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 21, ignoringExtraLines: true))
   }
 
   // MARK: - Casing Tests
@@ -551,7 +551,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       public struct AsDog: Myschema.MutableInlineFragment {
     """
 
-    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
   }
 
   func test__casingForMutableInlineFragment__givenUppercasedSchemaName_generatesUppercasedNamespace() throws {
@@ -593,7 +593,7 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       public struct AsDog: MYSCHEMA.MutableInlineFragment {
     """
 
-    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
   }
 
   func test__casingForMutableInlineFragment__givenCapitalizedSchemaName_generatesCapitalizedNamespace() throws {
@@ -635,6 +635,6 @@ class SelectionSetTemplate_LocalCacheMutationTests: XCTestCase {
       public struct AsDog: MySchema.MutableInlineFragment {
     """
 
-    expect(actual).to(equalLineByLine(expected, atLine: 17, ignoringExtraLines: true))
+    expect(actual).to(equalLineByLine(expected, atLine: 18, ignoringExtraLines: true))
   }
 }

--- a/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
+++ b/Tests/ApolloTests/Cache/ReadWriteFromStoreTests.swift
@@ -1670,6 +1670,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
         override class var __parentType: ParentType { Types.Human }
         override class var __selections: [Selection] {[
+          .field("__typename", String.self),
           .include(if: "a", .inlineFragment(IfA.self)),
           .include(if: "b", .inlineFragment(IfB.self))
         ]}
@@ -1711,6 +1712,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
 
             override class var __parentType: ParentType { Types.Human }
             override class var __selections: [Selection] {[
+              .field("__typename", String.self),
               .field("name", String.self)
             ]}
 
@@ -2237,6 +2239,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
       init(_dataDict: DataDict) { __data = _dataDict }
 
       static var __selections: [Selection] { [
+        .field("__typename", String.self),
         .field("id", String.self),
         .field("friends", [Friend].self),
       ]}
@@ -2251,6 +2254,7 @@ class ReadWriteFromStoreTests: XCTestCase, CacheDependentTesting, StoreLoading {
         init(_dataDict: DataDict) { __data = _dataDict }
 
         static var __selections: [Selection] { [
+          .field("__typename", String.self),
           .field("id", String.self),
           .field("name", String.self),
         ]}

--- a/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
+++ b/Tests/ApolloTests/GraphQLExecutor_SelectionSetMapper_FromResponse_Tests.swift
@@ -841,7 +841,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
   // MARK: - Inline Fragments
 
-  func test__inlineFragment__withoutExplicitTypeNameSelection_selectsTypenameField() throws {
+  func test__inlineFragment__withoutTypenameMatchingCondition_selectsTypeCaseField() throws {
     // given
     struct Types {
       static let Human = Object(typename: "Human", implementedInterfaces: [])
@@ -860,6 +860,7 @@ class GraphQLExecutor_SelectionSetMapper_FromResponse_Tests: XCTestCase {
 
         override class var __parentType: ParentType { Types.MockChildObject }
         override class var __selections: [Selection] {[
+          .field("__typename", String.self),
           .inlineFragment(AsHuman.self)
         ]}
 

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -925,6 +925,127 @@ class SelectionSetTests: XCTestCase {
 
   // MARK: - Initializer Tests
 
+  func test__selectionInitializer_givenOptionalListOfOptionalEntitiesField__setsFieldDataCorrectly() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Hero: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("friends", [Friend?]?.self)
+      ]}
+
+      var friends: [Friend?]? { __data["friends"] }
+
+      convenience init(
+        friends: [Friend?]? = nil
+      ) {
+        self.init(_dataDict: DataDict(data: [
+          "__typename": Types.Human.typename,
+          "friends": friends._fieldData,
+          "__fulfilled": Set([
+            ObjectIdentifier(Self.self),
+          ])
+        ]))
+      }
+
+      class Friend: MockSelectionSet {
+        typealias Schema = MockSchemaMetadata
+
+        override class var __parentType: ParentType { Types.Human }
+        override class var __selections: [Selection] {[
+          .field("name", String.self)
+        ]}
+        var name: String { __data["name"] }
+
+        convenience init(
+          name: String
+        ) {
+          self.init(_dataDict: DataDict(data: [
+            "__typename": Types.Human.typename,
+            "name": name,
+            "__fulfilled": Set([
+              ObjectIdentifier(Self.self),
+            ])
+          ]))
+        }
+      }
+    }
+
+    // when
+    let actual = Hero(friends: [
+      .init(name: "Han"),
+      nil,
+      .init(name: "Leia"),
+    ])
+
+    // then
+    expect(actual.friends?[0]?.name).to(equal("Han"))
+    expect(actual.friends?[1]).to(beNil())
+    expect(actual.friends?[2]?.name).to(equal("Leia"))
+  }
+
+  func test__selectionInitializer_givenOptionalListOfOptionalScalarsField__setsFieldDataCorrectly() {
+    // given
+    struct Types {
+      static let Human = Object(typename: "Human", implementedInterfaces: [])
+    }
+
+    MockSchemaMetadata.stub_objectTypeForTypeName = {
+      switch $0 {
+      case "Human": return Types.Human
+      default: XCTFail(); return nil
+      }
+    }
+
+    class Hero: MockSelectionSet {
+      typealias Schema = MockSchemaMetadata
+
+      override class var __parentType: ParentType { Types.Human }
+      override class var __selections: [Selection] {[
+        .field("names", [String?]?.self)
+      ]}
+
+      var names: [String?]? { __data["names"] }
+
+      convenience init(
+        names: [String?]? = nil
+      ) {
+        self.init(_dataDict: DataDict(data: [
+          "__typename": Types.Human.typename,
+          "names": names,
+          "__fulfilled": Set([
+            ObjectIdentifier(Self.self),
+          ])
+        ]))
+      }
+
+    }
+
+    // when
+    let actual = Hero(names: [
+      "Han",
+      nil,
+      "Leia",
+    ])
+
+    // then
+    expect(actual.names?[0]).to(equal("Han"))
+    expect(actual.names?[1]).to(beNil())
+    expect(actual.names?[2]).to(equal("Leia"))
+  }
+
   func test__selectionInitializer_givenInitTypeWithTypeCondition__canConvertToConditionalType() {
     // given
     struct Types {

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetails.graphql.swift
@@ -41,6 +41,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Unions.ClassroomPet }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .inlineFragment(AsAnimal.self),
       .inlineFragment(AsPet.self),
       .inlineFragment(AsWarmBlooded.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -23,6 +23,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Unions.ClassroomPet }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .inlineFragment(AsAnimal.self),
     ] }
 
@@ -52,6 +53,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("inches", Int.self),
         ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/DogFragment.graphql.swift
@@ -17,6 +17,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Dog }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("species", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/HeightInMeters.graphql.swift
@@ -20,6 +20,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("height", Height.self),
     ] }
 
@@ -34,6 +35,7 @@ public extension MyGraphQLSchema {
 
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("meters", Int.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/PetDetails.graphql.swift
@@ -22,6 +22,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("humanName", String?.self),
       .field("favoriteToy", String.self),
       .field("owner", Owner?.self),
@@ -40,6 +41,7 @@ public extension MyGraphQLSchema {
 
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Human }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("firstName", String.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Fragments/WarmBloodedDetails.graphql.swift
@@ -18,6 +18,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.WarmBlooded }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("bodyTemperature", Int.self),
       .fragment(HeightInMeters.self),
     ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -44,6 +44,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("species", String.self),
           .field("skinCovering", GraphQLEnum<MyGraphQLSchema.SkinCovering>?.self),
           .inlineFragment(AsBird.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -20,6 +20,7 @@ public extension MyGraphQLSchema {
 
     public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("owner", Owner?.self),
     ] }
 
@@ -50,6 +51,7 @@ public extension MyGraphQLSchema {
 
       public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Human }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("firstName", String.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -61,6 +61,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", MyGraphQLSchema.ID.self),
           .field("humanName", String?.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -47,6 +47,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", MyGraphQLSchema.ID.self),
           .field("humanName", String?.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -44,6 +44,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("height", Height?.self),
         ] }
 
@@ -58,6 +59,7 @@ public extension MyGraphQLSchema {
 
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("feet", Int?.self),
             .field("inches", Int.self),
           ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -109,6 +109,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("height", Height.self),
           .field("skinCovering", GraphQLEnum<MyGraphQLSchema.SkinCovering>?.self),
           .field("predators", [Predator].self),
@@ -147,6 +148,7 @@ public extension MyGraphQLSchema {
 
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("feet", Int.self),
             .field("inches", Int?.self),
           ] }
@@ -164,6 +166,7 @@ public extension MyGraphQLSchema {
 
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .include(if: "includeSpecies", .field("species", String.self)),
             .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
           ] }
@@ -326,6 +329,7 @@ public extension MyGraphQLSchema {
 
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .include(if: "varA", [
                 .field("relativeSize", GraphQLEnum<MyGraphQLSchema.RelativeSize>.self),
                 .field("centimeters", Double.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -91,6 +91,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("height", Height.self),
           .field("species", String.self),
           .field("skinCovering", GraphQLEnum<MyGraphQLSchema.SkinCovering>?.self),
@@ -130,6 +131,7 @@ public extension MyGraphQLSchema {
 
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("feet", Int.self),
             .field("inches", Int?.self),
           ] }
@@ -148,6 +150,7 @@ public extension MyGraphQLSchema {
 
           public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("species", String.self),
             .inlineFragment(AsWarmBlooded.self),
           ] }
@@ -194,6 +197,7 @@ public extension MyGraphQLSchema {
 
               public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
               public static var __selections: [ApolloAPI.Selection] { [
+                .field("__typename", String.self),
                 .field("species", String.self),
               ] }
 
@@ -286,6 +290,7 @@ public extension MyGraphQLSchema {
 
             public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Objects.Height }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .field("relativeSize", GraphQLEnum<MyGraphQLSchema.RelativeSize>.self),
               .field("centimeters", Double.self),
             ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -41,6 +41,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .fragment(ClassroomPetDetailsCCN.self),
         ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -41,6 +41,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Unions.ClassroomPet }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .fragment(ClassroomPetDetails.self),
         ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/DogQuery.graphql.swift
@@ -45,6 +45,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", MyGraphQLSchema.ID.self),
           .inlineFragment(AsDog.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-InSchemaModule/Sources/MySwiftPackage/Operations/Queries/PetSearchQuery.graphql.swift
@@ -58,6 +58,7 @@ public extension MyGraphQLSchema {
 
         public static var __parentType: ApolloAPI.ParentType { MyGraphQLSchema.Interfaces.Pet }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("id", MyGraphQLSchema.ID.self),
           .field("humanName", String?.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -109,6 +109,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("skinCovering", GraphQLEnum<MySchemaModule.SkinCovering>?.self),
         .field("predators", [Predator].self),
@@ -147,6 +148,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -164,6 +166,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .include(if: "includeSpecies", .field("species", String.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         ] }
@@ -326,6 +329,7 @@ class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .include(if: "varA", [
               .field("relativeSize", GraphQLEnum<MySchemaModule.RelativeSize>.self),
               .field("centimeters", Double.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsLocalCacheMutation.graphql.swift
@@ -44,6 +44,7 @@ class AllAnimalsLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<MySchemaModule.SkinCovering>?.self),
         .inlineFragment(AsBird.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/AllAnimalsQuery.graphql.swift
@@ -87,6 +87,7 @@ class AllAnimalsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<MySchemaModule.SkinCovering>?.self),
@@ -126,6 +127,7 @@ class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -144,6 +146,7 @@ class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("species", String.self),
           .inlineFragment(AsWarmBlooded.self),
         ] }
@@ -265,6 +268,7 @@ class AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("relativeSize", GraphQLEnum<MySchemaModule.RelativeSize>.self),
             .field("centimeters", Double.self),
           ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetDetails.graphql.swift
@@ -41,6 +41,7 @@ struct ClassroomPetDetails: MySchemaModule.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
     .inlineFragment(AsPet.self),
     .inlineFragment(AsWarmBlooded.self),

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ClassroomPetsQuery.graphql.swift
@@ -41,6 +41,7 @@ class ClassroomPetsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetails.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogFragment.graphql.swift
@@ -17,6 +17,7 @@ struct DogFragment: MySchemaModule.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Dog }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("species", String.self),
   ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/DogQuery.graphql.swift
@@ -41,6 +41,7 @@ class DogQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Dog }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(DogFragment.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/HeightInMeters.graphql.swift
@@ -20,6 +20,7 @@ struct HeightInMeters: MySchemaModule.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("height", Height.self),
   ] }
 
@@ -34,6 +35,7 @@ struct HeightInMeters: MySchemaModule.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("meters", Int.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetAdoptionMutation.graphql.swift
@@ -47,6 +47,7 @@ class PetAdoptionMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", MySchemaModule.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetails.graphql.swift
@@ -22,6 +22,7 @@ struct PetDetails: MySchemaModule.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("humanName", String?.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner?.self),
@@ -40,6 +41,7 @@ struct PetDetails: MySchemaModule.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetDetailsMutation.graphql.swift
@@ -20,6 +20,7 @@ struct PetDetailsMutation: MySchemaModule.MutableSelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("owner", Owner?.self),
   ] }
 
@@ -50,6 +51,7 @@ struct PetDetailsMutation: MySchemaModule.MutableSelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/PetSearchQuery.graphql.swift
@@ -58,6 +58,7 @@ class PetSearchQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", MySchemaModule.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/WarmBloodedDetails.graphql.swift
@@ -18,6 +18,7 @@ struct WarmBloodedDetails: MySchemaModule.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.WarmBlooded }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/AllAnimalsCCNQuery.graphql.swift
@@ -44,6 +44,7 @@ class AllAnimalsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height?.self),
       ] }
 
@@ -58,6 +59,7 @@ class AllAnimalsCCNQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int?.self),
           .field("inches", Int.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetDetailsCCN.graphql.swift
@@ -23,6 +23,7 @@ struct ClassroomPetDetailsCCN: MySchemaModule.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
   ] }
 
@@ -52,6 +53,7 @@ struct ClassroomPetDetailsCCN: MySchemaModule.SelectionSet, Fragment {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Objects.Height }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("inches", Int.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/EmbeddedInTarget-RelativeAbsolute/PackageOne/Sources/PackageOne/graphql/ccnGraphql/ClassroomPetsCCNQuery.graphql.swift
@@ -41,6 +41,7 @@ class ClassroomPetsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { MySchemaModule.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetailsCCN.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetails.graphql.swift
@@ -34,6 +34,7 @@ public struct ClassroomPetDetails: MyCustomProject.SelectionSet, Fragment {
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Unions.ClassroomPet }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
     .inlineFragment(AsPet.self),
     .inlineFragment(AsWarmBlooded.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -21,6 +21,7 @@ public struct ClassroomPetDetailsCCN: MyCustomProject.SelectionSet, Fragment {
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Unions.ClassroomPet }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
   ] }
 
@@ -50,6 +51,7 @@ public struct ClassroomPetDetailsCCN: MyCustomProject.SelectionSet, Fragment {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("inches", Int.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/DogFragment.graphql.swift
@@ -16,6 +16,7 @@ public struct DogFragment: MyCustomProject.SelectionSet, Fragment {
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Dog }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .field("species", String.self),
   ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/HeightInMeters.graphql.swift
@@ -19,6 +19,7 @@ public struct HeightInMeters: MyCustomProject.SelectionSet, Fragment {
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .field("height", Height.self),
   ] }
 
@@ -33,6 +34,7 @@ public struct HeightInMeters: MyCustomProject.SelectionSet, Fragment {
 
     public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
     public static var __selections: [Apollo.Selection] { [
+      .field("__typename", String.self),
       .field("meters", Int.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/PetDetails.graphql.swift
@@ -21,6 +21,7 @@ public struct PetDetails: MyCustomProject.SelectionSet, Fragment {
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .field("humanName", String?.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner?.self),
@@ -39,6 +40,7 @@ public struct PetDetails: MyCustomProject.SelectionSet, Fragment {
 
     public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Human }
     public static var __selections: [Apollo.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Fragments/WarmBloodedDetails.graphql.swift
@@ -17,6 +17,7 @@ public struct WarmBloodedDetails: MyCustomProject.SelectionSet, Fragment {
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.WarmBlooded }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<MyCustomProject.SkinCovering>?.self),
         .inlineFragment(AsBird.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -19,6 +19,7 @@ public struct PetDetailsMutation: MyCustomProject.MutableSelectionSet, Fragment 
 
   public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
   public static var __selections: [Apollo.Selection] { [
+    .field("__typename", String.self),
     .field("owner", Owner?.self),
   ] }
 
@@ -49,6 +50,7 @@ public struct PetDetailsMutation: MyCustomProject.MutableSelectionSet, Fragment 
 
     public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Human }
     public static var __selections: [Apollo.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -60,6 +60,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("id", MyCustomProject.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -46,6 +46,7 @@ public class PetAdoptionMutation: GraphQLMutation {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("id", MyCustomProject.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height?.self),
       ] }
 
@@ -57,6 +58,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
         public static var __selections: [Apollo.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int?.self),
           .field("inches", Int.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -102,6 +102,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("skinCovering", GraphQLEnum<MyCustomProject.SkinCovering>?.self),
         .field("predators", [Predator].self),
@@ -140,6 +141,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
         public static var __selections: [Apollo.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -157,6 +159,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
         public static var __selections: [Apollo.Selection] { [
+          .field("__typename", String.self),
           .include(if: "includeSpecies", .field("species", String.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         ] }
@@ -319,6 +322,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
           public static var __selections: [Apollo.Selection] { [
+            .field("__typename", String.self),
             .include(if: "varA", [
               .field("relativeSize", GraphQLEnum<MyCustomProject.RelativeSize>.self),
               .field("centimeters", Double.self),

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -83,6 +83,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<MyCustomProject.SkinCovering>?.self),
@@ -122,6 +123,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
         public static var __selections: [Apollo.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -140,6 +142,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
         public static var __selections: [Apollo.Selection] { [
+          .field("__typename", String.self),
           .field("species", String.self),
           .inlineFragment(AsWarmBlooded.self),
         ] }
@@ -186,6 +189,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
             public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
             public static var __selections: [Apollo.Selection] { [
+              .field("__typename", String.self),
               .field("species", String.self),
             ] }
 
@@ -278,6 +282,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: Apollo.ParentType { MyCustomProject.Objects.Height }
           public static var __selections: [Apollo.Selection] { [
+            .field("__typename", String.self),
             .field("relativeSize", GraphQLEnum<MyCustomProject.RelativeSize>.self),
             .field("centimeters", Double.self),
           ] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -40,6 +40,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Unions.ClassroomPet }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetailsCCN.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -40,6 +40,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Unions.ClassroomPet }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetails.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/DogQuery.graphql.swift
@@ -43,6 +43,7 @@ public class DogQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Animal }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("id", MyCustomProject.ID.self),
         .inlineFragment(AsDog.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CocoaPods/MyCustomProject/Operations/Queries/PetSearchQuery.graphql.swift
@@ -57,6 +57,7 @@ public class PetSearchQuery: GraphQLQuery {
 
       public static var __parentType: Apollo.ParentType { MyCustomProject.Interfaces.Pet }
       public static var __selections: [Apollo.Selection] { [
+        .field("__typename", String.self),
         .field("id", MyCustomProject.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetails.graphql.swift
@@ -40,6 +40,7 @@ public struct ClassroomPetDetails: GraphQLAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
     .inlineFragment(AsPet.self),
     .inlineFragment(AsWarmBlooded.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -22,6 +22,7 @@ public struct ClassroomPetDetailsCCN: GraphQLAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
   ] }
 
@@ -51,6 +52,7 @@ public struct ClassroomPetDetailsCCN: GraphQLAPI.SelectionSet, Fragment {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("inches", Int.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/DogFragment.graphql.swift
@@ -16,6 +16,7 @@ public struct DogFragment: GraphQLAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Dog }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("species", String.self),
   ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/HeightInMeters.graphql.swift
@@ -19,6 +19,7 @@ public struct HeightInMeters: GraphQLAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("height", Height.self),
   ] }
 
@@ -33,6 +34,7 @@ public struct HeightInMeters: GraphQLAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("meters", Int.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/PetDetails.graphql.swift
@@ -21,6 +21,7 @@ public struct PetDetails: GraphQLAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("humanName", String?.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner?.self),
@@ -39,6 +40,7 @@ public struct PetDetails: GraphQLAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Fragments/WarmBloodedDetails.graphql.swift
@@ -17,6 +17,7 @@ public struct WarmBloodedDetails: GraphQLAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.WarmBlooded }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<GraphQLAPI.SkinCovering>?.self),
         .inlineFragment(AsBird.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -19,6 +19,7 @@ public struct PetDetailsMutation: GraphQLAPI.MutableSelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("owner", Owner?.self),
   ] }
 
@@ -49,6 +50,7 @@ public struct PetDetailsMutation: GraphQLAPI.MutableSelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -46,6 +46,7 @@ public class PetAdoptionMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", GraphQLAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height?.self),
       ] }
 
@@ -57,6 +58,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int?.self),
           .field("inches", Int.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -108,6 +108,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("skinCovering", GraphQLEnum<GraphQLAPI.SkinCovering>?.self),
         .field("predators", [Predator].self),
@@ -146,6 +147,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -163,6 +165,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .include(if: "includeSpecies", .field("species", String.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         ] }
@@ -325,6 +328,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .include(if: "varA", [
               .field("relativeSize", GraphQLEnum<GraphQLAPI.RelativeSize>.self),
               .field("centimeters", Double.self),

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -86,6 +86,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<GraphQLAPI.SkinCovering>?.self),
@@ -125,6 +126,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -143,6 +145,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("species", String.self),
           .inlineFragment(AsWarmBlooded.self),
         ] }
@@ -264,6 +267,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("relativeSize", GraphQLEnum<GraphQLAPI.RelativeSize>.self),
             .field("centimeters", Double.self),
           ] }

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -40,6 +40,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetailsCCN.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -40,6 +40,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetails.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/DogQuery.graphql.swift
@@ -40,6 +40,7 @@ public class DogQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Objects.Dog }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(DogFragment.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/Other-CustomTarget/GraphQLAPI/Operations/Queries/PetSearchQuery.graphql.swift
@@ -57,6 +57,7 @@ public class PetSearchQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { GraphQLAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", GraphQLAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -40,6 +40,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
     .inlineFragment(AsPet.self),
     .inlineFragment(AsWarmBlooded.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -22,6 +22,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .inlineFragment(AsAnimal.self),
   ] }
 
@@ -51,6 +52,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("inches", Int.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/DogFragment.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/DogFragment.graphql.swift
@@ -16,6 +16,7 @@ public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Dog }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("species", String.self),
   ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/HeightInMeters.graphql.swift
@@ -19,6 +19,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("height", Height.self),
   ] }
 
@@ -33,6 +34,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("meters", Int.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/PetDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/PetDetails.graphql.swift
@@ -21,6 +21,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("humanName", String?.self),
     .field("favoriteToy", String.self),
     .field("owner", Owner?.self),
@@ -39,6 +40,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -17,6 +17,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.WarmBlooded }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("bodyTemperature", Int.self),
     .fragment(HeightInMeters.self),
   ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
         .inlineFragment(AsBird.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -19,6 +19,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
 
   public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
   public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
     .field("owner", Owner?.self),
   ] }
 
@@ -49,6 +50,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
 
     public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Human }
     public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
       .field("firstName", String.self),
     ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -60,6 +60,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -46,6 +46,7 @@ public class PetAdoptionMutation: GraphQLMutation {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .field("humanName", String?.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -43,6 +43,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height?.self),
       ] }
 
@@ -57,6 +58,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int?.self),
           .field("inches", Int.self),
         ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -108,6 +108,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
         .field("predators", [Predator].self),
@@ -146,6 +147,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -163,6 +165,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .include(if: "includeSpecies", .field("species", String.self)),
           .include(if: "getWarmBlooded", .inlineFragment(AsWarmBlooded.self)),
         ] }
@@ -325,6 +328,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .include(if: "varA", [
               .field("relativeSize", GraphQLEnum<AnimalKingdomAPI.RelativeSize>.self),
               .field("centimeters", Double.self),

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -90,6 +90,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("height", Height.self),
         .field("species", String.self),
         .field("skinCovering", GraphQLEnum<AnimalKingdomAPI.SkinCovering>?.self),
@@ -129,6 +130,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("feet", Int.self),
           .field("inches", Int?.self),
         ] }
@@ -147,6 +149,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
         public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
         public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
           .field("species", String.self),
           .inlineFragment(AsWarmBlooded.self),
         ] }
@@ -193,6 +196,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
             public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
             public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
               .field("species", String.self),
             ] }
 
@@ -285,6 +289,7 @@ public class AllAnimalsQuery: GraphQLQuery {
 
           public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Height }
           public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
             .field("relativeSize", GraphQLEnum<AnimalKingdomAPI.RelativeSize>.self),
             .field("centimeters", Double.self),
           ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -40,6 +40,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetailsCCN.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -40,6 +40,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Unions.ClassroomPet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .fragment(ClassroomPetDetails.self),
       ] }
 

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -44,6 +44,7 @@ public class DogQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Animal }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .inlineFragment(AsDog.self),
       ] }

--- a/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Tests/TestCodeGenConfigurations/SPMInXcodeProject/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -57,6 +57,7 @@ public class PetSearchQuery: GraphQLQuery {
 
       public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Interfaces.Pet }
       public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
         .field("id", AnimalKingdomAPI.ID.self),
         .field("humanName", String?.self),
       ] }


### PR DESCRIPTION
Add __typename selection to root of each entity (except operation root) and remove __typename addition from GraphQLExecutor