### PR TITLE
Fix: Pruning generated files for relative operations

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -465,7 +465,6 @@ public class ApolloCodegen {
     return try globs.reduce(into: []) { partialResult, glob in
       partialResult.formUnion(try glob.match())
     }
-
   }
 
   static func deleteExtraneousGeneratedFiles(

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -462,8 +462,23 @@ public class ApolloCodegen {
     default: break
     }
 
-    return try globs.reduce(into: []) { partialResult, glob in
+    var existingPaths: Set<String> = try globs.reduce(into: []) { partialResult, glob in
       partialResult.formUnion(try glob.match())
+    }
+    
+    try resolveSymlinksInPaths(&existingPaths)
+    
+    return existingPaths
+  }
+  
+  private static func resolveSymlinksInPaths(_ paths: inout Set<String>) throws {
+    for path in paths {
+      let url = URL(fileURLWithPath: path).deletingLastPathComponent()
+      let resourceValues = try url.resourceValues(forKeys: [.isSymbolicLinkKey])
+      if let isSymbolicLink = resourceValues.isSymbolicLink,
+         isSymbolicLink {
+        paths.remove(path)
+      }
     }
   }
 

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -462,24 +462,10 @@ public class ApolloCodegen {
     default: break
     }
 
-    var existingPaths: Set<String> = try globs.reduce(into: []) { partialResult, glob in
+    return try globs.reduce(into: []) { partialResult, glob in
       partialResult.formUnion(try glob.match())
     }
-    
-    try resolveSymlinksInPaths(&existingPaths)
-    
-    return existingPaths
-  }
-  
-  private static func resolveSymlinksInPaths(_ paths: inout Set<String>) throws {
-    for path in paths {
-      let url = URL(fileURLWithPath: path).deletingLastPathComponent()
-      let resourceValues = try url.resourceValues(forKeys: [.isSymbolicLinkKey])
-      if let isSymbolicLink = resourceValues.isSymbolicLink,
-         isSymbolicLink {
-        paths.remove(path)
-      }
-    }
+
   }
 
   static func deleteExtraneousGeneratedFiles(

--- a/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/FileGenerator.swift
@@ -26,6 +26,7 @@ extension FileGenerator {
   ) throws {
     let directoryPath = target.resolvePath(forConfig: config)
     let filePath = URL(fileURLWithPath: directoryPath)
+      .resolvingSymlinksInPath()
       .appendingPathComponent(fileName.firstUppercased)
       .appendingPathExtension(fileExtension)
       .path

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -177,7 +177,7 @@ public struct Glob {
           excludedSet.intersection(url.pathComponents).isEmpty
         else { continue }
 
-        directories.append(url)
+        directories.append(url.resolvingSymlinksInPath())
       }
 
     } catch(let error) {

--- a/Tests/ApolloInternalTestHelpers/TestIsolatedFileManager.swift
+++ b/Tests/ApolloInternalTestHelpers/TestIsolatedFileManager.swift
@@ -59,6 +59,7 @@ public class TestIsolatedFileManager {
     }
 
     let filePath: String = fileDirectoryURL
+      .resolvingSymlinksInPath()
       .appendingPathComponent(fileName, isDirectory: false).path
 
     guard fileManager.createFile(atPath: filePath, contents: data) else {


### PR DESCRIPTION
Updating code generation to always use resolved file paths when writing files, and getting lists of generated files to account for errors with files being deleted by mistake when symlink directories are used.

closes #2969