### PR TITLE
Add injecting additionalErrorHandler for upload operations to RequestChainNetworkTransport

### DIFF
--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -107,9 +107,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
     callbackQueue: DispatchQueue = .main,
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     
-    let interceptors = self.interceptorProvider.interceptors(for: operation)
-    let chain = InterceptorRequestChain(interceptors: interceptors, callbackQueue: callbackQueue)
-    chain.additionalErrorHandler = self.interceptorProvider.additionalErrorInterceptor(for: operation)
+    let chain = makeChain(operation: operation, callbackQueue: callbackQueue)
     let request = self.constructRequest(for: operation,
                                         cachePolicy: cachePolicy,
                                         contextIdentifier: contextIdentifier)
@@ -159,10 +157,18 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     
     let request = self.constructUploadRequest(for: operation, with: files)
+    let chain = makeChain(operation: operation, callbackQueue: callbackQueue)
+    chain.kickoff(request: request, completion: completionHandler)
+    return chain
+  }
+
+  public func makeChain<Operation: GraphQLOperation>(
+    operation: Operation,
+    callbackQueue: DispatchQueue = .main
+  ) -> RequestChain {
     let interceptors = self.interceptorProvider.interceptors(for: operation)
     let chain = InterceptorRequestChain(interceptors: interceptors, callbackQueue: callbackQueue)
-    
-    chain.kickoff(request: request, completion: completionHandler)
+    chain.additionalErrorHandler = self.interceptorProvider.additionalErrorInterceptor(for: operation)
     return chain
   }
 }

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -122,6 +122,17 @@ open class RequestChainNetworkTransport: NetworkTransport {
     chain.kickoff(request: request, completion: completionHandler)
     return chain
   }
+
+  private func makeChain<Operation: GraphQLOperation>(
+    operation: Operation,
+    callbackQueue: DispatchQueue = .main
+  ) -> RequestChain {
+    let interceptors = self.interceptorProvider.interceptors(for: operation)
+    let chain = InterceptorRequestChain(interceptors: interceptors, callbackQueue: callbackQueue)
+    chain.additionalErrorHandler = self.interceptorProvider.additionalErrorInterceptor(for: operation)
+    return chain
+  }
+  
 }
 
 extension RequestChainNetworkTransport: UploadingNetworkTransport {
@@ -159,16 +170,6 @@ extension RequestChainNetworkTransport: UploadingNetworkTransport {
     let request = self.constructUploadRequest(for: operation, with: files)
     let chain = makeChain(operation: operation, callbackQueue: callbackQueue)
     chain.kickoff(request: request, completion: completionHandler)
-    return chain
-  }
-
-  public func makeChain<Operation: GraphQLOperation>(
-    operation: Operation,
-    callbackQueue: DispatchQueue = .main
-  ) -> RequestChain {
-    let interceptors = self.interceptorProvider.interceptors(for: operation)
-    let chain = InterceptorRequestChain(interceptors: interceptors, callbackQueue: callbackQueue)
-    chain.additionalErrorHandler = self.interceptorProvider.additionalErrorInterceptor(for: operation)
     return chain
   }
 }


### PR DESCRIPTION
Currently `additionalErrorHandler ` is not being injected to `chain` for `Upload` operations. This PR fixes it and creates `makeChain(operation:callbackQueue:)` method which creates `chain` for `send` and `upload` the same way.