### PR TITLE
fix: Fragment definitions support escaped characters

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetails.graphql.swift
@@ -4,30 +4,9 @@
 @_exported import ApolloAPI
 
 public struct ClassroomPetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment ClassroomPetDetails on ClassroomPet {
-      __typename
-      ... on Animal {
-        species
-      }
-      ... on Pet {
-        humanName
-      }
-      ... on WarmBlooded {
-        laysEggs
-      }
-      ... on Cat {
-        bodyTemperature
-        isJellicle
-      }
-      ... on Bird {
-        wingspan
-      }
-      ... on PetRock {
-        favoriteToy
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment ClassroomPetDetails on ClassroomPet { __typename ... on Animal { species } ... on Pet { humanName } ... on WarmBlooded { laysEggs } ... on Cat { bodyTemperature isJellicle } ... on Bird { wingspan } ... on PetRock { favoriteToy } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/ClassroomPetDetailsCCN.graphql.swift
@@ -4,17 +4,9 @@
 @_exported import ApolloAPI
 
 public struct ClassroomPetDetailsCCN: AnimalKingdomAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment ClassroomPetDetailsCCN on ClassroomPet {
-      __typename
-      ... on Animal {
-        height {
-          __typename
-          inches!
-        }
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment ClassroomPetDetailsCCN on ClassroomPet { __typename ... on Animal { height { __typename inches! } } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/CrocodileFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/CrocodileFragment.graphql.swift
@@ -1,0 +1,43 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public struct CrocodileFragment: AnimalKingdomAPI.SelectionSet, Fragment {
+  public static var fragmentDefinition: StaticString {
+    #"fragment CrocodileFragment on Crocodile { __typename species age tag(id: "albino") }"#
+  }
+
+  public let __data: DataDict
+  public init(_dataDict: DataDict) { __data = _dataDict }
+
+  public static var __parentType: ApolloAPI.ParentType { AnimalKingdomAPI.Objects.Crocodile }
+  public static var __selections: [ApolloAPI.Selection] { [
+    .field("__typename", String.self),
+    .field("species", String.self),
+    .field("age", Int.self),
+    .field("tag", String?.self, arguments: ["id": "albino"]),
+  ] }
+
+  public var species: String { __data["species"] }
+  public var age: Int { __data["age"] }
+  public var tag: String? { __data["tag"] }
+
+  public init(
+    species: String,
+    age: Int,
+    tag: String? = nil
+  ) {
+    self.init(_dataDict: DataDict(
+      data: [
+        "__typename": AnimalKingdomAPI.Objects.Crocodile.typename,
+        "species": species,
+        "age": age,
+        "tag": tag,
+      ],
+      fulfilledFragments: [
+        ObjectIdentifier(CrocodileFragment.self)
+      ]
+    ))
+  }
+}

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/DogFragment.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct DogFragment: AnimalKingdomAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment DogFragment on Dog {
-      __typename
-      species
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment DogFragment on Dog { __typename species }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/HeightInMeters.graphql.swift
@@ -4,15 +4,9 @@
 @_exported import ApolloAPI
 
 public struct HeightInMeters: AnimalKingdomAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment HeightInMeters on Animal {
-      __typename
-      height {
-        __typename
-        meters
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment HeightInMeters on Animal { __typename height { __typename meters } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/PetDetails.graphql.swift
@@ -4,17 +4,9 @@
 @_exported import ApolloAPI
 
 public struct PetDetails: AnimalKingdomAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment PetDetails on Pet {
-      __typename
-      humanName
-      favoriteToy
-      owner {
-        __typename
-        firstName
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment PetDetails on Pet { __typename humanName favoriteToy owner { __typename firstName } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Fragments/WarmBloodedDetails.graphql.swift
@@ -4,13 +4,9 @@
 @_exported import ApolloAPI
 
 public struct WarmBloodedDetails: AnimalKingdomAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment WarmBloodedDetails on WarmBlooded {
-      __typename
-      bodyTemperature
-      ...HeightInMeters
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment WarmBloodedDetails on WarmBlooded { __typename bodyTemperature ...HeightInMeters }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift
@@ -4,15 +4,9 @@
 @_exported import ApolloAPI
 
 public struct PetDetailsMutation: AnimalKingdomAPI.MutableSelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment PetDetailsMutation on Pet {
-      __typename
-      owner {
-        __typename
-        firstName
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment PetDetailsMutation on Pet { __typename owner { __typename firstName } }"#
+  }
 
   public var __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Mutations/PetAdoptionMutation.graphql.swift
@@ -7,15 +7,7 @@ public class PetAdoptionMutation: GraphQLMutation {
   public static let operationName: String = "PetAdoptionMutation"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      mutation PetAdoptionMutation($input: PetAdoptionInput!) {
-        adoptPet(input: $input) {
-          __typename
-          id
-          humanName
-        }
-      }
-      """#
+      #"mutation PetAdoptionMutation($input: PetAdoptionInput!) { adoptPet(input: $input) { __typename id humanName } }"#
     ))
 
   public var input: PetAdoptionInput

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsCCNQuery.graphql.swift
@@ -7,18 +7,7 @@ public class AllAnimalsCCNQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsCCN"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query AllAnimalsCCN {
-        allAnimals {
-          __typename
-          height? {
-            __typename
-            feet?
-            inches!
-          }
-        }
-      }
-      """#
+      #"query AllAnimalsCCN { allAnimals { __typename height? { __typename feet? inches! } } }"#
     ))
 
   public init() {}

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -7,50 +7,7 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsIncludeSkipQuery"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) {
-        allAnimals {
-          __typename
-          height {
-            __typename
-            feet
-            inches
-          }
-          ...HeightInMeters @skip(if: $skipHeightInMeters)
-          ...WarmBloodedDetails @include(if: $getWarmBlooded)
-          species @include(if: $includeSpecies)
-          skinCovering
-          ... on Pet {
-            ...PetDetails
-            ...WarmBloodedDetails
-            ... on Animal {
-              height {
-                __typename
-                relativeSize @include(if: $varA)
-                centimeters @include(if: $varA)
-              }
-            }
-          }
-          ... on Cat @include(if: $getCat) {
-            isJellicle
-          }
-          ... on ClassroomPet {
-            ... on Bird {
-              wingspan
-            }
-          }
-          predators {
-            __typename
-            species @include(if: $includeSpecies)
-            ... on WarmBlooded @include(if: $getWarmBlooded) {
-              species
-              ...WarmBloodedDetails
-              laysEggs @include(if: $getWarmBlooded)
-            }
-          }
-        }
-      }
-      """#,
+      #"query AllAnimalsIncludeSkipQuery($includeSpecies: Boolean!, $skipHeightInMeters: Boolean!, $getCat: Boolean!, $getWarmBlooded: Boolean!, $varA: Boolean!) { allAnimals { __typename height { __typename feet inches } ...HeightInMeters @skip(if: $skipHeightInMeters) ...WarmBloodedDetails @include(if: $getWarmBlooded) species @include(if: $includeSpecies) skinCovering ... on Pet { ...PetDetails ...WarmBloodedDetails ... on Animal { height { __typename relativeSize @include(if: $varA) centimeters @include(if: $varA) } } } ... on Cat @include(if: $getCat) { isJellicle } ... on ClassroomPet { ... on Bird { wingspan } } predators { __typename species @include(if: $includeSpecies) ... on WarmBlooded @include(if: $getWarmBlooded) { species ...WarmBloodedDetails laysEggs @include(if: $getWarmBlooded) } } } }"#,
       fragments: [HeightInMeters.self, WarmBloodedDetails.self, PetDetails.self]
     ))
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -7,57 +7,7 @@ public class AllAnimalsQuery: GraphQLQuery {
   public static let operationName: String = "AllAnimalsQuery"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query AllAnimalsQuery {
-        allAnimals {
-          __typename
-          height {
-            __typename
-            feet
-            inches
-          }
-          ...HeightInMeters
-          ...WarmBloodedDetails
-          species
-          skinCovering
-          ... on Pet {
-            ...PetDetails
-            ...WarmBloodedDetails
-            ... on Animal {
-              height {
-                __typename
-                relativeSize
-                centimeters
-              }
-            }
-          }
-          ... on Cat {
-            isJellicle
-          }
-          ... on ClassroomPet {
-            ... on Bird {
-              wingspan
-            }
-          }
-          ... on Dog {
-            favoriteToy
-            birthdate
-          }
-          predators {
-            __typename
-            species
-            ... on WarmBlooded {
-              predators {
-                __typename
-                species
-              }
-              ...WarmBloodedDetails
-              laysEggs
-            }
-          }
-        }
-      }
-      """#,
+      #"query AllAnimalsQuery { allAnimals { __typename height { __typename feet inches } ...HeightInMeters ...WarmBloodedDetails species skinCovering ... on Pet { ...PetDetails ...WarmBloodedDetails ... on Animal { height { __typename relativeSize centimeters } } } ... on Cat { isJellicle } ... on ClassroomPet { ... on Bird { wingspan } } ... on Dog { favoriteToy birthdate } predators { __typename species ... on WarmBlooded { predators { __typename species } ...WarmBloodedDetails laysEggs } } } }"#,
       fragments: [HeightInMeters.self, WarmBloodedDetails.self, PetDetails.self]
     ))
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsCCNQuery.graphql.swift
@@ -7,14 +7,7 @@ public class ClassroomPetsCCNQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPetsCCN"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query ClassroomPetsCCN {
-        classroomPets[!]? {
-          __typename
-          ...ClassroomPetDetailsCCN
-        }
-      }
-      """#,
+      #"query ClassroomPetsCCN { classroomPets[!]? { __typename ...ClassroomPetDetailsCCN } }"#,
       fragments: [ClassroomPetDetailsCCN.self]
     ))
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/ClassroomPetsQuery.graphql.swift
@@ -7,14 +7,7 @@ public class ClassroomPetsQuery: GraphQLQuery {
   public static let operationName: String = "ClassroomPets"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query ClassroomPets {
-        classroomPets {
-          __typename
-          ...ClassroomPetDetails
-        }
-      }
-      """#,
+      #"query ClassroomPets { classroomPets { __typename ...ClassroomPetDetails } }"#,
       fragments: [ClassroomPetDetails.self]
     ))
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/DogQuery.graphql.swift
@@ -7,18 +7,7 @@ public class DogQuery: GraphQLQuery {
   public static let operationName: String = "DogQuery"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query DogQuery {
-        allAnimals {
-          __typename
-          id
-          skinCovering
-          ... on Dog {
-            ...DogFragment
-          }
-        }
-      }
-      """#,
+      #"query DogQuery { allAnimals { __typename id skinCovering ... on Dog { ...DogFragment } } }"#,
       fragments: [DogFragment.self]
     ))
 

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/PetSearchQuery.graphql.swift
@@ -7,15 +7,7 @@ public class PetSearchQuery: GraphQLQuery {
   public static let operationName: String = "PetSearch"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) {
-        pets(filters: $filters) {
-          __typename
-          id
-          humanName
-        }
-      }
-      """#
+      #"query PetSearch($filters: PetSearchFilters = {species: ["Dog", "Cat"], size: SMALL, measurements: {height: 10.5, weight: 5.0}}) { pets(filters: $filters) { __typename id humanName } }"#
     ))
 
   public var filters: GraphQLNullable<PetSearchFilters>

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Crocodile+Mock.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/TestMocks/Crocodile+Mock.graphql.swift
@@ -10,27 +10,33 @@ public class Crocodile: MockObject {
   public typealias MockValueCollectionType = Array<Mock<Crocodile>>
 
   public struct MockFields {
+    @Field<Int>("age") public var age
     @Field<Height>("height") public var height
     @Field<AnimalKingdomAPI.ID>("id") public var id
     @Field<[Animal]>("predators") public var predators
     @Field<GraphQLEnum<AnimalKingdomAPI.SkinCovering>>("skinCovering") public var skinCovering
     @Field<String>("species") public var species
+    @Field<String>("tag") public var tag
   }
 }
 
 public extension Mock where O == Crocodile {
   convenience init(
+    age: Int? = nil,
     height: Mock<Height>? = nil,
     id: AnimalKingdomAPI.ID? = nil,
     predators: [AnyMock]? = nil,
     skinCovering: GraphQLEnum<AnimalKingdomAPI.SkinCovering>? = nil,
-    species: String? = nil
+    species: String? = nil,
+    tag: String? = nil
   ) {
     self.init()
+    _setScalar(age, for: \.age)
     _setEntity(height, for: \.height)
     _setScalar(id, for: \.id)
     _setList(predators, for: \.predators)
     _setScalar(skinCovering, for: \.skinCovering)
     _setScalar(species, for: \.species)
+    _setScalar(tag, for: \.tag)
   }
 }

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/AnimalSchema.graphqls
@@ -166,6 +166,7 @@ type Crocodile implements Animal {
   predators: [Animal!]!
   skinCovering: SkinCovering
   age: Int!
+  tag(id: String): String
 }
 
 type PetRock implements Pet {

--- a/Sources/AnimalKingdomAPI/animalkingdom-graphql/CrocodileFragment.graphql
+++ b/Sources/AnimalKingdomAPI/animalkingdom-graphql/CrocodileFragment.graphql
@@ -1,0 +1,5 @@
+fragment CrocodileFragment on Crocodile {
+    species
+    age
+    tag(id: "albino")
+}

--- a/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/FragmentTemplate.swift
@@ -20,7 +20,7 @@ struct FragmentTemplate: TemplateRenderer {
     \(definition.renderedSelectionSetType(config)), Fragment {
       \(accessControlModifier(for: .member))\
     static var fragmentDefinition: StaticString {
-        "\(fragment.definition.source.convertedToSingleLine())"
+        #"\(fragment.definition.source.convertedToSingleLine())"#
       }
 
       \(SelectionSetTemplate(

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Fragments/AuthorDetails.graphql.swift
@@ -4,17 +4,9 @@
 @_exported import ApolloAPI
 
 public struct AuthorDetails: GitHubAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment AuthorDetails on Actor {
-      __typename
-      login
-      ... on User {
-        __typename
-        id
-        name
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment AuthorDetails on Actor { __typename login ... on User { __typename id name } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/IssuesAndCommentsForRepositoryQuery.graphql.swift
@@ -7,37 +7,7 @@ public class IssuesAndCommentsForRepositoryQuery: GraphQLQuery {
   public static let operationName: String = "IssuesAndCommentsForRepository"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query IssuesAndCommentsForRepository {
-        repository(name: "apollo-ios", owner: "apollographql") {
-          __typename
-          name
-          issues(last: 100) {
-            __typename
-            nodes {
-              __typename
-              title
-              author {
-                __typename
-                ...AuthorDetails
-              }
-              body
-              comments(last: 100) {
-                __typename
-                nodes {
-                  __typename
-                  body
-                  author {
-                    __typename
-                    ...AuthorDetails
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      """#,
+      #"query IssuesAndCommentsForRepository { repository(name: "apollo-ios", owner: "apollographql") { __typename name issues(last: 100) { __typename nodes { __typename title author { __typename ...AuthorDetails } body comments(last: 100) { __typename nodes { __typename body author { __typename ...AuthorDetails } } } } } } }"#,
       fragments: [AuthorDetails.self]
     ))
 

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepoURLQuery.graphql.swift
@@ -7,14 +7,7 @@ public class RepoURLQuery: GraphQLQuery {
   public static let operationName: String = "RepoURL"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query RepoURL {
-        repository(owner: "apollographql", name: "apollo-ios") {
-          __typename
-          url
-        }
-      }
-      """#
+      #"query RepoURL { repository(owner: "apollographql", name: "apollo-ios") { __typename url } }"#
     ))
 
   public init() {}

--- a/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
+++ b/Sources/GitHubAPI/GitHubAPI/Sources/Operations/Queries/RepositoryQuery.graphql.swift
@@ -7,39 +7,7 @@ public class RepositoryQuery: GraphQLQuery {
   public static let operationName: String = "Repository"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      query Repository {
-        repository(owner: "apollographql", name: "apollo-ios") {
-          __typename
-          issueOrPullRequest(number: 13) {
-            __typename
-            ... on Issue {
-              __typename
-              body
-              ... on UniformResourceLocatable {
-                __typename
-                url
-              }
-              author {
-                __typename
-                avatarUrl
-              }
-            }
-            ... on Reactable {
-              __typename
-              viewerCanReact
-              ... on Comment {
-                __typename
-                author {
-                  __typename
-                  login
-                }
-              }
-            }
-          }
-        }
-      }
-      """#
+      #"query Repository { repository(owner: "apollographql", name: "apollo-ios") { __typename issueOrPullRequest(number: 13) { __typename ... on Issue { __typename body ... on UniformResourceLocatable { __typename url } author { __typename avatarUrl } } ... on Reactable { __typename viewerCanReact ... on Comment { __typename author { __typename login } } } } } }"#
     ))
 
   public init() {}

--- a/Sources/GitHubAPI/graphql/operationIDs.json
+++ b/Sources/GitHubAPI/graphql/operationIDs.json
@@ -1,14 +1,24 @@
 {
-  "187f0f83986b0269e8d0860e24c1b40ef4243ccbc86c15495076dabfef7a70c1" : {
-    "name" : "IssuesAndCommentsForRepository",
-    "source" : "query IssuesAndCommentsForRepository {\n  repository(name: \"apollo-ios\", owner: \"apollographql\") {\n    __typename\n    name\n    issues(last: 100) {\n      __typename\n      nodes {\n        __typename\n        title\n        author {\n          __typename\n          ...AuthorDetails\n        }\n        body\n        comments(last: 100) {\n          __typename\n          nodes {\n            __typename\n            body\n            author {\n              __typename\n              ...AuthorDetails\n            }\n          }\n        }\n      }\n    }\n  }\n}\nfragment AuthorDetails on Actor {\n  __typename\n  login\n  ... on User {\n    __typename\n    id\n    name\n  }\n}"
-  },
-  "68de6d66c791c0d7b4fe4c21496b4623acb91c0086366aded49366f57e9f0b68" : {
-    "name" : "Repository",
-    "source" : "query Repository {\n  repository(owner: \"apollographql\", name: \"apollo-ios\") {\n    __typename\n    issueOrPullRequest(number: 13) {\n      __typename\n      ... on Issue {\n        __typename\n        body\n        ... on UniformResourceLocatable {\n          __typename\n          url\n        }\n        author {\n          __typename\n          avatarUrl\n        }\n      }\n      ... on Reactable {\n        __typename\n        viewerCanReact\n        ... on Comment {\n          __typename\n          author {\n            __typename\n            login\n          }\n        }\n      }\n    }\n  }\n}"
-  },
-  "b55f22bcbfaea0d861089b3fbe06299675a21d11ba7138ace39ecbde606a3dc1" : {
-    "name" : "RepoURL",
-    "source" : "query RepoURL {\n  repository(owner: \"apollographql\", name: \"apollo-ios\") {\n    __typename\n    url\n  }\n}"
-  }
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "f9431d2905352492e89d6e534226f4c744080f58ad36b8e2e82765180da7c1bc",
+      "body": "query IssuesAndCommentsForRepository { repository(name: "apollo-ios", owner: "apollographql") { __typename name issues(last: 100) { __typename nodes { __typename title author { __typename ...AuthorDetails } body comments(last: 100) { __typename nodes { __typename body author { __typename ...AuthorDetails } } } } } } }\nfragment AuthorDetails on Actor { __typename login ... on User { __typename id name } }",
+      "name": "IssuesAndCommentsForRepository",
+      "type": "query"
+    },
+    {
+      "id": "1f953a3d73d4458dc80babe734a112c32a1cea3338eb7c5eb09d8288ece9f2e6",
+      "body": "query Repository { repository(owner: "apollographql", name: "apollo-ios") { __typename issueOrPullRequest(number: 13) { __typename ... on Issue { __typename body ... on UniformResourceLocatable { __typename url } author { __typename avatarUrl } } ... on Reactable { __typename viewerCanReact ... on Comment { __typename author { __typename login } } } } } }",
+      "name": "Repository",
+      "type": "query"
+    },
+    {
+      "id": "ecd015ec1bf1ae0670be0b6f8563b7e0ff8498eccbab9934316e2288fc3470d8",
+      "body": "query RepoURL { repository(owner: "apollographql", name: "apollo-ios") { __typename url } }",
+      "name": "RepoURL",
+      "type": "query"
+    }
+  ]
 }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterAppearsIn.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterAppearsIn: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterAppearsIn on Character {
-      __typename
-      appearsIn
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterAppearsIn on Character { __typename appearsIn }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterName.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterName: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterName on Character {
-      __typename
-      name
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterName on Character { __typename name }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsIn.graphql.swift
@@ -4,13 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterNameAndAppearsIn: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterNameAndAppearsIn on Character {
-      __typename
-      name
-      appearsIn
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterNameAndAppearsIn on Character { __typename name appearsIn }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndAppearsInWithNestedFragments.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterNameAndAppearsInWithNestedFragments: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterNameAndAppearsInWithNestedFragments on Character {
-      __typename
-      ...CharacterNameWithNestedAppearsInFragment
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterNameAndAppearsInWithNestedFragments on Character { __typename ...CharacterNameWithNestedAppearsInFragment }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidAppearsIn.graphql.swift
@@ -4,16 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterNameAndDroidAppearsIn: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterNameAndDroidAppearsIn on Character {
-      __typename
-      name
-      ... on Droid {
-        __typename
-        appearsIn
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterNameAndDroidAppearsIn on Character { __typename name ... on Droid { __typename appearsIn } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameAndDroidPrimaryFunction.graphql.swift
@@ -4,13 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterNameAndDroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterNameAndDroidPrimaryFunction on Character {
-      __typename
-      ...CharacterName
-      ...DroidPrimaryFunction
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterNameAndDroidPrimaryFunction on Character { __typename ...CharacterName ...DroidPrimaryFunction }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithInlineFragment.graphql.swift
@@ -4,23 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterNameWithInlineFragment: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterNameWithInlineFragment on Character {
-      __typename
-      ... on Human {
-        __typename
-        friends {
-          __typename
-          appearsIn
-        }
-      }
-      ... on Droid {
-        __typename
-        ...CharacterName
-        ...FriendsNames
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterNameWithInlineFragment on Character { __typename ... on Human { __typename friends { __typename appearsIn } } ... on Droid { __typename ...CharacterName ...FriendsNames } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/CharacterNameWithNestedAppearsInFragment.graphql.swift
@@ -4,13 +4,9 @@
 @_exported import ApolloAPI
 
 public struct CharacterNameWithNestedAppearsInFragment: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment CharacterNameWithNestedAppearsInFragment on Character {
-      __typename
-      name
-      ...CharacterAppearsIn
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment CharacterNameWithNestedAppearsInFragment on Character { __typename name ...CharacterAppearsIn }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidDetails.graphql.swift
@@ -4,13 +4,9 @@
 @_exported import ApolloAPI
 
 public struct DroidDetails: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment DroidDetails on Droid {
-      __typename
-      name
-      primaryFunction
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment DroidDetails on Droid { __typename name primaryFunction }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidName.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct DroidName: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment DroidName on Droid {
-      __typename
-      name
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment DroidName on Droid { __typename name }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidNameAndPrimaryFunction.graphql.swift
@@ -4,13 +4,9 @@
 @_exported import ApolloAPI
 
 public struct DroidNameAndPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment DroidNameAndPrimaryFunction on Droid {
-      __typename
-      ...CharacterName
-      ...DroidPrimaryFunction
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment DroidNameAndPrimaryFunction on Droid { __typename ...CharacterName ...DroidPrimaryFunction }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/DroidPrimaryFunction.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct DroidPrimaryFunction: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment DroidPrimaryFunction on Droid {
-      __typename
-      primaryFunction
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment DroidPrimaryFunction on Droid { __typename primaryFunction }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/FriendsNames.graphql.swift
@@ -4,15 +4,9 @@
 @_exported import ApolloAPI
 
 public struct FriendsNames: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment FriendsNames on Character {
-      __typename
-      friends {
-        __typename
-        name
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment FriendsNames on Character { __typename friends { __typename name } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HeroDetails.graphql.swift
@@ -4,20 +4,9 @@
 @_exported import ApolloAPI
 
 public struct HeroDetails: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment HeroDetails on Character {
-      __typename
-      name
-      ... on Human {
-        __typename
-        height
-      }
-      ... on Droid {
-        __typename
-        primaryFunction
-      }
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment HeroDetails on Character { __typename name ... on Human { __typename height } ... on Droid { __typename primaryFunction } }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Fragments/HumanHeightWithVariable.graphql.swift
@@ -4,12 +4,9 @@
 @_exported import ApolloAPI
 
 public struct HumanHeightWithVariable: StarWarsAPI.SelectionSet, Fragment {
-  public static var fragmentDefinition: StaticString { """
-    fragment HumanHeightWithVariable on Human {
-      __typename
-      height(unit: $heightUnit)
-    }
-    """ }
+  public static var fragmentDefinition: StaticString {
+    #"fragment HumanHeightWithVariable on Human { __typename height(unit: $heightUnit) }"#
+  }
 
   public let __data: DataDict
   public init(_dataDict: DataDict) { __data = _dataDict }

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateAwesomeReviewMutation.graphql.swift
@@ -6,17 +6,9 @@
 public class CreateAwesomeReviewMutation: GraphQLMutation {
   public static let operationName: String = "CreateAwesomeReview"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "4a1250de93ebcb5cad5870acf15001112bf27bb963e8709555b5ff67a1405374",
+    operationIdentifier: "36634ea692d455075551673f2f529e85c8acf6f5e3707243781324cd3d968d02",
     definition: .init(
-      #"""
-      mutation CreateAwesomeReview {
-        createReview(episode: JEDI, review: {stars: 10, commentary: "This is awesome!"}) {
-          __typename
-          stars
-          commentary
-        }
-      }
-      """#
+      #"mutation CreateAwesomeReview { createReview(episode: JEDI, review: {stars: 10, commentary: "This is awesome!"}) { __typename stars commentary } }"#
     ))
 
   public init() {}

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewForEpisodeMutation.graphql.swift
@@ -6,17 +6,9 @@
 public class CreateReviewForEpisodeMutation: GraphQLMutation {
   public static let operationName: String = "CreateReviewForEpisode"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "9bbf5b4074d0635fb19d17c621b7b04ebfb1920d468a94266819e149841e7d5d",
+    operationIdentifier: "3edcd1f17839f43db021eccbe2ecd41ad7dcb1ba6cd4b7e9897afb4162e4c223",
     definition: .init(
-      #"""
-      mutation CreateReviewForEpisode($episode: Episode!, $review: ReviewInput!) {
-        createReview(episode: $episode, review: $review) {
-          __typename
-          stars
-          commentary
-        }
-      }
-      """#
+      #"mutation CreateReviewForEpisode($episode: Episode!, $review: ReviewInput!) { createReview(episode: $episode, review: $review) { __typename stars commentary } }"#
     ))
 
   public var episode: GraphQLEnum<Episode>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Mutations/CreateReviewWithNullFieldMutation.graphql.swift
@@ -6,17 +6,9 @@
 public class CreateReviewWithNullFieldMutation: GraphQLMutation {
   public static let operationName: String = "CreateReviewWithNullField"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "a9600d176cd7e4671b8689f1d01fe79ea896932bfafb8a925af673f0e4111828",
+    operationIdentifier: "e962313bc77c193dc516d097b5e41efea073de16c3a5f2e8c00f082853835d49",
     definition: .init(
-      #"""
-      mutation CreateReviewWithNullField {
-        createReview(episode: JEDI, review: {stars: 10, commentary: null}) {
-          __typename
-          stars
-          commentary
-        }
-      }
-      """#
+      #"mutation CreateReviewWithNullField { createReview(episode: JEDI, review: {stars: 10, commentary: null}) { __typename stars commentary } }"#
     ))
 
   public init() {}

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/DroidDetailsWithFragmentQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class DroidDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "DroidDetailsWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "7277e97563e911ac8f5c91d401028d218aae41f38df014d7fa0b037bb2a2e739",
+    operationIdentifier: "6696d5064faa0c379b73574aa6d4c5b912eb17339afc8b66babae61542d233d7",
     definition: .init(
-      #"""
-      query DroidDetailsWithFragment($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          ...DroidDetails
-        }
-      }
-      """#,
+      #"query DroidDetailsWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...DroidDetails } }"#,
       fragments: [DroidDetails.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsIDsQuery.graphql.swift
@@ -6,21 +6,9 @@
 public class HeroAndFriendsIDsQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsIDs"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "117d0f6831d8f4abe5b61ed1dbb8071b0825e19649916c0fe0906a6f578bb088",
+    operationIdentifier: "8f1f880891cdfbf7be7ea11bb4b09708bcbf1e3f8e8a40ecb6fcb33c6078955f",
     definition: .init(
-      #"""
-      query HeroAndFriendsIDs($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          id
-          name
-          friends {
-            __typename
-            id
-          }
-        }
-      }
-      """#
+      #"query HeroAndFriendsIDs($episode: Episode) { hero(episode: $episode) { __typename id name friends { __typename id } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesQuery.graphql.swift
@@ -6,20 +6,9 @@
 public class HeroAndFriendsNamesQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNames"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "fe3f21394eb861aa515c4d582e645469045793c9cbbeca4b5d4ce4d7dd617556",
+    operationIdentifier: "1e36c3331171b74c012b86caa04fbb01062f37c61227655d9c0729a62c6f7285",
     definition: .init(
-      #"""
-      query HeroAndFriendsNames($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          name
-          friends {
-            __typename
-            name
-          }
-        }
-      }
-      """#
+      #"query HeroAndFriendsNames($episode: Episode) { hero(episode: $episode) { __typename name friends { __typename name } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "1d3ad903dad146ff9d7aa09813fc01becd017489bfc1af8ffd178498730a5a26",
+    operationIdentifier: "07c54599c2b5f9d4215d1bff7f5f6ff458c983aa5c13338fd44b051210d5ecc6",
     definition: .init(
-      #"""
-      query HeroAndFriendsNamesWithFragment($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          name
-          ...FriendsNames
-        }
-      }
-      """#,
+      #"query HeroAndFriendsNamesWithFragment($episode: Episode) { hero(episode: $episode) { __typename name ...FriendsNames } }"#,
       fragments: [FriendsNames.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithFragmentTwiceQuery.graphql.swift
@@ -6,26 +6,9 @@
 public class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithFragmentTwice"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b5f4eca712a136f0d5d9f96203ef7d03cd119d8388f093f4b78ae124acb904cb",
+    operationIdentifier: "9a769ab058900912bff4e4c51c1b257f609e4dfb4aaa1f17166adc19d510e363",
     definition: .init(
-      #"""
-      query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          friends {
-            __typename
-            ...CharacterName
-          }
-          ... on Droid {
-            __typename
-            friends {
-              __typename
-              ...CharacterName
-            }
-          }
-        }
-      }
-      """#,
+      #"query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) { hero(episode: $episode) { __typename friends { __typename ...CharacterName } ... on Droid { __typename friends { __typename ...CharacterName } } } }"#,
       fragments: [CharacterName.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDForParentOnlyQuery.graphql.swift
@@ -6,21 +6,9 @@
 public class HeroAndFriendsNamesWithIDForParentOnlyQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithIDForParentOnly"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "f091468a629f3b757c03a1b7710c6ede8b5c8f10df7ba3238f2bbcd71c56f90f",
+    operationIdentifier: "de03aaedeb69050ef75e3aa56b262b4ea1e08bb6fd174f2e91ddd9b84a8ff897",
     definition: .init(
-      #"""
-      query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          id
-          name
-          friends {
-            __typename
-            name
-          }
-        }
-      }
-      """#
+      #"query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) { hero(episode: $episode) { __typename id name friends { __typename name } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAndFriendsNamesWithIDsQuery.graphql.swift
@@ -6,22 +6,9 @@
 public class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
   public static let operationName: String = "HeroAndFriendsNamesWithIDs"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "8e4ca76c63660898cfd5a3845e3709027750b5f0151c7f9be65759b869c5486d",
+    operationIdentifier: "cdf121c8a2f2188bd1c4dcc04df6104e989164b27f1e7f13d27ccc9c03fbda0c",
     definition: .init(
-      #"""
-      query HeroAndFriendsNamesWithIDs($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          id
-          name
-          friends {
-            __typename
-            id
-            name
-          }
-        }
-      }
-      """#
+      #"query HeroAndFriendsNamesWithIDs($episode: Episode) { hero(episode: $episode) { __typename id name friends { __typename id name } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsIn"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "22d772c0fc813281705e8f0a55fc70e71eeff6e98f3f9ef96cf67fb896914522",
+    operationIdentifier: "59243627e0166c9b631551b56dc4d29701f2d90336d83c231172c50152e02475",
     definition: .init(
-      #"""
-      query HeroAppearsIn {
-        hero {
-          __typename
-          appearsIn
-        }
-      }
-      """#
+      #"query HeroAppearsIn { hero { __typename appearsIn } }"#
     ))
 
   public init() {}

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroAppearsInWithFragmentQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroAppearsInWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "1756158bd7736d58db45a48d74a724fa1b6fdac735376df8afac8318ba5431fb",
+    operationIdentifier: "b7e9c75d75c77765849b67116235609b3a05b9052975c617f51a315f8fbaf45a",
     definition: .init(
-      #"""
-      query HeroAppearsInWithFragment($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          ...CharacterAppearsIn
-        }
-      }
-      """#,
+      #"query HeroAppearsInWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterAppearsIn } }"#,
       fragments: [CharacterAppearsIn.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsFragmentConditionalInclusionQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsFragmentConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b0fa7927ff93b4a579c3460fb04d093072d34c8018e41197c7e080aeeec5e19b",
+    operationIdentifier: "17dfb13c5d9e6c67703fc037b9114ea53ccc8f9274dfecb4abfc2d5a168cf612",
     definition: .init(
-      #"""
-      query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {
-        hero {
-          __typename
-          ...HeroDetails @include(if: $includeDetails)
-        }
-      }
-      """#,
+      #"query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) { hero { __typename ...HeroDetails @include(if: $includeDetails) } }"#,
       fragments: [HeroDetails.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsInlineConditionalInclusionQuery.graphql.swift
@@ -6,20 +6,9 @@
 public class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsInlineConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "3091d9d3f1d2374e2f835ce05d332e50b3fe61502d73213b9aa511f0f94f091c",
+    operationIdentifier: "e251576f8c1cfcd442f44d2fbe5fd4b425a36ddd41fb4b6c1019c501ac6ac5bc",
     definition: .init(
-      #"""
-      query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) {
-        hero {
-          __typename
-          ... @include(if: $includeDetails) {
-            __typename
-            name
-            appearsIn
-          }
-        }
-      }
-      """#
+      #"query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) { hero { __typename ... @include(if: $includeDetails) { __typename name appearsIn } } }"#
     ))
 
   public var includeDetails: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsQuery.graphql.swift
@@ -6,24 +6,9 @@
 public class HeroDetailsQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetails"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "207d29944f5822bff08a07db4a55274ea14035bacfe20699da41a47454f1181e",
+    operationIdentifier: "bf81c1338a3953d1c17c5cad3db3c3ab18b16a6822125ab81c15eb0dd3e82193",
     definition: .init(
-      #"""
-      query HeroDetails($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          name
-          ... on Human {
-            __typename
-            height
-          }
-          ... on Droid {
-            __typename
-            primaryFunction
-          }
-        }
-      }
-      """#
+      #"query HeroDetails($episode: Episode) { hero(episode: $episode) { __typename name ... on Human { __typename height } ... on Droid { __typename primaryFunction } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroDetailsWithFragmentQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroDetailsWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroDetailsWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b55bd9d56d1b5972345412b6adb88ceb64d6086c8051d2588d8ab701f0ee7c2f",
+    operationIdentifier: "09fe4fc0cbcde5f0ba08b1207526cae13eb2b73ca95f929d4153dd3f643b6780",
     definition: .init(
-      #"""
-      query HeroDetailsWithFragment($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          ...HeroDetails
-        }
-      }
-      """#,
+      #"query HeroDetailsWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...HeroDetails } }"#,
       fragments: [HeroDetails.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsConditionalInclusionQuery.graphql.swift
@@ -6,23 +6,9 @@
 public class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsDetailsConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "8cada231691ff2f5a0a07c54b7332114588f11b947795da345c5b054211fbcfd",
+    operationIdentifier: "ca1b86ff4a0f8212bdac70fbb59c9bb8023d0a30ca0225b24831bb3e807b22a0",
     definition: .init(
-      #"""
-      query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) {
-        hero {
-          __typename
-          friends @include(if: $includeFriendsDetails) {
-            __typename
-            name
-            ... on Droid {
-              __typename
-              primaryFunction
-            }
-          }
-        }
-      }
-      """#
+      #"query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) { hero { __typename friends @include(if: $includeFriendsDetails) { __typename name ... on Droid { __typename primaryFunction } } } }"#
     ))
 
   public var includeFriendsDetails: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery.graphql.swift
@@ -6,27 +6,9 @@
 public class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsDetailsUnconditionalAndConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "65381a20574db4b458a0821328252deb0da1a107f9ab77c99fb2467e66a5f12d",
+    operationIdentifier: "e36c8e5d752afda2a90fe44bcbfeb92de68f0da92b8390d626d3005cbad16dbe",
     definition: .init(
-      #"""
-      query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) {
-        hero {
-          __typename
-          friends {
-            __typename
-            name
-          }
-          friends @include(if: $includeFriendsDetails) {
-            __typename
-            name
-            ... on Droid {
-              __typename
-              primaryFunction
-            }
-          }
-        }
-      }
-      """#
+      #"query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) { hero { __typename friends { __typename name } friends @include(if: $includeFriendsDetails) { __typename name ... on Droid { __typename primaryFunction } } } }"#
     ))
 
   public var includeFriendsDetails: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroFriendsOfFriendsNamesQuery.graphql.swift
@@ -6,23 +6,9 @@
 public class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
   public static let operationName: String = "HeroFriendsOfFriendsNames"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "37cd5626048e7243716ffda9e56503939dd189772124a1c21b0e0b87e69aae01",
+    operationIdentifier: "513b65fa459185f88540be8d60cdeefb69fd6c82a21b804214337558aa6ecb0b",
     definition: .init(
-      #"""
-      query HeroFriendsOfFriendsNames($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          friends {
-            __typename
-            id
-            friends {
-              __typename
-              name
-            }
-          }
-        }
-      }
-      """#
+      #"query HeroFriendsOfFriendsNames($episode: Episode) { hero(episode: $episode) { __typename friends { __typename id friends { __typename name } } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class HeroNameAndAppearsInQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsIn"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "f714414a2002404f9943490c8cc9c1a7b8ecac3ca229fa5a326186b43c1385ce",
+    operationIdentifier: "ecdf5248575524004a9d43832abc54e8c0e1d2b3c0afb8bb0c1c1c514b4f9baf",
     definition: .init(
-      #"""
-      query HeroNameAndAppearsIn($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          name
-          appearsIn
-        }
-      }
-      """#
+      #"query HeroNameAndAppearsIn($episode: Episode) { hero(episode: $episode) { __typename name appearsIn } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameAndAppearsInWithFragmentQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameAndAppearsInWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "0664fed3eb4f9fbdb44e8691d9e8fd11f2b3c097ba11327592054f602bd3ba1a",
+    operationIdentifier: "4fc9c2e7f9fbe8ef3f28936bd0b12e8f32bc8d70f3e8ec5df8a6aaf3efd4921c",
     definition: .init(
-      #"""
-      query HeroNameAndAppearsInWithFragment($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          ...CharacterNameAndAppearsIn
-        }
-      }
-      """#,
+      #"query HeroNameAndAppearsInWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterNameAndAppearsIn } }"#,
       fragments: [CharacterNameAndAppearsIn.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroNameConditionalBothQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalBoth"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "66f4dc124b6374b1912b22a2a208e34a4b1997349402a372b95bcfafc7884064",
+    operationIdentifier: "e063fa4ab5493e9c67bfa96dfedfa8570475f6286f38c482f6e85ced4ea206af",
     definition: .init(
-      #"""
-      query HeroNameConditionalBoth($skipName: Boolean!, $includeName: Boolean!) {
-        hero {
-          __typename
-          name @skip(if: $skipName) @include(if: $includeName)
-        }
-      }
-      """#
+      #"query HeroNameConditionalBoth($skipName: Boolean!, $includeName: Boolean!) { hero { __typename name @skip(if: $skipName) @include(if: $includeName) } }"#
     ))
 
   public var skipName: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalBothSeparateQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalBothSeparate"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "d0f9e9205cdc09320035662f528a177654d3275b0bf94cf0e259a65fde33e7e5",
+    operationIdentifier: "60741c6fca15865a9af75a269ed05871e681f48ac48edfac2a77d953d217d03c",
     definition: .init(
-      #"""
-      query HeroNameConditionalBothSeparate($skipName: Boolean!, $includeName: Boolean!) {
-        hero {
-          __typename
-          name @skip(if: $skipName)
-          name @include(if: $includeName)
-        }
-      }
-      """#
+      #"query HeroNameConditionalBothSeparate($skipName: Boolean!, $includeName: Boolean!) { hero { __typename name @skip(if: $skipName) name @include(if: $includeName) } }"#
     ))
 
   public var skipName: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalExclusionQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroNameConditionalExclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalExclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "3dd42259adf2d0598e89e0279bee2c128a7913f02b1da6aa43f3b5def6a8a1f8",
+    operationIdentifier: "b6d6f1d10cde449adbf2891d489159006188e63d4dea4edb9a23eddcbe0bd361",
     definition: .init(
-      #"""
-      query HeroNameConditionalExclusion($skipName: Boolean!) {
-        hero {
-          __typename
-          name @skip(if: $skipName)
-        }
-      }
-      """#
+      #"query HeroNameConditionalExclusion($skipName: Boolean!) { hero { __typename name @skip(if: $skipName) } }"#
     ))
 
   public var skipName: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameConditionalInclusionQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroNameConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "338081aea3acc83d04af0741ecf0da1ec2ee8e6468a88383476b681015905ef8",
+    operationIdentifier: "dd8e5df9634bb4fb6455e4aaddd2941c5abf785b7d28cda959aba65157e950c6",
     definition: .init(
-      #"""
-      query HeroNameConditionalInclusion($includeName: Boolean!) {
-        hero {
-          __typename
-          name @include(if: $includeName)
-        }
-      }
-      """#
+      #"query HeroNameConditionalInclusion($includeName: Boolean!) { hero { __typename name @include(if: $includeName) } }"#
     ))
 
   public var includeName: Bool

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroNameQuery: GraphQLQuery {
   public static let operationName: String = "HeroName"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671",
+    operationIdentifier: "b9d49e889d6f5877c0bf09b8b4f88a71f88836a771e0e48c270a9aa8b506dda1",
     definition: .init(
-      #"""
-      query HeroName($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          name
-        }
-      }
-      """#
+      #"query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameTypeSpecificConditionalInclusionQuery.graphql.swift
@@ -6,20 +6,9 @@
 public class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameTypeSpecificConditionalInclusion"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "76aecc75265295818d3990000b17e32d5524ca85a4bc159ae8a3f8ec7ce91cc3",
+    operationIdentifier: "c05a6e91e1a3ddc3df21205ed7fca49cf6f3f171e4390ac98e7690c391b18baf",
     definition: .init(
-      #"""
-      query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) {
-        hero(episode: $episode) {
-          __typename
-          name @include(if: $includeName)
-          ... on Droid {
-            __typename
-            name
-          }
-        }
-      }
-      """#
+      #"query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) { hero(episode: $episode) { __typename name @include(if: $includeName) ... on Droid { __typename name } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentAndIDQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class HeroNameWithFragmentAndIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragmentAndID"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "a87a0694c09d1ed245e9a80f245d96a5f57b20a4aa936ee9ab09b2a43620db02",
+    operationIdentifier: "ec14e5fffc56163c516a21f0d211a7a86d68a3512e6fb6df38a19babe0d1df8d",
     definition: .init(
-      #"""
-      query HeroNameWithFragmentAndID($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          id
-          ...CharacterName
-        }
-      }
-      """#,
+      #"query HeroNameWithFragmentAndID($episode: Episode) { hero(episode: $episode) { __typename id ...CharacterName } }"#,
       fragments: [CharacterName.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithFragmentQuery.graphql.swift
@@ -6,16 +6,9 @@
 public class HeroNameWithFragmentQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithFragment"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b952f0054915a32ec524ac0dde0244bcda246649debe149f9e32e303e21c8266",
+    operationIdentifier: "68baad3c27796cb1bf980681324e43b948aa1109698ba57404c1afa46e914ab1",
     definition: .init(
-      #"""
-      query HeroNameWithFragment($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          ...CharacterName
-        }
-      }
-      """#,
+      #"query HeroNameWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterName } }"#,
       fragments: [CharacterName.self]
     ))
 

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroNameWithIDQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class HeroNameWithIDQuery: GraphQLQuery {
   public static let operationName: String = "HeroNameWithID"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "83c03f612c46fca72f6cb902df267c57bffc9209bc44dd87d2524fb2b34f6f18",
+    operationIdentifier: "675d636002a28e24e3802d5f04772943b0a78b8795203fcab53f4c8466e1e53c",
     definition: .init(
-      #"""
-      query HeroNameWithID($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          id
-          name
-        }
-      }
-      """#
+      #"query HeroNameWithID($episode: Episode) { hero(episode: $episode) { __typename id name } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroParentTypeDependentFieldQuery.graphql.swift
@@ -6,38 +6,9 @@
 public class HeroParentTypeDependentFieldQuery: GraphQLQuery {
   public static let operationName: String = "HeroParentTypeDependentField"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "39eb41b5a9477c36fa529c23d6f0de6ebcc0312daf5bdcfe208d5baec752dc5b",
+    operationIdentifier: "dc3b582f2baa66cfb5cd53eb3c215933427fd0537076767c8e0ef894d3990d15",
     definition: .init(
-      #"""
-      query HeroParentTypeDependentField($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          name
-          ... on Human {
-            __typename
-            friends {
-              __typename
-              name
-              ... on Human {
-                __typename
-                height(unit: FOOT)
-              }
-            }
-          }
-          ... on Droid {
-            __typename
-            friends {
-              __typename
-              name
-              ... on Human {
-                __typename
-                height(unit: METER)
-              }
-            }
-          }
-        }
-      }
-      """#
+      #"query HeroParentTypeDependentField($episode: Episode) { hero(episode: $episode) { __typename name ... on Human { __typename friends { __typename name ... on Human { __typename height(unit: FOOT) } } } ... on Droid { __typename friends { __typename name ... on Human { __typename height(unit: METER) } } } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HeroTypeDependentAliasedFieldQuery.graphql.swift
@@ -6,23 +6,9 @@
 public class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
   public static let operationName: String = "HeroTypeDependentAliasedField"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "eac5a52f9020fc2e9b5dc5facfd6a6295683b8d57ea62ee84254069fcd5e504c",
+    operationIdentifier: "5b1ed6a84e96a4e48a3cad675ebb46020bce176f47361d097d8a0a824b7b8452",
     definition: .init(
-      #"""
-      query HeroTypeDependentAliasedField($episode: Episode) {
-        hero(episode: $episode) {
-          __typename
-          ... on Human {
-            __typename
-            property: homePlanet
-          }
-          ... on Droid {
-            __typename
-            property: primaryFunction
-          }
-        }
-      }
-      """#
+      #"query HeroTypeDependentAliasedField($episode: Episode) { hero(episode: $episode) { __typename ... on Human { __typename property: homePlanet } ... on Droid { __typename property: primaryFunction } } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/HumanQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class HumanQuery: GraphQLQuery {
   public static let operationName: String = "Human"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b37eb69b82fd52358321e49453769750983be1c286744dbf415735d7bcf12f1e",
+    operationIdentifier: "22b975c180932a926f48bfec1e002b9d1389e0ee1d84b3cdfa337d80fb036a26",
     definition: .init(
-      #"""
-      query Human($id: ID!) {
-        human(id: $id) {
-          __typename
-          name
-          mass
-        }
-      }
-      """#
+      #"query Human($id: ID!) { human(id: $id) { __typename name mass } }"#
     ))
 
   public var id: ID

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SameHeroTwiceQuery.graphql.swift
@@ -6,20 +6,9 @@
 public class SameHeroTwiceQuery: GraphQLQuery {
   public static let operationName: String = "SameHeroTwice"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "2a8ad85a703add7d64622aaf6be76b58a1134caf28e4ff6b34dd00ba89541364",
+    operationIdentifier: "3d960acb3caffc4e42701ccada8535b1a5640f0cc46966b6a12830c755ff46d8",
     definition: .init(
-      #"""
-      query SameHeroTwice {
-        hero {
-          __typename
-          name
-        }
-        r2: hero {
-          __typename
-          appearsIn
-        }
-      }
-      """#
+      #"query SameHeroTwice { hero { __typename name } r2: hero { __typename appearsIn } }"#
     ))
 
   public init() {}

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/SearchQuery.graphql.swift
@@ -6,30 +6,9 @@
 public class SearchQuery: GraphQLQuery {
   public static let operationName: String = "Search"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "477b77c476899915498a56ae7bb835667b1e875cb94f6daa7f75e05018be2c3a",
+    operationIdentifier: "29ecc9c7acac3eab2585d305aed9f8257b448bc7ea57341a135d1fa476973ecb",
     definition: .init(
-      #"""
-      query Search($term: String) {
-        search(text: $term) {
-          __typename
-          ... on Human {
-            __typename
-            id
-            name
-          }
-          ... on Droid {
-            __typename
-            id
-            name
-          }
-          ... on Starship {
-            __typename
-            id
-            name
-          }
-        }
-      }
-      """#
+      #"query Search($term: String) { search(text: $term) { __typename ... on Human { __typename id name } ... on Droid { __typename id name } ... on Starship { __typename id name } } }"#
     ))
 
   public var term: GraphQLNullable<String>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipCoordinatesQuery.graphql.swift
@@ -6,18 +6,9 @@
 public class StarshipCoordinatesQuery: GraphQLQuery {
   public static let operationName: String = "StarshipCoordinates"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "8dd77d4bc7494c184606da092a665a7c2ca3c2a3f14d3b23fa5e469e207b3406",
+    operationIdentifier: "c10b54b8dd9361556f3b12d71f28c859ace043525d8d19541b39eadc47d14b15",
     definition: .init(
-      #"""
-      query StarshipCoordinates($coordinates: [[Float!]!]) {
-        starshipCoordinates(coordinates: $coordinates) {
-          __typename
-          name
-          coordinates
-          length
-        }
-      }
-      """#
+      #"query StarshipCoordinates($coordinates: [[Float!]!]) { starshipCoordinates(coordinates: $coordinates) { __typename name coordinates length } }"#
     ))
 
   public var coordinates: GraphQLNullable<[[Double]]>

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/StarshipQuery.graphql.swift
@@ -6,17 +6,9 @@
 public class StarshipQuery: GraphQLQuery {
   public static let operationName: String = "Starship"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "a3734516185da9919e3e66d74fe92b60d65292a1943dc54913f7332637dfdd2a",
+    operationIdentifier: "e42a9be2ae0f222985e3eacf8d8d513002954d5031dcf544bbb0d27b1089fc58",
     definition: .init(
-      #"""
-      query Starship {
-        starship(id: 3000) {
-          __typename
-          name
-          coordinates
-        }
-      }
-      """#
+      #"query Starship { starship(id: 3000) { __typename name coordinates } }"#
     ))
 
   public init() {}

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Queries/TwoHeroesQuery.graphql.swift
@@ -6,20 +6,9 @@
 public class TwoHeroesQuery: GraphQLQuery {
   public static let operationName: String = "TwoHeroes"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "b868fa9c48f19b8151c08c09f46831e3b9cd09f5c617d328647de785244b52bb",
+    operationIdentifier: "79c1cf70ead0fb9d7bb0811982560f1585b0b0a4ad7507c934b43a4482bb2097",
     definition: .init(
-      #"""
-      query TwoHeroes {
-        r2: hero {
-          __typename
-          name
-        }
-        luke: hero(episode: EMPIRE) {
-          __typename
-          name
-        }
-      }
-      """#
+      #"query TwoHeroes { r2: hero { __typename name } luke: hero(episode: EMPIRE) { __typename name } }"#
     ))
 
   public init() {}

--- a/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
+++ b/Sources/StarWarsAPI/StarWarsAPI/Sources/Operations/Subscriptions/ReviewAddedSubscription.graphql.swift
@@ -6,18 +6,9 @@
 public class ReviewAddedSubscription: GraphQLSubscription {
   public static let operationName: String = "ReviewAdded"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
-    operationIdentifier: "38644c5e7cf4fd506b91d2e7010cabf84e63dfcd33cf1deb443b4b32b55e2cbe",
+    operationIdentifier: "2a05903b49a3b665eeb8f7a24240623aff77f1555e006f11bca604540c7cdba8",
     definition: .init(
-      #"""
-      subscription ReviewAdded($episode: Episode) {
-        reviewAdded(episode: $episode) {
-          __typename
-          episode
-          stars
-          commentary
-        }
-      }
-      """#
+      #"subscription ReviewAdded($episode: Episode) { reviewAdded(episode: $episode) { __typename episode stars commentary } }"#
     ))
 
   public var episode: GraphQLNullable<GraphQLEnum<Episode>>

--- a/Sources/StarWarsAPI/starwars-graphql/operationIDs.json
+++ b/Sources/StarWarsAPI/starwars-graphql/operationIDs.json
@@ -1,158 +1,240 @@
 {
-  "fe3f21394eb861aa515c4d582e645469045793c9cbbeca4b5d4ce4d7dd617556" : {
-    "name" : "HeroAndFriendsNames",
-    "source" : "query HeroAndFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    friends {\n      __typename\n      name\n    }\n  }\n}"
-  },
-  "8e4ca76c63660898cfd5a3845e3709027750b5f0151c7f9be65759b869c5486d" : {
-    "name" : "HeroAndFriendsNamesWithIDs",
-    "source" : "query HeroAndFriendsNamesWithIDs($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      id\n      name\n    }\n  }\n}"
-  },
-  "117d0f6831d8f4abe5b61ed1dbb8071b0825e19649916c0fe0906a6f578bb088" : {
-    "name" : "HeroAndFriendsIDs",
-    "source" : "query HeroAndFriendsIDs($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      id\n    }\n  }\n}"
-  },
-  "f091468a629f3b757c03a1b7710c6ede8b5c8f10df7ba3238f2bbcd71c56f90f" : {
-    "name" : "HeroAndFriendsNamesWithIDForParentOnly",
-    "source" : "query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      name\n    }\n  }\n}"
-  },
-  "37cd5626048e7243716ffda9e56503939dd189772124a1c21b0e0b87e69aae01" : {
-    "name" : "HeroFriendsOfFriendsNames",
-    "source" : "query HeroFriendsOfFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      id\n      friends {\n        __typename\n        name\n      }\n    }\n  }\n}"
-  },
-  "1d3ad903dad146ff9d7aa09813fc01becd017489bfc1af8ffd178498730a5a26" : {
-    "name" : "HeroAndFriendsNamesWithFragment",
-    "source" : "query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ...FriendsNames\n  }\n}\nfragment FriendsNames on Character {\n  __typename\n  friends {\n    __typename\n    name\n  }\n}"
-  },
-  "b5f4eca712a136f0d5d9f96203ef7d03cd119d8388f093f4b78ae124acb904cb" : {
-    "name" : "HeroAndFriendsNamesWithFragmentTwice",
-    "source" : "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      ...CharacterName\n    }\n    ... on Droid {\n      __typename\n      friends {\n        __typename\n        ...CharacterName\n      }\n    }\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
-  },
-  "f714414a2002404f9943490c8cc9c1a7b8ecac3ca229fa5a326186b43c1385ce" : {
-    "name" : "HeroNameAndAppearsIn",
-    "source" : "query HeroNameAndAppearsIn($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    appearsIn\n  }\n}"
-  },
-  "0664fed3eb4f9fbdb44e8691d9e8fd11f2b3c097ba11327592054f602bd3ba1a" : {
-    "name" : "HeroNameAndAppearsInWithFragment",
-    "source" : "query HeroNameAndAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterNameAndAppearsIn\n  }\n}\nfragment CharacterNameAndAppearsIn on Character {\n  __typename\n  name\n  appearsIn\n}"
-  },
-  "a3734516185da9919e3e66d74fe92b60d65292a1943dc54913f7332637dfdd2a" : {
-    "name" : "Starship",
-    "source" : "query Starship {\n  starship(id: 3000) {\n    __typename\n    name\n    coordinates\n  }\n}"
-  },
-  "8dd77d4bc7494c184606da092a665a7c2ca3c2a3f14d3b23fa5e469e207b3406" : {
-    "name" : "StarshipCoordinates",
-    "source" : "query StarshipCoordinates($coordinates: [[Float!]!]) {\n  starshipCoordinates(coordinates: $coordinates) {\n    __typename\n    name\n    coordinates\n    length\n  }\n}"
-  },
-  "22d772c0fc813281705e8f0a55fc70e71eeff6e98f3f9ef96cf67fb896914522" : {
-    "name" : "HeroAppearsIn",
-    "source" : "query HeroAppearsIn {\n  hero {\n    __typename\n    appearsIn\n  }\n}"
-  },
-  "1756158bd7736d58db45a48d74a724fa1b6fdac735376df8afac8318ba5431fb" : {
-    "name" : "HeroAppearsInWithFragment",
-    "source" : "query HeroAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterAppearsIn\n  }\n}\nfragment CharacterAppearsIn on Character {\n  __typename\n  appearsIn\n}"
-  },
-  "207d29944f5822bff08a07db4a55274ea14035bacfe20699da41a47454f1181e" : {
-    "name" : "HeroDetails",
-    "source" : "query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n    }\n  }\n}"
-  },
-  "b55bd9d56d1b5972345412b6adb88ceb64d6086c8051d2588d8ab701f0ee7c2f" : {
-    "name" : "HeroDetailsWithFragment",
-    "source" : "query HeroDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...HeroDetails\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    __typename\n    height\n  }\n  ... on Droid {\n    __typename\n    primaryFunction\n  }\n}"
-  },
-  "7277e97563e911ac8f5c91d401028d218aae41f38df014d7fa0b037bb2a2e739" : {
-    "name" : "DroidDetailsWithFragment",
-    "source" : "query DroidDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...DroidDetails\n  }\n}\nfragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}"
-  },
-  "2a8ad85a703add7d64622aaf6be76b58a1134caf28e4ff6b34dd00ba89541364" : {
-    "name" : "SameHeroTwice",
-    "source" : "query SameHeroTwice {\n  hero {\n    __typename\n    name\n  }\n  r2: hero {\n    __typename\n    appearsIn\n  }\n}"
-  },
-  "b868fa9c48f19b8151c08c09f46831e3b9cd09f5c617d328647de785244b52bb" : {
-    "name" : "TwoHeroes",
-    "source" : "query TwoHeroes {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    name\n  }\n}"
-  },
-  "3dd42259adf2d0598e89e0279bee2c128a7913f02b1da6aa43f3b5def6a8a1f8" : {
-    "name" : "HeroNameConditionalExclusion",
-    "source" : "query HeroNameConditionalExclusion($skipName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName)\n  }\n}"
-  },
-  "338081aea3acc83d04af0741ecf0da1ec2ee8e6468a88383476b681015905ef8" : {
-    "name" : "HeroNameConditionalInclusion",
-    "source" : "query HeroNameConditionalInclusion($includeName: Boolean!) {\n  hero {\n    __typename\n    name @include(if: $includeName)\n  }\n}"
-  },
-  "66f4dc124b6374b1912b22a2a208e34a4b1997349402a372b95bcfafc7884064" : {
-    "name" : "HeroNameConditionalBoth",
-    "source" : "query HeroNameConditionalBoth($skipName: Boolean!, $includeName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName) @include(if: $includeName)\n  }\n}"
-  },
-  "d0f9e9205cdc09320035662f528a177654d3275b0bf94cf0e259a65fde33e7e5" : {
-    "name" : "HeroNameConditionalBothSeparate",
-    "source" : "query HeroNameConditionalBothSeparate($skipName: Boolean!, $includeName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName)\n    name @include(if: $includeName)\n  }\n}"
-  },
-  "3091d9d3f1d2374e2f835ce05d332e50b3fe61502d73213b9aa511f0f94f091c" : {
-    "name" : "HeroDetailsInlineConditionalInclusion",
-    "source" : "query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ... @include(if: $includeDetails) {\n      __typename\n      name\n      appearsIn\n    }\n  }\n}"
-  },
-  "b0fa7927ff93b4a579c3460fb04d093072d34c8018e41197c7e080aeeec5e19b" : {
-    "name" : "HeroDetailsFragmentConditionalInclusion",
-    "source" : "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ...HeroDetails @include(if: $includeDetails)\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    __typename\n    height\n  }\n  ... on Droid {\n    __typename\n    primaryFunction\n  }\n}"
-  },
-  "76aecc75265295818d3990000b17e32d5524ca85a4bc159ae8a3f8ec7ce91cc3" : {
-    "name" : "HeroNameTypeSpecificConditionalInclusion",
-    "source" : "query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n    ... on Droid {\n      __typename\n      name\n    }\n  }\n}"
-  },
-  "8cada231691ff2f5a0a07c54b7332114588f11b947795da345c5b054211fbcfd" : {
-    "name" : "HeroFriendsDetailsConditionalInclusion",
-    "source" : "query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        __typename\n        primaryFunction\n      }\n    }\n  }\n}"
-  },
-  "65381a20574db4b458a0821328252deb0da1a107f9ab77c99fb2467e66a5f12d" : {
-    "name" : "HeroFriendsDetailsUnconditionalAndConditionalInclusion",
-    "source" : "query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends {\n      __typename\n      name\n    }\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        __typename\n        primaryFunction\n      }\n    }\n  }\n}"
-  },
-  "477b77c476899915498a56ae7bb835667b1e875cb94f6daa7f75e05018be2c3a" : {
-    "name" : "Search",
-    "source" : "query Search($term: String) {\n  search(text: $term) {\n    __typename\n    ... on Human {\n      __typename\n      id\n      name\n    }\n    ... on Droid {\n      __typename\n      id\n      name\n    }\n    ... on Starship {\n      __typename\n      id\n      name\n    }\n  }\n}"
-  },
-  "f6e76545cd03aa21368d9969cb39447f6e836a16717823281803778e7805d671" : {
-    "name" : "HeroName",
-    "source" : "query HeroName($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n  }\n}"
-  },
-  "83c03f612c46fca72f6cb902df267c57bffc9209bc44dd87d2524fb2b34f6f18" : {
-    "name" : "HeroNameWithID",
-    "source" : "query HeroNameWithID($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n  }\n}"
-  },
-  "b952f0054915a32ec524ac0dde0244bcda246649debe149f9e32e303e21c8266" : {
-    "name" : "HeroNameWithFragment",
-    "source" : "query HeroNameWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterName\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
-  },
-  "a87a0694c09d1ed245e9a80f245d96a5f57b20a4aa936ee9ab09b2a43620db02" : {
-    "name" : "HeroNameWithFragmentAndID",
-    "source" : "query HeroNameWithFragmentAndID($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    ...CharacterName\n  }\n}\nfragment CharacterName on Character {\n  __typename\n  name\n}"
-  },
-  "eac5a52f9020fc2e9b5dc5facfd6a6295683b8d57ea62ee84254069fcd5e504c" : {
-    "name" : "HeroTypeDependentAliasedField",
-    "source" : "query HeroTypeDependentAliasedField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ... on Human {\n      __typename\n      property: homePlanet\n    }\n    ... on Droid {\n      __typename\n      property: primaryFunction\n    }\n  }\n}"
-  },
-  "38644c5e7cf4fd506b91d2e7010cabf84e63dfcd33cf1deb443b4b32b55e2cbe" : {
-    "name" : "ReviewAdded",
-    "source" : "subscription ReviewAdded($episode: Episode) {\n  reviewAdded(episode: $episode) {\n    __typename\n    episode\n    stars\n    commentary\n  }\n}"
-  },
-  "39eb41b5a9477c36fa529c23d6f0de6ebcc0312daf5bdcfe208d5baec752dc5b" : {
-    "name" : "HeroParentTypeDependentField",
-    "source" : "query HeroParentTypeDependentField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      __typename\n      friends {\n        __typename\n        name\n        ... on Human {\n          __typename\n          height(unit: FOOT)\n        }\n      }\n    }\n    ... on Droid {\n      __typename\n      friends {\n        __typename\n        name\n        ... on Human {\n          __typename\n          height(unit: METER)\n        }\n      }\n    }\n  }\n}"
-  },
-  "9bbf5b4074d0635fb19d17c621b7b04ebfb1920d468a94266819e149841e7d5d" : {
-    "name" : "CreateReviewForEpisode",
-    "source" : "mutation CreateReviewForEpisode($episode: Episode!, $review: ReviewInput!) {\n  createReview(episode: $episode, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}"
-  },
-  "4a1250de93ebcb5cad5870acf15001112bf27bb963e8709555b5ff67a1405374" : {
-    "name" : "CreateAwesomeReview",
-    "source" : "mutation CreateAwesomeReview {\n  createReview(episode: JEDI, review: {stars: 10, commentary: \"This is awesome!\"}) {\n    __typename\n    stars\n    commentary\n  }\n}"
-  },
-  "a9600d176cd7e4671b8689f1d01fe79ea896932bfafb8a925af673f0e4111828" : {
-    "name" : "CreateReviewWithNullField",
-    "source" : "mutation CreateReviewWithNullField {\n  createReview(episode: JEDI, review: {stars: 10, commentary: null}) {\n    __typename\n    stars\n    commentary\n  }\n}"
-  },
-  "b37eb69b82fd52358321e49453769750983be1c286744dbf415735d7bcf12f1e" : {
-    "name" : "Human",
-    "source" : "query Human($id: ID!) {\n  human(id: $id) {\n    __typename\n    name\n    mass\n  }\n}"
-  }
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "1e36c3331171b74c012b86caa04fbb01062f37c61227655d9c0729a62c6f7285",
+      "body": "query HeroAndFriendsNames($episode: Episode) { hero(episode: $episode) { __typename name friends { __typename name } } }",
+      "name": "HeroAndFriendsNames",
+      "type": "query"
+    },
+    {
+      "id": "cdf121c8a2f2188bd1c4dcc04df6104e989164b27f1e7f13d27ccc9c03fbda0c",
+      "body": "query HeroAndFriendsNamesWithIDs($episode: Episode) { hero(episode: $episode) { __typename id name friends { __typename id name } } }",
+      "name": "HeroAndFriendsNamesWithIDs",
+      "type": "query"
+    },
+    {
+      "id": "8f1f880891cdfbf7be7ea11bb4b09708bcbf1e3f8e8a40ecb6fcb33c6078955f",
+      "body": "query HeroAndFriendsIDs($episode: Episode) { hero(episode: $episode) { __typename id name friends { __typename id } } }",
+      "name": "HeroAndFriendsIDs",
+      "type": "query"
+    },
+    {
+      "id": "de03aaedeb69050ef75e3aa56b262b4ea1e08bb6fd174f2e91ddd9b84a8ff897",
+      "body": "query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) { hero(episode: $episode) { __typename id name friends { __typename name } } }",
+      "name": "HeroAndFriendsNamesWithIDForParentOnly",
+      "type": "query"
+    },
+    {
+      "id": "513b65fa459185f88540be8d60cdeefb69fd6c82a21b804214337558aa6ecb0b",
+      "body": "query HeroFriendsOfFriendsNames($episode: Episode) { hero(episode: $episode) { __typename friends { __typename id friends { __typename name } } } }",
+      "name": "HeroFriendsOfFriendsNames",
+      "type": "query"
+    },
+    {
+      "id": "07c54599c2b5f9d4215d1bff7f5f6ff458c983aa5c13338fd44b051210d5ecc6",
+      "body": "query HeroAndFriendsNamesWithFragment($episode: Episode) { hero(episode: $episode) { __typename name ...FriendsNames } }\nfragment FriendsNames on Character { __typename friends { __typename name } }",
+      "name": "HeroAndFriendsNamesWithFragment",
+      "type": "query"
+    },
+    {
+      "id": "9a769ab058900912bff4e4c51c1b257f609e4dfb4aaa1f17166adc19d510e363",
+      "body": "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) { hero(episode: $episode) { __typename friends { __typename ...CharacterName } ... on Droid { __typename friends { __typename ...CharacterName } } } }\nfragment CharacterName on Character { __typename name }",
+      "name": "HeroAndFriendsNamesWithFragmentTwice",
+      "type": "query"
+    },
+    {
+      "id": "ecdf5248575524004a9d43832abc54e8c0e1d2b3c0afb8bb0c1c1c514b4f9baf",
+      "body": "query HeroNameAndAppearsIn($episode: Episode) { hero(episode: $episode) { __typename name appearsIn } }",
+      "name": "HeroNameAndAppearsIn",
+      "type": "query"
+    },
+    {
+      "id": "4fc9c2e7f9fbe8ef3f28936bd0b12e8f32bc8d70f3e8ec5df8a6aaf3efd4921c",
+      "body": "query HeroNameAndAppearsInWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterNameAndAppearsIn } }\nfragment CharacterNameAndAppearsIn on Character { __typename name appearsIn }",
+      "name": "HeroNameAndAppearsInWithFragment",
+      "type": "query"
+    },
+    {
+      "id": "e42a9be2ae0f222985e3eacf8d8d513002954d5031dcf544bbb0d27b1089fc58",
+      "body": "query Starship { starship(id: 3000) { __typename name coordinates } }",
+      "name": "Starship",
+      "type": "query"
+    },
+    {
+      "id": "c10b54b8dd9361556f3b12d71f28c859ace043525d8d19541b39eadc47d14b15",
+      "body": "query StarshipCoordinates($coordinates: [[Float!]!]) { starshipCoordinates(coordinates: $coordinates) { __typename name coordinates length } }",
+      "name": "StarshipCoordinates",
+      "type": "query"
+    },
+    {
+      "id": "59243627e0166c9b631551b56dc4d29701f2d90336d83c231172c50152e02475",
+      "body": "query HeroAppearsIn { hero { __typename appearsIn } }",
+      "name": "HeroAppearsIn",
+      "type": "query"
+    },
+    {
+      "id": "b7e9c75d75c77765849b67116235609b3a05b9052975c617f51a315f8fbaf45a",
+      "body": "query HeroAppearsInWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterAppearsIn } }\nfragment CharacterAppearsIn on Character { __typename appearsIn }",
+      "name": "HeroAppearsInWithFragment",
+      "type": "query"
+    },
+    {
+      "id": "bf81c1338a3953d1c17c5cad3db3c3ab18b16a6822125ab81c15eb0dd3e82193",
+      "body": "query HeroDetails($episode: Episode) { hero(episode: $episode) { __typename name ... on Human { __typename height } ... on Droid { __typename primaryFunction } } }",
+      "name": "HeroDetails",
+      "type": "query"
+    },
+    {
+      "id": "09fe4fc0cbcde5f0ba08b1207526cae13eb2b73ca95f929d4153dd3f643b6780",
+      "body": "query HeroDetailsWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...HeroDetails } }\nfragment HeroDetails on Character { __typename name ... on Human { __typename height } ... on Droid { __typename primaryFunction } }",
+      "name": "HeroDetailsWithFragment",
+      "type": "query"
+    },
+    {
+      "id": "6696d5064faa0c379b73574aa6d4c5b912eb17339afc8b66babae61542d233d7",
+      "body": "query DroidDetailsWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...DroidDetails } }\nfragment DroidDetails on Droid { __typename name primaryFunction }",
+      "name": "DroidDetailsWithFragment",
+      "type": "query"
+    },
+    {
+      "id": "3d960acb3caffc4e42701ccada8535b1a5640f0cc46966b6a12830c755ff46d8",
+      "body": "query SameHeroTwice { hero { __typename name } r2: hero { __typename appearsIn } }",
+      "name": "SameHeroTwice",
+      "type": "query"
+    },
+    {
+      "id": "79c1cf70ead0fb9d7bb0811982560f1585b0b0a4ad7507c934b43a4482bb2097",
+      "body": "query TwoHeroes { r2: hero { __typename name } luke: hero(episode: EMPIRE) { __typename name } }",
+      "name": "TwoHeroes",
+      "type": "query"
+    },
+    {
+      "id": "b6d6f1d10cde449adbf2891d489159006188e63d4dea4edb9a23eddcbe0bd361",
+      "body": "query HeroNameConditionalExclusion($skipName: Boolean!) { hero { __typename name @skip(if: $skipName) } }",
+      "name": "HeroNameConditionalExclusion",
+      "type": "query"
+    },
+    {
+      "id": "dd8e5df9634bb4fb6455e4aaddd2941c5abf785b7d28cda959aba65157e950c6",
+      "body": "query HeroNameConditionalInclusion($includeName: Boolean!) { hero { __typename name @include(if: $includeName) } }",
+      "name": "HeroNameConditionalInclusion",
+      "type": "query"
+    },
+    {
+      "id": "e063fa4ab5493e9c67bfa96dfedfa8570475f6286f38c482f6e85ced4ea206af",
+      "body": "query HeroNameConditionalBoth($skipName: Boolean!, $includeName: Boolean!) { hero { __typename name @skip(if: $skipName) @include(if: $includeName) } }",
+      "name": "HeroNameConditionalBoth",
+      "type": "query"
+    },
+    {
+      "id": "60741c6fca15865a9af75a269ed05871e681f48ac48edfac2a77d953d217d03c",
+      "body": "query HeroNameConditionalBothSeparate($skipName: Boolean!, $includeName: Boolean!) { hero { __typename name @skip(if: $skipName) name @include(if: $includeName) } }",
+      "name": "HeroNameConditionalBothSeparate",
+      "type": "query"
+    },
+    {
+      "id": "e251576f8c1cfcd442f44d2fbe5fd4b425a36ddd41fb4b6c1019c501ac6ac5bc",
+      "body": "query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) { hero { __typename ... @include(if: $includeDetails) { __typename name appearsIn } } }",
+      "name": "HeroDetailsInlineConditionalInclusion",
+      "type": "query"
+    },
+    {
+      "id": "17dfb13c5d9e6c67703fc037b9114ea53ccc8f9274dfecb4abfc2d5a168cf612",
+      "body": "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) { hero { __typename ...HeroDetails @include(if: $includeDetails) } }\nfragment HeroDetails on Character { __typename name ... on Human { __typename height } ... on Droid { __typename primaryFunction } }",
+      "name": "HeroDetailsFragmentConditionalInclusion",
+      "type": "query"
+    },
+    {
+      "id": "c05a6e91e1a3ddc3df21205ed7fca49cf6f3f171e4390ac98e7690c391b18baf",
+      "body": "query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) { hero(episode: $episode) { __typename name @include(if: $includeName) ... on Droid { __typename name } } }",
+      "name": "HeroNameTypeSpecificConditionalInclusion",
+      "type": "query"
+    },
+    {
+      "id": "ca1b86ff4a0f8212bdac70fbb59c9bb8023d0a30ca0225b24831bb3e807b22a0",
+      "body": "query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) { hero { __typename friends @include(if: $includeFriendsDetails) { __typename name ... on Droid { __typename primaryFunction } } } }",
+      "name": "HeroFriendsDetailsConditionalInclusion",
+      "type": "query"
+    },
+    {
+      "id": "e36c8e5d752afda2a90fe44bcbfeb92de68f0da92b8390d626d3005cbad16dbe",
+      "body": "query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) { hero { __typename friends { __typename name } friends @include(if: $includeFriendsDetails) { __typename name ... on Droid { __typename primaryFunction } } } }",
+      "name": "HeroFriendsDetailsUnconditionalAndConditionalInclusion",
+      "type": "query"
+    },
+    {
+      "id": "29ecc9c7acac3eab2585d305aed9f8257b448bc7ea57341a135d1fa476973ecb",
+      "body": "query Search($term: String) { search(text: $term) { __typename ... on Human { __typename id name } ... on Droid { __typename id name } ... on Starship { __typename id name } } }",
+      "name": "Search",
+      "type": "query"
+    },
+    {
+      "id": "b9d49e889d6f5877c0bf09b8b4f88a71f88836a771e0e48c270a9aa8b506dda1",
+      "body": "query HeroName($episode: Episode) { hero(episode: $episode) { __typename name } }",
+      "name": "HeroName",
+      "type": "query"
+    },
+    {
+      "id": "675d636002a28e24e3802d5f04772943b0a78b8795203fcab53f4c8466e1e53c",
+      "body": "query HeroNameWithID($episode: Episode) { hero(episode: $episode) { __typename id name } }",
+      "name": "HeroNameWithID",
+      "type": "query"
+    },
+    {
+      "id": "68baad3c27796cb1bf980681324e43b948aa1109698ba57404c1afa46e914ab1",
+      "body": "query HeroNameWithFragment($episode: Episode) { hero(episode: $episode) { __typename ...CharacterName } }\nfragment CharacterName on Character { __typename name }",
+      "name": "HeroNameWithFragment",
+      "type": "query"
+    },
+    {
+      "id": "ec14e5fffc56163c516a21f0d211a7a86d68a3512e6fb6df38a19babe0d1df8d",
+      "body": "query HeroNameWithFragmentAndID($episode: Episode) { hero(episode: $episode) { __typename id ...CharacterName } }\nfragment CharacterName on Character { __typename name }",
+      "name": "HeroNameWithFragmentAndID",
+      "type": "query"
+    },
+    {
+      "id": "5b1ed6a84e96a4e48a3cad675ebb46020bce176f47361d097d8a0a824b7b8452",
+      "body": "query HeroTypeDependentAliasedField($episode: Episode) { hero(episode: $episode) { __typename ... on Human { __typename property: homePlanet } ... on Droid { __typename property: primaryFunction } } }",
+      "name": "HeroTypeDependentAliasedField",
+      "type": "query"
+    },
+    {
+      "id": "2a05903b49a3b665eeb8f7a24240623aff77f1555e006f11bca604540c7cdba8",
+      "body": "subscription ReviewAdded($episode: Episode) { reviewAdded(episode: $episode) { __typename episode stars commentary } }",
+      "name": "ReviewAdded",
+      "type": "subscription"
+    },
+    {
+      "id": "dc3b582f2baa66cfb5cd53eb3c215933427fd0537076767c8e0ef894d3990d15",
+      "body": "query HeroParentTypeDependentField($episode: Episode) { hero(episode: $episode) { __typename name ... on Human { __typename friends { __typename name ... on Human { __typename height(unit: FOOT) } } } ... on Droid { __typename friends { __typename name ... on Human { __typename height(unit: METER) } } } } }",
+      "name": "HeroParentTypeDependentField",
+      "type": "query"
+    },
+    {
+      "id": "3edcd1f17839f43db021eccbe2ecd41ad7dcb1ba6cd4b7e9897afb4162e4c223",
+      "body": "mutation CreateReviewForEpisode($episode: Episode!, $review: ReviewInput!) { createReview(episode: $episode, review: $review) { __typename stars commentary } }",
+      "name": "CreateReviewForEpisode",
+      "type": "mutation"
+    },
+    {
+      "id": "36634ea692d455075551673f2f529e85c8acf6f5e3707243781324cd3d968d02",
+      "body": "mutation CreateAwesomeReview { createReview(episode: JEDI, review: {stars: 10, commentary: "This is awesome!"}) { __typename stars commentary } }",
+      "name": "CreateAwesomeReview",
+      "type": "mutation"
+    },
+    {
+      "id": "e962313bc77c193dc516d097b5e41efea073de16c3a5f2e8c00f082853835d49",
+      "body": "mutation CreateReviewWithNullField { createReview(episode: JEDI, review: {stars: 10, commentary: null}) { __typename stars commentary } }",
+      "name": "CreateReviewWithNullField",
+      "type": "mutation"
+    },
+    {
+      "id": "22b975c180932a926f48bfec1e002b9d1389e0ee1d84b3cdfa337d80fb036a26",
+      "body": "query Human($id: ID!) { human(id: $id) { __typename name mass } }",
+      "name": "Human",
+      "type": "query"
+    }
+  ]
 }

--- a/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
+++ b/Sources/SubscriptionAPI/SubscriptionAPI/Sources/Operations/Subscriptions/IncrementingSubscription.graphql.swift
@@ -7,11 +7,7 @@ public class IncrementingSubscription: GraphQLSubscription {
   public static let operationName: String = "Incrementing"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      subscription Incrementing {
-        numberIncremented
-      }
-      """#
+      #"subscription Incrementing { numberIncremented }"#
     ))
 
   public init() {}

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToDifferentParametersMutation.graphql.swift
@@ -7,17 +7,7 @@ public class UploadMultipleFilesToDifferentParametersMutation: GraphQLMutation {
   public static let operationName: String = "UploadMultipleFilesToDifferentParameters"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {
-        multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) {
-          __typename
-          id
-          path
-          filename
-          mimetype
-        }
-      }
-      """#
+      #"mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) { multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) { __typename id path filename mimetype } }"#
     ))
 
   public var singleFile: Upload

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadMultipleFilesToTheSameParameterMutation.graphql.swift
@@ -7,17 +7,7 @@ public class UploadMultipleFilesToTheSameParameterMutation: GraphQLMutation {
   public static let operationName: String = "UploadMultipleFilesToTheSameParameter"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {
-        multipleUpload(files: $files) {
-          __typename
-          id
-          path
-          filename
-          mimetype
-        }
-      }
-      """#
+      #"mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) { multipleUpload(files: $files) { __typename id path filename mimetype } }"#
     ))
 
   public var files: [Upload]

