### PR TITLE
Fix RootEntityType and FulfilledFragment name generation

### DIFF
--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -23,7 +23,7 @@ public class CompilationResult: JavaScriptObject {
     lazy var subscriptionType: GraphQLNamedType? = self["subscriptionType"]
   }
   
-  public class OperationDefinition: JavaScriptObject, Equatable {
+  public class OperationDefinition: JavaScriptObject, Hashable {
     lazy var name: String = self["name"]
     
     lazy var operationType: OperationType = self["operationType"]
@@ -44,6 +44,10 @@ public class CompilationResult: JavaScriptObject {
       "\(name) on \(rootType.debugDescription)"
     }
 
+    public func hash(into hasher: inout Hasher) {
+      hasher.combine(name)
+    }
+    
     public static func ==(lhs: OperationDefinition, rhs: OperationDefinition) -> Bool {
       return lhs.name == rhs.name
     }

--- a/Sources/ApolloCodegenLib/IR+Formatting.swift
+++ b/Sources/ApolloCodegenLib/IR+Formatting.swift
@@ -14,19 +14,19 @@ extension GraphQLType {
 
 extension IR.EntityField {
 
-  /// Takes the associated ``IR.EntityField`` and formats it into a selection set name
+  /// Takes the associated `IR.EntityField` and formats it into a selection set name
   func formattedSelectionSetName(
     with pluralizer: Pluralizer
   ) -> String {
-    IR.Entity.FieldPathComponent(name: responseKey, type: type)
+    IR.Entity.Location.FieldComponent(name: responseKey, type: type)
       .formattedSelectionSetName(with: pluralizer)
   }
 
 }
 
-extension IR.Entity.FieldPathComponent {
+extension IR.Entity.Location.FieldComponent {
 
-  /// Takes the associated ``IR.Entity.FieldPathComponent`` and formats it into a selection set name
+  /// Takes the associated `IR.Entity.Location.FieldComponent` and formats it into a selection set name
   func formattedSelectionSetName(
     with pluralizer: Pluralizer
   ) -> String {
@@ -35,6 +35,18 @@ extension IR.Entity.FieldPathComponent {
       fieldName = pluralizer.singularize(fieldName)
     }
     return fieldName.asSelectionSetName
+  }
+
+}
+
+extension IR.Entity.Location.SourceDefinition {
+
+  /// Takes the associated `IR.Entity.Location.SourceDefinition` and formats it into a selection set name
+  func formattedSelectionSetName() -> String {
+    switch self {
+    case .operation: return "Data"
+    case let .namedFragment(fragment): return fragment.generatedDefinitionName
+    }
   }
 
 }

--- a/Sources/ApolloCodegenLib/IR/IR+NamedFragmentBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+NamedFragmentBuilder.swift
@@ -15,8 +15,7 @@ extension IR {
     )
 
     let rootEntity = Entity(
-      source: .namedFragment(fragmentDefinition),
-      rootTypePath: LinkedList(fragmentDefinition.type)
+      source: .namedFragment(fragmentDefinition)      
     )
 
     let result = RootFieldBuilder.buildRootEntityField(

--- a/Sources/ApolloCodegenLib/IR/IR+NamedFragmentBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+NamedFragmentBuilder.swift
@@ -15,8 +15,8 @@ extension IR {
     )
 
     let rootEntity = Entity(
-      rootTypePath: LinkedList(fragmentDefinition.type),
-      fieldPath: [.init(name: rootField.name, type: rootField.type)]
+      source: .namedFragment(fragmentDefinition),
+      rootTypePath: LinkedList(fragmentDefinition.type)
     )
 
     let result = RootFieldBuilder.buildRootEntityField(

--- a/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
@@ -11,8 +11,7 @@ extension IR {
     )
 
     let rootEntity = Entity(
-      source: .operation(operationDefinition),
-      rootTypePath: LinkedList(operationDefinition.rootType)
+      source: .operation(operationDefinition)      
     )
 
     let result = RootFieldBuilder.buildRootEntityField(

--- a/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
@@ -11,11 +11,8 @@ extension IR {
     )
 
     let rootEntity = Entity(
-      rootTypePath: LinkedList(operationDefinition.rootType),
-      fieldPath: [.init(
-        name: "\(operationDefinition.generatedDefinitionName).Data",
-        type: rootField.type
-      )]
+      source: .operation(operationDefinition),
+      rootTypePath: LinkedList(operationDefinition.rootType)
     )
 
     let result = RootFieldBuilder.buildRootEntityField(

--- a/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
@@ -12,7 +12,10 @@ extension IR {
 
     let rootEntity = Entity(
       rootTypePath: LinkedList(operationDefinition.rootType),
-      fieldPath: [.init(name: rootField.name, type: rootField.type)]
+      fieldPath: [.init(
+        name: "\(operationDefinition.generatedDefinitionName).Data",
+        type: rootField.type
+      )]
     )
 
     let result = RootFieldBuilder.buildRootEntityField(

--- a/Sources/ApolloCodegenLib/LinkedList.swift
+++ b/Sources/ApolloCodegenLib/LinkedList.swift
@@ -71,24 +71,25 @@ public struct LinkedList<T>: ExpressibleByArrayLiteral {
     self.headNode = head
   }
 
+  @_disfavoredOverload
   public init(_ headValue: T) {    
     self.init(head: HeadNode(value: headValue))
   }
 
-  public init(array: [T]) {
-    precondition(!array.isEmpty, "Cannot initialize LinkedList with an empty array. LinkedList must have at least one element.")
-    var segments = array
-    let headNode = HeadNode(value: segments.removeFirst())
+  public init<C: Collection<T>>(_ collection: C) {
+    precondition(!collection.isEmpty, "Cannot initialize LinkedList with an empty collection. LinkedList must have at least one element.")
+    var iterator = collection.makeIterator()
+    let headNode = HeadNode(value: iterator.next()!)
 
     self.init(head: headNode)
 
-    for segment in segments {
+    while let segment = iterator.next() {
       append(segment)
     }
   }
 
   public init(arrayLiteral segments: T...) {
-    self.init(array: segments)
+    self.init(segments)
   }
 
   private func copy() -> Self {

--- a/Sources/ApolloCodegenLib/LinkedList.swift
+++ b/Sources/ApolloCodegenLib/LinkedList.swift
@@ -21,6 +21,10 @@ public struct LinkedList<T>: ExpressibleByArrayLiteral {
       self.value = value
       self.index = index
     }
+
+    public var isHead: Bool {
+      index == 0      
+    }
   }
 
   final class HeadNode: Node {

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
@@ -24,10 +24,16 @@ extension IR.Definition {
 
 }
 
+extension CompilationResult.OperationDefinition {
+  var generatedDefinitionName: String {
+    nameWithSuffix.firstUppercased
+  }
+}
+
 extension IR.Operation {
 
   var generatedDefinitionName: String {
-    definition.nameWithSuffix.firstUppercased
+    definition.generatedDefinitionName
   }
 
 }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/IRDefinition+RenderingHelpers.swift
@@ -38,10 +38,16 @@ extension IR.Operation {
 
 }
 
+extension CompilationResult.FragmentDefinition {
+  var generatedDefinitionName: String {
+    name.firstUppercased
+  }
+}
+
 extension IR.NamedFragment {
 
   var generatedDefinitionName: String {
-    definition.name.firstUppercased
+    definition.generatedDefinitionName
   }
 
 }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -484,13 +484,10 @@ struct SelectionSetTemplate {
     while next.next != nil {
       defer { next = next.next.unsafelyUnwrapped }
 
-      let selectionSetName = SelectionSetNameGenerator.generatedSelectionSetName(
-        from: selectionSet.scopePath.head,
-        to: next,
-        withFieldPath: selectionSet.entity.fieldPath.head,
-        removingFirst: selectionSet.scopePath.head.value.type.isRootFieldType,
-        pluralizer: config.pluralizer
-      )
+      let selectionSetName = fullyQualifiedGeneratedSelectionSetName(
+        for: selectionSet.typeInfo,
+        to: next
+      )      
 
       fulfilledFragments.append(selectionSetName)
     }
@@ -546,7 +543,6 @@ struct SelectionSetTemplate {
       from: typeInfo.scopePath.head,
       to: toNode,
       withFieldPath: typeInfo.entity.fieldPath.head,
-      removingFirst: false,
       pluralizer: config.pluralizer
     )
   }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -77,15 +77,6 @@ struct SelectionSetTemplate {
 
   // MARK: - Selection Set Name Documentation
   func SelectionSetNameDocumentation(_ selectionSet: IR.SelectionSet) -> TemplateString {
-//    let startingConditionNode: LinkedList<IR.ScopeCondition>.Node
-//    let startingEntityPath: LinkedList<IR.ScopeDescriptor>.Node
-//    if let rootEntityConditionNode = selectionSet.scopePath.head.value.scopePath.head.next {
-//      startingConditionNode = rootEntityConditionNode
-//      startingEntityPath = selectionSet.scopePath.head
-//    } else {
-//      startingConditionNode = selectionSet.scopePath.head.next?.value.scopePath.head
-//      startingEntityPath = selectionSet.scopePath.head.next
-//    }
     """
     /// \(SelectionSetNameGenerator.generatedSelectionSetName(
           for: selectionSet,

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -542,19 +542,13 @@ struct SelectionSetTemplate {
     for typeInfo: IR.SelectionSet.TypeInfo,
     to toNode: LinkedList<IR.ScopeCondition>.Node? = nil
   ) -> String {
-    let rootNode = typeInfo.scopePath.head
-    let rootTypeIsOperationRoot = rootNode.value.type.isRootFieldType
-
-    let rootEntityName = SelectionSetNameGenerator.generatedSelectionSetName(
-      from: rootNode,
+    return SelectionSetNameGenerator.generatedSelectionSetName(
+      from: typeInfo.scopePath.head,
       to: toNode,
       withFieldPath: typeInfo.entity.fieldPath.head,
-      removingFirst: rootTypeIsOperationRoot,
+      removingFirst: false,
       pluralizer: config.pluralizer
     )
-
-    return rootTypeIsOperationRoot ?
-    "\(definition.generatedDefinitionName.firstUppercased).Data.\(rootEntityName)" : rootEntityName
   }
 
 }

--- a/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/IR+Mocking.swift
@@ -61,10 +61,11 @@ extension IR.NamedFragment {
     type: GraphQLCompositeType = .mock("MockType"),
     source: String? = nil
   ) -> IR.NamedFragment {
+    let definition = CompilationResult.FragmentDefinition.mock(name, type: type, source: source)
     let rootField = CompilationResult.Field.mock(name, type: .entity(type))
     let rootEntity = IR.Entity(
-      rootTypePath: LinkedList(type),
-      fieldPath: [.init(name: name, type: .entity(type))]
+      location: .init(source: .namedFragment(definition), fieldPath: nil),
+      rootTypePath: LinkedList(type)
     )
     let rootEntityField = IR.EntityField.init(
       rootField,
@@ -79,10 +80,10 @@ extension IR.NamedFragment {
           ))))
 
     return IR.NamedFragment(
-      definition: CompilationResult.FragmentDefinition.mock(name, type: type, source: source),
+      definition: definition,
       rootField: rootEntityField,
       referencedFragments: [],
-      entities: [rootEntity.fieldPath: rootEntity]
+      entities: [rootEntity.location: rootEntity]
     )
   }
 }
@@ -93,15 +94,17 @@ extension IR.Operation {
     definition: CompilationResult.OperationDefinition? = nil,
     referencedFragments: OrderedSet<IR.NamedFragment> = []
   ) -> IR.Operation {
-    IR.Operation.init(
-      definition: definition ?? .mock(),
+    let definition = definition ?? .mock()
+    return IR.Operation.init(
+      definition: definition,
       rootField: .init(
         .mock(),
         inclusionConditions: nil,
         selectionSet: .init(
           entity: .init(
-            rootTypePath: [.mock()],
-            fieldPath: [.init(name: "mock", type: .entity(.mock("name")))]),
+            location: .init(source: .operation(definition), fieldPath: nil),
+            rootTypePath: [.mock()]
+          ),
           scopePath: [.descriptor(
             forType: .mock(),
             inclusionConditions: nil,

--- a/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
@@ -82,8 +82,8 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootType).to(equal(Object_Query))
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Query)))
-    expect(self.subject.rootField.selectionSet.entity.fieldPath)
-      .to(equal([.init(name: "TestQuery.Data", type: .nonNull(.entity(Object_Query)))]))
+    expect(self.subject.rootField.selectionSet.entity.location)
+      .to(equal(.init(source: .operation(self.subject.definition), fieldPath: nil)))
   }
 
   func test__buildOperation__givenSubscription_hasRootFieldAsSubscription() throws {
@@ -126,8 +126,8 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootType).to(equal(Object_Subscription))
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Subscription)))
-    expect(self.subject.rootField.selectionSet.entity.fieldPath)
-      .to(equal([.init(name: "TestSubscription.Data", type: .nonNull(.entity(Object_Subscription)))]))
+    expect(self.subject.rootField.selectionSet.entity.location)
+      .to(equal(.init(source: .operation(self.subject.definition), fieldPath: nil)))
   }
 
   func test__buildOperation__givenMutation_hasRootFieldAsMutation() throws {
@@ -170,8 +170,8 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootType).to(equal(Object_Mutation))
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Mutation)))
-    expect(self.subject.rootField.selectionSet.entity.fieldPath)
-      .to(equal([.init(name: "TestMutation.Data", type: .nonNull(.entity(Object_Mutation)))]))
+    expect(self.subject.rootField.selectionSet.entity.location)
+      .to(equal(.init(source: .operation(self.subject.definition), fieldPath: nil)))
   }
 
   // MARK: - Operation Identifier Computation

--- a/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
@@ -83,7 +83,7 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Query)))
     expect(self.subject.rootField.selectionSet.entity.fieldPath)
-      .to(equal([.init(name: "query", type: .nonNull(.entity(Object_Query)))]))
+      .to(equal([.init(name: "TestQuery.Data", type: .nonNull(.entity(Object_Query)))]))
   }
 
   func test__buildOperation__givenSubscription_hasRootFieldAsSubscription() throws {
@@ -127,7 +127,7 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Subscription)))
     expect(self.subject.rootField.selectionSet.entity.fieldPath)
-      .to(equal([.init(name: "subscription", type: .nonNull(.entity(Object_Subscription)))]))      
+      .to(equal([.init(name: "TestSubscription.Data", type: .nonNull(.entity(Object_Subscription)))]))
   }
 
   func test__buildOperation__givenMutation_hasRootFieldAsMutation() throws {
@@ -171,7 +171,7 @@ class IROperationBuilderTests: XCTestCase {
     expect(self.subject.rootField.selectionSet.entity.rootTypePath)
       .to(equal(LinkedList(Object_Mutation)))
     expect(self.subject.rootField.selectionSet.entity.fieldPath)
-      .to(equal([.init(name: "mutation", type: .nonNull(.entity(Object_Mutation)))]))
+      .to(equal([.init(name: "TestMutation.Data", type: .nonNull(.entity(Object_Mutation)))]))
   }
 
   // MARK: - Operation Identifier Computation

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -43,8 +43,8 @@ class IRRootFieldBuilderTests: XCTestCase {
         selectionSet: operation.selectionSet
       ),
       onRootEntity: IR.Entity(
-        rootTypePath: LinkedList(operation.rootType),
-        fieldPath: [.init(name: "query", type: .nonNull(.entity(operation.rootType)))]
+        source: .operation(operation),
+        rootTypePath: LinkedList(operation.rootType)
       ),
       inIR: ir
     )
@@ -2617,7 +2617,7 @@ class IRRootFieldBuilderTests: XCTestCase {
       givenAllTypesInSchema: schema.referencedTypes
     )
 
-    let expectedTypePath = LinkedList(array: [
+    let expectedTypePath = LinkedList([
       query_TypeScope,
       allAnimals_TypeScope,
     ])
@@ -3704,13 +3704,13 @@ class IRRootFieldBuilderTests: XCTestCase {
       inclusionConditions: nil,
       givenAllTypesInSchema: schema.referencedTypes)
 
-    let allAnimals_asCat_predator_expectedTypePath = LinkedList(array: [
+    let allAnimals_asCat_predator_expectedTypePath = LinkedList([
       query_TypeScope,
       allAnimals_asCat_TypeScope,
       allAnimals_asCat_predator_TypeScope
     ])
 
-    let allAnimals_asCat_predator_height_expectedTypePath = LinkedList(array: [
+    let allAnimals_asCat_predator_height_expectedTypePath = LinkedList([
       query_TypeScope,
       allAnimals_asCat_TypeScope,
       allAnimals_asCat_predator_TypeScope,
@@ -3811,13 +3811,13 @@ class IRRootFieldBuilderTests: XCTestCase {
       givenAllTypesInSchema: schema.referencedTypes
     )
 
-    let allAnimals_asCat_predator_expectedTypePath = LinkedList(array: [
+    let allAnimals_asCat_predator_expectedTypePath = LinkedList([
       query_TypeScope,
       allAnimals_asCat_TypeScope,
       allAnimals_asCat_predator_TypeScope
     ])
 
-    let allAnimals_asCat_predator_height_expectedTypePath = LinkedList(array: [
+    let allAnimals_asCat_predator_height_expectedTypePath = LinkedList([
       query_TypeScope,
       allAnimals_asCat_TypeScope,
       allAnimals_asCat_predator_asPet_TypeScope,

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -42,10 +42,7 @@ class IRRootFieldBuilderTests: XCTestCase {
         type: .nonNull(.entity(operation.rootType)),
         selectionSet: operation.selectionSet
       ),
-      onRootEntity: IR.Entity(
-        source: .operation(operation),
-        rootTypePath: LinkedList(operation.rootType)
-      ),
+      onRootEntity: IR.Entity(source: .operation(operation)),
       inIR: ir
     )
     subject = result.rootField

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
@@ -41,8 +41,8 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
         selectionSet: operation.selectionSet
       ),
       onRootEntity: IR.Entity(
-        rootTypePath: LinkedList(operation.rootType),
-        fieldPath: [.init(name: "query", type: .nonNull(.entity(operation.rootType)))]
+        source: .operation(operation),
+        rootTypePath: LinkedList(operation.rootType)        
       ),
       inIR: ir
     )

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRSelectionSet_IncludeSkip_Tests.swift
@@ -40,10 +40,7 @@ class IRSelectionSet_IncludeSkip_Tests: XCTestCase {
         type: .nonNull(.entity(operation.rootType)),
         selectionSet: operation.selectionSet
       ),
-      onRootEntity: IR.Entity(
-        source: .operation(operation),
-        rootTypePath: LinkedList(operation.rootType)        
-      ),
+      onRootEntity: IR.Entity(source: .operation(operation)),
       inIR: ir
     )
     subject = result.rootField

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplate_Initializers_Tests.swift
@@ -365,8 +365,8 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
-            ObjectIdentifier(AllAnimal.self),
-            ObjectIdentifier(AllAnimal.AsAnimalUnion.self)
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self),
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.AsAnimalUnion.self)
           ]
         ))
       }
@@ -430,8 +430,8 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
-            ObjectIdentifier(AllAnimal.self),
-            ObjectIdentifier(AllAnimal.AsPet.self)
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self),
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.AsPet.self)
           ]
         ))
       }
@@ -1116,7 +1116,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
-            ObjectIdentifier(AllAnimal.self)
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self)
           ]
         ))
       }
@@ -1378,7 +1378,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
-            ObjectIdentifier(AllAnimal.self),
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self),
             ObjectIdentifier(AnimalDetails.self)
           ]
         ))
@@ -1455,7 +1455,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
-            ObjectIdentifier(AllAnimal.self),
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self),
             ObjectIdentifier(AnimalDetails.self)
           ]
         ))
@@ -1574,7 +1574,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
             ],
             fulfilledFragments: [
               ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self)
+              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self)
             ]
           ))
         }
@@ -1633,7 +1633,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
             ],
             fulfilledFragments: [
               ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self)
+              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self)
             ]
           ))
         }
@@ -1694,8 +1694,8 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
             ],
             fulfilledFragments: [
               ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
-              ObjectIdentifier(AllAnimal.IfA.self)
+              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self),
+              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.IfA.self)
             ]
           ))
         }
@@ -1756,7 +1756,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
             ],
             fulfilledFragments: [
               ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.IfA.Friend.self)
+              ObjectIdentifier(TestOperationQuery.Data.AllAnimal.IfA.Friend.self)
             ]
           ))
         }
@@ -1834,7 +1834,7 @@ class SelectionSetTemplate_Initializers_Tests: XCTestCase {
           ],
           fulfilledFragments: [
             ObjectIdentifier(Self.self),
-            ObjectIdentifier(AllAnimal.self),
+            ObjectIdentifier(TestOperationQuery.Data.AllAnimal.self),
             ObjectIdentifier(AnimalDetails.self)
           ]
         ))


### PR DESCRIPTION
Fully qualified names should be generated at all times for `FulfilledFragments` and `RootEntityType`. Due to the issue indicated in #2949 

Fully qualified names were not being calculated properly for fragments on the root of a query. Simplified the calculation of these by adding the fully qualified root type names to the root of the `FieldPathComponents`. This fixes #2962.