### PR TITLE
update: HTTP subscriptions protocol update

### DIFF
--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -113,12 +113,6 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
             )
           }
 
-          if let done = object["done"] as? Bool, done {
-            // Exit at this point because the router will close the connection; errors would have
-            // been reported or the subscription is complete.
-            return
-          }
-
           guard
             let payload = object["payload"] as? JSONObject,
             let data: Data = try? JSONSerializationFormat.serialize(value: payload)

--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -99,7 +99,6 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
             )
             return
           }
-          continue
 
         case let .json(object):
           if let errors = object["errors"] as? [JSONObject] {
@@ -135,8 +134,6 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
             chain.proceedAsync(request: request, response: response, completion: completion)
           }
 
-          continue
-
         case .unknown:
           chain.handleErrorAsync(
             MultipartResponseParsingError.cannotParseChunkData,
@@ -144,7 +141,6 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
             response: response,
             completion: completion
           )
-          continue
         }
       }
     }

--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -111,6 +111,9 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
               response: response,
               completion: completion
             )
+
+            // These are fatal-level transport errors, don't process anything else.
+            return
           }
 
           guard

--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -81,7 +81,7 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
     }
 
     for chunk in dataString.components(separatedBy: "--\(boundaryString)") {
-      if chunk.isEmpty { continue }
+      if chunk.isEmpty || chunk.isBoundaryPrefix { continue }
 
       for dataLine in chunk.components(separatedBy: Self.dataLineSeparator.description) {
         switch (parse(dataLine: dataLine.trimmingCharacters(in: .newlines))) {
@@ -171,4 +171,8 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
 
     return .unknown
   }
+}
+
+fileprivate extension String {
+  var isBoundaryPrefix: Bool { self == "--" }
 }

--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -116,25 +116,24 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
             return
           }
 
-          guard
-            let payload = object["payload"] as? JSONObject,
-            let data: Data = try? JSONSerializationFormat.serialize(value: payload)
-          else {
-            chain.handleErrorAsync(
-              MultipartResponseParsingError.cannotParsePayloadData,
-              request: request,
-              response: response,
-              completion: completion
-            )
-            return
-          }
+          if let payload = object["payload"] as? JSONObject {
+            guard let data: Data = try? JSONSerializationFormat.serialize(value: payload) else {
+              chain.handleErrorAsync(
+                MultipartResponseParsingError.cannotParsePayloadData,
+                request: request,
+                response: response,
+                completion: completion
+              )
+              return
+            }
 
-          let response = HTTPResponse<Operation>(
-            response: response.httpResponse,
-            rawData: data,
-            parsedResponse: nil
-          )
-          chain.proceedAsync(request: request, response: response, completion: completion)
+            let response = HTTPResponse<Operation>(
+              response: response.httpResponse,
+              rawData: data,
+              parsedResponse: nil
+            )
+            chain.proceedAsync(request: request, response: response, completion: completion)
+          }
 
           continue
 

--- a/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
@@ -6,6 +6,8 @@ import ApolloInternalTestHelpers
 
 final class MultipartResponseParsingInterceptorTests: XCTestCase {
 
+  let defaultTimeout = 0.5
+
   private class ErrorRequestChain: RequestChain {
     var isCancelled: Bool = false
     var error: Error? = nil
@@ -117,8 +119,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
               {
                 "message" : "forced test failure!"
               }
-            ],
-            "done": true
+            ]
           }
           --graphql
           """.crlfFormattedData()
@@ -225,7 +226,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
       expectation.fulfill()
     }
 
-    wait(for: [expectation], timeout: 1)
+    wait(for: [expectation], timeout: defaultTimeout)
   }
 
   func test__parsing__givenPayloadNull_shouldIgnore() throws {
@@ -240,14 +241,14 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
       """.crlfFormattedData()
     )
 
-    let expectation = expectation(description: "Heartbeat ignored")
+    let expectation = expectation(description: "Payload (null) ignored")
     expectation.isInverted = true
 
     _ = network.send(operation: MockSubscription<Time>()) { result in
       expectation.fulfill()
     }
 
-    wait(for: [expectation], timeout: 1)
+    wait(for: [expectation], timeout: defaultTimeout)
   }
 
   func test__parsing__givenSingleChunk_shouldReturnSuccess() throws {
@@ -287,7 +288,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
       }
     }
 
-    wait(for: [expectation], timeout: 1)
+    wait(for: [expectation], timeout: defaultTimeout)
   }
 
   func test__parsing__givenMultipleChunks_shouldReturnMultipleSuccesses() throws {
@@ -340,7 +341,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
       }
     }
 
-    wait(for: [expectation], timeout: 1)
+    wait(for: [expectation], timeout: defaultTimeout)
   }
 
   func test__parsing__givenChunkWithGraphQLError_shouldReturnSuccessWithGraphQLError() throws {
@@ -386,7 +387,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
       }
     }
 
-    wait(for: [expectation], timeout: 1)
+    wait(for: [expectation], timeout: defaultTimeout)
   }
   
   func test__parsing__givenEndOfStream_shouldReturnSuccess() throws {
@@ -426,6 +427,6 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
       }
     }
 
-    wait(for: [expectation], timeout: 1)
+    wait(for: [expectation], timeout: defaultTimeout)
   }
 }


### PR DESCRIPTION
Changes per the protocol spec to:
- remove `done` from JSON test data
- handle null `payload` data
- end processing when a fatal error is received
- fix crash at end of steam terminator