### PR TITLE
ci: Update tooling versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: "15.5"
   macos_version: # The user-facing version string for macOS builds
     type: string
-    default: "13.3"
+    default: "13.2"
   tvos_version: # The user-facing version string of tvOS builds
     type: string
     default: "16.4"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,10 @@ commands:
   build_and_run_xcode_tests:
     steps:
       - run:
-          command: xcodebuild clean build-for-testing -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" | xcbeautify
+          command: xcodebuild clean build-for-testing -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" -verbose
           name: Clean and build for testing
       - run:
-          command: xcodebuild test-without-building -resultBundlePath ~/TestResults/ResultBundle.xcresult -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" | xcbeautify
+          command: xcodebuild test-without-building -resultBundlePath ~/TestResults/ResultBundle.xcresult -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" -verbose
           name: Run Xcode tests
       - save-xcodebuild-artifacts
   run_js_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,8 @@ commands:
   build_and_run_xcode_tests:
     steps:
       - run:
-          command: xcodebuild clean build-for-testing -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" -verbose
-          name: Clean and build for testing
-      - run:
-          command: xcodebuild test-without-building -resultBundlePath ~/TestResults/ResultBundle.xcresult -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" -verbose
-          name: Run Xcode tests
+          command: xcodebuild clean test -resultBundlePath ~/TestResults/ResultBundle.xcresult -project "Apollo.xcodeproj" -scheme "${CIRCLE_XCODE_SCHEME}" -destination "${DESTINATION}" -testPlan "${CIRCLE_XCODE_TEST_PLAN}" | xcbeautify
+          name: Clean, build and run Xcode tests
       - save-xcodebuild-artifacts
   run_js_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 parameters:
+  resource_class:
+    type: string
+    default: "macos.x86.medium.gen2"
   xcode_version:
     type: string
     default: "14.3.0"
@@ -133,6 +136,7 @@ commands:
 # executes by also adding it to the `workflows` section below!
 jobs:
   Swift_Build:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     steps:
@@ -141,6 +145,7 @@ jobs:
           command: swift build
 
   XCFramework_Build:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     steps:
@@ -156,6 +161,7 @@ jobs:
           command: xcodebuild -create-xcframework -output ./build/Apollo.xcframework -framework ./build/iphonesimulator.xcarchive/Products/@rpath/Apollo.framework -framework ./build/iphoneos.xcarchive/Products/@rpath/Apollo.framework
 
   IntegrationTests_macOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -168,6 +174,7 @@ jobs:
       - integration_test_cleanup
 
   macOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -179,6 +186,7 @@ jobs:
       - build_and_run_xcode_tests
 
   iOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -190,6 +198,7 @@ jobs:
       - build_and_run_xcode_tests
 
   iOS_previous:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -201,6 +210,7 @@ jobs:
       - build_and_run_xcode_tests
 
   tvOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -212,6 +222,7 @@ jobs:
       - build_and_run_xcode_tests
 
   CodegenLib_macOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -224,6 +235,7 @@ jobs:
       - run_js_tests
   
   CodegenCLI_macOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -235,6 +247,7 @@ jobs:
       - build_and_run_xcode_tests
   
   CocoaPodsIntegration_macOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     environment:
@@ -244,6 +257,7 @@ jobs:
       - cocoapods_install_test
 
   CodegenTestConfigurations_macOS_current:
+    resource_class: << pipeline.parameters.resource_class >>
     macos:
       xcode: << pipeline.parameters.xcode_version >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,19 @@ version: 2.1
 parameters:
   xcode_version:
     type: string
-    default: "14.1.0"
+    default: "14.3.0"
   ios_current_version:
     type: string
-    default: "16.1"
+    default: "16.4"
   ios_previous_version:
     type: string
     default: "15.5"
   macos_version: # The user-facing version string for macOS builds
     type: string
-    default: "12.5.1"
+    default: "13.3"
   tvos_version: # The user-facing version string of tvOS builds
     type: string
-    default: "16.1"
+    default: "16.4"
 
 commands:
   integration_test_setup:

--- a/scripts/install-node-v12.sh
+++ b/scripts/install-node-v12.sh
@@ -5,4 +5,4 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 echo nvm install v12.22.10 >> $BASH_ENV
-echo nvm use v16.18.0 >> $BASH_ENV
+echo nvm use v18.15.0 >> $BASH_ENV


### PR DESCRIPTION
CircleCI is deprecating certain resource classes and we need to move our CI suite to use macOS images that will continue to be updated - [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891?mkt_tok=NDg1LVpNSC02MjYAAAGK0gP2h8fU9M1cRfp1IL-x0Z4PeRBD0lad98jp2VLP4rnSxK0EYNwmapCZSNVbqJOury6pN-NIxtqROok6vpJxac1BnIy2d3M0JuAiMDfEp7r26Q).

Includes the following updates:
* Specifies the new resource class
* Moves to Xcode 14.3 from 14.1
* Uses the latest [SDK versions included](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11629/manifest.txt) with Xcode 14.3
* References the correct [pre-installed version of Node.js](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11629/manifest.txt) when installing Node 12.22.0
* Combines the `clean build-for-testing` and `test-without-building` steps into a single `clean test` step.

Closes #3021 