### PR TITLE
Fix merged source name generation when shared root is operation root

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -58,7 +58,7 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
         "__typename": __typename,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(ClassroomPetDetails.self)
       ]
     ))
   }
@@ -88,8 +88,8 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "species": species,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetails.self)
+          ObjectIdentifier(ClassroomPetDetails.self),
+          ObjectIdentifier(ClassroomPetDetails.AsAnimal.self)
         ]
       ))
     }
@@ -120,8 +120,8 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "humanName": humanName,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetails.self)
+          ObjectIdentifier(ClassroomPetDetails.self),
+          ObjectIdentifier(ClassroomPetDetails.AsPet.self)
         ]
       ))
     }
@@ -155,8 +155,9 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "species": species,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetails.self)
+          ObjectIdentifier(ClassroomPetDetails.self),
+          ObjectIdentifier(ClassroomPetDetails.AsWarmBlooded.self),
+          ObjectIdentifier(ClassroomPetDetails.AsAnimal.self)
         ]
       ))
     }
@@ -199,8 +200,11 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "laysEggs": laysEggs,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetails.self)
+          ObjectIdentifier(ClassroomPetDetails.self),
+          ObjectIdentifier(ClassroomPetDetails.AsCat.self),
+          ObjectIdentifier(ClassroomPetDetails.AsAnimal.self),
+          ObjectIdentifier(ClassroomPetDetails.AsPet.self),
+          ObjectIdentifier(ClassroomPetDetails.AsWarmBlooded.self)
         ]
       ))
     }
@@ -239,8 +243,11 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "laysEggs": laysEggs,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetails.self)
+          ObjectIdentifier(ClassroomPetDetails.self),
+          ObjectIdentifier(ClassroomPetDetails.AsBird.self),
+          ObjectIdentifier(ClassroomPetDetails.AsAnimal.self),
+          ObjectIdentifier(ClassroomPetDetails.AsPet.self),
+          ObjectIdentifier(ClassroomPetDetails.AsWarmBlooded.self)
         ]
       ))
     }
@@ -273,8 +280,9 @@ public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "humanName": humanName,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetails.self)
+          ObjectIdentifier(ClassroomPetDetails.self),
+          ObjectIdentifier(ClassroomPetDetails.AsPetRock.self),
+          ObjectIdentifier(ClassroomPetDetails.AsPet.self)
         ]
       ))
     }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -35,7 +35,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
         "__typename": __typename,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(ClassroomPetDetailsCCN.self)
       ]
     ))
   }
@@ -65,8 +65,8 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
           "height": height._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(ClassroomPetDetailsCCN.self)
+          ObjectIdentifier(ClassroomPetDetailsCCN.self),
+          ObjectIdentifier(ClassroomPetDetailsCCN.AsAnimal.self)
         ]
       ))
     }
@@ -95,7 +95,7 @@ public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
             "inches": inches,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(ClassroomPetDetailsCCN.AsAnimal.Height.self)
           ]
         ))
       }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
@@ -31,7 +31,7 @@ public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
         "species": species,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(DogFragment.self)
       ]
     ))
   }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -35,7 +35,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
         "height": height._fieldData,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(HeightInMeters.self)
       ]
     ))
   }
@@ -64,7 +64,7 @@ public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
           "meters": meters,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeightInMeters.Height.self)
         ]
       ))
     }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
@@ -45,7 +45,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
         "owner": owner._fieldData,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(PetDetails.self)
       ]
     ))
   }
@@ -74,7 +74,7 @@ public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
           "firstName": firstName,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(PetDetails.Owner.self)
         ]
       ))
     }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -44,7 +44,7 @@ public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
         "height": height._fieldData,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self),
+        ObjectIdentifier(WarmBloodedDetails.self),
         ObjectIdentifier(HeightInMeters.self)
       ]
     ))

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift
@@ -31,7 +31,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
           "allAnimals": allAnimals._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(AllAnimalsLocalCacheMutation.Data.self)
         ]
       ))
     }
@@ -77,7 +77,7 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
             "skinCovering": skinCovering,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(AllAnimalsLocalCacheMutation.Data.AllAnimal.self)
           ]
         ))
       }
@@ -121,8 +121,8 @@ public class AllAnimalsLocalCacheMutation: LocalCacheMutation {
               "skinCovering": skinCovering,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self)
+              ObjectIdentifier(AllAnimalsLocalCacheMutation.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsLocalCacheMutation.Data.AllAnimal.AsBird.self)
             ]
           ))
         }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -38,7 +38,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
         "owner": owner._fieldData,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(PetDetailsMutation.self)
       ]
     ))
   }
@@ -70,7 +70,7 @@ public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment
           "firstName": firstName,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(PetDetailsMutation.Owner.self)
         ]
       ))
     }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetSearchLocalCacheMutation.graphql.swift
@@ -48,7 +48,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
           "pets": pets._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(PetSearchLocalCacheMutation.Data.self)
         ]
       ))
     }
@@ -88,7 +88,7 @@ public class PetSearchLocalCacheMutation: LocalCacheMutation {
             "humanName": humanName,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(PetSearchLocalCacheMutation.Data.Pet.self)
           ]
         ))
       }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -46,7 +46,7 @@ public class PetAdoptionMutation: GraphQLMutation {
           "adoptPet": adoptPet._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(PetAdoptionMutation.Data.self)
         ]
       ))
     }
@@ -80,7 +80,7 @@ public class PetAdoptionMutation: GraphQLMutation {
             "humanName": humanName,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(PetAdoptionMutation.Data.AdoptPet.self)
           ]
         ))
       }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -43,7 +43,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
           "allAnimals": allAnimals._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(AllAnimalsCCNQuery.Data.self)
         ]
       ))
     }
