### PR TITLE
RFC: GraphQL `@defer`

### DIFF
--- a/Design/0000-graphql-defer.md
+++ b/Design/0000-graphql-defer.md
@@ -201,6 +201,20 @@ public struct GraphQLResult<Data: RootSelectionSet> {
 }
 ```
 
+_Sample usage in an app_
+```swift
+  client.fetch(query: ExampleQuery()) { result in
+    switch (result) {
+    case let .success(data):
+      switch (data.response) {
+      case .complete:
+      case .partial:
+      }
+    case let .failure(error):
+    }
+  }
+```
+
 Another way which may be a bit more intuitive is to make the `server` case on `Source` have an associated value since `cache` sources will always be complete. The cache could return partial responses for deferred operations but for the initial implementation we will probably only write the cache record once all deferred fragments have been received.
 
 ```swift
@@ -217,6 +231,21 @@ public struct GraphQLResult<Data: RootSelectionSet> {
     case server(_ response: Response)
   }
 }
+```
+
+_Sample usage in an app_
+```swift
+  client.fetch(query: ExampleQuery()) { result in
+    switch (result) {
+    case let .success(data):
+      switch (data.source) {
+      case .server(.complete):
+      case .server(.partial):
+      case .cache:
+      }
+    case let .failure(error):
+    }
+  }
 ```
 
 ## GraphQL execution

--- a/Design/0000-graphql-defer.md
+++ b/Design/0000-graphql-defer.md
@@ -29,17 +29,53 @@ Adding support for `@defer` brings new meaning of the word 'deferred' to the cod
 
 ## Generated models
 
-### Deferred fragments
+Generated models will definitely be affected by `@defer` statements in the operation. Ideally there is easy-to-read annotation indicating something is deferred by simply reading the generated model code but more importantly it must be easy when using the generated models in code to detect whether something is deferred or not.
 
-_In progress_
+The most simple solution is to change the deferred property type to an optional version of that type. This hides detail though because you wouldn't be able to tell whether the value is `nil` because the response data has been received yet (i.e.: deferred) or whether the data was returned and it was explicitly `null`. It also gets more complicated when a type is already optional; would that result in a Swift double-optional type? As we learnt with the legacy implementation of GraphQL nullability, double-optionals are difficult to interpret and easy lead to errors.
 
-### Merged fields
+I explored Swift's property wrappers but they suffer from the limitation of not being able to be applied to a computed property. All model properties are computed properties because they simply route access the value in the underlying dictionary data storage. It would be nice to be able to simply annotate fragments and fields with some like `@Deferred` but it doesn't look like that is possible.
 
-_In progress_
+An idea that was suggested by [`@Iron-Ham`](https://github.com/apollographql/apollo-ios/issues/2395#issuecomment-1433628466) is to wrap the type in a Swift enum that can expose the deferred state as well as the underlying value once it has been received.
 
-### Selection set initializers
+_Example enum to wrap deferred properties_
+```swift
+enum DeferredValue<T> {
+    case loading
+    case result(Result<T, Error>)
+}
+```
+_Sample model with `DeferredResponse`_
+```swift
+public struct ModelSelectionSet: GraphAPI.SelectionSet {
+  // other properties no shown
 
-_In progress_
+  public var name: DeferredValue<String?> { __data["name"] }
+}
+```
+
+Deferred fragment definitions in generated models will get an additional property to indicate they are deferred.
+
+_Updated `Selection` enum_
+```swift
+public enum Selection {
+  // other cases not shown
+  case fragment(any Fragment.Type, deferred: Bool)
+  case inlineFragment(any InlineFragment.Type, deferred: Bool)
+
+  // other properties and types not shown
+}
+```
+
+_Example usage in a generated model_
+```swift
+  public static var __selections: [ApolloAPI.Selection] { [
+    .inlineFragment(AsEntity.self, deferred: true),
+  ] }
+
+  public static var __selections: [ApolloAPI.Selection] { [
+    .fragment(EntityFragment.self, deferred: true),
+  ] }
+```
 
 ## Networking 
 

--- a/Design/0000-graphql-defer.md
+++ b/Design/0000-graphql-defer.md
@@ -21,7 +21,7 @@ There are a few options for updating the graphql-js dependency:
 2. Use `17.0.0-alpha.2`, or the latest 17.0.0 alpha release, as-is and remove the experimental Client Controlled Nullability feature. We do not know how many users rely on the CCN functionality so this may be a controversial decision. This path doesn’t necessarily imply an easier dependency update because there will be changes needed to our frontend javascript to adapt to the changes in graphql-js.
 3. Another option is a staggered approach where we adopt `17.0.0-alpha.2`, or the latest 17.0.0 alpha release, limiting the changes to our frontend javascript only and at a later stage bring the CCN changes from [PR `#3510`](https://github.com/graphql/graphql-js/pull/3510) to the `17.x` release path and reintroduce support for CCN to Apollo iOS. This would also require the experiemental CCN feature to be removed, with no committment to when it would be reintroduced.
 
