### PR TITLE
chore: Apply a suggested change in test renaming which was omitted in past PR

### DIFF
--- a/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/JSONResponseParsingInterceptorTests.swift
@@ -4,7 +4,7 @@ import ApolloInternalTestHelpers
 import XCTest
 
 class JSONResponseParsingInterceptorTests: XCTestCase {
-  func testJSONResponseParsingInterceptorFailsWithImproperlyOrderedCalls() {
+  func testJSONResponseParsingInterceptorFailsWhenNoResponse() {
     let provider = MockInterceptorProvider([
       JSONResponseParsingInterceptor()
     ])


### PR DESCRIPTION
Apply a renaming that was previously suggested. (I forgot, sorry!)

ref: https://github.com/apollographql/apollo-ios/pull/2903#discussion_r1152209541

```diff
- func testJSONResponseParsingInterceptorFailsWithImproperlyOrderedCalls() {
+ func testJSONResponseParsingInterceptorFailsWhenNoResponse() {
```