### PR TITLE
Make SOCKS proxy support public

### DIFF
--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -40,7 +40,7 @@ public struct SSLSettings {
 
 //WebSocket implementation
 
-public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSocketStreamDelegate {
+public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSocketStreamDelegate, SOCKSProxyable {
 
   public enum OpCode : UInt8 {
     case continueFrame = 0x0
@@ -165,6 +165,29 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
   public var currentURL: URL { return request.url! }
 
   public var respondToPingWithPong: Bool = true
+
+  /// Determines whether a SOCKS proxy is enabled on the underlying request.
+  /// Mostly useful for debugging with tools like Charles Proxy.
+  /// Note: Will return `false` from the getter and no-op the setter for implementations that do not conform to `SOCKSProxyable`.
+  public var enableSOCKSProxy: Bool {
+    get {
+      guard let stream = stream as? SOCKSProxyable else {
+        // If it's not proxyable, then the proxy can't be enabled
+        return false
+      }
+
+      return stream.enableSOCKSProxy
+    }
+
+    set {
+      guard var stream = stream as? SOCKSProxyable else {
+        // If it's not proxyable, there's nothing to do here.
+        return
+      }
+
+      stream.enableSOCKSProxy = newValue
+    }
+  }
 
   // MARK: - Private
 

--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocketStream.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocketStream.swift
@@ -15,6 +15,12 @@ protocol WebSocketStreamDelegate: AnyObject {
   func streamDidError(error: Error?)
 }
 
+public protocol SOCKSProxyable {
+  /// Determines whether a SOCKS proxy is enabled on the underlying request.
+  /// Mostly useful for debugging with tools like Charles Proxy.
+  var enableSOCKSProxy: Bool { get set }
+}
+
 // This protocol is to allow custom implemention of the underlining stream.
 // This way custom socket libraries (e.g. linux) can be used
 protocol WebSocketStream {
@@ -36,7 +42,7 @@ protocol WebSocketStream {
   #endif
 }
 
-class FoundationStream : NSObject, WebSocketStream, StreamDelegate  {
+class FoundationStream : NSObject, WebSocketStream, StreamDelegate, SOCKSProxyable  {
   private let workQueue = DispatchQueue(label: "com.apollographql.websocket", attributes: [])
   private var inputStream: InputStream?
   private var outputStream: OutputStream?

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -125,6 +125,29 @@ public class WebSocketTransport {
     }
   }
 
+  /// Determines whether a SOCKS proxy is enabled on the underlying request.
+  /// Mostly useful for debugging with tools like Charles Proxy.
+  /// Note: Will return `false` from the getter and no-op the setter for implementations that do not conform to `SOCKSProxyable`.
+  public var enableSOCKSProxy: Bool {
+    get {
+      guard let websocket = websocket as? SOCKSProxyable else {
+        // If it's not proxyable, then the proxy can't be enabled
+        return false
+      }
+
+      return websocket.enableSOCKSProxy
+    }
+
+    set {
+      guard var websocket = websocket as? SOCKSProxyable else {
+        // If it's not proxyable, there's nothing to do here.
+        return
+      }
+
+      websocket.enableSOCKSProxy = newValue
+    }
+  }
+
   /// Designated initializer
   ///
   /// - Parameters:

--- a/Tests/ApolloInternalTestHelpers/MockWebSocket.swift
+++ b/Tests/ApolloInternalTestHelpers/MockWebSocket.swift
@@ -35,3 +35,7 @@ public class MockWebSocket: WebSocketClient {
   public func connect() {
   }
 }
+
+public class ProxyableMockWebSocket: MockWebSocket, SOCKSProxyable {
+  public var enableSOCKSProxy: Bool = false
+}

--- a/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
+++ b/Tests/ApolloTests/WebSocket/WebSocketTransportTests.swift
@@ -84,4 +84,28 @@ class WebSocketTransportTests: XCTestCase {
       XCTFail("Delay interrupted")
     }
   }
+
+  func testSocksProxyable_whenNotProxyable() {
+    let request = URLRequest(url: TestURL.mockServer.url)
+    self.webSocketTransport = WebSocketTransport(
+      websocket: MockWebSocket(request: request, protocol: .graphql_ws),
+      store: ApolloStore()
+    )
+
+    self.webSocketTransport.enableSOCKSProxy = true
+
+    XCTAssertEqual(self.webSocketTransport.enableSOCKSProxy, false)
+  }
+
+  func testSocksProxyable() {
+    let request = URLRequest(url: TestURL.mockServer.url)
+    self.webSocketTransport = WebSocketTransport(
+      websocket: ProxyableMockWebSocket(request: request, protocol: .graphql_ws),
+      store: ApolloStore()
+    )
+
+    self.webSocketTransport.enableSOCKSProxy = true
+
+    XCTAssertEqual(self.webSocketTransport.enableSOCKSProxy, true)
+  }
 }


### PR DESCRIPTION
Closes #2788 

This was originally added in #1108 but removed when `Starscream` was removed but for debugging tools like Charles, it is very useful to be able to see the web socket traffic. 

I made the implementation non-breaking by using the sam approach of `SOCKSProxyable` protocol from #1108.

Added tests for `WebSocketTransport` but I couldn't find create tests of `WebSocket` due to how it is written.