### PR TITLE
fix: fixes two issues in the generation of mocks.

### DIFF
--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -76,6 +76,8 @@ struct MockObjectTemplate: TemplateRenderer {
   
   private func mockFunctionDescriptor(_ graphQLType: GraphQLType) -> String {
     switch graphQLType {
+      case .list(.nonNull(.scalar(_))):
+        return "ScalarList"
       case .list(_):
         return "List"
       case .scalar(_), .enum(_):

--- a/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/MockObjectTemplate.swift
@@ -95,7 +95,7 @@ struct MockObjectTemplate: TemplateRenderer {
       \(if: $0.propertyName.isConflictingTestMockFieldName, """
         var \($0.propertyName): \($0.mockType)? {
           get { _data["\($0.propertyName)"] as? \($0.mockType) }
-          set { _set(newValue, for: \\.\($0.propertyName)) }
+          set { _set\(mockFunctionDescriptor($0.type))(newValue, for: \\.\($0.propertyName)) }
         }
         """)
       """ }, separator: "\n", terminator: "\n")

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -83,11 +83,11 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
       return _data[field.key.description] as? [T]
     }
     set {
-      _setList(newValue, for: keyPath)
+      _setScalarList(newValue, for: keyPath)
     }
   }
 
-  public func _setList<T: AnyScalarType & Hashable>(
+  public func _setScalarList<T: AnyScalarType & Hashable>(
     _ value: [T]?,
     for keyPath: KeyPath<O.MockFields, Field<Array<T>>>
   ) {

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -75,6 +75,14 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
     _data[field.key.description] = value?._unsafelyConvertToMockValue()
   }
 
+  public func _setList<T: AnyScalarType & Hashable>(
+    _ value: [T]?,
+    for keyPath: KeyPath<O.MockFields, Field<Array<T>>>
+  ) {
+    let field = O._mockFields[keyPath: keyPath]
+    _data[field.key.description] = value?._unsafelyConvertToMockValue()
+  }
+
   public var _selectionSetMockData: JSONObject {
     _data.mapValues {
       if let mock = $0 as? AnyMock {

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -75,6 +75,18 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
     _data[field.key.description] = value?._unsafelyConvertToMockValue()
   }
 
+  public subscript<T: AnyScalarType & Hashable>(
+    dynamicMember keyPath: KeyPath<O.MockFields, Field<Array<T>>>
+  ) -> [T]? {
+    get {
+      let field = O._mockFields[keyPath: keyPath]
+      return _data[field.key.description] as? [T]
+    }
+    set {
+      _setList(newValue, for: keyPath)
+    }
+  }
+
   public func _setList<T: AnyScalarType & Hashable>(
     _ value: [T]?,
     for keyPath: KeyPath<O.MockFields, Field<Array<T>>>

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -462,7 +462,7 @@ class MockObjectTemplateTests: XCTestCase {
     let expected = """
       var hash: String? {
         get { _data["hash"] as? String }
-        set { _set(newValue, for: \\.hash) }
+        set { _setScalar(newValue, for: \\.hash) }
       }
 
     """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -536,7 +536,7 @@ class MockObjectTemplateTests: XCTestCase {
       ) {
         self.init()
         _setScalar(customScalar, for: \\.customScalar)
-        _setList(customScalarList, for: \\.customScalarList)
+        _setScalarList(customScalarList, for: \\.customScalarList)
         _setScalar(enumType, for: \\.enumType)
         _setEntity(interface, for: \\.interface)
         _setList(interfaceList, for: \\.interfaceList)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/MockObjectTemplateTests.swift
@@ -487,6 +487,7 @@ class MockObjectTemplateTests: XCTestCase {
     subject.graphqlObject.fields = [
       "string": .mock("string", type: .nonNull(.string())),
       "customScalar": .mock("customScalar", type: .nonNull(.scalar(.mock(name: "CustomScalar")))),
+      "customScalarList": .mock("customScalarList", type: .list(.nonNull(.scalar(.mock(name: "CustomScalar"))))),
       "optionalString": .mock("optionalString", type: .string()),
       "object": .mock("object", type: Cat),
       "objectList": .mock("objectList", type: .list(.nonNull(Cat))),
@@ -516,6 +517,7 @@ class MockObjectTemplateTests: XCTestCase {
     public extension Mock where O == Dog {
       convenience init(
         customScalar: TestSchema.CustomScalar? = nil,
+        customScalarList: [TestSchema.CustomScalar]? = nil,
         enumType: GraphQLEnum<TestSchema.EnumType>? = nil,
         interface: AnyMock? = nil,
         interfaceList: [AnyMock]? = nil,
@@ -534,6 +536,7 @@ class MockObjectTemplateTests: XCTestCase {
       ) {
         self.init()
         _setScalar(customScalar, for: \\.customScalar)
+        _setList(customScalarList, for: \\.customScalarList)
         _setScalar(enumType, for: \\.enumType)
         _setEntity(interface, for: \\.interface)
         _setList(interfaceList, for: \\.interfaceList)

--- a/Tests/CodegenIntegrationTests/Tests/3120-listOfCustomScalarsNeedsSetScalarList/README.MD
+++ b/Tests/CodegenIntegrationTests/Tests/3120-listOfCustomScalarsNeedsSetScalarList/README.MD
@@ -1,0 +1,10 @@
+# Overview
+
+When a field has a list type containing custom scalars, the generated initializer for mock objects should use a version of the `_set` function that is appropriate for that type. 
+Previously, the `_setList` function was used for all lists of objects, even if it would not compile since custom scalars do not conform to `GraphQLField`.
+
+## Reference Issue: https://github.com/apollographql/apollo-ios/pull/3120
+
+## Solution
+
+All properties that are lists of scalars should use the `_setScalarList` function when initialized inside mock objects.

--- a/Tests/CodegenIntegrationTests/Tests/3120-listOfCustomScalarsNeedsSetScalarList/operation.graphql
+++ b/Tests/CodegenIntegrationTests/Tests/3120-listOfCustomScalarsNeedsSetScalarList/operation.graphql
@@ -1,0 +1,6 @@
+query TestMeWithMocks {
+  testMeWithMocks {
+    scalarList
+    nullableScalarList
+  }
+}

--- a/Tests/CodegenIntegrationTests/Tests/3120-listOfCustomScalarsNeedsSetScalarList/schema.graphqls
+++ b/Tests/CodegenIntegrationTests/Tests/3120-listOfCustomScalarsNeedsSetScalarList/schema.graphqls
@@ -1,0 +1,10 @@
+type Query {
+  testMeWithMocks: Event!
+}
+
+type Event {
+  scalarList: [Text!]!
+  nullableScalarList: [Text]!
+}
+
+scalar Text


### PR DESCRIPTION
Hello 👋 

I found and fixed a couple issues with the generation of mocks.

![Screenshot 2023-07-13 at 11 26 06](https://github.com/apollographql/apollo-ios/assets/15340382/c9af21ba-d9f6-46b3-8dba-9311730803e8)

1. when generating properties with conflicting names in the Mock extensions, the setter always uses a `_set` function that is undefined. I changed it to use the appropriate `_set{List, Scalar, ...}` function.
2. when generating the convenience init for Mock objects, if the mock requires a list of custom scalars the current implementation just tries to use the existing `_setList` function that requires the elements of the list to conform to `MockFieldValue`. Since scalars do not conform to `MockField`, this doesn't compile in the client app. I fixed it by adding two overloads: one to the `_setList` function that takes an array of `AnyScalarType` instead, and one to `subscript`. 

Please double check my logic, I'm not very familiar with how this new Mock system works.

I also updated the tests to reflect these changes. I noticed that the `ApolloCodegenLib` does not test the result of the code generation; it would be very nice to have a "two steps" setup where first we test the generation of the code itself, as today's tests do, and then compile the result of the code generation and assert that the compilation is successful. 
A similar setup would have caught both these issues. Just a suggestion 😄 