@@ -73,7 +73,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
             "height": height._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(AllAnimalsCCNQuery.Data.AllAnimal.self)
           ]
         ))
       }
@@ -106,7 +106,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
               "inches": inches,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(AllAnimalsCCNQuery.Data.AllAnimal.Height.self)
             ]
           ))
         }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -102,7 +102,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
           "allAnimals": allAnimals._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.self)
         ]
       ))
     }
@@ -162,7 +162,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
             "predators": predators._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self)
           ]
         ))
       }
@@ -195,7 +195,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "inches": inches,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self)
             ]
           ))
         }
@@ -229,7 +229,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "species": species,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Predator.self)
             ]
           ))
         }
@@ -278,8 +278,8 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "height": height._fieldData,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(AllAnimal.Predator.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Predator.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Predator.AsWarmBloodedIfGetWarmBlooded.self),
                 ObjectIdentifier(WarmBloodedDetails.self),
                 ObjectIdentifier(HeightInMeters.self)
               ]
@@ -329,8 +329,8 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "predators": predators._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.IfNotSkipHeightInMeters.self),
               ObjectIdentifier(HeightInMeters.self)
             ]
           ))
@@ -362,7 +362,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "meters": meters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.IfNotSkipHeightInMeters.Height.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self)
               ]
             ))
           }
@@ -414,8 +416,8 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "bodyTemperature": bodyTemperature,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsWarmBloodedIfGetWarmBlooded.self),
               ObjectIdentifier(WarmBloodedDetails.self),
               ObjectIdentifier(HeightInMeters.self)
             ]
@@ -448,7 +450,9 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "meters": meters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsWarmBloodedIfGetWarmBlooded.Height.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self)
               ]
             ))
           }
@@ -510,8 +514,8 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "owner": owner._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.self),
               ObjectIdentifier(PetDetails.self)
             ]
           ))
@@ -553,7 +557,8 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "inches": inches,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.Height.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self)
               ]
             ))
           }
@@ -614,12 +619,12 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "bodyTemperature": bodyTemperature,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(AllAnimal.self),
-                ObjectIdentifier(AllAnimal.AsPet.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
+                ObjectIdentifier(PetDetails.self),
                 ObjectIdentifier(WarmBloodedDetails.self),
-                ObjectIdentifier(HeightInMeters.self),
-                ObjectIdentifier(PetDetails.self)
+                ObjectIdentifier(HeightInMeters.self)
               ]
             ))
           }
@@ -656,7 +661,10 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                   "meters": meters,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self)
+                  ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.Height.self),
+                  ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self),
+                  ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.Height.self),
+                  ObjectIdentifier(HeightInMeters.Height.self)
                 ]
               ))
             }
@@ -721,11 +729,14 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "bodyTemperature": bodyTemperature,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
-              ObjectIdentifier(HeightInMeters.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsCatIfGetCat.self),
               ObjectIdentifier(PetDetails.self),
-              ObjectIdentifier(WarmBloodedDetails.self)
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.self),
+              ObjectIdentifier(WarmBloodedDetails.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self),
+              ObjectIdentifier(HeightInMeters.self)
             ]
           ))
         }
@@ -762,7 +773,10 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "meters": meters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsCatIfGetCat.Height.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self)
               ]
             ))
           }
@@ -812,8 +826,8 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               "predators": predators._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self)
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsClassroomPet.self)
             ]
           ))
         }
@@ -875,12 +889,15 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 "bodyTemperature": bodyTemperature,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(AllAnimal.self),
-                ObjectIdentifier(AllAnimal.AsClassroomPet.self),
-                ObjectIdentifier(HeightInMeters.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsClassroomPet.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsClassroomPet.AsBird.self),
                 ObjectIdentifier(PetDetails.self),
-                ObjectIdentifier(WarmBloodedDetails.self)
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.self),
+                ObjectIdentifier(WarmBloodedDetails.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
+                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self),
+                ObjectIdentifier(HeightInMeters.self)
               ]
             ))
           }
@@ -917,7 +934,10 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                   "meters": meters,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self)
+                  ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsClassroomPet.AsBird.Height.self),
+                  ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.Height.self),
+                  ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.Height.self),
+                  ObjectIdentifier(HeightInMeters.Height.self)
                 ]
               ))
             }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -83,7 +83,7 @@ public class AllAnimalsQuery: GraphQLQuery {
           "allAnimals": allAnimals._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(AllAnimalsQuery.Data.self)
         ]
       ))
     }
@@ -144,8 +144,7 @@ public class AllAnimalsQuery: GraphQLQuery {
             "predators": predators._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
-            ObjectIdentifier(HeightInMeters.self)
+            ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self)
           ]
         ))
       }
@@ -181,7 +180,8 @@ public class AllAnimalsQuery: GraphQLQuery {
               "meters": meters,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+              ObjectIdentifier(HeightInMeters.Height.self)
             ]
           ))
         }
@@ -215,7 +215,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               "species": species,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Predator.self)
             ]
           ))
         }
@@ -267,8 +267,8 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "height": height._fieldData,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(AllAnimal.Predator.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Predator.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Predator.AsWarmBlooded.self),
                 ObjectIdentifier(WarmBloodedDetails.self),
                 ObjectIdentifier(HeightInMeters.self)
               ]
@@ -300,7 +300,7 @@ public class AllAnimalsQuery: GraphQLQuery {
                   "species": species,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self)
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Predator.AsWarmBlooded.Predator.self)
                 ]
               ))
             }
@@ -353,10 +353,10 @@ public class AllAnimalsQuery: GraphQLQuery {
               "bodyTemperature": bodyTemperature,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
-              ObjectIdentifier(WarmBloodedDetails.self),
-              ObjectIdentifier(HeightInMeters.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
+              ObjectIdentifier(HeightInMeters.self),
+              ObjectIdentifier(WarmBloodedDetails.self)
             ]
           ))
         }