--- a/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
+++ b/Sources/UploadAPI/UploadAPI/Sources/Operations/Mutations/UploadOneFileMutation.graphql.swift
@@ -7,17 +7,7 @@ public class UploadOneFileMutation: GraphQLMutation {
   public static let operationName: String = "UploadOneFile"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"""
-      mutation UploadOneFile($file: Upload!) {
-        singleUpload(file: $file) {
-          __typename
-          id
-          path
-          filename
-          mimetype
-        }
-      }
-      """#
+      #"mutation UploadOneFile($file: Upload!) { singleUpload(file: $file) { __typename id path filename mimetype } }"#
     ))
 
   public var file: Upload

--- a/Sources/UploadAPI/graphql/operationIDs.json
+++ b/Sources/UploadAPI/graphql/operationIDs.json
@@ -1,14 +1,24 @@
 {
-  "88858c283bb72f18c0049dc85b140e72a4046f469fa16a8bf4bcf01c11d8a2b7" : {
-    "name" : "UploadMultipleFilesToTheSameParameter",
-    "source" : "mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {\n  multipleUpload(files: $files) {\n    __typename\n    id\n    path\n    filename\n    mimetype\n  }\n}"
-  },
-  "1ec89997a185c50bacc5f62ad41f27f3070f4a950d72e4a1510a4c64160812d5" : {
-    "name" : "UploadMultipleFilesToDifferentParameters",
-    "source" : "mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {\n  multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) {\n    __typename\n    id\n    path\n    filename\n    mimetype\n  }\n}"
-  },
-  "c5d5919f77d9ba16a9689b6b0ad4b781cb05dc1dc4812623bf80f7c044c09533" : {
-    "name" : "UploadOneFile",
-    "source" : "mutation UploadOneFile($file: Upload!) {\n  singleUpload(file: $file) {\n    __typename\n    id\n    path\n    filename\n    mimetype\n  }\n}"
-  }
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "93d5a278f1e14f434bcb6978c5da1ac4aec6a5ad8c81aa396f60edf825cf09fc",
+      "body": "mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) { multipleUpload(files: $files) { __typename id path filename mimetype } }",
+      "name": "UploadMultipleFilesToTheSameParameter",
+      "type": "mutation"
+    },
+    {
+      "id": "d9562c30ed2555c852d7e7e49a4f29645a93807991fe6e733059fe87404eb25c",
+      "body": "mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) { multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) { __typename id path filename mimetype } }",
+      "name": "UploadMultipleFilesToDifferentParameters",
+      "type": "mutation"
+    },
+    {
+      "id": "d67bee226e4f3b990d0d860826e93cd0ee158f02564d8fccff941eb04a9e4f07",
+      "body": "mutation UploadOneFile($file: Upload!) { singleUpload(file: $file) { __typename id path filename mimetype } }",
+      "name": "UploadOneFile",
+      "type": "mutation"
+    }
+  ]
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -653,6 +653,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("Sources/Fragments/ClassroomPetDetails.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Fragments/HeightInMeters.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Fragments/WarmBloodedDetails.graphql.swift").path,
+      directoryURL.appendingPathComponent("Sources/Fragments/CrocodileFragment.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
@@ -749,6 +750,7 @@ class ApolloCodegenTests: XCTestCase {
       operationsOutputURL.appendingPathComponent("Fragments/ClassroomPetDetails.graphql.swift").path,
       operationsOutputURL.appendingPathComponent("Fragments/HeightInMeters.graphql.swift").path,
       operationsOutputURL.appendingPathComponent("Fragments/WarmBloodedDetails.graphql.swift").path,
+      operationsOutputURL.appendingPathComponent("Fragments/CrocodileFragment.graphql.swift").path,
 
       operationsOutputURL.appendingPathComponent("LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       operationsOutputURL.appendingPathComponent("LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
@@ -848,6 +850,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("Sources/Fragments/ClassroomPetDetails.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Fragments/HeightInMeters.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/Fragments/WarmBloodedDetails.graphql.swift").path,
+      directoryURL.appendingPathComponent("Sources/Fragments/CrocodileFragment.graphql.swift").path,
 
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
@@ -1016,6 +1019,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("RelativePath/Sources/Fragments/ClassroomPetDetails.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativePath/Sources/Fragments/HeightInMeters.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativePath/Sources/Fragments/WarmBloodedDetails.graphql.swift").path,
+      directoryURL.appendingPathComponent("RelativePath/Sources/Fragments/CrocodileFragment.graphql.swift").path,
 
       directoryURL.appendingPathComponent("RelativePath/Sources/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativePath/Sources/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,
@@ -1115,6 +1119,7 @@ class ApolloCodegenTests: XCTestCase {
       directoryURL.appendingPathComponent("RelativeOperations/Fragments/ClassroomPetDetails.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativeOperations/Fragments/HeightInMeters.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativeOperations/Fragments/WarmBloodedDetails.graphql.swift").path,
+      directoryURL.appendingPathComponent("RelativeOperations/Fragments/CrocodileFragment.graphql.swift").path,
 
       directoryURL.appendingPathComponent("RelativeOperations/LocalCacheMutations/AllAnimalsLocalCacheMutation.graphql.swift").path,
       directoryURL.appendingPathComponent("RelativeOperations/LocalCacheMutations/PetDetailsMutation.graphql.swift").path,

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/FragmentTemplateTests.swift
@@ -68,7 +68,7 @@ class FragmentTemplateTests: XCTestCase {
     """
     struct TestFragment: TestSchema.SelectionSet, Fragment {
       static var fragmentDefinition: StaticString {
-        "fragment TestFragment on Query { __typename allAnimals { __typename species } }"
+        #"fragment TestFragment on Query { __typename allAnimals { __typename species } }"#
       }
 
       let __data: DataDict
@@ -99,7 +99,7 @@ class FragmentTemplateTests: XCTestCase {
     """
     struct TestFragment: TestSchema.SelectionSet, Fragment {
       static var fragmentDefinition: StaticString {
-        "fragment testFragment on Query { __typename allAnimals { __typename species } }"
+        #"fragment testFragment on Query { __typename allAnimals { __typename species } }"#
     """
 
     // when
@@ -248,7 +248,7 @@ class FragmentTemplateTests: XCTestCase {
     let expected = """
     struct TestFragment: TestSchema.SelectionSet, Fragment {
       static var fragmentDefinition: StaticString {
-        "fragment TestFragment on Query { __typename }"
+        #"fragment TestFragment on Query { __typename }"#
       }
 
       let __data: DataDict
@@ -281,7 +281,7 @@ class FragmentTemplateTests: XCTestCase {
     let expected = """
     struct TestFragment: TestSchema.SelectionSet, Fragment {
       static var fragmentDefinition: StaticString {
-        "fragment TestFragment on Animal { __typename }"
+        #"fragment TestFragment on Animal { __typename }"#
       }
 
       let __data: DataDict
@@ -615,7 +615,7 @@ class FragmentTemplateTests: XCTestCase {
     """
     struct TestFragment: TestSchema.MutableSelectionSet, Fragment {
       static var fragmentDefinition: StaticString {
-        "fragment TestFragment on Query { __typename allAnimals { __typename species } }"
+        #"fragment TestFragment on Query { __typename allAnimals { __typename species } }"#
       }
     """
 

--- a/Tests/ApolloTests/UploadRequestTests.swift
+++ b/Tests/ApolloTests/UploadRequestTests.swift
@@ -56,7 +56,7 @@ class UploadRequestTests: XCTestCase {
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"operationName":"UploadOneFile","query":"mutation UploadOneFile($file: Upload!) {\\n  singleUpload(file: $file) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"file":null}}
+{"operationName":"UploadOneFile","query":"mutation UploadOneFile($file: Upload!) { singleUpload(file: $file) { __typename id path filename mimetype } }","variables":{"file":null}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
@@ -104,7 +104,7 @@ Alpha file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"operationName":"UploadMultipleFilesToTheSameParameter","query":"mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) {\\n  multipleUpload(files: $files) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"files":[null,null]}}
+{"operationName":"UploadMultipleFilesToTheSameParameter","query":"mutation UploadMultipleFilesToTheSameParameter($files: [Upload!]!) { multipleUpload(files: $files) { __typename id path filename mimetype } }","variables":{"files":[null,null]}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 
@@ -166,7 +166,7 @@ Bravo file content.
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="operations"
 
-{"operationName":"UploadMultipleFilesToDifferentParameters","query":"mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) {\\n  multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) {\\n    __typename\\n    id\\n    path\\n    filename\\n    mimetype\\n  }\\n}","variables":{"multipleFiles":["b.txt","c.txt"],\"secondField\":null,"singleFile":"a.txt","uploads\":null}}
+{"operationName":"UploadMultipleFilesToDifferentParameters","query":"mutation UploadMultipleFilesToDifferentParameters($singleFile: Upload!, $multipleFiles: [Upload!]!) { multipleParameterUpload(singleFile: $singleFile, multipleFiles: $multipleFiles) { __typename id path filename mimetype } }","variables":{"multipleFiles":["b.txt","c.txt"],"secondField":null,"singleFile":"a.txt","uploads":null}}
 --TEST.BOUNDARY
 Content-Disposition: form-data; name="map"
 

--- a/scripts/run-test-codegen-configurations.sh
+++ b/scripts/run-test-codegen-configurations.sh
@@ -23,18 +23,21 @@ CodeGenConfigsDirectory="./Tests/TestCodeGenConfigurations"
 for dir in `ls $CodeGenConfigsDirectory`;
 do
   echo "-- Generating code for project: $dir --"
-  swift run apollo-ios-cli generate -p $CodeGenConfigsDirectory/$dir/apollo-codegen-config.json
+  if swift run apollo-ios-cli generate -p $CodeGenConfigsDirectory/$dir/apollo-codegen-config.json; then
+    if [ "$test_projects" = true ]; then
+      echo -e "-- Testing project: $dir --"
+      cd $CodeGenConfigsDirectory/$dir
 
-  if [ "$test_projects" = true ]
-  then
-    echo -e "-- Testing project: $dir --"
-    cd $CodeGenConfigsDirectory/$dir
-
-    if /bin/bash ./test-project.sh; then
-      echo -e "\n"
-      cd - > /dev/null
-    else
-      exit 1
+      if /bin/bash ./test-project.sh; then
+        echo -e "\n"
+        cd - > /dev/null
+      else
+        exit 1
+      fi
     fi
+  else
+    exit 1
   fi
+
+  
 done


### PR DESCRIPTION
-Updated the fragment definition generation to be a raw string like the operation definition to be able to support containing characters like quotes 
-Updated run-test-codegen-configurations.sh script to fail if code generation gives an error 
-Added a new field to Crocodile in AnimalKingdomAPI that accepts a String parameter 
-Added a new fragment to AnimalKingdomAPI that uses the field with string parameter to validate fragment definition generation

Closes #3134 