### PR TITLE
test: Measure `MultipartResponseParsingInterceptor` performance

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -782,6 +782,7 @@
 		E6AAA737286C11E600F4659D /* OperationIdentifiersFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AAA735286C0F8E00F4659D /* OperationIdentifiersFileGeneratorTests.swift */; };
 		E6AAA739286C87EA00F4659D /* OperationIdentifiersTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AAA738286C87EA00F4659D /* OperationIdentifiersTemplate.swift */; };
 		E6AAA73B286CC7EF00F4659D /* OperationIdentifiersTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AAA73A286CC7EF00F4659D /* OperationIdentifiersTemplateTests.swift */; };
+		E6B1FEBB29F2FC97003D12E0 /* ResponseCaptureRequestChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B1FEBA29F2FC97003D12E0 /* ResponseCaptureRequestChain.swift */; };
 		E6B2B26C29C2447F004B16F4 /* MultipartResponseParsingInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B2B26B29C2447F004B16F4 /* MultipartResponseParsingInterceptorTests.swift */; };
 		E6B42D0927A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */; };
 		E6B42D0B27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B42D0A27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift */; };
@@ -1954,6 +1955,7 @@
 		E6AAA735286C0F8E00F4659D /* OperationIdentifiersFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationIdentifiersFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E6AAA738286C87EA00F4659D /* OperationIdentifiersTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationIdentifiersTemplate.swift; sourceTree = "<group>"; };
 		E6AAA73A286CC7EF00F4659D /* OperationIdentifiersTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationIdentifiersTemplateTests.swift; sourceTree = "<group>"; };
+		E6B1FEBA29F2FC97003D12E0 /* ResponseCaptureRequestChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseCaptureRequestChain.swift; sourceTree = "<group>"; };
 		E6B2B26B29C2447F004B16F4 /* MultipartResponseParsingInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartResponseParsingInterceptorTests.swift; sourceTree = "<group>"; };
 		E6B42D0827A472A700A3BD58 /* SwiftPackageManagerModuleTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPackageManagerModuleTemplate.swift; sourceTree = "<group>"; };
 		E6B42D0A27A4746800A3BD58 /* SchemaModuleFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaModuleFileGeneratorTests.swift; sourceTree = "<group>"; };
@@ -2487,6 +2489,7 @@
 				9B2061162591B3550020D1E0 /* Resources */,
 				DEC2EA89291D5E2E0088D3BB /* TestIsolatedFileManager.swift */,
 				E6931D4A29CE44EA005DD9E4 /* String+Data.swift */,
+				E6B1FEBA29F2FC97003D12E0 /* ResponseCaptureRequestChain.swift */,
 			);
 			name = ApolloInternalTestHelpers;
 			path = Tests/ApolloInternalTestHelpers;
@@ -5135,6 +5138,7 @@
 				E660A4D129CA56A4001EA373 /* MockHTTPRequest.swift in Sources */,
 				9FBE0D4025407B64002ED0B1 /* AsyncResultObserver.swift in Sources */,
 				9F3910272549741400AF54A6 /* MockGraphQLServer.swift in Sources */,
+				E6B1FEBB29F2FC97003D12E0 /* ResponseCaptureRequestChain.swift in Sources */,
 				DE71FDC22853C4C8005FA9CC /* MockLocalCacheMutation.swift in Sources */,
 				DEC2EA8A291D5E2E0088D3BB /* TestIsolatedFileManager.swift in Sources */,
 				DED45E6B261B9EAC0086EF63 /* SQLiteTestCacheProvider.swift in Sources */,

--- a/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/B07DC9C5-A477-43FC-8906-C01C8B98086A.plist
+++ b/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/B07DC9C5-A477-43FC-8906-C01C8B98086A.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.003480</real>
+					<real>0.020300</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/B07DC9C5-A477-43FC-8906-C01C8B98086A.plist
+++ b/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/B07DC9C5-A477-43FC-8906-C01C8B98086A.plist
@@ -6,6 +6,16 @@
 	<dict>
 		<key>ParsingPerformanceTests</key>
 		<dict>
+			<key>testMultipartResponseParsingInterceptor()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.003480</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
 			<key>testParseResult()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>

--- a/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/B07DC9C5-A477-43FC-8906-C01C8B98086A.plist
+++ b/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/B07DC9C5-A477-43FC-8906-C01C8B98086A.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ParsingPerformanceTests</key>
+		<dict>
+			<key>testParseResult()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.045500</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testParseResultFast()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.023300</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>SelectionSetInitializerPerformanceTests</key>
+		<dict>
+			<key>testPerformance_selectionSetInitialization_concreteObjectTypeCaseWithMultipleFulfilledFragments()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.041800</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>TypeCaseConversionPerformanceTests</key>
+		<dict>
+			<key>testPerformance_typeConversion_checkTypeConformsToInterface()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.034200</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformance_typeConversion_inclusionCondition()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.023600</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/Info.plist
+++ b/Apollo.xcodeproj/xcshareddata/xcbaselines/9F54C8B3255D760B0065AFD6.xcbaseline/Info.plist
@@ -83,6 +83,30 @@
 				<string>com.apple.platform.iphonesimulator</string>
 			</dict>
 		</dict>
