### PR TITLE
Throw error when an invalid key is present in a `JSON` Apollo configuration

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -202,7 +202,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     // MARK: Codable
 
-    enum CodingKeys: CodingKey {
+    enum CodingKeys: CodingKey, CaseIterable {
       case schemaTypes
       case operations
       case testMocks
@@ -214,6 +214,15 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// specified defaults when not present.
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
+        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
+          codingPath: values.codingPath,
+          debugDescription: "Unrecognized key found",
+          underlyingError: nil
+        ))
+      }
 
       schemaTypes = try values.decode(
         SchemaTypesFileOutput.self,
@@ -617,7 +626,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     // MARK: Codable
 
-    enum CodingKeys: CodingKey {
+    enum CodingKeys: CodingKey, CaseIterable {
       case additionalInflectionRules
       case queryStringLiteralFormat
       case deprecatedEnumCases
@@ -633,6 +642,15 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
+        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
+          codingPath: values.codingPath,
+          debugDescription: "Unrecognized key found",
+          underlyingError: nil
+        ))
+      }
 
       additionalInflectionRules = try values.decodeIfPresent(
         [InflectionRule].self,
@@ -757,6 +775,13 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
+      guard values.allKeys.first != nil else {
+        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
+          codingPath: values.codingPath,
+          debugDescription: "Invalid number of keys found, expected one.",
+          underlyingError: nil
+        ))
+      }
 
       enumCases = try values.decodeIfPresent(
         CaseConversionStrategy.self,
@@ -931,13 +956,22 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     // MARK: Codable
 
-    public enum CodingKeys: CodingKey {
+    public enum CodingKeys: CodingKey, CaseIterable {
       case clientControlledNullability
       case legacySafelistingCompatibleOperations
     }
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
+
+      let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
+        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
+          codingPath: values.codingPath,
+          debugDescription: "Unrecognized key found",
+          underlyingError: nil
+        ))
+      }
 
       clientControlledNullability = try values.decodeIfPresent(
         Bool.self,
@@ -1008,7 +1042,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
   // MARK: Codable
 
-  enum CodingKeys: CodingKey {
+  enum CodingKeys: CodingKey, CaseIterable {
     case schemaName
     case schemaNamespace
     case input
@@ -1034,6 +1068,14 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
+    let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
+      throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
+        codingPath: values.codingPath,
+        debugDescription: "Unrecognized key found",
+        underlyingError: nil
+      ))
+    }
 
     func getSchemaNamespaceValue() throws -> String {
       if let value = try values.decodeIfPresent(String.self, forKey: .schemaNamespace) {
@@ -1152,7 +1194,7 @@ extension ApolloCodegenConfiguration.SelectionSetInitializers {
 
   // MARK: Codable
 
-  enum CodingKeys: CodingKey {
+  enum CodingKeys: CodingKey, CaseIterable {
     case operations
     case namedFragments
     case localCacheMutations
@@ -1161,6 +1203,14 @@ extension ApolloCodegenConfiguration.SelectionSetInitializers {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
+    let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
+      throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
+        codingPath: values.codingPath,
+        debugDescription: "Unrecognized key found",
+        underlyingError: nil
+      ))
+    }
     var options: Options = []
 
     func decode(option: @autoclosure () -> Options, forKey key: CodingKeys) throws {
@@ -1369,4 +1419,19 @@ extension ApolloCodegenConfiguration.OutputOptions {
       return .disabled
     }
   }
+}
+
+private struct AnyCodingKey: CodingKey {
+    var stringValue: String
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    var intValue: Int?
+
+    init?(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = "\(intValue)"
+    }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1402,8 +1402,11 @@ private func throwIfContainsUnexpectedKey<T, C: CodingKey & CaseIterable>(
   type: T.Type,
   decoder: Decoder
 ) throws {
-  let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
-  guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(C.allCases.map(\.stringValue))) else {
+  // Map all keys from the input object
+  let allKeys = Set(try decoder.container(keyedBy: AnyCodingKey.self).allKeys.map(\.stringValue))
+  // Map all valid keys from the given `CodingKey` enum
+  let validKeys = Set(C.allCases.map(\.stringValue))
+  guard allKeys.isSubset(of: validKeys) else {
     throw DecodingError.typeMismatch(type, DecodingError.Context.init(
       codingPath: container.codingPath,
       debugDescription: "Unrecognized key found",

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -946,7 +946,6 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
-      try throwIfContainsUnexpectedKey(container: values, type: Self.self, decoder: decoder)
 
       clientControlledNullability = try values.decodeIfPresent(
         Bool.self,
@@ -1407,9 +1406,10 @@ private func throwIfContainsUnexpectedKey<T, C: CodingKey & CaseIterable>(
   // Map all valid keys from the given `CodingKey` enum
   let validKeys = Set(C.allCases.map(\.stringValue))
   guard allKeys.isSubset(of: validKeys) else {
+    let invalidKeys = allKeys.subtracting(validKeys)
     throw DecodingError.typeMismatch(type, DecodingError.Context.init(
       codingPath: container.codingPath,
-      debugDescription: "Unrecognized key found",
+      debugDescription: "Unrecognized \(invalidKeys.count > 1 ? "keys" : "key") found: \(invalidKeys.joined(separator: ", "))",
       underlyingError: nil
     ))
   }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -214,16 +214,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// specified defaults when not present.
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
-
-      let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
-      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
-        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
-          codingPath: values.codingPath,
-          debugDescription: "Unrecognized key found",
-          underlyingError: nil
-        ))
-      }
-
+      try throwIfContainsUnexpectedKey(container: values, type: Self.self, decoder: decoder)
       schemaTypes = try values.decode(
         SchemaTypesFileOutput.self,
         forKey: .schemaTypes
@@ -642,15 +633,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
-
-      let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
-      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
-        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
-          codingPath: values.codingPath,
-          debugDescription: "Unrecognized key found",
-          underlyingError: nil
-        ))
-      }
+      try throwIfContainsUnexpectedKey(container: values, type: Self.self, decoder: decoder)
 
       additionalInflectionRules = try values.decodeIfPresent(
         [InflectionRule].self,
@@ -963,15 +946,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
     public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
-
-      let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
-      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
-        throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
-          codingPath: values.codingPath,
-          debugDescription: "Unrecognized key found",
-          underlyingError: nil
-        ))
-      }
+      try throwIfContainsUnexpectedKey(container: values, type: Self.self, decoder: decoder)
 
       clientControlledNullability = try values.decodeIfPresent(
         Bool.self,
@@ -1068,14 +1043,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
-    let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
-      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
-      throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
-        codingPath: values.codingPath,
-        debugDescription: "Unrecognized key found",
-        underlyingError: nil
-      ))
-    }
+    try throwIfContainsUnexpectedKey(container: values, type: Self.self, decoder: decoder)
 
     func getSchemaNamespaceValue() throws -> String {
       if let value = try values.decodeIfPresent(String.self, forKey: .schemaNamespace) {
@@ -1203,14 +1171,7 @@ extension ApolloCodegenConfiguration.SelectionSetInitializers {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
-    let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
-      guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(CodingKeys.allCases.map(\.stringValue))) else {
-      throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
-        codingPath: values.codingPath,
-        debugDescription: "Unrecognized key found",
-        underlyingError: nil
-      ))
-    }
+    try throwIfContainsUnexpectedKey(container: values, type: Self.self, decoder: decoder)
     var options: Options = []
 
     func decode(option: @autoclosure () -> Options, forKey key: CodingKeys) throws {
@@ -1434,4 +1395,19 @@ private struct AnyCodingKey: CodingKey {
         self.intValue = intValue
         self.stringValue = "\(intValue)"
     }
+}
+
+private func throwIfContainsUnexpectedKey<T, C: CodingKey & CaseIterable>(
+  container: KeyedDecodingContainer<C>,
+  type: T.Type,
+  decoder: Decoder
+) throws {
+  let allKeysContainer = try decoder.container(keyedBy: AnyCodingKey.self)
+  guard Set(allKeysContainer.allKeys.map(\.stringValue)).isSubset(of: Set(C.allCases.map(\.stringValue))) else {
+    throw DecodingError.typeMismatch(type, DecodingError.Context.init(
+      codingPath: container.codingPath,
+      debugDescription: "Unrecognized key found",
+      underlyingError: nil
+    ))
+  }
 }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1406,7 +1406,7 @@ private func throwIfContainsUnexpectedKey<T, C: CodingKey & CaseIterable>(
   // Map all valid keys from the given `CodingKey` enum
   let validKeys = Set(C.allCases.map(\.stringValue))
   guard allKeys.isSubset(of: validKeys) else {
-    let invalidKeys = allKeys.subtracting(validKeys)
+    let invalidKeys = allKeys.subtracting(validKeys).sorted()
     throw DecodingError.typeMismatch(type, DecodingError.Context.init(
       codingPath: container.codingPath,
       debugDescription: "Unrecognized \(invalidKeys.count > 1 ? "keys" : "key") found: \(invalidKeys.joined(separator: ", "))",

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1382,18 +1382,18 @@ extension ApolloCodegenConfiguration.OutputOptions {
 }
 
 private struct AnyCodingKey: CodingKey {
-    var stringValue: String
+  var stringValue: String
 
-    init?(stringValue: String) {
-        self.stringValue = stringValue
-    }
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+  }
 
-    var intValue: Int?
+  var intValue: Int?
 
-    init?(intValue: Int) {
-        self.intValue = intValue
-        self.stringValue = "\(intValue)"
-    }
+  init?(intValue: Int) {
+    self.intValue = intValue
+    self.stringValue = "\(intValue)"
+  }
 }
 
 private func throwIfContainsUnexpectedKey<T, C: CodingKey & CaseIterable>(

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -1067,7 +1067,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     }
   }
 
-  func test__decodeApolloCodegenConfiguration__withBaseConfiguration_multipleErrors() throws {
+  func test__decodeApolloCodegenConfiguration__withInvalidBaseConfiguration_multipleErrors() throws {
     // given
     let subject = """
     {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -924,7 +924,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     )
   }
 
-  func test__decodeApolloCodegenConfiguration__withInvalidOptions() throws {
+  func test__decodeApolloCodegenConfiguration__withInvalidFileOutput() throws {
     // given
     let subject = """
     {
@@ -965,7 +965,154 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
       try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
     }
     XCTAssertThrowsError(try decodeConfiguration(subject: subject)) { error in
-      XCTAssert(error is DecodingError)
+      guard case let DecodingError.typeMismatch(type, context) = error else { return fail("Incorrect error type") }
+      XCTAssertEqual("\(type)", String(describing: ApolloCodegenConfiguration.FileOutput.self))
+      XCTAssertEqual(context.debugDescription, "Unrecognized key found: options")
+    }
+  }
+
+  func test__decodeApolloCodegenConfiguration__withInvalidOptions() throws {
+    // given
+    let subject = """
+    {
+      "schemaName": "MySchema",
+      "input": {
+        "operationSearchPaths": ["/search/path/**/*.graphql"],
+        "schemaSearchPaths": ["/path/to/schema.graphqls"]
+      },
+      "output": {
+        "testMocks": {
+          "none": {}
+        },
+        "schemaTypes": {
+          "path": "./MySchema",
+          "moduleType": {
+            "swiftPackageManager": {}
+          }
+        },
+        "operations": {
+          "inSchemaModule": {}
+        }
+      },
+      "options": {
+        "secret_feature": "flappy_bird",
+        "selectionSetInitializers" : {
+          "operations": true,
+          "namedFragments": true,
+          "localCacheMutations" : true
+        },
+        "queryStringLiteralFormat": "multiline",
+        "schemaDocumentation": "include",
+        "apqs": "disabled",
+        "warningsOnDeprecatedUsage": "include"
+      }
+    }
+    """.asData
+
+    func decodeConfiguration(subject: Data) throws -> ApolloCodegenConfiguration {
+      try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
+    }
+    XCTAssertThrowsError(try decodeConfiguration(subject: subject)) { error in
+      guard case let DecodingError.typeMismatch(type, context) = error else { return fail("Incorrect error type") }
+      XCTAssertEqual("\(type)", String(describing: ApolloCodegenConfiguration.OutputOptions.self))
+      XCTAssertEqual(context.debugDescription, "Unrecognized key found: secret_feature")
+    }
+  }
+
+  func test__decodeApolloCodegenConfiguration__withBaseConfiguration() throws {
+    // given
+    let subject = """
+    {
+      "contact_info": "42 Wallaby Way, Sydney",
+      "schemaName": "MySchema",
+      "input": {
+        "operationSearchPaths": ["/search/path/**/*.graphql"],
+        "schemaSearchPaths": ["/path/to/schema.graphqls"]
+      },
+      "output": {
+        "testMocks": {
+          "none": {}
+        },
+        "schemaTypes": {
+          "path": "./MySchema",
+          "moduleType": {
+            "swiftPackageManager": {}
+          }
+        },
+        "operations": {
+          "inSchemaModule": {}
+        }
+      },
+      "options": {
+        "selectionSetInitializers" : {
+          "operations": true,
+          "namedFragments": true,
+          "localCacheMutations" : true
+        },
+        "queryStringLiteralFormat": "multiline",
+        "schemaDocumentation": "include",
+        "apqs": "disabled",
+        "warningsOnDeprecatedUsage": "include"
+      }
+    }
+    """.asData
+
+    func decodeConfiguration(subject: Data) throws -> ApolloCodegenConfiguration {
+      try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
+    }
+    XCTAssertThrowsError(try decodeConfiguration(subject: subject)) { error in
+      guard case let DecodingError.typeMismatch(type, context) = error else { return fail("Incorrect error type") }
+      XCTAssertEqual("\(type)", String(describing: ApolloCodegenConfiguration.self))
+      XCTAssertEqual(context.debugDescription, "Unrecognized key found: contact_info")
+    }
+  }
+
+  func test__decodeApolloCodegenConfiguration__withBaseConfiguration_multipleErrors() throws {
+    // given
+    let subject = """
+    {
+      "contact_info": "42 Wallaby Way, Sydney",
+      "motto": "Just keep swimming",
+      "schemaName": "MySchema",
+      "input": {
+        "operationSearchPaths": ["/search/path/**/*.graphql"],
+        "schemaSearchPaths": ["/path/to/schema.graphqls"]
+      },
+      "output": {
+        "testMocks": {
+          "none": {}
+        },
+        "schemaTypes": {
+          "path": "./MySchema",
+          "moduleType": {
+            "swiftPackageManager": {}
+          }
+        },
+        "operations": {
+          "inSchemaModule": {}
+        }
+      },
+      "options": {
+        "selectionSetInitializers" : {
+          "operations": true,
+          "namedFragments": true,
+          "localCacheMutations" : true
+        },
+        "queryStringLiteralFormat": "multiline",
+        "schemaDocumentation": "include",
+        "apqs": "disabled",
+        "warningsOnDeprecatedUsage": "include"
+      }
+    }
+    """.asData
+
+    func decodeConfiguration(subject: Data) throws -> ApolloCodegenConfiguration {
+      try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
+    }
+    XCTAssertThrowsError(try decodeConfiguration(subject: subject)) { error in
+      guard case let DecodingError.typeMismatch(type, context) = error else { return fail("Incorrect error type") }
+      XCTAssertEqual("\(type)", String(describing: ApolloCodegenConfiguration.self))
+      XCTAssertEqual(context.debugDescription, "Unrecognized keys found: motto, contact_info")
     }
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -1112,7 +1112,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     XCTAssertThrowsError(try decodeConfiguration(subject: subject)) { error in
       guard case let DecodingError.typeMismatch(type, context) = error else { return fail("Incorrect error type") }
       XCTAssertEqual("\(type)", String(describing: ApolloCodegenConfiguration.self))
-      XCTAssertEqual(context.debugDescription, "Unrecognized keys found: motto, contact_info")
+      XCTAssertEqual(context.debugDescription, "Unrecognized keys found: contact_info, motto")
     }
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -923,4 +923,49 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
       ))
     )
   }
