### PR TITLE
fix data dict lookup

### DIFF
--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -24,7 +24,13 @@ public struct DataDict: Hashable {
   }
 
   @inlinable public subscript<T: AnyScalarType & Hashable>(_ key: String) -> T {
-    get { _data[key]?.base as! T }
+    get {
+#if swift(>=5.4)
+        _data[key] as! T
+#else
+        _data[key]?.base as! T
+#endif
+    }
     set { _data[key] = newValue }
     _modify {
       var value = _data[key] as! T
@@ -110,7 +116,13 @@ extension Array: SelectionSetEntityValue where Element: SelectionSetEntityValue 
     guard let data = data as? [AnyHashable?] else {
       fatalError("\(Self.self) expected list of data for entity.")
     }
-    self = data.map { Element.init(_fieldData:$0?.base as? AnyHashable) }
+    self = data.map {
+#if swift(>=5.4)
+        Element.init(_fieldData:$0)
+#else
+        Element.init(_fieldData:$0?.base as? AnyHashable)
+#endif
+    }
   }
 
   @inlinable public var _fieldData: AnyHashable { map(\._fieldData) }


### PR DESCRIPTION
We're seeing the same crash caused by https://github.com/apollographql/apollo-ios/pull/2784 as noted in https://github.com/apollographql/apollo-ios/issues/2861.

I haven't had the time to delve into why this is occurring, but we were hydrating a model with a mock json string.

This puts in a swift version check to maintain the iOS <= 14.4 fix.