+		<key>B07DC9C5-A477-43FC-8906-C01C8B98086A</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro17,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+		</dict>
 		<key>FA3A7E89-3F08-4E7F-890A-B0903F68A94C</key>
 		<dict>
 			<key>localComputer</key>

--- a/Configuration/Apollo/Apollo-Target-PerformanceTests.xcconfig
+++ b/Configuration/Apollo/Apollo-Target-PerformanceTests.xcconfig
@@ -1,3 +1,4 @@
 #include "../Shared/Workspace-Target-Test.xcconfig"
 
 INFOPLIST_FILE = Tests/ApolloPerformanceTests/Info.plist
+TREAT_MISSING_BASELINES_AS_TEST_FAILURES = YES

--- a/Tests/ApolloInternalTestHelpers/ResponseCaptureRequestChain.swift
+++ b/Tests/ApolloInternalTestHelpers/ResponseCaptureRequestChain.swift
@@ -1,0 +1,48 @@
+import Apollo
+
+/// Use this mock response chain when you want to isolate a single `ApolloInterceptor` vs. having
+/// to end your interceptor chain with `JSONResponseParsingInterceptor` to get a parsed `Result`
+/// for the standard callback.
+public class ResponseCaptureRequestChain: RequestChain {
+  public var isCancelled: Bool = false
+  public var error: Error? = nil
+  public var data: Data? = nil
+
+  public init() {}
+
+  public func kickoff<Operation>(
+    request: Apollo.HTTPRequest<Operation>,
+    completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+  ) {}
+
+  public func proceedAsync<Operation>(
+    request: Apollo.HTTPRequest<Operation>,
+    response: Apollo.HTTPResponse<Operation>?,
+    completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+  ) {
+    self.data = response?.rawData
+  }
+
+  public func cancel() {}
+
+  public func retry<Operation>(
+    request: Apollo.HTTPRequest<Operation>,
+    completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+  ) {}
+
+  public func handleErrorAsync<Operation>(
+    _ error: Error,
+    request: Apollo.HTTPRequest<Operation>,
+    response: Apollo.HTTPResponse<Operation>?,
+    completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+  ) {
+    self.error = error
+    self.data = response?.rawData
+  }
+
+  public func returnValueAsync<Operation>(
+    for request: Apollo.HTTPRequest<Operation>,
+    value: Apollo.GraphQLResult<Operation.Data>,
+    completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+  ) {}
+}

