### PR TITLE
fix: `RequestChain` `managedSelf` cleanup

### DIFF
--- a/Sources/Apollo/ApolloInterceptorReentrantWrapper.swift
+++ b/Sources/Apollo/ApolloInterceptorReentrantWrapper.swift
@@ -56,6 +56,15 @@ class ApolloInterceptorReentrantWrapper: RequestChain {
     }
   }
 
+  func terminate() {
+    guard !self.isCancelled else {
+      // Do not proceed, this chain has been cancelled.
+      return
+    }
+
+    requestChain.takeUnretainedValue().terminate()
+  }
+
   func retry<Operation>(
     request: HTTPRequest<Operation>,
     completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void

--- a/Sources/Apollo/CacheReadInterceptor.swift
+++ b/Sources/Apollo/CacheReadInterceptor.swift
@@ -65,6 +65,7 @@ public struct CacheReadInterceptor: ApolloInterceptor {
               chain.returnValueAsync(for: request,
                                      value: graphQLResult,
                                      completion: completion)
+              chain.terminate()
             }
           }
         case .returnCacheDataDontFetch:
@@ -81,6 +82,8 @@ public struct CacheReadInterceptor: ApolloInterceptor {
                                      value: result,
                                      completion: completion)
             }
+
+            chain.terminate()
           }
         }
       }

--- a/Sources/Apollo/InterceptorRequestChain.swift
+++ b/Sources/Apollo/InterceptorRequestChain.swift
@@ -174,6 +174,20 @@ final public class InterceptorRequestChain: Cancellable, RequestChain {
     _ = self.releaseManagedSelf
   }
 
+  /// Ends execution of the request chain.
+  ///
+  /// Call this function when there is an early exit of the request chain, such as a cache read
+  /// interceptor that handles a request to only fetch from the cache and not send the request to
+  /// the server.
+  public func terminate() {
+    guard !self.isCancelled else {
+      // Do not proceed, this chain has been cancelled.
+      return
+    }
+
+    _ = self.releaseManagedSelf
+  }
+
   /// Restarts the request starting from the first interceptor.
   ///
   /// - Parameters:

--- a/Sources/Apollo/RequestChain.swift
+++ b/Sources/Apollo/RequestChain.swift
@@ -3,6 +3,22 @@ import Foundation
 import ApolloAPI
 #endif
 
+/// A request chain defines a sequence of interceptors that handle the lifecycle of a particular
+/// GraphQL operation's execution. One interceptor might add custom HTTP headers to a request,
+/// while the next might be responsible for actually sending the request to a GraphQL server over
+/// HTTP. A third interceptor might then write the operation's result to the cache.
+///
+/// When an operation is executed an object called an `InterceptorProvider` generates a RequestChain
+/// for the operation. Then `kickoff` is called on the request chain, which runs the first
+/// interceptor in the chain.
+///
+/// An interceptor can perform arbitrary, asynchronous logic on any thread. When an interceptor
+/// finishes running, it calls `proceedAsync` on its `RequestChain`, which advances to the next
+/// interceptor.
+///
+/// By default when the last interceptor in the chain finishes, if a parsed operation result is
+/// available, that result is returned to the operation's original caller. Otherwise, error-handling
+/// logic is called.
 public protocol RequestChain: Cancellable {
   func kickoff<Operation>(
     request: HTTPRequest<Operation>,
@@ -16,6 +32,8 @@ public protocol RequestChain: Cancellable {
   ) where Operation : GraphQLOperation
 
   func cancel()
+
+  func terminate()
 
   func retry<Operation>(
     request: HTTPRequest<Operation>,

--- a/Tests/ApolloInternalTestHelpers/InterceptorTester.swift
+++ b/Tests/ApolloInternalTestHelpers/InterceptorTester.swift
@@ -49,6 +49,8 @@ fileprivate class ResponseCaptureRequestChain: RequestChain {
 
   func cancel() {}
 
+  func terminate() {}
+
   func retry<Operation>(
     request: Apollo.HTTPRequest<Operation>,
     completion: @escaping (Result<Apollo.GraphQLResult<Operation.Data>, Error>) -> Void


### PR DESCRIPTION
Fixes #3057 

Resolves the leak of `managedSelf` by providing a `terminate` function on `RequestChain` that allows an interceptor to signal whether it is ending the request chain. This allows interceptors such as the `CacheReadInterceptor` to signal an early exit of the request, such as in the case of using the `returnCacheDataDontFetch` cache policy with a cache hit.