### PR TITLE
[WIP] Update codegen module to support building on linux 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM swift:latest as builder
+WORKDIR /app
+COPY . .
+
+RUN apt-get update && apt-get install -y libjavascriptcoregtk-4.0-dev \
+    && pkg-config --libs javascriptcoregtk-4.0
+
+RUN swift build --product apollo-ios-cli -c release
+
+CMD ["/app/.build/release/apollo-ios-cli"]

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,9 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       .upToNextMajor(from: "1.2.0")),
+    .package(
+      url: "https://github.com/apple/swift-crypto.git",
+      "1.0.0"..<"3.0.0"),
   ],
   targets: [
     .target(
@@ -54,6 +57,7 @@ let package = Package(
     .target(
       name: "ApolloCodegenLib",
       dependencies: [
+        .product(name: "Crypto", package: "swift-crypto"),
         .product(name: "Pluralize", package: "pluralize"),
         .product(name: "OrderedCollections", package: "swift-collections")
       ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,13 +27,13 @@ let package = Package(
       url: "https://github.com/stephencelis/SQLite.swift.git",
       .upToNextMajor(from: "0.13.1")),
     .package(
-      url: "https://github.com/mattt/InflectorKit",
+      url: "https://github.com/alchemy-swift/pluralize",
       .upToNextMajor(from: "1.0.0")),
     .package(
       url: "https://github.com/apple/swift-collections",
       .upToNextMajor(from: "1.0.0")),
     .package(
-      url: "https://github.com/apple/swift-argument-parser.git", 
+      url: "https://github.com/apple/swift-argument-parser.git",
       .upToNextMajor(from: "1.2.0")),
   ],
   targets: [
@@ -50,11 +50,11 @@ let package = Package(
       dependencies: [],
       exclude: [
         "Info.plist"
-      ]),    
+      ]),
     .target(
       name: "ApolloCodegenLib",
       dependencies: [
-        .product(name: "InflectorKit", package: "InflectorKit"),
+        .product(name: "Pluralize", package: "pluralize"),
         .product(name: "OrderedCollections", package: "swift-collections")
       ],
       exclude: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,9 @@ let package = Package(
       url: "https://github.com/apple/swift-argument-parser.git",
       .upToNextMajor(from: "1.2.0")),
     .package(
+      url: "https://github.com/jectivex/JXKit.git",
+      .upToNextMajor(from: "3.0.0")),
+    .package(
       url: "https://github.com/apple/swift-crypto.git",
       "1.0.0"..<"3.0.0"),
   ],
@@ -58,8 +61,9 @@ let package = Package(
       name: "ApolloCodegenLib",
       dependencies: [
         .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "JXKit", package: "JXKit"),
+        .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Pluralize", package: "pluralize"),
-        .product(name: "OrderedCollections", package: "swift-collections")
       ],
       exclude: [
         "Info.plist",

--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -1,4 +1,4 @@
-import JavaScriptCore
+import JXKit
 
 /// The output of the frontend compiler.
 public class CompilationResult: JavaScriptObject {
@@ -12,22 +12,22 @@ public class CompilationResult: JavaScriptObject {
   lazy var fragments: [FragmentDefinition] = self["fragments"]
 
   lazy var schemaDocumentation: String? = self["schemaDocumentation"]
-  
+
   public class OperationDefinition: JavaScriptObject, Equatable {
     lazy var name: String = self["name"]
-    
+
     lazy var operationType: OperationType = self["operationType"]
-    
+
     lazy var variables: [VariableDefinition] = self["variables"]
-    
+
     lazy var rootType: GraphQLCompositeType = self["rootType"]
-    
+
     lazy var selectionSet: SelectionSet = self["selectionSet"]
 
     lazy var directives: [Directive]? = self["directives"]
-    
+
     lazy var source: String = self["source"]
-    
+
     lazy var filePath: String = self["filePath"]
 
     override public var debugDescription: String {
@@ -64,39 +64,39 @@ public class CompilationResult: JavaScriptObject {
       return name+suffix
     }()
   }
-  
+
   public enum OperationType: String, Equatable, JavaScriptValueDecodable {
     case query
     case mutation
     case subscription
-    
-    init(_ jsValue: JSValue, bridge: JavaScriptBridge) {
-      let rawValue: String = .fromJSValue(jsValue, bridge: bridge)
+
+    init(_ jsValue: JXValue, bridge: JavaScriptBridge) {
+      let rawValue: String = .fromJXValue(jsValue, bridge: bridge)
       guard let operationType = Self(rawValue: rawValue) else {
         preconditionFailure("Unknown GraphQL operation type: \(rawValue)")
       }
-      
+
       self = operationType
     }
   }
-  
+
   public class VariableDefinition: JavaScriptObject {
     lazy var name: String = self["name"]
-    
+
     lazy var type: GraphQLType = self["type"]
-    
+
     lazy var defaultValue: GraphQLValue? = self["defaultValue"]
   }
-  
+
   public class FragmentDefinition: JavaScriptObject, Hashable {
     lazy var name: String = self["name"]
-    
+
     lazy var type: GraphQLCompositeType = self["typeCondition"]
-    
+
     lazy var selectionSet: SelectionSet = self["selectionSet"]
-    
+
     lazy var source: String = self["source"]
-    
+
     lazy var filePath: String = self["filePath"]
 
     lazy var directives: [Directive]? = self["directives"]
@@ -117,10 +117,10 @@ public class CompilationResult: JavaScriptObject {
       return lhs.name == rhs.name
     }
   }
-  
+
   public class SelectionSet: JavaScriptWrapper, Hashable, CustomDebugStringConvertible {
     lazy var parentType: GraphQLCompositeType = self["parentType"]
-    
+
     lazy var selections: [Selection] = self["selections"]
 
     required convenience init(
@@ -194,13 +194,13 @@ public class CompilationResult: JavaScriptObject {
       lhs.directives == rhs.directives
     }
   }
-  
+
   public enum Selection: JavaScriptValueDecodable, CustomDebugStringConvertible, Hashable {
     case field(Field)
     case inlineFragment(InlineFragment)
     case fragmentSpread(FragmentSpread)
-    
-    init(_ jsValue: JSValue, bridge: JavaScriptBridge) {
+
+    init(_ jsValue: JXValue, bridge: JavaScriptBridge) {
       precondition(jsValue.isObject, "Expected JavaScript object but found: \(jsValue)")
 
       let kind: String = jsValue["kind"].toString()
@@ -238,16 +238,16 @@ public class CompilationResult: JavaScriptObject {
       }
     }
   }
-  
+
   public class Field: JavaScriptWrapper, Hashable, CustomDebugStringConvertible {
     lazy var name: String = self["name"]!
-    
+
     lazy var alias: String? = self["alias"]
-    
+
     var responseKey: String {
       alias ?? name
     }
-    
+
     lazy var type: GraphQLType = self["type"]!
 
     lazy var arguments: [Argument]? = self["arguments"]
@@ -255,15 +255,15 @@ public class CompilationResult: JavaScriptObject {
     lazy var inclusionConditions: [InclusionCondition]? = self["inclusionConditions"]
 
     lazy var directives: [Directive]? = self["directives"]
-    
+
     lazy var selectionSet: SelectionSet? = self["selectionSet"]
-    
+
     lazy var deprecationReason: String? = self["deprecationReason"]
-    
+
     var isDeprecated: Bool {
       return deprecationReason != nil
     }
-    
+
     lazy var documentation: String? = self["description"]
 
     required convenience init(
@@ -315,7 +315,7 @@ public class CompilationResult: JavaScriptObject {
       lhs.selectionSet == rhs.selectionSet
     }
   }
-  
+
   public class Argument: JavaScriptObject, Hashable {
     lazy var name: String = self["name"]
 
@@ -367,7 +367,7 @@ public class CompilationResult: JavaScriptObject {
     case skipped
     case variable(String, isInverted: Bool)
 
-    init(_ jsValue: JSValue, bridge: JavaScriptBridge) {
+    init(_ jsValue: JXValue, bridge: JavaScriptBridge) {
       if jsValue.isString, let value = jsValue.toString() {
         switch value {
         case "INCLUDED":
@@ -377,7 +377,7 @@ public class CompilationResult: JavaScriptObject {
           self = .skipped
           return
         default:
-          preconditionFailure("Unrecognized value for include condition. Got \(value)")          
+          preconditionFailure("Unrecognized value for include condition. Got \(value)")
         }
       }
 

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLError.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLError.swift
@@ -1,5 +1,5 @@
 import Foundation
-import JavaScriptCore
+import JXKit
 
 /// A GraphQL error.
 /// Corresponds to [graphql-js/GraphQLError](https://graphql.org/graphql-js/error/#graphqlerror)
@@ -7,11 +7,11 @@ import JavaScriptCore
 /// that lets Xcode show inline errors.
 public class GraphQLError: JavaScriptError {
   private lazy var source: GraphQLSource = self["source"]
-  
+
   /// The source locations associated with this error.
   private(set) lazy var sourceLocations: [GraphQLSourceLocation] = {
     let locations: [JavaScriptObject] = self["locations"]
-    
+
     if let nodes: [ASTNode] = self["nodes"] {
       // We have AST nodes, so this is a validation error.
       // Because errors can be associated with locations from different
@@ -19,20 +19,20 @@ public class GraphQLError: JavaScriptError {
       // individual nodes instead.
 
       precondition(locations.count == nodes.count)
-      
+
       return zip(locations, nodes).map { (location, node) in
         return GraphQLSourceLocation(filePath: node.filePath, lineNumber: location["line"].toInt(), columnNumber: location["column"].toInt())
       }
     } else {
       // We have no AST nodes, so this is a syntax error. Those only apply to a single source file,
       // so we can rely on the `source` property.
-            
+
       return locations.map {
         GraphQLSourceLocation(filePath: source.filePath, lineNumber: $0["line"].toInt(), columnNumber: $0["column"].toInt())
       }
     }
   }()
-  
+
   /// Log lines for this error in a format that allows Xcode to show errors inline at the correct location.
   /// See https://shazronatadobe.wordpress.com/2010/12/04/xcode-shell-build-phase-reporting-of-errors/
   var logLines: [String] {

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLJSFrontend.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLJSFrontend.swift
@@ -1,5 +1,5 @@
 import Foundation
-import JavaScriptCore
+import JXKit
 
 public final class GraphQLJSFrontend {
   private let bridge: JavaScriptBridge
@@ -13,7 +13,7 @@ public final class GraphQLJSFrontend {
       bridge.context.evaluateScript(ApolloCodegenFrontendBundle)
     }
 
-    self.library = bridge.fromJSValue(bridge.context.globalObject["ApolloCodegenFrontend"])
+    self.library = bridge.fromJXValue(bridge.context.globalObject["ApolloCodegenFrontend"])
 
     bridge.register(GraphQLSource.self, forJavaScriptClass: "Source", from: library)
     bridge.register(GraphQLError.self, from: library)
@@ -25,7 +25,7 @@ public final class GraphQLJSFrontend {
     bridge.register(GraphQLObjectType.self, from: library)
     bridge.register(GraphQLInterfaceType.self, from: library)
     bridge.register(GraphQLUnionType.self, from: library)
-  }  
+  }
 
   /// Load a schema by parsing  an introspection result.
   public func loadSchema(from sources: [GraphQLSource]) throws -> GraphQLSchema {
@@ -38,7 +38,7 @@ public final class GraphQLJSFrontend {
     }
 
   private lazy var sourceConstructor: JavaScriptObject = {
-    self.bridge.fromJSValue(library["Source"])
+    self.bridge.fromJXValue(library["Source"])
   }()
 
   /// Create a `GraphQLSource` object from a string.

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSchema.swift
@@ -1,4 +1,4 @@
-import JavaScriptCore
+import JXKit
 import OrderedCollections
 
 // These classes correspond directly to the ones in
@@ -6,24 +6,24 @@ import OrderedCollections
 // and are partially described in https://graphql.org/graphql-js/type/
 
 /// A GraphQL schema.
-public class GraphQLSchema: JavaScriptObject {  
+public class GraphQLSchema: JavaScriptObject {
   func getType(named typeName: String) throws -> GraphQLNamedType? {
     try invokeMethod("getType", with: typeName)
   }
-  
+
   func getPossibleTypes(_ abstractType: GraphQLAbstractType) throws -> [GraphQLObjectType] {
     return try invokeMethod("getPossibleTypes", with: abstractType)
   }
-  
+
   func getImplementations(interfaceType: GraphQLInterfaceType) throws -> InterfaceImplementations {
     return try invokeMethod("getImplementations", with: interfaceType)
   }
-  
+
   class InterfaceImplementations: JavaScriptObject {
     private(set) lazy var objects: [GraphQLObjectType] = self["objects"]
     private(set) lazy var interfaces: [GraphQLInterfaceType] = self["interfaces"]
   }
-    
+
   func isSubType(abstractType: GraphQLAbstractType, maybeSubType: GraphQLNamedType) throws -> Bool {
     return try invokeMethod("isSubType", with: abstractType, maybeSubType)
   }
@@ -44,7 +44,7 @@ public class GraphQLNamedType: JavaScriptObject, Hashable {
 }
 
 public class GraphQLScalarType: GraphQLNamedType {
-  
+
   lazy var specifiedByURL: String? = self["specifiedByUrl"]
 
   var isCustomScalar: Bool {
@@ -55,7 +55,7 @@ public class GraphQLScalarType: GraphQLNamedType {
       return false
     default:
       return true
-    }    
+    }
   }
 
   var isSwiftType: Bool {
@@ -79,9 +79,9 @@ public class GraphQLEnumValue: JavaScriptObject {
   }
 
   lazy var name: Name = Name(value: self["name"])
-  
+
   lazy var documentation: String? = self["description"]
-    
+
   lazy var deprecationReason: String? = self["deprecationReason"]
 
   var isDeprecated: Bool { deprecationReason != nil }
@@ -95,16 +95,16 @@ public class GraphQLInputObjectType: GraphQLNamedType {
 
 public class GraphQLInputField: JavaScriptObject {
   lazy var name: String = self["name"]
-  
+
   lazy var type: GraphQLType = self["type"]
-  
+
   lazy var documentation: String? = self["description"]
-  
+
   lazy var defaultValue: GraphQLValue? = {
     let node: JavaScriptObject? = self["astNode"]
     return node?["defaultValue"]
   }()
-    
+
   lazy var deprecationReason: String? = self["deprecationReason"]
 }
 
@@ -130,7 +130,7 @@ extension GraphQLInterfaceImplementingType {
 
 public class GraphQLObjectType: GraphQLCompositeType, GraphQLInterfaceImplementingType {
   lazy var fields: [String: GraphQLField] = try! invokeMethod("getFields")
-  
+
   lazy var interfaces: [GraphQLInterfaceType] = try! invokeMethod("getInterfaces")
 
   public override var debugDescription: String {
@@ -141,11 +141,11 @@ public class GraphQLObjectType: GraphQLCompositeType, GraphQLInterfaceImplementi
 public class GraphQLAbstractType: GraphQLCompositeType {
 }
 
-public class GraphQLInterfaceType: GraphQLAbstractType, GraphQLInterfaceImplementingType {  
+public class GraphQLInterfaceType: GraphQLAbstractType, GraphQLInterfaceImplementingType {
   lazy var deprecationReason: String? = self["deprecationReason"]
-  
+
   lazy var fields: [String: GraphQLField] = try! invokeMethod("getFields")
-  
+
   lazy var interfaces: [GraphQLInterfaceType] = try! invokeMethod("getInterfaces")
 
   public override var debugDescription: String {
@@ -164,13 +164,13 @@ public class GraphQLUnionType: GraphQLAbstractType {
 public class GraphQLField: JavaScriptObject, Hashable {
 
   lazy var name: String = self["name"]
-  
+
   lazy var type: GraphQLType = self["type"]
 
   lazy var arguments: [GraphQLFieldArgument] = self["args"]
-  
+
   lazy var documentation: String? = self["description"]
-  
+
   lazy var deprecationReason: String? = self["deprecationReason"]
 
   public func hash(into hasher: inout Hasher) {
@@ -209,5 +209,5 @@ public class GraphQLFieldArgument: JavaScriptObject, Hashable {
     lhs.name == rhs.name &&
     lhs.type == rhs.type
   }
-  
+
 }

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLSource.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLSource.swift
@@ -1,18 +1,18 @@
 import Foundation
-import JavaScriptCore
+import JXKit
 
 /// A representation of source input to GraphQL parsing.
 /// Corresponds to https://github.com/graphql/graphql-js/blob/master/src/language/source.js
 public class GraphQLSource: JavaScriptObject {
   private(set) lazy var filePath: String = self["name"]
-  
+
   private(set) lazy var body: String = self["body"]
 }
 
 /// Represents a location in a GraphQL source file.
 public struct GraphQLSourceLocation {
   let filePath: String
-  
+
   let lineNumber: Int
   let columnNumber: Int
 }
@@ -25,18 +25,18 @@ public struct GraphQLSourceLocation {
 /// An AST node.
 public class ASTNode: JavaScriptObject {
   lazy var kind: String = self["kind"]
-      
-  private lazy var source: GraphQLSource = bridge.fromJSValue(self["loc"]["source"])
+
+  private lazy var source: GraphQLSource = bridge.fromJXValue(self["loc"]["source"])
   private(set) lazy var filePath: String = source.filePath
 }
 
 /// A parsed GraphQL document.
 public class GraphQLDocument: ASTNode {
   private(set) lazy var definitions: [ASTNode] = self["definitions"]
-  
-  required init(_ jsValue: JSValue, bridge: JavaScriptBridge) {
+
+  required init(_ jsValue: JXValue, bridge: JavaScriptBridge) {
     super.init(jsValue, bridge: bridge)
-    
+
     precondition(kind == "Document", "Expected GraphQL DocumentNode but found: \(jsValue)")
   }
 }

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLType.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLType.swift
@@ -1,4 +1,4 @@
-import JavaScriptCore
+import JXKit
 
 /// A GraphQL type.
 public indirect enum GraphQLType: Hashable {
@@ -63,7 +63,7 @@ extension GraphQLType: CustomDebugStringConvertible {
 }
 
 extension GraphQLType: JavaScriptValueDecodable {
-  init(_ jsValue: JSValue, bridge: JavaScriptBridge) {
+  init(_ jsValue: JXValue, bridge: JavaScriptBridge) {
     precondition(jsValue.isObject, "Expected JavaScript object but found: \(jsValue)")
 
     let tag = jsValue[jsValue.context.globalObject["Symbol"]["toStringTag"]].toString()
@@ -76,7 +76,7 @@ extension GraphQLType: JavaScriptValueDecodable {
       let ofType = jsValue["ofType"]
       self = .list(GraphQLType(ofType, bridge: bridge))
     default:
-      let namedType: GraphQLNamedType = bridge.fromJSValue(jsValue)
+      let namedType: GraphQLNamedType = bridge.fromJXValue(jsValue)
 
       switch namedType {
       case let entityType as GraphQLCompositeType:
@@ -92,7 +92,7 @@ extension GraphQLType: JavaScriptValueDecodable {
         self = .inputObject(inputObjectType)
 
       default:
-        fatalError("JSValue: \(jsValue) is not a recognized GraphQLType value.")
+        fatalError("JXValue: \(jsValue) is not a recognized GraphQLType value.")
       }
     }
   }

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLValue.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLValue.swift
@@ -1,5 +1,5 @@
 import Foundation
-import JavaScriptCore
+import JXKit
 import OrderedCollections
 
 indirect enum GraphQLValue: Hashable {
@@ -15,7 +15,7 @@ indirect enum GraphQLValue: Hashable {
 }
 
 extension GraphQLValue: JavaScriptValueDecodable {
-  init(_ jsValue: JSValue, bridge: JavaScriptBridge) {
+  init(_ jsValue: JXValue, bridge: JavaScriptBridge) {
     precondition(jsValue.isObject, "Expected JavaScript object but found: \(jsValue)")
 
     let kind: String = jsValue["kind"].toString()
@@ -40,9 +40,9 @@ extension GraphQLValue: JavaScriptValueDecodable {
       if value.isUndefined {
         value = jsValue["values"]
       }
-      self = .list(.fromJSValue(value, bridge: bridge))
+      self = .list(.fromJXValue(value, bridge: bridge))
     case "ObjectValue":
-      self = .object(.fromJSValue(jsValue["value"], bridge: bridge))
+      self = .object(.fromJXValue(jsValue["value"], bridge: bridge))
     default:
       preconditionFailure("""
         Unknown GraphQL value of kind "\(kind)"

--- a/Sources/ApolloCodegenLib/Frontend/ValidationOptions.swift
+++ b/Sources/ApolloCodegenLib/Frontend/ValidationOptions.swift
@@ -1,5 +1,5 @@
 import Foundation
-import JavaScriptCore
+import JXKit
 
 public struct ValidationOptions {
 
@@ -48,20 +48,20 @@ public struct ValidationOptions {
 
   public class Bridged: JavaScriptObject {
     convenience init(from options: ValidationOptions, bridge: JavaScriptBridge) {
-      let jsValue = JSValue(newObjectIn: bridge.context)
+      let jsValue = JXValue(newObjectIn: bridge.context)
 
       jsValue?.setValue(
-        JSValue(object: options.schemaNamespace, in: bridge.context),
+        JXValue(object: options.schemaNamespace, in: bridge.context),
         forProperty: "schemaNamespace"
       )
 
       jsValue?.setValue(
-        JSValue(object: options.disallowedFieldNames.asDictionary, in: bridge.context),
+        JXValue(object: options.disallowedFieldNames.asDictionary, in: bridge.context),
         forProperty: "disallowedFieldNames"
       )
 
       jsValue?.setValue(
-        JSValue(object: Array(options.disallowedInputParameterNames), in: bridge.context),
+        JXValue(object: Array(options.disallowedInputParameterNames), in: bridge.context),
         forProperty: "disallowedInputParameterNames"
       )
 

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -1,5 +1,5 @@
 import OrderedCollections
-import CryptoKit
+import Crypto
 
 class IR {
 
@@ -155,7 +155,7 @@ class IR {
     /// being spread into. This allows merged field calculations to include the fields merged in
     /// from the fragment.
     let fragment: NamedFragment
-    
+
     /// Indicates the location where the fragment has been "spread into" its enclosing
     /// operation/fragment. It's `scopePath` and `entity` reference are scoped to the operation it
     /// belongs to.
@@ -195,5 +195,5 @@ class IR {
       return description
     }
   }
-  
+
 }

--- a/Sources/ApolloCodegenLib/Pluralizer.swift
+++ b/Sources/ApolloCodegenLib/Pluralizer.swift
@@ -1,33 +1,33 @@
 import Foundation
-import InflectorKit
+import Pluralize
 
-/// The types of inflection rules that can be used to customize pluralization. 
+/// The types of inflection rules that can be used to customize pluralization.
 public enum InflectionRule: Codable, Equatable {
 
   /// A pluralization rule that allows taking a singular word and pluralizing it.
   /// - singularRegex: A regular expression representing the single version of the word
   /// - replacementRegex: A regular expression representing how to replace the singular version.
   case pluralization(singularRegex: String, replacementRegex: String)
-  
+
   /// A singularization rule that allows taking a plural word and singularizing it.
   /// - pluralRegex: A regular expression represeinting the plural version of the word
   /// - replacementRegex: A regular expression representing how to replace the singular version
   case singularization(pluralRegex: String, replacementRegex: String)
-  
+
   /// A definition of an irregular pluralization rule not easily captured by regex - for example "person" and "people".
   /// - singular: The singular version of the word
   /// - plural: The plural version of the word.
   case irregular(singular: String, plural: String)
-  
+
   /// A definition of a word that should never be pluralized or de-pluralized because it's the same no matter what the count - for example, "fish".
   /// - word: The word that should never be adjusted.
   case uncountable(word: String)
 }
 
 struct Pluralizer {
-  
+
   private let inflector: StringInflector
-  
+
   init(rules: [InflectionRule] = []) {
     let inflector = StringInflector()
     self.inflector = inflector
@@ -50,11 +50,11 @@ struct Pluralizer {
       }
     }
   }
-  
+
   func singularize(_ string: String) -> String {
     self.inflector.singularize(string)
   }
-  
+
   func pluralize(_ string: String) -> String {
     self.inflector.pluralize(string)
   }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLInputField+Rendered.swift
@@ -1,4 +1,4 @@
-import JavaScriptCore
+import JXKit
 
 extension GraphQLInputField {
   func renderInputValueType(

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -1,4 +1,4 @@
-import InflectorKit
+import Pluralize
 import OrderedCollections
 
 struct SelectionSetTemplate {
@@ -535,7 +535,7 @@ struct SelectionSetTemplate {
         "\($0.map { render(inlineFragment: $0) }, separator: "\n\n")"
       })
     \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")
-    """    
+    """
   }
 
 }
@@ -635,7 +635,7 @@ fileprivate extension IR.Entity.FieldPathComponent {
     var fieldName = name.firstUppercased
     if type.isListType {
       fieldName = pluralizer.singularize(fieldName)
-    }    
+    }
     return fieldName.asSelectionSetName
   }
 
@@ -650,7 +650,7 @@ fileprivate extension GraphQLType {
     case .entity, .enum, .inputObject, .scalar: return false
     }
   }
-  
+
 }
 
 fileprivate extension IR.MergedSelections.MergedSource {
@@ -783,7 +783,7 @@ fileprivate extension IR.ScopeCondition {
     \(ifLet: conditions, { "If\($0.typeNameComponents)"})
     """).description
   }
-  
+
 }
 
 fileprivate extension AnyOf where T == IR.InclusionConditions {

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Package.resolved
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "state" : {
+        "revision" : "bdeff49547241d917ce670d9b7dfb0c5efca9cde",
+        "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "inflectorkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/InflectorKit",
+      "state" : {
+        "revision" : "d8cbcc04972690aaa5fc760a2b9ddb3e9f0decd7",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
+        "version" : "0.14.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/ApolloCodegenInternalTestHelpers/MockJavaScriptObject.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockJavaScriptObject.swift
@@ -1,13 +1,13 @@
 @testable import ApolloCodegenLib
-@testable import JavaScriptCore
+@testable import JXKit
 
 private var mockJavaScriptBridge = try! JavaScriptBridge()
 
 extension JavaScriptObject {
 
   @objc public class func emptyMockObject() -> Self {
-    let object = JSValue(newObjectIn: mockJavaScriptBridge.context)!
-    return Self.fromJSValue(object, bridge: mockJavaScriptBridge)
+    let object = JXValue(newObjectIn: mockJavaScriptBridge.context)!
+    return Self.fromJXValue(object, bridge: mockJavaScriptBridge)
   }
-  
+
 }


### PR DESCRIPTION
I realize this isn't a very common workflow for iOS development, but as part of our build, we rely on Docker for quite a large portion of it. Although I think there's probably a day or more work to get this building, I wanted to throw this up to get any early feedback and thoughts. 

## Goal

command line code-gen tool can be moved over to linux build pipeline since it generates code as part of a Docker build pipeline

## Example

```sh
docker buildx build . -t ghcr.io/apollographql/apollo-ios-cli:1.1.1 --load
```

Then instead of needing to build the tool, or include it via any other way, one can simply add this to their build flow to grab exact versions or "latest"

```sh
docker run ghcr.io/apollographql/apollo-ios-cli:1.1.1 
```

## Current Status

- [x] InflectorKit -> pluralize
- [x] CryptoKit -> apple-swift-crypto
- [ ] JavaScriptCore -> JXCore

Note: JavaScriptCore bits seem the most finicky so I wanted to stop, get some feedback before diving further down that road.

There is no objective-c runtime on linux and so some of that would have to be refactored. 