--- a/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
+++ b/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
@@ -37,7 +37,7 @@ class ParsingPerformanceTests: XCTestCase {
 
   func testMultipartResponseParsingInterceptor() throws {
     var rawData: String = ""
-    for _ in 0..<100 {
+    for _ in 0..<1000 {
       rawData.append("""
         --graphql
         content-type: application/json

--- a/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
+++ b/Tests/ApolloPerformanceTests/ParsingPerformanceTests.swift
@@ -35,6 +35,102 @@ class ParsingPerformanceTests: XCTestCase {
     }
   }
 
+  func testMultipartResponseParsingInterceptor() throws {
+    class DataCaptureRequestChain<Operation: GraphQLOperation>: RequestChain {
+      var isCancelled: Bool = false
+      var completion: (Data?) -> Void
+
+      init(
+        _ completion: @escaping (Data?) -> Void
+      ) {
+        self.completion = completion
+      }
+
+      func kickoff<Operation>(
+        request: Apollo.HTTPRequest<Operation>,
+        completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+      ) {}
+
+      func proceedAsync<Operation>(
+        request: Apollo.HTTPRequest<Operation>,
+        response: Apollo.HTTPResponse<Operation>?,
+        completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+      ) {
+        self.completion(response?.rawData)
+      }
+
+      func cancel() {}
+
+      func retry<Operation>(
+        request: Apollo.HTTPRequest<Operation>,
+        completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+      ) {}
+
+      func handleErrorAsync<Operation>(
+        _ error: Error,
+        request: Apollo.HTTPRequest<Operation>,
+        response: Apollo.HTTPResponse<Operation>?,
+        completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+      ) {}
+
+      func returnValueAsync<Operation>(
+        for request: Apollo.HTTPRequest<Operation>,
+        value: Apollo.GraphQLResult<Operation.Data>,
+        completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
+      ) {}
+    }
+
+    var rawData: String = ""
+    for _ in 0..<100 {
+      rawData.append("""
+        --graphql
+        content-type: application/json
+
+        {
+          "payload": {
+            "data": {
+              "ticker": 1
+            }
+          }
+        }
+        --graphql
+        """)
+    }
+
+    let operation = MockSubscription.mock()
+    let request = JSONRequest(
+      operation: operation,
+      graphQLEndpoint: TestURL.mockServer.url,
+      clientName: "ApolloPerformanceTest",
+      clientVersion: "0",
+      additionalHeaders: [
+        "Accept" : "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0,application/json",
+      ])
+    let response = HTTPResponse<MockSubscription<MockSelectionSet>>(
+      response: HTTPURLResponse(
+        url: TestURL.mockServer.url,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: [
+          "Content-Type": "multipart/mixed;boundary=graphql",
+        ])!,
+      rawData: rawData.crlfFormattedData(),
+      parsedResponse: nil)
+
+    let expectedData = "{\"data\":{\"ticker\":1}}".data(using: .utf8)
+    let chain = DataCaptureRequestChain<MockSubscription<MockSelectionSet>> { data in
+      XCTAssertEqual(data, expectedData)
+    }
+
+    measure {
+      MultipartResponseParsingInterceptor().interceptAsync(
+        chain: chain,
+        request: request,
+        response: response
+      ) { _ in }
+    }
+  }
+
   // MARK - Helpers
 
   func loadResponse<Query: GraphQLQuery>(

--- a/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
+++ b/Tests/ApolloTests/Interceptors/MultipartResponseParsingInterceptorTests.swift
@@ -8,50 +8,10 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
 
   let defaultTimeout = 0.5
 
-  private class ErrorRequestChain: RequestChain {
-    var isCancelled: Bool = false
-    var error: Error? = nil
-
-    init() {}
-
-    func kickoff<Operation>(
-      request: Apollo.HTTPRequest<Operation>,
-      completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
-    ) {}
-
-    func proceedAsync<Operation>(
-      request: Apollo.HTTPRequest<Operation>,
-      response: Apollo.HTTPResponse<Operation>?,
-      completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
-    ) {}
-
-    func cancel() {}
-
-    func retry<Operation>(
-      request: Apollo.HTTPRequest<Operation>,
-      completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
-    ) {}
-
-    func handleErrorAsync<Operation>(
-      _ error: Error,
-      request: Apollo.HTTPRequest<Operation>,
-      response: Apollo.HTTPResponse<Operation>?,
-      completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
-    ) {
-      self.error = error
-    }
-
-    func returnValueAsync<Operation>(
-      for request: Apollo.HTTPRequest<Operation>,
-      value: Apollo.GraphQLResult<Operation.Data>,
-      completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void
-    ) {}
-  }
-
   // MARK: - Error tests
 
   func test__error__givenNoResponse_shouldReturnError() throws {
-    let requestChain = ErrorRequestChain()
+    let requestChain = ResponseCaptureRequestChain()
 
     MultipartResponseParsingInterceptor().interceptAsync(
       chain: requestChain,
@@ -64,7 +24,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
   }
 
   func test__error__givenResponse_withMissingMultipartBoundaryHeader_shouldReturnError() throws {
-    let requestChain = ErrorRequestChain()
+    let requestChain = ResponseCaptureRequestChain()
 
     MultipartResponseParsingInterceptor().interceptAsync(
       chain: requestChain,
@@ -77,7 +37,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
   }
 
   func test__error__givenChunk_withIncorrectContentType_shouldReturnError() throws {
-    let requestChain = ErrorRequestChain()
+    let requestChain = ResponseCaptureRequestChain()
 
     MultipartResponseParsingInterceptor().interceptAsync(
       chain: requestChain,
@@ -103,7 +63,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
   }
 
   func test__error__givenChunk_withTransportError_shouldReturnError() throws {
-    let requestChain = ErrorRequestChain()
+    let requestChain = ResponseCaptureRequestChain()
 
     MultipartResponseParsingInterceptor().interceptAsync(
       chain: requestChain,
@@ -131,7 +91,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
   }
 
   func test__error__givenUnrecognizableChunk_shouldReturnError() throws {
-    let requestChain = ErrorRequestChain()
+    let requestChain = ResponseCaptureRequestChain()
 
     MultipartResponseParsingInterceptor().interceptAsync(
       chain: requestChain,
@@ -153,7 +113,7 @@ final class MultipartResponseParsingInterceptorTests: XCTestCase {
   }
 
   func test__error__givenChunk_withMissingPayload_shouldReturnError() throws {
-    let requestChain = ErrorRequestChain()
+    let requestChain = ResponseCaptureRequestChain()
 
     MultipartResponseParsingInterceptor().interceptAsync(
       chain: requestChain,


### PR DESCRIPTION
Closes #2971 

* Adds a performance test focused on the response data parsing of `MultipartResponseParsingInterceptor`. This gives us a benchmark to improve the parsing performance of multipart responses and test the impact of `@defer` implementation to the multipart processing.
* Changes performance test configuration to fail when no benchmark is found. I believe this is better default behaviour rather than letting an unaware developer believe the test passed within thresholds.
* Refactors a mock request chain for better general usage