@@ -387,7 +387,9 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "meters": meters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self)
               ]
             ))
           }
@@ -449,10 +451,9 @@ public class AllAnimalsQuery: GraphQLQuery {
               "owner": owner._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
-              ObjectIdentifier(PetDetails.self),
-              ObjectIdentifier(HeightInMeters.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
+              ObjectIdentifier(PetDetails.self)
             ]
           ))
         }
@@ -494,7 +495,9 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "meters": meters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self)
               ]
             ))
           }
@@ -555,11 +558,11 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "owner": owner._fieldData,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(AllAnimal.self),
-                ObjectIdentifier(AllAnimal.AsPet.self),
-                ObjectIdentifier(WarmBloodedDetails.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
                 ObjectIdentifier(HeightInMeters.self),
+                ObjectIdentifier(WarmBloodedDetails.self),
                 ObjectIdentifier(PetDetails.self)
               ]
             ))
@@ -597,7 +600,10 @@ public class AllAnimalsQuery: GraphQLQuery {
                   "centimeters": centimeters,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self)
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.Height.self),
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                  ObjectIdentifier(HeightInMeters.Height.self),
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.Height.self)
                 ]
               ))
             }
@@ -662,11 +668,15 @@ public class AllAnimalsQuery: GraphQLQuery {
               "owner": owner._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsCat.self),
               ObjectIdentifier(HeightInMeters.self),
               ObjectIdentifier(WarmBloodedDetails.self),
-              ObjectIdentifier(PetDetails.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
+              ObjectIdentifier(PetDetails.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self)
             ]
           ))
         }
@@ -703,7 +713,10 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "centimeters": centimeters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsCat.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.Height.self)
               ]
             ))
           }
@@ -753,8 +766,8 @@ public class AllAnimalsQuery: GraphQLQuery {
               "predators": predators._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsClassroomPet.self),
               ObjectIdentifier(HeightInMeters.self)
             ]
           ))
@@ -786,7 +799,9 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "meters": meters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsClassroomPet.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self)
               ]
             ))
           }
@@ -849,12 +864,16 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "owner": owner._fieldData,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(AllAnimal.self),
-                ObjectIdentifier(AllAnimal.AsClassroomPet.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsClassroomPet.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsClassroomPet.AsBird.self),
                 ObjectIdentifier(HeightInMeters.self),
                 ObjectIdentifier(WarmBloodedDetails.self),
-                ObjectIdentifier(PetDetails.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
+                ObjectIdentifier(PetDetails.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self)
               ]
             ))
           }
@@ -891,7 +910,10 @@ public class AllAnimalsQuery: GraphQLQuery {
                   "centimeters": centimeters,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self)
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsClassroomPet.AsBird.Height.self),
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                  ObjectIdentifier(HeightInMeters.Height.self),
+                  ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.Height.self)
                 ]
               ))
             }
@@ -957,11 +979,15 @@ public class AllAnimalsQuery: GraphQLQuery {
               "owner": owner._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsDog.self),
               ObjectIdentifier(HeightInMeters.self),
               ObjectIdentifier(WarmBloodedDetails.self),
-              ObjectIdentifier(PetDetails.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
+              ObjectIdentifier(PetDetails.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self)
             ]
           ))
         }
@@ -998,7 +1024,10 @@ public class AllAnimalsQuery: GraphQLQuery {
                 "centimeters": centimeters,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsDog.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.Height.self),
+                ObjectIdentifier(HeightInMeters.Height.self),
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.Height.self)
               ]
             ))
           }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -40,7 +40,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
           "classroomPets": classroomPets._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(ClassroomPetsCCNQuery.Data.self)
         ]
       ))
     }
@@ -75,8 +75,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
-            ObjectIdentifier(ClassroomPetDetailsCCN.self)
+            ObjectIdentifier(ClassroomPetsCCNQuery.Data.ClassroomPet.self)
           ]
         ))
       }
@@ -114,9 +113,10 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
               "height": height._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetailsCCN.self)
+              ObjectIdentifier(ClassroomPetsCCNQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsCCNQuery.Data.ClassroomPet.AsAnimal.self),
+              ObjectIdentifier(ClassroomPetDetailsCCN.self),
+              ObjectIdentifier(ClassroomPetDetailsCCN.AsAnimal.self)
             ]
           ))
         }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -40,7 +40,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
           "classroomPets": classroomPets._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(ClassroomPetsQuery.Data.self)
         ]
       ))
     }
@@ -80,8 +80,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
-            ObjectIdentifier(ClassroomPetDetails.self)
+            ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self)
           ]
         ))
       }
@@ -119,9 +118,10 @@ public class ClassroomPetsQuery: GraphQLQuery {
               "species": species,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetails.self)
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.AsAnimal.self),
+              ObjectIdentifier(ClassroomPetDetails.self),
+              ObjectIdentifier(ClassroomPetDetails.AsAnimal.self)
             ]
           ))
         }
@@ -160,9 +160,10 @@ public class ClassroomPetsQuery: GraphQLQuery {
               "humanName": humanName,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetails.self)
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.AsPet.self),
+              ObjectIdentifier(ClassroomPetDetails.self),
+              ObjectIdentifier(ClassroomPetDetails.AsPet.self)
             ]
           ))
         }
@@ -205,9 +206,11 @@ public class ClassroomPetsQuery: GraphQLQuery {
               "laysEggs": laysEggs,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetails.self)
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.AsWarmBlooded.self),
+              ObjectIdentifier(ClassroomPetDetails.self),
+              ObjectIdentifier(ClassroomPetDetails.AsAnimal.self),
+              ObjectIdentifier(ClassroomPetDetails.AsWarmBlooded.self)
             ]
           ))
         }
