### PR TITLE
fix: Exclude script from target source

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,7 @@ let package = Package(
       exclude: [
         "Info.plist",
         "Frontend/JavaScript",
+        "Frontend/auto_rollup.sh",
       ]),
     .target(
       name: "ApolloSQLite",


### PR DESCRIPTION
Excludes the internal script from the target source to fix the build warning:
```
❯ swift build
warning: 'apollo-ios': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/calvincestari/Projects/apollo-ios/Sources/ApolloCodegenLib/Frontend/auto_rollup.sh
```