### PR TITLE
Also look for Package.resolved in .xcworkspace when performing version check

### DIFF
--- a/Tests/CodegenCLITests/VersionCheckerTests.swift
+++ b/Tests/CodegenCLITests/VersionCheckerTests.swift
@@ -255,6 +255,30 @@ class VersionCheckerTests: XCTestCase {
     // then
     expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
   }
+  
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspaceAndProject_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch_fromWorkspace() throws {
+    // given
+    try fileManager.createFile(
+      body: version2PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
+      named: "Package.resolved",
+      inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
+    )
+    
+    let apolloProjectVersion = "1.0.0.test-1"
+    try fileManager.createFile(
+      body: version2PackageResolvedFileBody(apolloVersion: apolloProjectVersion),
+      named: "Package.resolved",
+      inDirectory: "MyProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
+    )
+
+    // when
+    let result = try VersionChecker.matchCLIVersionToApolloVersion(
+      projectRootURL: fileManager.directoryURL
+    )
+
+    // then
+    expect(result).to(equal(.versionMatch))
+  }
 
 }
 

--- a/Tests/CodegenCLITests/VersionCheckerTests.swift
+++ b/Tests/CodegenCLITests/VersionCheckerTests.swift
@@ -186,6 +186,41 @@ class VersionCheckerTests: XCTestCase {
     expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
   }
 
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspace_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch() throws {
+    // given
+    try fileManager.createFile(
+      body: version2PackageResolvedFileBody(apolloVersion: Constants.CLIVersion),
+      named: "Package.resolved",
+      inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
+    )
+
+    // when
+    let result = try VersionChecker.matchCLIVersionToApolloVersion(
+      projectRootURL: fileManager.directoryURL
+    )
+
+    // then
+    expect(result).to(equal(.versionMatch))
+  }
+
+  func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeWorkspace_withVersion2FileFormat_hasNonMatchingVersion_returns_versionMismatch() throws {
+    // given
+    let apolloVersion = "1.0.0.test-1"
+    try fileManager.createFile(
+      body: version2PackageResolvedFileBody(apolloVersion: apolloVersion),
+      named: "Package.resolved",
+      inDirectory: "MyProject.xcworkspace/xcshareddata/swiftpm"
+    )
+
+    // when
+    let result = try VersionChecker.matchCLIVersionToApolloVersion(
+      projectRootURL: fileManager.directoryURL
+    )
+
+    // then
+    expect(result).to(equal(.versionMismatch(cliVersion: Constants.CLIVersion, apolloVersion: apolloVersion)))
+  }
+
   func test__matchCLIVersionToApolloVersion__givenPackageResolvedFileInXcodeProject_withVersion2FileFormat_hasMatchingVersion_returns_versionMatch() throws {
     // given
     try fileManager.createFile(


### PR DESCRIPTION
When using an xcworkspace the Package.resolved file is stored at `my.xcworkspace/xcshareddata/swiftpm/Package.resolved`

This change prioritises Package.resolved located in .xcworkspace over those in .xcodeproj, but below those located in the root.