### PR TITLE
ci: Enable manual clone from forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
       - run:
           command: |
             if [[ ! -z "${CIRCLE_PR_REPONAME}" ]]; then
-              git clone "https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME.git"
+              git clone "https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME.git" apollo-ios
               cd apollo-ios
               git checkout $CIRCLE_SHA1
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ commands:
           command: |
             if [[ ! -z "${CIRCLE_PR_REPONAME}" ]]; then
               git clone "https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME.git"
+              cd apollo-ios
               git checkout $CIRCLE_SHA1
             else
               git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,13 @@ commands:
   codegen_test_configurations_generate_and_test:
     steps:
       - run:
-          command: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
+          command: |
+            if [[ ! -z "${CIRCLE_PR_REPONAME}" ]]; then
+              git clone "https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME.git"
+              git checkout $CIRCLE_SHA1
+            else
+              git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
+            fi
           name: Manually clone Apollo iOS repository
       - run:
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify


### PR DESCRIPTION
Fixes the codegen test configurations manual clone command to work with PRs from forked repos. This applies the same fix as #2715.

There are three PRs to verify the change works as expected in each case:

1.  **PRs on the official repo - `apollographql/apollo-ios`**
* These PRs use a branch as the repo source - [config.yml line 127](https://github.com/apollographql/apollo-ios/pull/3080/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R127).
* This PR is an example, which successfully clones the repo.
* Looking at the [Codegen Test Configurations test](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4752/workflows/9d49221e-b6af-4c96-8856-506864057a13/jobs/38577) job on the last build of this PR, for commit 3c8dc374, you can see the [successful clone](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4750/workflows/fbf65ce7-d592-4975-90ed-414d7f78f964/jobs/38577?invite=true#step-101-1).

2. **PRs from forked repos with the same repo name - `calvincestari/apollo-ios`**
* These PRs use a combination of the forked username and repo name as the repo source then checkout the last commit hash - [config.yml line 123](https://github.com/apollographql/apollo-ios/pull/3080/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R123).
* The PR #3081 is an example, which successfully clones the repo.
* Looking at the [Codegen Test Configurations test](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4738/workflows/c88c6495-a269-4f40-a00f-03e4a7715fc8/jobs/38417) job on the last build of that PR, for commit 9a43820, you can see the [successful clone](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4738/workflows/c88c6495-a269-4f40-a00f-03e4a7715fc8/jobs/38417?invite=true#step-101-1).

3. **PRs from forked repos but with a different repo name - `calvincestari/custom-repo-name`**
* These PRs use a combination of the forked username and repo name as the repo source then checkout the last commit hash - [config.yml line 123](https://github.com/apollographql/apollo-ios/pull/3080/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R123).
* The PR #3082 is an example, which successfully clones the repo.
* CI build of that PR can be found [here](https://app.circleci.com/pipelines/github/apollographql/apollo-ios?branch=pull%2F3082).
* Looking at the [Codegen Test Configurations test](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4753/workflows/5ec58a7d-f4e2-46f0-8cf8-ffe855b2bb54/jobs/38583) job on the last build of that PR, for commit a4ac39f3, you can see the [successful clone](https://app.circleci.com/pipelines/github/apollographql/apollo-ios/4751/workflows/42ce9476-510d-404c-ac24-417f2815f667/jobs/38583?invite=true#step-101-1).