### PR TITLE
fix: Update graphql-js error handling

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -309,7 +309,7 @@ public class ApolloCodegen {
         if let logLines = $0.logLines {
           return logLines
         } else {
-          return ["[Error] \($0.name ?? "unknown"): \($0.message ?? "")"]
+          return ["\($0.name ?? "unknown"): \($0.message ?? "")"]
         }
       })
       CodegenLogger.log(errorlines.joined(separator: "\n"), logLevel: .error)

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -305,8 +305,14 @@ public class ApolloCodegen {
     )
 
     guard graphqlErrors.isEmpty else {
-      let errorlines = graphqlErrors.flatMap({ $0.logLines })
-      CodegenLogger.log(String(describing: errorlines), logLevel: .error)
+      let errorlines = graphqlErrors.flatMap({
+        if let logLines = $0.logLines {
+          return logLines
+        } else {
+          return ["[Error] \($0.name ?? "unknown"): \($0.message ?? "")"]
+        }
+      })
+      CodegenLogger.log(errorlines.joined(separator: "\n"), logLevel: .error)
       throw Error.graphQLSourceValidationFailure(atLines: errorlines)
     }
 

--- a/Sources/ApolloCodegenLib/Frontend/GraphQLError.swift
+++ b/Sources/ApolloCodegenLib/Frontend/GraphQLError.swift
@@ -9,8 +9,10 @@ public class GraphQLError: JavaScriptError {
   private lazy var source: GraphQLSource = self["source"]
   
   /// The source locations associated with this error.
-  private(set) lazy var sourceLocations: [GraphQLSourceLocation] = {
-    let locations: [JavaScriptObject] = self["locations"]
+  private(set) lazy var sourceLocations: [GraphQLSourceLocation]? = {
+    guard let locations: [JavaScriptObject] = self["locations"] else {
+      return nil
+    }
     
     if let nodes: [ASTNode] = self["nodes"] {
       // We have AST nodes, so this is a validation error.
@@ -35,8 +37,8 @@ public class GraphQLError: JavaScriptError {
   
   /// Log lines for this error in a format that allows Xcode to show errors inline at the correct location.
   /// See https://shazronatadobe.wordpress.com/2010/12/04/xcode-shell-build-phase-reporting-of-errors/
-  var logLines: [String] {
-    return sourceLocations.map {
+  var logLines: [String]? {
+    return sourceLocations?.map {
       return [$0.filePath, String($0.lineNumber), "error", message ?? "?"].joined(separator: ":")
     }
   }

--- a/Tests/ApolloCodegenTests/Frontend/SchemaLoadingTests.swift
+++ b/Tests/ApolloCodegenTests/Frontend/SchemaLoadingTests.swift
@@ -54,9 +54,9 @@ class SchemaLoadingTests: XCTestCase {
         let error = try XCTDowncast(error as AnyObject, to: GraphQLError.self)
         XCTAssert(try XCTUnwrap(error.message).starts(with: "Syntax Error"))
         
-        XCTAssertEqual(error.sourceLocations.count, 1)
-        XCTAssertEqual(error.sourceLocations[0].filePath, "schema.graphqls")
-        XCTAssertEqual(error.sourceLocations[0].lineNumber, 3)
+        XCTAssertEqual(error.sourceLocations?.count, 1)
+        XCTAssertEqual(error.sourceLocations?[0].filePath, "schema.graphqls")
+        XCTAssertEqual(error.sourceLocations?[0].lineNumber, 3)
       }
     }
   }


### PR DESCRIPTION
-Updating the handling of graphql-js errors to check if source locations exist to determine how to process and display the error 
-This fixes the issue of reaching the max error limit of graphql-js

Closes #3126 