+
+  func test__decodeApolloCodegenConfiguration__withInvalidOptions() throws {
+    // given
+    let subject = """
+    {
+      "schemaName": "MySchema",
+      "input": {
+        "operationSearchPaths": ["/search/path/**/*.graphql"],
+        "schemaSearchPaths": ["/path/to/schema.graphqls"]
+      },
+      "output": {
+        "testMocks": {
+          "none": {}
+        },
+        "schemaTypes": {
+          "path": "./MySchema",
+          "moduleType": {
+            "swiftPackageManager": {}
+          }
+        },
+        "operations": {
+          "inSchemaModule": {}
+        },
+        "options": {
+          "selectionSetInitializers" : {
+            "operations": true,
+            "namedFragments": true,
+            "localCacheMutations" : true
+          },
+          "queryStringLiteralFormat": "multiline",
+          "schemaDocumentation": "include",
+          "apqs": "disabled",
+          "warningsOnDeprecatedUsage": "include"
+        }
+      }
+    }
+    """.asData
+
+    func decodeConfiguration(subject: Data) throws -> ApolloCodegenConfiguration {
+      try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: subject)
+    }
+    XCTAssertThrowsError(try decodeConfiguration(subject: subject)) { error in
+      XCTAssert(error is DecodingError)
+    }
+  }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -1019,7 +1019,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     }
   }
 
-  func test__decodeApolloCodegenConfiguration__withBaseConfiguration() throws {
+  func test__decodeApolloCodegenConfiguration__withInvalidBaseConfiguration() throws {
     // given
     let subject = """
     {


### PR DESCRIPTION
### What are you trying to accomplish?

closes https://github.com/apollographql/apollo-ios/issues/2942

Notify users when they create an invalid `apollo-codegen-config.json`. 

### What approach did you choose and why?

I created an `AnyCodingKey` struct which cannot fail. I create sets of all the keys present in the input, and then make sure that the input keys are a subset of the `CodingKeys` defined for that object.

### Anything you want to highlight for special attention from reviewers?

Is the error text here sufficient to explain to users that something is wrong? 