### PR TITLE
Operation Manifest Generation Updates

### DIFF
--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -57,8 +57,22 @@ struct OperationManifestFileGenerator {
   func generate(fileManager: ApolloFileManager = .default) throws {
     let rendered: String = try template.render(operations: operationManifest)
 
+    var manifestPath = config.output.operationManifest.unsafelyUnwrapped.path
+    let relativePrefix = "./"
+      
+    // if path begins with './' the path should be relative to the config.rootURL
+    if manifestPath.hasPrefix(relativePrefix) {
+      let fileURL = URL(fileURLWithPath: String(manifestPath.dropFirst(relativePrefix.count)), relativeTo: config.rootURL)
+      manifestPath = fileURL
+          .resolvingSymlinksInPath()
+          .appendingPathExtension("json")
+          .path
+    } else {
+      manifestPath.append(".json")
+    }
+      
     try fileManager.createFile(
-      atPath: config.output.operationManifest.unsafelyUnwrapped.path,
+      atPath: manifestPath,
       data: rendered.data(using: .utf8),
       overwrite: true
     )


### PR DESCRIPTION
- Updated the Operation Manifest generation to be able to do either an absolute path as provided (which is the current functionality) or to take relative paths that begin with './' and have the pathing be relative to the config rootURL 
-Updated tests to reflect these changes