@@ -260,9 +263,13 @@ public class ClassroomPetsQuery: GraphQLQuery {
               "isJellicle": isJellicle,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetails.self)
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.AsCat.self),
+              ObjectIdentifier(ClassroomPetDetails.self),
+              ObjectIdentifier(ClassroomPetDetails.AsAnimal.self),
+              ObjectIdentifier(ClassroomPetDetails.AsPet.self),
+              ObjectIdentifier(ClassroomPetDetails.AsWarmBlooded.self),
+              ObjectIdentifier(ClassroomPetDetails.AsCat.self)
             ]
           ))
         }
@@ -312,9 +319,13 @@ public class ClassroomPetsQuery: GraphQLQuery {
               "wingspan": wingspan,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetails.self)
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.AsBird.self),
+              ObjectIdentifier(ClassroomPetDetails.self),
+              ObjectIdentifier(ClassroomPetDetails.AsAnimal.self),
+              ObjectIdentifier(ClassroomPetDetails.AsPet.self),
+              ObjectIdentifier(ClassroomPetDetails.AsWarmBlooded.self),
+              ObjectIdentifier(ClassroomPetDetails.AsBird.self)
             ]
           ))
         }
@@ -356,9 +367,11 @@ public class ClassroomPetsQuery: GraphQLQuery {
               "favoriteToy": favoriteToy,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(ClassroomPet.self),
-              ObjectIdentifier(ClassroomPetDetails.self)
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.self),
+              ObjectIdentifier(ClassroomPetsQuery.Data.ClassroomPet.AsPetRock.self),
+              ObjectIdentifier(ClassroomPetDetails.self),
+              ObjectIdentifier(ClassroomPetDetails.AsPet.self),
+              ObjectIdentifier(ClassroomPetDetails.AsPetRock.self)
             ]
           ))
         }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -44,7 +44,7 @@ public class DogQuery: GraphQLQuery {
           "allAnimals": allAnimals._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(DogQuery.Data.self)
         ]
       ))
     }
@@ -81,7 +81,7 @@ public class DogQuery: GraphQLQuery {
             "skinCovering": skinCovering,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(DogQuery.Data.AllAnimal.self)
           ]
         ))
       }
@@ -123,8 +123,8 @@ public class DogQuery: GraphQLQuery {
               "species": species,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(AllAnimal.self),
+              ObjectIdentifier(DogQuery.Data.AllAnimal.self),
+              ObjectIdentifier(DogQuery.Data.AllAnimal.AsDog.self),
               ObjectIdentifier(DogFragment.self)
             ]
           ))

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -57,7 +57,7 @@ public class PetSearchQuery: GraphQLQuery {
           "pets": pets._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(PetSearchQuery.Data.self)
         ]
       ))
     }
@@ -91,7 +91,7 @@ public class PetSearchQuery: GraphQLQuery {
             "humanName": humanName,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(PetSearchQuery.Data.Pet.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
@@ -33,7 +33,7 @@ public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
         "appearsIn": appearsIn,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(CharacterAppearsIn.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
@@ -33,7 +33,7 @@ public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(CharacterName.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
@@ -39,7 +39,7 @@ public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
         "appearsIn": appearsIn,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(CharacterNameAndAppearsIn.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
@@ -45,9 +45,9 @@ public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.Selectio
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self),
-        ObjectIdentifier(CharacterNameWithNestedAppearsInFragment.self),
-        ObjectIdentifier(CharacterAppearsIn.self)
+        ObjectIdentifier(CharacterNameAndAppearsInWithNestedFragments.self),
+        ObjectIdentifier(CharacterAppearsIn.self),
+        ObjectIdentifier(CharacterNameWithNestedAppearsInFragment.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -40,7 +40,7 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(CharacterNameAndDroidAppearsIn.self)
       ]
     ))
   }
@@ -74,8 +74,8 @@ public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment
           "name": name,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(CharacterNameAndDroidAppearsIn.self)
+          ObjectIdentifier(CharacterNameAndDroidAppearsIn.self),
+          ObjectIdentifier(CharacterNameAndDroidAppearsIn.AsDroid.self)
         ]
       ))
     }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -44,7 +44,7 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self),
+        ObjectIdentifier(CharacterNameAndDroidPrimaryFunction.self),
         ObjectIdentifier(CharacterName.self)
       ]
     ))
@@ -87,10 +87,10 @@ public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fr
           "primaryFunction": primaryFunction,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
           ObjectIdentifier(CharacterNameAndDroidPrimaryFunction.self),
-          ObjectIdentifier(DroidPrimaryFunction.self),
-          ObjectIdentifier(CharacterName.self)
+          ObjectIdentifier(CharacterNameAndDroidPrimaryFunction.AsDroid.self),
+          ObjectIdentifier(CharacterName.self),
+          ObjectIdentifier(DroidPrimaryFunction.self)
         ]
       ))
     }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -43,7 +43,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
         "__typename": __typename,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(CharacterNameWithInlineFragment.self)
       ]
     ))
   }
@@ -73,8 +73,8 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
           "friends": friends._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(CharacterNameWithInlineFragment.self)
+          ObjectIdentifier(CharacterNameWithInlineFragment.self),
+          ObjectIdentifier(CharacterNameWithInlineFragment.AsHuman.self)
         ]
       ))
     }
@@ -105,7 +105,7 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
             "appearsIn": appearsIn,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(CharacterNameWithInlineFragment.AsHuman.Friend.self)
           ]
         ))
       }
@@ -150,8 +150,8 @@ public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragmen
           "friends": friends._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
           ObjectIdentifier(CharacterNameWithInlineFragment.self),