-## Rename PossiblyDeferred types/functions
+## Rename `PossiblyDeferred` types/functions
 
 Adding support for `@defer` brings new meaning of the word 'deferred' to the codebase. There is an enum type named [`PossiblyDeferred`](https://github.com/apollographql/apollo-ios/blob/spike/defer/Sources/Apollo/PossiblyDeferred.swift#L47) which would cause confusion when trying to understand it’s intent. This type and its related functions should be renamed to disambiguate it from the incoming `@defer` related types and functions.
 
@@ -166,18 +166,28 @@ struct DeferResponseParser: MultipartResponseSpecificationParser {
 }
 ```
 
-#### Data
+#### Response data
 
 The initial response data and data received in each incremental response will need to be retained and combined so that each incremental response can insert the latest received incremental response data at the correct path and return an up-to-date response to the request callback.
 
-The data being retained and augmented should not require another pass through the GraphQL executor though.
+The data being retained and combined should not require another pass through the GraphQL executor though.
+
+### Completion handler
+
+_In progress_
+
 
 ## GraphQL execution
 
 The executor currently executes on an entire operation selection set. It will need to be adapted to be able to execute on an isolated fragment selection set so that incremental responses can be parsed in isolation instead of needing to execute on the whole operation’s selection set.
+
+_In progress_
 
 ## Caching
 
 Similarly to GraphQL execution the cache write interceptor is designed to work holistically on the operation and write cache records for a single response. This currently works in HTTP-based subscriptions because each incremental response is a selection set for the entire operation.
 
 Resolve cache key info on each incremental payload to gather the key required for the incremental data update to the cache record.
+
+_In progress_
+

--- a/Design/0000-graphql-defer.md
+++ b/Design/0000-graphql-defer.md
@@ -1,0 +1,64 @@
+* Feature Name: GraphQL `@defer`
+* Start Date: 2023-06-26
+* RFC PR:
+
+# Summary
+
+The specification for `@defer`/`@stream` is slowly making it's way through the GraphQL Foundation approval process and once formally merged into the GraphQL specification Apollo iOS will need to support it. Apollo already has support for `@defer` in the other OSS offerings, namely Apollo Server, Apollo Client, and Apollo Kotlin.
+
+Based on the progress of `@defer`/`@stream` through the approval process there may be some differences in the final specification vs. what is currently implemented in Apollo's OSS. This project does not attempt to preemptively anticipate those changes and comply with the potential merged specification. The goal of this project is to implement support for `@defer` that matches the other OSS clients. Any client affecting-changes in the merged specification will be implemented into Apollo iOS.
+
+# Proposed Changes
+
+## Update graphql-js dependency
+
+Apollo iOS uses [graphql-js](https://github.com/graphql/graphql-js) for validation of the GraphQL schema and operation documents as the first step in the code generation workflow. The version of this dependency is fixed at [`16.3.0-canary.pr.3510.5099f4491dc2a35a3e4a0270a55e2a228c15f13b`](https://www.npmjs.com/package/graphql/v/16.3.0-canary.pr.3510.5099f4491dc2a35a3e4a0270a55e2a228c15f13b?activeTab=versions). This is a version of graphql-js that supports the [Client Controlled Nullability](https://github.com/graphql/graphql-wg/blob/main/rfcs/ClientControlledNullability.md) feature but does not support the `@defer` directive.
+
+The latest `16.x` release of graphql-js with support for the `@defer` directive is [`16.1.0-experimental-stream-defer.6`](https://www.npmjs.com/package/graphql/v/16.1.0-experimental-stream-defer.6) but it looks like the 'experimental' named releases for `@defer` have been discontinued and the recommendation is to use [`17.0.0-alpha.2`](https://www.npmjs.com/package/graphql/v/17.0.0-alpha.2). This is further validated by the fact that [`16.7.0` does not](https://github.com/graphql/graphql-js/blob/v16.7.0/src/type/directives.ts#L167) include the @defer directive whereas [`17.0.0-alpha.2` does](https://github.com/graphql/graphql-js/blob/v17.0.0-alpha.2/src/type/directives.ts#L159).
+
+There are a few options for updating the graphql-js dependency:
+1. Add support for Client Controlled Nullability to `17.0.0-alpha.2` and publish that to NPM. The level of effort for this is unknown but it would allow us to maintain support for CCN.
+2. Use `17.0.0-alpha.2` as-is and remove the experimental feature of Client Controlled Nullability. We do not know how many users rely on the CCN functionality so this may be a controversial decision. This path doesn’t necessarily imply an easier dependency update because there will be changes needed to our frontend javascript to adapt to the changes in graphql-js.
+3. Another option is a staggered approach where we adopt `17.0.0-alpha.2` limiting the changes to our frontend javascript only and at a later stage bring the CCN changes from [PR `#3510`](https://github.com/graphql/graphql-js/pull/3510) to the `17.x` release path and reintroduce support for CCN to Apollo iOS. This would also require the experiemental CCN feature to be removed, with no committment to when it would be reintroduced.
+
+## Rename PossiblyDeferred types/functions
+
+Adding support for `@defer` brings new meaning of the word 'deferred' to the codebase. There is an enum type named [`PossiblyDeferred`](https://github.com/apollographql/apollo-ios/blob/main/Sources/Apollo/PossiblyDeferred.swift#L47) which would cause confusion when trying to understand it’s intent. This type and its related functions should be renamed to disambiguate it from the incoming `@defer` related types and functions.
+
+`PossiblyDeferred` is an internal type so this should have no adverse effect to users’ code.
+
+## Generated models
+
+_In progress_
+
+## Networking 
+
+### Request header
+
+Operation requests that want an incremental delivery response need to send the version of the protocol specification that they are compliant with. Apollo iOS currently requests incremental delivery responses for HTTP-based subscriptions. `@defer` would introduce another operation feature that would request an incremental delivery response.
+
+At the time of writing the latest `deferSpec` version is `20220824`. This should not be sent with all requests though so operations will need to be identifiable as having deferred fragments to signal inclusion of the request header.
+
+### Response parsing
+
+Apollo iOS already has support for parsing incremental delivery responses. That provides a great foundation to build on however there are some changes needed.
+
+#### Specification
+
+The current `MultipartResponseParsingInterceptor` implementation is specific to the `subscriptionSpec` version `1.0` specification. Adopting a `MultipartResponseSpecification` protocol that states the specification and version will enable us to support any number of incremental delivery specifications in the future. These will be registered with the `MultipartResponseParsingInterceptor` and when a response is received the correct specification parser will be used.
+
+#### Data
+
+The initial response data and data received in each incremental response will need to be retained and combined so that each incremental response can insert the latest received incremental response data at the correct path and return an up-to-date response to the request callback.
+
+The data being retained and augmented should not require another pass through the GraphQL executor though.
+
+## GraphQL execution
+
+The executor currently executes on an entire operation selection set. It will need to be adapted to be able to execute on an isolated fragment selection set so that incremental responses can be parsed in isolation instead of needing to execute on the whole operation’s selection set.
+
+## Caching
+
+Similarly to GraphQL execution the cache write interceptor is designed to work holistically on the operation and write cache records for a single response. This currently works in HTTP-based subscriptions because each incremental response is a selection set for the entire operation.
+
+Resolve cache key info on each incremental payload to gather the key required for the incremental data update to the cache record.

--- a/Design/0000-graphql-defer.md
+++ b/Design/0000-graphql-defer.md
@@ -1,29 +1,29 @@
 * Feature Name: GraphQL `@defer`
 * Start Date: 2023-06-26
-* RFC PR:
+* RFC PR: TBD
 
 # Summary
 
-The specification for `@defer`/`@stream` is slowly making it's way through the GraphQL Foundation approval process and once formally merged into the GraphQL specification Apollo iOS will need to support it. Apollo already has support for `@defer` in the other OSS offerings, namely Apollo Server, Apollo Client, and Apollo Kotlin.
+The specification for `@defer`/`@stream` is slowly making it's way through the GraphQL Foundation approval process and once formally merged into the GraphQL specification Apollo iOS will need to support it. However, Apollo already has a public implementation of `@defer` in the other OSS offerings, namely Apollo Server, Apollo Client, and Apollo Kotlin. The goal of this project is to implement support for `@defer` that matches the other Apollo OSS clients.
 
-Based on the progress of `@defer`/`@stream` through the approval process there may be some differences in the final specification vs. what is currently implemented in Apollo's OSS. This project does not attempt to preemptively anticipate those changes and comply with the potential merged specification. The goal of this project is to implement support for `@defer` that matches the other OSS clients. Any client affecting-changes in the merged specification will be implemented into Apollo iOS.
+Based on the progress of `@defer`/`@stream` through the approval process there may be some differences in the final specification vs. what is currently implemented in Apollo's OSS. This project does not attempt to preemptively anticipate those changes nor comply with the potential merged specification. Any client affecting-changes in the merged specification will be implemented into Apollo iOS.
 
 # Proposed Changes
 
 ## Update graphql-js dependency
 
-Apollo iOS uses [graphql-js](https://github.com/graphql/graphql-js) for validation of the GraphQL schema and operation documents as the first step in the code generation workflow. The version of this dependency is fixed at [`16.3.0-canary.pr.3510.5099f4491dc2a35a3e4a0270a55e2a228c15f13b`](https://www.npmjs.com/package/graphql/v/16.3.0-canary.pr.3510.5099f4491dc2a35a3e4a0270a55e2a228c15f13b?activeTab=versions). This is a version of graphql-js that supports the [Client Controlled Nullability](https://github.com/graphql/graphql-wg/blob/main/rfcs/ClientControlledNullability.md) feature but does not support the `@defer` directive.
+Apollo iOS uses [graphql-js](https://github.com/graphql/graphql-js) for validation of the GraphQL schema and operation documents as the first step in the code generation workflow. The version of this [dependency](https://github.com/apollographql/apollo-ios/blob/main/Sources/ApolloCodegenLib/Frontend/JavaScript/package.json#L16) is fixed at [`16.3.0-canary.pr.3510.5099f4491dc2a35a3e4a0270a55e2a228c15f13b`](https://www.npmjs.com/package/graphql/v/16.3.0-canary.pr.3510.5099f4491dc2a35a3e4a0270a55e2a228c15f13b?activeTab=versions). This is a version of graphql-js that supports the [Client Controlled Nullability](https://github.com/graphql/graphql-wg/blob/main/rfcs/ClientControlledNullability.md) feature but does not support the `@defer` directive.
 
 The latest `16.x` release of graphql-js with support for the `@defer` directive is [`16.1.0-experimental-stream-defer.6`](https://www.npmjs.com/package/graphql/v/16.1.0-experimental-stream-defer.6) but it looks like the 'experimental' named releases for `@defer` have been discontinued and the recommendation is to use [`17.0.0-alpha.2`](https://www.npmjs.com/package/graphql/v/17.0.0-alpha.2). This is further validated by the fact that [`16.7.0` does not](https://github.com/graphql/graphql-js/blob/v16.7.0/src/type/directives.ts#L167) include the @defer directive whereas [`17.0.0-alpha.2` does](https://github.com/graphql/graphql-js/blob/v17.0.0-alpha.2/src/type/directives.ts#L159).
 
 There are a few options for updating the graphql-js dependency:
-1. Add support for Client Controlled Nullability to `17.0.0-alpha.2` and publish that to NPM. The level of effort for this is unknown but it would allow us to maintain support for CCN.
-2. Use `17.0.0-alpha.2` as-is and remove the experimental feature of Client Controlled Nullability. We do not know how many users rely on the CCN functionality so this may be a controversial decision. This path doesn’t necessarily imply an easier dependency update because there will be changes needed to our frontend javascript to adapt to the changes in graphql-js.
-3. Another option is a staggered approach where we adopt `17.0.0-alpha.2` limiting the changes to our frontend javascript only and at a later stage bring the CCN changes from [PR `#3510`](https://github.com/graphql/graphql-js/pull/3510) to the `17.x` release path and reintroduce support for CCN to Apollo iOS. This would also require the experiemental CCN feature to be removed, with no committment to when it would be reintroduced.
+1. Add support for Client Controlled Nullability to `17.0.0-alpha.2`, or the latest 17.0.0 alpha release, and publish that to NPM. The level of effort for this is unknown but it would allow us to maintain support for CCN.
+2. Use `17.0.0-alpha.2`, or the latest 17.0.0 alpha release, as-is and remove the experimental Client Controlled Nullability feature. We do not know how many users rely on the CCN functionality so this may be a controversial decision. This path doesn’t necessarily imply an easier dependency update because there will be changes needed to our frontend javascript to adapt to the changes in graphql-js.
+3. Another option is a staggered approach where we adopt `17.0.0-alpha.2`, or the latest 17.0.0 alpha release, limiting the changes to our frontend javascript only and at a later stage bring the CCN changes from [PR `#3510`](https://github.com/graphql/graphql-js/pull/3510) to the `17.x` release path and reintroduce support for CCN to Apollo iOS. This would also require the experiemental CCN feature to be removed, with no committment to when it would be reintroduced.
 
 ## Rename PossiblyDeferred types/functions
 
-Adding support for `@defer` brings new meaning of the word 'deferred' to the codebase. There is an enum type named [`PossiblyDeferred`](https://github.com/apollographql/apollo-ios/blob/main/Sources/Apollo/PossiblyDeferred.swift#L47) which would cause confusion when trying to understand it’s intent. This type and its related functions should be renamed to disambiguate it from the incoming `@defer` related types and functions.
+Adding support for `@defer` brings new meaning of the word 'deferred' to the codebase. There is an enum type named [`PossiblyDeferred`](https://github.com/apollographql/apollo-ios/blob/spike/defer/Sources/Apollo/PossiblyDeferred.swift#L47) which would cause confusion when trying to understand it’s intent. This type and its related functions should be renamed to disambiguate it from the incoming `@defer` related types and functions.
 
 `PossiblyDeferred` is an internal type so this should have no adverse effect to users’ code.
 

--- a/Design/0000-graphql-defer.md
+++ b/Design/0000-graphql-defer.md
@@ -250,9 +250,9 @@ _Sample usage in an app_
 
 ## GraphQL execution
 
-The executor currently executes on an entire operation selection set. It will need to be adapted to be able to execute on an isolated fragment selection set so that incremental responses can be parsed in isolation instead of needing to execute on the whole operation’s selection set.
+The executor currently executes on an entire operation selection set. It will need to be adapted to be able to execute on a partial response when deferred fragments have not been received and on an isolated fragment selection set so that incremental responses can be parsed alone instead of needing to execute on the whole operation’s selection set.
 
-_In progress_
+An alternative to parsing isolated fragment selection sets would be to execute on all the data currently received. The inefficiency with this is executing on data that would have already been executed on during prior responses.
 
 ## Caching
 

--- a/Design/3093-graphql-defer.md
+++ b/Design/3093-graphql-defer.md
@@ -77,18 +77,6 @@ _Example usage in a generated model_
   ] }
 ```
 
-### Deferred fragments
-
-_In progress_
-
-### Merged fields
-
-_In progress_
-
-### Selection set initializers
-
-_In progress_
-
 ## Networking 
 
 ### Request header

--- a/Design/3093-graphql-defer.md
+++ b/Design/3093-graphql-defer.md
@@ -77,6 +77,18 @@ _Example usage in a generated model_
   ] }
 ```
 
+### Deferred fragments
+
+_In progress_
+
+### Merged fields
+
+_In progress_
+
+### Selection set initializers
+
+_In progress_
+
 ## Networking 
 
 ### Request header

--- a/Design/3093-graphql-defer.md
+++ b/Design/3093-graphql-defer.md
@@ -223,7 +223,7 @@ The data being retained and combined should not require another pass through the
 `GraphQLResult` should be modified to provide query completion blocks with a high-level abstraction of whether the request has been fulfilled or is still in progress. This prevents clients from having to dig into the deferred fragments to identify the state of the overall request.
 
 Potential solutions:
-1. Introduce a new property on the `GraphQLResult` type that can be used to express the state of the request
+1. Introduce a new property on the `GraphQLResult` type that can be used to express the state of the request.
 
 ```swift
 // New Response type and property
@@ -251,7 +251,7 @@ client.fetch(query: ExampleQuery()) { result in
 }
 ```
 
-2. Another way which may be a bit more intuitive is to make the `server` case on `Source` have an associated value since `cache` sources will always be complete. The cache could return partial responses for deferred operations but for the initial implementation we will probably only write the cache record once all deferred fragments have been received.
+2. Another way which may be a bit more intuitive is to make the `server` case on `Source` have an associated value since `cache` sources will always be complete. The cache could return partial responses for deferred operations but for the initial implementation we will probably only write the cache record once all deferred fragments have been received. This solution becomes invalid though once the cache can return partial responses, with that in mind maybe option 1 is better.
 
 ```swift
 // Updated server case on Source with associated value of Response type

--- a/Design/3093-graphql-defer.md
+++ b/Design/3093-graphql-defer.md
@@ -72,7 +72,7 @@ client.fetch(query: ExampleQuery()) { result in
     client.fetch(query: ExampleQuery()) { result in
       switch (result) {
       case let .success(data):
-        guard let fragment = data.data?.item.fragments.entityFragment {
+        guard let fragment = data.data?.item.fragments.entityFragment else {
           // partial result
         }
     

--- a/Design/3093-graphql-defer.md
+++ b/Design/3093-graphql-defer.md
@@ -139,7 +139,7 @@ Apollo iOS already has support for parsing incremental delivery responses. That 
 
 The current `MultipartResponseParsingInterceptor` implementation is specific to the `subscriptionSpec` version `1.0` specification. Adopting a protocol with implementations for each of the supported specifications will enable us to support any number of incremental delivery specifications in the future.
 
-These would be registered with the `MultipartResponseParsingInterceptor` for an each specification string, and when a response is received the specification string is extracted from the response `content-type` header, and the correct specification parser can be used to parse the response data.
+These would be registered with the `MultipartResponseParsingInterceptor` each with a unique specification string, to be used as a lookup key. When a response is received the specification string is extracted from the response `content-type` header, and the correct specification parser can be used to parse the response data.
 
 _Sample code in `MultipartResponseParsingInterceptor`_
 ```swift

--- a/Design/3093-graphql-defer.md
+++ b/Design/3093-graphql-defer.md
@@ -60,7 +60,7 @@ public class ExampleQuery: GraphQLQuery {
 
   public struct Data: ExampleSchema.SelectionSet {
     public static var __selections: [ApolloAPI.Selection] { [
-      .fragment(EntityFragment?.self)
+      .fragment(EntityFragment?.self, deferred: true)
     ] }
   }
 }


### PR DESCRIPTION
Read the formatted RFC [here](https://github.com/apollographql/apollo-ios/blob/spike/defer/Design/3093-graphql-defer.md).

```[tasklist]
### Codegen
- [ ] https://github.com/apollographql/apollo-ios/issues/3113
- [ ] https://github.com/apollographql/apollo-ios/issues/3114
- [ ] https://github.com/apollographql/apollo-ios/issues/3139
- [ ] https://github.com/apollographql/apollo-ios/issues/3140
- [ ] https://github.com/apollographql/apollo-ios/issues/3141
- [ ] https://github.com/apollographql/apollo-ios/issues/3142
```

```[tasklist]
### Execution
- [ ] https://github.com/apollographql/apollo-ios/issues/3144
- [ ] https://github.com/apollographql/apollo-ios/issues/3145
```

```[tasklist]
### Networking
- [ ] https://github.com/apollographql/apollo-ios/issues/3118
- [ ] https://github.com/apollographql/apollo-ios/issues/3143
- [ ] https://github.com/apollographql/apollo-ios/issues/3146
- [ ] https://github.com/apollographql/apollo-ios/issues/3147
- [ ] https://github.com/apollographql/apollo-ios/issues/3148
```

```[tasklist]
### Caching
- [ ] https://github.com/apollographql/apollo-ios/issues/3149
```