### PR TITLE
Update CODEOWNERS.md

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,2 +1,2 @@
 # https://help.github.com/articles/about-code-owners/
-/docs/ @stephenbarlow
+/docs/ @apollographql/docs


### PR DESCRIPTION
This PR updates the `/docs` codeowners to the [docs team](https://github.com/orgs/apollographql/teams/docs).