+          ObjectIdentifier(CharacterNameWithInlineFragment.AsDroid.self),
           ObjectIdentifier(CharacterName.self),
           ObjectIdentifier(FriendsNames.self)
         ]

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
@@ -46,7 +46,7 @@ public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet
         "appearsIn": appearsIn,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self),
+        ObjectIdentifier(CharacterNameWithNestedAppearsInFragment.self),
         ObjectIdentifier(CharacterAppearsIn.self)
       ]
     ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
@@ -38,7 +38,7 @@ public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
         "primaryFunction": primaryFunction,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(DroidDetails.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
@@ -32,7 +32,7 @@ public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(DroidName.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
@@ -46,9 +46,9 @@ public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self),
-        ObjectIdentifier(CharacterName.self),
-        ObjectIdentifier(DroidPrimaryFunction.self)
+        ObjectIdentifier(DroidNameAndPrimaryFunction.self),
+        ObjectIdentifier(DroidPrimaryFunction.self),
+        ObjectIdentifier(CharacterName.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
@@ -32,7 +32,7 @@ public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
         "primaryFunction": primaryFunction,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(DroidPrimaryFunction.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
@@ -36,7 +36,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
         "friends": friends._fieldData,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(FriendsNames.self)
       ]
     ))
   }
@@ -67,7 +67,7 @@ public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
           "name": name,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(FriendsNames.Friend.self)
         ]
       ))
     }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -46,7 +46,7 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
         "name": name,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(HeroDetails.self)
       ]
     ))
   }
@@ -80,8 +80,8 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
           "name": name,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(HeroDetails.self)
+          ObjectIdentifier(HeroDetails.self),
+          ObjectIdentifier(HeroDetails.AsHuman.self)
         ]
       ))
     }
@@ -116,8 +116,8 @@ public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
           "name": name,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self),
-          ObjectIdentifier(HeroDetails.self)
+          ObjectIdentifier(HeroDetails.self),
+          ObjectIdentifier(HeroDetails.AsDroid.self)
         ]
       ))
     }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
@@ -32,7 +32,7 @@ public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
         "height": height,
       ],
       fulfilledFragments: [
-        ObjectIdentifier(Self.self)
+        ObjectIdentifier(HumanHeightWithVariable.self)
       ]
     ))
   }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -47,7 +47,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
           "createReview": createReview._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(CreateAwesomeReviewMutation.Data.self)
         ]
       ))
     }
@@ -82,7 +82,7 @@ public class CreateAwesomeReviewMutation: GraphQLMutation {
             "commentary": commentary,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(CreateAwesomeReviewMutation.Data.CreateReview.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -58,7 +58,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
           "createReview": createReview._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(CreateReviewForEpisodeMutation.Data.self)
         ]
       ))
     }
@@ -93,7 +93,7 @@ public class CreateReviewForEpisodeMutation: GraphQLMutation {
             "commentary": commentary,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(CreateReviewForEpisodeMutation.Data.CreateReview.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -47,7 +47,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
           "createReview": createReview._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(CreateReviewWithNullFieldMutation.Data.self)
         ]
       ))
     }
@@ -82,7 +82,7 @@ public class CreateReviewWithNullFieldMutation: GraphQLMutation {
             "commentary": commentary,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(CreateReviewWithNullFieldMutation.Data.CreateReview.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -47,7 +47,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(DroidDetailsWithFragmentQuery.Data.self)
         ]
       ))
     }
@@ -75,7 +75,7 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(DroidDetailsWithFragmentQuery.Data.Hero.self)
           ]
         ))
       }
@@ -116,8 +116,8 @@ public class DroidDetailsWithFragmentQuery: GraphQLQuery {
               "primaryFunction": primaryFunction,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self),
+              ObjectIdentifier(DroidDetailsWithFragmentQuery.Data.Hero.self),
+              ObjectIdentifier(DroidDetailsWithFragmentQuery.Data.Hero.AsDroid.self),
               ObjectIdentifier(DroidDetails.self)
             ]
           ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -51,7 +51,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAndFriendsIDsQuery.Data.self)
         ]
       ))
     }
@@ -92,7 +92,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroAndFriendsIDsQuery.Data.Hero.self)
           ]
         ))
       }
@@ -123,7 +123,7 @@ public class HeroAndFriendsIDsQuery: GraphQLQuery {
               "id": id,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroAndFriendsIDsQuery.Data.Hero.Friend.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -50,7 +50,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAndFriendsNamesQuery.Data.self)
         ]
       ))
     }
@@ -86,7 +86,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroAndFriendsNamesQuery.Data.Hero.self)
           ]
         ))
       }
@@ -117,7 +117,7 @@ public class HeroAndFriendsNamesQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroAndFriendsNamesQuery.Data.Hero.Friend.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -48,7 +48,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAndFriendsNamesWithFragmentQuery.Data.self)
         ]
       ))
     }
@@ -91,7 +91,7 @@ public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
+            ObjectIdentifier(HeroAndFriendsNamesWithFragmentQuery.Data.Hero.self),
             ObjectIdentifier(FriendsNames.self)
           ]
         ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -57,7 +57,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAndFriendsNamesWithFragmentTwiceQuery.Data.self)
         ]
       ))
     }
@@ -91,7 +91,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroAndFriendsNamesWithFragmentTwiceQuery.Data.Hero.self)
           ]
         ))
       }
@@ -129,7 +129,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
+              ObjectIdentifier(HeroAndFriendsNamesWithFragmentTwiceQuery.Data.Hero.Friend.self),
               ObjectIdentifier(CharacterName.self)
             ]
           ))
@@ -161,8 +161,8 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
               "friends": friends._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroAndFriendsNamesWithFragmentTwiceQuery.Data.Hero.self),
