### PR TITLE
test: Apollo client operation cache test when `publishResultToStore` is true

### DIFF
--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -92,7 +92,21 @@ final class ApolloClientOperationTests: XCTestCase {
     self.wait(for: [serverRequestExpectation, performResultFromServerExpectation], timeout: 0.2)
 
     // then
-    expect(self.store.publishedRecordSets).notTo(beEmpty())
+    expect(self.store.publishedRecordSets.count).to(equal(1))
+    
+    let actual = self.store.publishedRecordSets[0]
+    expect(actual["MUTATION_ROOT"]).to(equal(
+      Record(key: "MUTATION_ROOT", [
+        "createReview": CacheReference("MUTATION_ROOT.createReview")
+      ])
+    ))
+    expect(actual["MUTATION_ROOT.createReview"]).to(equal(
+      Record(key: "MUTATION_ROOT.createReview", [
+        "__typename": "Review",
+        "stars": 3,
+        "commentary": ""
+      ])
+    ))
   }
 
   func test__performMutation_givenPublishResultToStore_false_doesNotPublishResultsToStore() throws {

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -41,6 +41,57 @@ final class ApolloClientOperationTests: XCTestCase {
     }
   }
 
+  func test__performMutation_givenPublishResultToStore_true_publishResultsToStore() throws {
+    // given
+    class GivenSelectionSet: MockSelectionSet {
+      override class var __selections: [Selection] { [
+        .field("createReview", CreateReview.self)
+      ] }
+
+      class CreateReview: MockSelectionSet {
+        override class var __selections: [Selection] { [
+          .field("__typename", String.self),
+          .field("stars", Int.self),
+          .field("commentary", String?.self)
+        ] }
+      }
+    }
+    let mutation = MockMutation<GivenSelectionSet>()
+    let resultObserver = self.makeResultObserver(for: mutation)
+
+    let serverRequestExpectation = self.server.expect(MockMutation<GivenSelectionSet>.self) { _ in
+      [
+        "data": [
+          "createReview": [
+            "__typename": "Review",
+            "stars": 3,
+            "commentary": ""
+          ]
+        ]
+      ]
+    }
+
+    let performResultFromServerExpectation =
+      resultObserver.expectation(description: "Mutation was successful") { result in
+        switch (result) {
+        case .success:
+          break
+        case let .failure(error):
+          fail("Unexpected failure! \(error)")
+        }
+      }
+
+    // when
+    self.client.perform(mutation: mutation,
+                        publishResultToStore: true,
+                        resultHandler: resultObserver.handler)
+
+    self.wait(for: [serverRequestExpectation, performResultFromServerExpectation], timeout: 0.2)
+
+    // then
+    expect(self.store.publishedRecordSets).notTo(beEmpty())
+  }
+
   func test__performMutation_givenPublishResultToStore_false_doesNotPublishResultsToStore() throws {
     // given
     class GivenSelectionSet: MockSelectionSet {

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -41,21 +41,22 @@ final class ApolloClientOperationTests: XCTestCase {
     }
   }
 
-  func test__performMutation_givenPublishResultToStore_true_publishResultsToStore() throws {
-    // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("createReview", CreateReview.self)
-      ] }
+  // given
+  class GivenSelectionSet: MockSelectionSet {
+    override class var __selections: [Selection] { [
+      .field("createReview", CreateReview.self)
+    ] }
 
-      class CreateReview: MockSelectionSet {
-        override class var __selections: [Selection] { [
-          .field("__typename", String.self),
-          .field("stars", Int.self),
-          .field("commentary", String?.self)
-        ] }
-      }
+    class CreateReview: MockSelectionSet {
+      override class var __selections: [Selection] { [
+        .field("__typename", String.self),
+        .field("stars", Int.self),
+        .field("commentary", String?.self)
+      ] }
     }
+  }
+
+  func test__performMutation_givenPublishResultToStore_true_publishResultsToStore() throws {
     let mutation = MockMutation<GivenSelectionSet>()
     let resultObserver = self.makeResultObserver(for: mutation)
 
@@ -93,20 +94,6 @@ final class ApolloClientOperationTests: XCTestCase {
   }
 
   func test__performMutation_givenPublishResultToStore_false_doesNotPublishResultsToStore() throws {
-    // given
-    class GivenSelectionSet: MockSelectionSet {
-      override class var __selections: [Selection] { [
-        .field("createReview", CreateReview.self)
-      ] }
-
-      class CreateReview: MockSelectionSet {
-        override class var __selections: [Selection] { [
-          .field("__typename", String.self),
-          .field("stars", Int.self),
-          .field("commentary", String?.self)
-        ] }
-      }
-    }
     let mutation = MockMutation<GivenSelectionSet>()
     let resultObserver = self.makeResultObserver(for: mutation)
 

--- a/Tests/ApolloTests/ApolloClientOperationTests.swift
+++ b/Tests/ApolloTests/ApolloClientOperationTests.swift
@@ -56,20 +56,22 @@ final class ApolloClientOperationTests: XCTestCase {
     }
   }
 
+  let jsonObject: JSONObject = [
+    "data": [
+      "createReview": [
+        "__typename": "Review",
+        "stars": 3,
+        "commentary": ""
+      ]
+    ]
+  ]
+
   func test__performMutation_givenPublishResultToStore_true_publishResultsToStore() throws {
     let mutation = MockMutation<GivenSelectionSet>()
     let resultObserver = self.makeResultObserver(for: mutation)
 
-    let serverRequestExpectation = self.server.expect(MockMutation<GivenSelectionSet>.self) { _ in
-      [
-        "data": [
-          "createReview": [
-            "__typename": "Review",
-            "stars": 3,
-            "commentary": ""
-          ]
-        ]
-      ]
+    let serverRequestExpectation = server.expect(MockMutation<GivenSelectionSet>.self) { _ in
+      self.jsonObject
     }
 
     let performResultFromServerExpectation =
@@ -97,16 +99,8 @@ final class ApolloClientOperationTests: XCTestCase {
     let mutation = MockMutation<GivenSelectionSet>()
     let resultObserver = self.makeResultObserver(for: mutation)
 
-    let serverRequestExpectation = self.server.expect(MockMutation<GivenSelectionSet>.self) { _ in
-      [
-        "data": [
-          "createReview": [
-            "__typename": "Review",
-            "stars": 3,
-            "commentary": ""
-          ]
-        ]
-      ]
+    let serverRequestExpectation = server.expect(MockMutation<GivenSelectionSet>.self) { _ in
+      self.jsonObject
     }
 
     let performResultFromServerExpectation =


### PR DESCRIPTION
ref: #2952, #2929

- Add a test if the `publishResultToStore` argument to `ApolloClient.perform` is true, i.e. cached after perform, and `publishedRecordSets` in `MockStore` is not empty.