### PR TITLE
Remove '0' label from Introduction

### DIFF
--- a/docs/source/tutorial/tutorial-introduction.mdx
+++ b/docs/source/tutorial/tutorial-introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "0. Introduction"
+title: "Introduction"
 ---
 
 Welcome! This tutorial demonstrates adding the Apollo iOS SDK to an app to communicate with a GraphQL server. In this tutorial you will learn how to:


### PR DESCRIPTION
Removing '0' label from the Introduction page like we already did from the sidebar