+              ObjectIdentifier(HeroAndFriendsNamesWithFragmentTwiceQuery.Data.Hero.AsDroid.self)
             ]
           ))
         }
@@ -200,7 +200,7 @@ public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
                 "name": name,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
+                ObjectIdentifier(HeroAndFriendsNamesWithFragmentTwiceQuery.Data.Hero.AsDroid.Friend.self),
                 ObjectIdentifier(CharacterName.self)
               ]
             ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -51,7 +51,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAndFriendsNamesWithIDForParentOnlyQuery.Data.self)
         ]
       ))
     }
@@ -92,7 +92,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroAndFriendsNamesWithIDForParentOnlyQuery.Data.Hero.self)
           ]
         ))
       }
@@ -123,7 +123,7 @@ public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroAndFriendsNamesWithIDForParentOnlyQuery.Data.Hero.Friend.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -52,7 +52,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAndFriendsNamesWithIDsQuery.Data.self)
         ]
       ))
     }
@@ -93,7 +93,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroAndFriendsNamesWithIDsQuery.Data.Hero.self)
           ]
         ))
       }
@@ -129,7 +129,7 @@ public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroAndFriendsNamesWithIDsQuery.Data.Hero.Friend.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -40,7 +40,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAppearsInQuery.Data.self)
         ]
       ))
     }
@@ -71,7 +71,7 @@ public class HeroAppearsInQuery: GraphQLQuery {
             "appearsIn": appearsIn,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroAppearsInQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroAppearsInWithFragmentQuery.Data.self)
         ]
       ))
     }
@@ -85,7 +85,7 @@ public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
             "appearsIn": appearsIn,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
+            ObjectIdentifier(HeroAppearsInWithFragmentQuery.Data.Hero.self),
             ObjectIdentifier(CharacterAppearsIn.self)
           ]
         ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroDetailsFragmentConditionalInclusionQuery.Data.self)
         ]
       ))
     }
@@ -82,7 +82,7 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroDetailsFragmentConditionalInclusionQuery.Data.Hero.self)
           ]
         ))
       }
@@ -120,8 +120,8 @@ public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self),
+              ObjectIdentifier(HeroDetailsFragmentConditionalInclusionQuery.Data.Hero.self),
+              ObjectIdentifier(HeroDetailsFragmentConditionalInclusionQuery.Data.Hero.IfIncludeDetails.self),
               ObjectIdentifier(HeroDetails.self)
             ]
           ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -50,7 +50,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroDetailsInlineConditionalInclusionQuery.Data.self)
         ]
       ))
     }
@@ -78,7 +78,7 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroDetailsInlineConditionalInclusionQuery.Data.Hero.self)
           ]
         ))
       }
@@ -114,8 +114,8 @@ public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
               "appearsIn": appearsIn,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroDetailsInlineConditionalInclusionQuery.Data.Hero.self),
+              ObjectIdentifier(HeroDetailsInlineConditionalInclusionQuery.Data.Hero.IfIncludeDetails.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -54,7 +54,7 @@ public class HeroDetailsQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroDetailsQuery.Data.self)
         ]
       ))
     }
@@ -90,7 +90,7 @@ public class HeroDetailsQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroDetailsQuery.Data.Hero.self)
           ]
         ))
       }
@@ -124,8 +124,8 @@ public class HeroDetailsQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroDetailsQuery.Data.Hero.self),
+              ObjectIdentifier(HeroDetailsQuery.Data.Hero.AsHuman.self)
             ]
           ))
         }
@@ -160,8 +160,8 @@ public class HeroDetailsQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroDetailsQuery.Data.Hero.self),
+              ObjectIdentifier(HeroDetailsQuery.Data.Hero.AsDroid.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroDetailsWithFragmentQuery.Data.self)
         ]
       ))
     }
@@ -88,7 +88,7 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
+            ObjectIdentifier(HeroDetailsWithFragmentQuery.Data.Hero.self),
             ObjectIdentifier(HeroDetails.self)
           ]
         ))
@@ -132,9 +132,10 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
               "height": height,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self),
-              ObjectIdentifier(HeroDetails.self)
+              ObjectIdentifier(HeroDetailsWithFragmentQuery.Data.Hero.self),
+              ObjectIdentifier(HeroDetailsWithFragmentQuery.Data.Hero.AsHuman.self),
+              ObjectIdentifier(HeroDetails.self),
+              ObjectIdentifier(HeroDetails.AsHuman.self)
             ]
           ))
         }
@@ -178,9 +179,10 @@ public class HeroDetailsWithFragmentQuery: GraphQLQuery {
               "primaryFunction": primaryFunction,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self),
-              ObjectIdentifier(HeroDetails.self)
+              ObjectIdentifier(HeroDetailsWithFragmentQuery.Data.Hero.self),
+              ObjectIdentifier(HeroDetailsWithFragmentQuery.Data.Hero.AsDroid.self),
+              ObjectIdentifier(HeroDetails.self),
+              ObjectIdentifier(HeroDetails.AsDroid.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -53,7 +53,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroFriendsDetailsConditionalInclusionQuery.Data.self)
         ]
       ))
     }
@@ -84,7 +84,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroFriendsDetailsConditionalInclusionQuery.Data.Hero.self)
           ]
         ))
       }
@@ -118,7 +118,7 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroFriendsDetailsConditionalInclusionQuery.Data.Hero.Friend.self)
             ]
           ))
         }
@@ -152,8 +152,8 @@ public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
                 "name": name,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(Hero.Friend.self)
