### PR TITLE
fix: Disallow certain targetNames in code generation (#2958)

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -52,6 +52,10 @@ enum SwiftKeywords {
   static let DisallowedSchemaNamespaceNames: Set<String> = [
     "schema", "apolloapi"
   ]
+  
+  static let DisallowedEmbeddedTargetNames: Set<String> = [
+    "apollo", "apolloapi"
+  ]
 
   static let SelectionSetTypeNamesToSuffix: Set<String> = [
     "Any",

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -2157,6 +2157,24 @@ class ApolloCodegenTests: XCTestCase {
         .to(throwError(ApolloCodegen.Error.schemaNameConflict(name: config.schemaNamespace)))
     }
   }
+  
+  func test__validation__givenTargetName_matchingDisallowedTargetName_shouldThrow() throws {
+    // given
+    let disallowedNames = ["apollo", "Apollo", "apolloapi", "ApolloAPI"]
+    
+    // when
+    for name in disallowedNames {
+      let config = ApolloCodegenConfiguration.mock(
+        output: .mock(
+          moduleType: .embeddedInTarget(name: name)
+        )
+      )
+      
+      // then
+      expect(try ApolloCodegen._validate(config: config))
+        .to(throwError(ApolloCodegen.Error.targetNameConflict(name: name)))
+    }
+  }
 
   func test__validation__givenEmptySchemaName_shouldThrow() throws {
     let config = ApolloCodegenConfiguration.mock(schemaNamespace: "")


### PR DESCRIPTION
Added new validation check to ensure the `targetName` given when using the `embeddedInTarget` module type does not conflict with existing libraries.