### PR TITLE
fix nil AnyHashable

### DIFF
--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -88,11 +88,16 @@ extension Optional: SelectionSetEntityValue where Wrapped: SelectionSetEntityVal
   /// - Warning: This function is not supported for external use.
   /// Unsupported usage may result in unintended consequences including crashes.
   @inlinable public init(_fieldData data: AnyHashable?) {
-    guard case let .some(data) = data else {
-      self = .none
-      return
+    switch data {
+      case .none:
+        self = .none
+      case .some(let hashable):
+        if let optional = hashable.base as? Optional<AnyHashable>, optional == nil {
+          self = .none
+          return
+        }
+        self = .some(Wrapped.init(_fieldData: data))
     }
-    self = .some(Wrapped.init(_fieldData: data))
   }
 
   @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }


### PR DESCRIPTION
This attempts to fix #2907, which does the job in our use case, though I don't know if there is a better way to tackle this, as this could probably be fixed up the stack somewhere.

This approach unwraps the data from a double optional if required.