+                ObjectIdentifier(HeroFriendsDetailsConditionalInclusionQuery.Data.Hero.Friend.self),
+                ObjectIdentifier(HeroFriendsDetailsConditionalInclusionQuery.Data.Hero.Friend.AsDroid.self)
               ]
             ))
           }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -57,7 +57,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.self)
         ]
       ))
     }
@@ -88,7 +88,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.self)
           ]
         ))
       }
@@ -123,7 +123,7 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.self)
             ]
           ))
         }
@@ -157,8 +157,8 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
                 "name": name,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(Hero.Friend.self)
+                ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.self),
+                ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.IfIncludeFriendsDetails.self)
               ]
             ))
           }
@@ -192,8 +192,8 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
                   "name": name,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self),
-                  ObjectIdentifier(Hero.Friend.self)
+                  ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.self),
+                  ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.AsDroid.self)
                 ]
               ))
             }
@@ -229,8 +229,8 @@ public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQ
                 "primaryFunction": primaryFunction,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self),
-                ObjectIdentifier(Hero.Friend.self)
+                ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.self),
+                ObjectIdentifier(HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.Data.Hero.Friend.AsDroid.self)
               ]
             ))
           }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -53,7 +53,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroFriendsOfFriendsNamesQuery.Data.self)
         ]
       ))
     }
@@ -84,7 +84,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
             "friends": friends._fieldData,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroFriendsOfFriendsNamesQuery.Data.Hero.self)
           ]
         ))
       }
@@ -120,7 +120,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
               "friends": friends._fieldData,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self)
+              ObjectIdentifier(HeroFriendsOfFriendsNamesQuery.Data.Hero.Friend.self)
             ]
           ))
         }
@@ -151,7 +151,7 @@ public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
                 "name": name,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(HeroFriendsOfFriendsNamesQuery.Data.Hero.Friend.Friend.self)
               ]
             ))
           }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameAndAppearsInQuery.Data.self)
         ]
       ))
     }
@@ -83,7 +83,7 @@ public class HeroNameAndAppearsInQuery: GraphQLQuery {
             "appearsIn": appearsIn,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameAndAppearsInQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameAndAppearsInWithFragmentQuery.Data.self)
         ]
       ))
     }
@@ -89,7 +89,7 @@ public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
             "appearsIn": appearsIn,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
+            ObjectIdentifier(HeroNameAndAppearsInWithFragmentQuery.Data.Hero.self),
             ObjectIdentifier(CharacterNameAndAppearsIn.self)
           ]
         ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -54,7 +54,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameConditionalBothQuery.Data.self)
         ]
       ))
     }
@@ -85,7 +85,7 @@ public class HeroNameConditionalBothQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameConditionalBothQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -55,7 +55,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameConditionalBothSeparateQuery.Data.self)
         ]
       ))
     }
@@ -86,7 +86,7 @@ public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameConditionalBothSeparateQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -46,7 +46,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameConditionalExclusionQuery.Data.self)
         ]
       ))
     }
@@ -77,7 +77,7 @@ public class HeroNameConditionalExclusionQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameConditionalExclusionQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -46,7 +46,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameConditionalInclusionQuery.Data.self)
         ]
       ))
     }
@@ -77,7 +77,7 @@ public class HeroNameConditionalInclusionQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameConditionalInclusionQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -46,7 +46,7 @@ public class HeroNameQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameQuery.Data.self)
         ]
       ))
     }
@@ -77,7 +77,7 @@ public class HeroNameQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -58,7 +58,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameTypeSpecificConditionalInclusionQuery.Data.self)
         ]
       ))
     }
@@ -92,7 +92,7 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameTypeSpecificConditionalInclusionQuery.Data.Hero.self)
           ]
         ))
       }
@@ -122,8 +122,8 @@ public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroNameTypeSpecificConditionalInclusionQuery.Data.Hero.self),
+              ObjectIdentifier(HeroNameTypeSpecificConditionalInclusionQuery.Data.Hero.AsDroid.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -48,7 +48,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameWithFragmentAndIDQuery.Data.self)
         ]
       ))
     }
@@ -91,7 +91,7 @@ public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
+            ObjectIdentifier(HeroNameWithFragmentAndIDQuery.Data.Hero.self),
             ObjectIdentifier(CharacterName.self)
           ]
         ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameWithFragmentQuery.Data.self)
         ]
       ))
     }
@@ -85,7 +85,7 @@ public class HeroNameWithFragmentQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self),
+            ObjectIdentifier(HeroNameWithFragmentQuery.Data.Hero.self),
             ObjectIdentifier(CharacterName.self)
           ]
         ))

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroNameWithIDQuery.Data.self)
         ]
       ))
     }
@@ -83,7 +83,7 @@ public class HeroNameWithIDQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroNameWithIDQuery.Data.Hero.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -68,7 +68,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.self)
         ]
       ))
     }
@@ -104,7 +104,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.self)
           ]
         ))
       }
@@ -138,8 +138,8 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.self),
+              ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsHuman.self)
             ]
           ))
         }
@@ -173,7 +173,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
                 "name": name,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsHuman.Friend.self)
               ]
             ))
           }
@@ -207,8 +207,8 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
                   "name": name,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self),
-                  ObjectIdentifier(Hero.AsHuman.Friend.self)
+                  ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsHuman.Friend.self),
+                  ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsHuman.Friend.AsHuman.self)
                 ]
               ))
             }
@@ -245,8 +245,8 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.self),
+              ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsDroid.self)
             ]
           ))
         }
@@ -280,7 +280,7 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
                 "name": name,
               ],
               fulfilledFragments: [
-                ObjectIdentifier(Self.self)
+                ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsDroid.Friend.self)
               ]
             ))
           }
