### PR TITLE
Add linker settings for iOSApplicationExtension

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,13 +44,25 @@ let package = Package(
       ],
       exclude: [
         "Info.plist"
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-Xfrontend", "-application-extension"])
+      ],
+      linkerSettings: [
+        .unsafeFlags(["-Xlinker", "-application_extension"])
       ]),
     .target(
       name: "ApolloAPI",
       dependencies: [],
       exclude: [
         "Info.plist"
-      ]),    
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-Xfrontend", "-application-extension"])
+      ],
+      linkerSettings: [
+        .unsafeFlags(["-Xlinker", "-application_extension"])
+      ]),
     .target(
       name: "ApolloCodegenLib",
       dependencies: [
@@ -69,6 +81,12 @@ let package = Package(
       ],
       exclude: [
         "Info.plist"
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-Xfrontend", "-application-extension"])
+      ],
+      linkerSettings: [
+        .unsafeFlags(["-Xlinker", "-application_extension"])
       ]),
     .target(
       name: "ApolloWebSocket",


### PR DESCRIPTION
This package doesn't use any APIs disallowed by `iOSApplicationExtension`.  In some instances, linking against this package can still trigger the warning: `ld: warning: linking against a dylib which is not safe for use in application extensions`.  This commit adds linker settings to suppress this warning, while simultaneously adding a build setting that treats these warnings as errors.