### PR TITLE
fix: Cocoapods build

### DIFF
--- a/Sources/Apollo/ApolloInterceptorReentrantWrapper.swift
+++ b/Sources/Apollo/ApolloInterceptorReentrantWrapper.swift
@@ -96,7 +96,7 @@ extension ApolloInterceptorReentrantWrapper : ApolloInterceptor {
     request: HTTPRequest<Operation>,
     response: HTTPResponse<Operation>?,
     completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void
-  ) where Operation : ApolloAPI.GraphQLOperation {
+  ) where Operation : GraphQLOperation {
     wrappedInterceptor.interceptAsync(
       chain: self,
       request: request,

--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -50,7 +50,7 @@ public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
     request: HTTPRequest<Operation>,
     response: HTTPResponse<Operation>?,
     completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void
-  ) where Operation : ApolloAPI.GraphQLOperation {
+  ) where Operation : GraphQLOperation {
 
     guard let response else {
       chain.handleErrorAsync(

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -1,7 +1,7 @@
 #if !COCOAPODS
 @_exported @testable import ApolloAPI
-#endif
 @testable import Apollo
+#endif
 import Foundation
 
 @dynamicMemberLookup


### PR DESCRIPTION
Fixes #2936 

* Remove `ApolloAPI` module reference in type declarations
* Move import statement into non-cocoapod section