@@ -314,8 +314,8 @@ public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
                   "name": name,
                 ],
                 fulfilledFragments: [
-                  ObjectIdentifier(Self.self),
-                  ObjectIdentifier(Hero.AsDroid.Friend.self)
+                  ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsDroid.Friend.self),
+                  ObjectIdentifier(HeroParentTypeDependentFieldQuery.Data.Hero.AsDroid.Friend.AsHuman.self)
                 ]
               ))
             }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -53,7 +53,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
           "hero": hero._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HeroTypeDependentAliasedFieldQuery.Data.self)
         ]
       ))
     }
@@ -83,7 +83,7 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HeroTypeDependentAliasedFieldQuery.Data.Hero.self)
           ]
         ))
       }
@@ -113,8 +113,8 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
               "property": property,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroTypeDependentAliasedFieldQuery.Data.Hero.self),
+              ObjectIdentifier(HeroTypeDependentAliasedFieldQuery.Data.Hero.AsHuman.self)
             ]
           ))
         }
@@ -145,8 +145,8 @@ public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
               "property": property,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Hero.self)
+              ObjectIdentifier(HeroTypeDependentAliasedFieldQuery.Data.Hero.self),
+              ObjectIdentifier(HeroTypeDependentAliasedFieldQuery.Data.Hero.AsDroid.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -47,7 +47,7 @@ public class HumanQuery: GraphQLQuery {
           "human": human._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(HumanQuery.Data.self)
         ]
       ))
     }
@@ -82,7 +82,7 @@ public class HumanQuery: GraphQLQuery {
             "mass": mass,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(HumanQuery.Data.Human.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -48,7 +48,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
           "r2": r2._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(SameHeroTwiceQuery.Data.self)
         ]
       ))
     }
@@ -79,7 +79,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(SameHeroTwiceQuery.Data.Hero.self)
           ]
         ))
       }
@@ -111,7 +111,7 @@ public class SameHeroTwiceQuery: GraphQLQuery {
             "appearsIn": appearsIn,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(SameHeroTwiceQuery.Data.R2.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -60,7 +60,7 @@ public class SearchQuery: GraphQLQuery {
           "search": search._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(SearchQuery.Data.self)
         ]
       ))
     }
@@ -92,7 +92,7 @@ public class SearchQuery: GraphQLQuery {
             "__typename": __typename,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(SearchQuery.Data.Search.self)
           ]
         ))
       }
@@ -127,8 +127,8 @@ public class SearchQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Search.self)
+              ObjectIdentifier(SearchQuery.Data.Search.self),
+              ObjectIdentifier(SearchQuery.Data.Search.AsHuman.self)
             ]
           ))
         }
@@ -164,8 +164,8 @@ public class SearchQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Search.self)
+              ObjectIdentifier(SearchQuery.Data.Search.self),
+              ObjectIdentifier(SearchQuery.Data.Search.AsDroid.self)
             ]
           ))
         }
@@ -201,8 +201,8 @@ public class SearchQuery: GraphQLQuery {
               "name": name,
             ],
             fulfilledFragments: [
-              ObjectIdentifier(Self.self),
-              ObjectIdentifier(Search.self)
+              ObjectIdentifier(SearchQuery.Data.Search.self),
+              ObjectIdentifier(SearchQuery.Data.Search.AsStarship.self)
             ]
           ))
         }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -48,7 +48,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
           "starshipCoordinates": starshipCoordinates._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(StarshipCoordinatesQuery.Data.self)
         ]
       ))
     }
@@ -87,7 +87,7 @@ public class StarshipCoordinatesQuery: GraphQLQuery {
             "length": length,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(StarshipCoordinatesQuery.Data.StarshipCoordinates.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -41,7 +41,7 @@ public class StarshipQuery: GraphQLQuery {
           "starship": starship._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(StarshipQuery.Data.self)
         ]
       ))
     }
@@ -75,7 +75,7 @@ public class StarshipQuery: GraphQLQuery {
             "coordinates": coordinates,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(StarshipQuery.Data.Starship.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -48,7 +48,7 @@ public class TwoHeroesQuery: GraphQLQuery {
           "luke": luke._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(TwoHeroesQuery.Data.self)
         ]
       ))
     }
@@ -79,7 +79,7 @@ public class TwoHeroesQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(TwoHeroesQuery.Data.R2.self)
           ]
         ))
       }
@@ -111,7 +111,7 @@ public class TwoHeroesQuery: GraphQLQuery {
             "name": name,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(TwoHeroesQuery.Data.Luke.self)
           ]
         ))
       }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -48,7 +48,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
           "reviewAdded": reviewAdded._fieldData,
         ],
         fulfilledFragments: [
-          ObjectIdentifier(Self.self)
+          ObjectIdentifier(ReviewAddedSubscription.Data.self)
         ]
       ))
     }
@@ -88,7 +88,7 @@ public class ReviewAddedSubscription: GraphQLSubscription {
             "commentary": commentary,
           ],
           fulfilledFragments: [
-            ObjectIdentifier(Self.self)
+            ObjectIdentifier(ReviewAddedSubscription.Data.ReviewAdded.self)
           ]
         ))
       }


### PR DESCRIPTION
This fixes #3071 

When the shared root of a merged source is the direct parent or a direct sibling, we remove the parent from the namespacing of the referenced selection set. If the shared root is the root of the operation/fragment, that component of the namespacing should be removed.

Since the change to the way we indicate the location of a `SelectionSet` in the `IR` changed in #3045, in this case, the shared root is now not part of the `fieldPath`, causing the "shared root" to be at an index of `-1` (because its represented by the `location.source` now). This was causing a crash with an invalid range bounds.

This PR fixes this by using `max(0, sharedRootIndex)` to ensure we don't use `-1`, and then _not_ removing the first component in that case (because that component would be the `location.source` which is already not included.