### PR TITLE
Updated 1.3 migration guide to include Reserved Keyword change

### DIFF
--- a/docs/source/migrations/1.3.mdx
+++ b/docs/source/migrations/1.3.mdx
@@ -29,3 +29,53 @@ chain.proceedAsync(
   completion: completion
 )
 ```
+## Reserved Keyword Type Name Suffxing
+
+When using certain keywords as the name of a GraphQL Type the generated code would fail to compile, as a result we decided to enforce the same reserved keyword list already being used for a Selection Set to the following other GraphQL Types:
+
+- Custom Scalar
+- Enum
+- Fragment
+- Input Object
+- Interface
+- Object
+- Union
+
+Names for these types will be checked (case insensitive) against the following reserved list:
+
+- Any
+- DataDict
+- DocumentType
+- Fragments
+- FragmentContainer
+- ParentType
+- Protocol
+- Schema
+- Selection
+- Self
+- String
+- Bool
+- Int
+- Float
+- Double
+- ID
+- Type
+- Error
+- _
+
+If a reserved keyword is found it will have its type name suffixed based on the type it represents, take the following Enum example:
+
+```graphql title="Enum Example"
+enum Type {
+  valueOne
+  valueTwo
+}
+```
+
+This would result in a generated Swift enum that looks like this:
+
+```swift title="Generated Enum"
+enum Type_Enum: String, EnumType
+```
+
+Not all of the reserved keywords listed cause a compilation error, however we felt it best to apply suffixing to all of them. This could result in some minor breaking changes to your generated code if you are currently using any of the listed reserved keywords and will require you to update their usage to the new suffixed name.

--- a/docs/source/migrations/1.3.mdx
+++ b/docs/source/migrations/1.3.mdx
@@ -31,7 +31,7 @@ chain.proceedAsync(
 ```
 ## Reserved Keyword Type Name Suffxing
 
-When using certain keywords as the name of a GraphQL Type the generated code would fail to compile, as a result we decided to enforce the same reserved keyword list already being used for a Selection Set to the following other GraphQL Types:
+When using certain keywords as the name of a GraphQL type the generated code would fail to compile, as a result we decided to enforce the same reserved keyword list already being used for a Selection Set to the following other GraphQL types:
 
 - Custom Scalar
 - Enum
@@ -43,25 +43,25 @@ When using certain keywords as the name of a GraphQL Type the generated code wou
 
 Names for these types will be checked (case insensitive) against the following reserved list:
 
-- Any
-- DataDict
-- DocumentType
-- Fragments
-- FragmentContainer
-- ParentType
-- Protocol
-- Schema
-- Selection
-- Self
-- String
-- Bool
-- Int
-- Float
-- Double
-- ID
-- Type
-- Error
-- _
+- ``Any``
+- ``DataDict``
+- ``DocumentType``
+- ``Fragments``
+- ``FragmentContainer``
+- ``ParentType``
+- ``Protocol``
+- ``Schema``
+- ``Selection``
+- ``Self``
+- ``String``
+- ``Bool``
+- ``Int``
+- ``Float``
+- ``Double``
+- ``ID``
+- ``Type``
+- ``Error``
+- ``_``
 
 If a reserved keyword is found it will have its type name suffixed based on the type it represents, take the following Enum example:
 


### PR DESCRIPTION
Added a section to the 1.3 migration guide to cover the reserved keyword suffixing changes to code generation.