### PR TITLE
chore: makefile improvements

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,13 +12,20 @@ build:
 	swift build -c release
 
 build-cli:
-	swift build --product apollo-ios-cli -c release
+	swift build --product apollo-ios-cli -c release; \
+	cp -f .build/release/apollo-ios-cli apollo-ios-cli
 
 build-cli-universal:
-	swift build --product apollo-ios-cli -c release --arch arm64 --arch x86_64
+	swift build --product apollo-ios-cli -c release --arch arm64 --arch x86_64; \
+	cp -f .build/apple/Products/Release/apollo-ios-cli apollo-ios-cli
 
 build-cli-for-cocoapods:
 	swift build --product apollo-ios-cli -c release -Xswiftc -DCOCOAPODS
+
+archive-cli-for-release:
+	make build-cli-universal; \
+	tar -czf apollo-ios-cli.tar.gz apollo-ios-cli; \
+	echo "Attach apollo-ios-cli.tar.gz to the GitHub release"
 
 test: 
 	swift test


### PR DESCRIPTION
Some small quality-of-life improvements:
* copy the built CLI binary into the current path
* adds a target to archive the built CLI for easier workflow during GitHub releases