### PR TITLE
refactor: `Selection` enum and `Condition` type

### DIFF
--- a/Sources/Apollo/FieldSelectionCollector.swift
+++ b/Sources/Apollo/FieldSelectionCollector.swift
@@ -77,14 +77,16 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
                             info: info)
         }
 
-      case let .fragment(fragment):
+      // TODO: _ is fine for now but will need to be handled in #3145
+      case let .fragment(fragment, _):
         groupedFields.addFulfilledFragment(fragment)
         try collectFields(from: fragment.__selections,
                           into: &groupedFields,
                           for: object,
                           info: info)
 
-      case let .inlineFragment(typeCase):
+      // TODO: _ is fine for now but will need to be handled in #3145
+      case let .inlineFragment(typeCase, _):
         if let runtimeType = info.runtimeObjectType(for: object),
            typeCase.__parentType.canBeConverted(from: runtimeType) {
           groupedFields.addFulfilledFragment(typeCase)
@@ -146,7 +148,8 @@ struct CustomCacheDataWritingFieldSelectionCollector: FieldSelectionCollector {
                           info: info,
                           asConditionalFields: true)
 
-      case let .fragment(fragment):
+      // TODO: _ is fine for now but will need to be handled in #3145
+      case let .fragment(fragment, _):
         if groupedFields.fulfilledFragments.contains(type: fragment) {
           try collectFields(from: fragment.__selections,
                             into: &groupedFields,
@@ -155,7 +158,8 @@ struct CustomCacheDataWritingFieldSelectionCollector: FieldSelectionCollector {
                             asConditionalFields: false)
         }
 
-      case let .inlineFragment(typeCase):
+      // TODO: _ is fine for now but will need to be handled in #3145
+      case let .inlineFragment(typeCase, _):
         if groupedFields.fulfilledFragments.contains(type: typeCase) {
           try collectFields(from: typeCase.__selections,
                             into: &groupedFields,

--- a/Sources/ApolloAPI/Selection+Conditions.swift
+++ b/Sources/ApolloAPI/Selection+Conditions.swift
@@ -32,7 +32,7 @@ public extension Selection {
     }
   }
 
-  enum Condition: ExpressibleByStringLiteral, Hashable {
+  enum Condition: ExpressibleByStringLiteral, ExpressibleByBooleanLiteral, Hashable {
     case value(Bool)
     case variable(name: String, inverted: Bool)
 
@@ -45,6 +45,10 @@ public extension Selection {
 
     public init(stringLiteral value: StringLiteralType) {
       self = .variable(name: value, inverted: false)
+    }
+
+    public init(booleanLiteral value: BooleanLiteralType) {
+      self = .value(value)
     }
 
     @inlinable public static prefix func !(condition: Condition) -> Condition {

--- a/Sources/ApolloAPI/Selection+Conditions.swift
+++ b/Sources/ApolloAPI/Selection+Conditions.swift
@@ -51,6 +51,14 @@ public extension Selection {
       self = .value(value)
     }
 
+    @inlinable public static func `if`(_ condition: StringLiteralType) -> Condition {
+      .variable(name: condition, inverted: false)
+    }
+
+    @inlinable public static func `if`(_ condition: Condition) -> Condition {
+      condition
+    }
+
     @inlinable public static prefix func !(condition: Condition) -> Condition {
       switch condition {
       case let .value(value):

--- a/Sources/ApolloAPI/Selection+Conditions.swift
+++ b/Sources/ApolloAPI/Selection+Conditions.swift
@@ -32,25 +32,28 @@ public extension Selection {
     }
   }
 
-  struct Condition: ExpressibleByStringLiteral, Hashable {
-    public let variableName: String
-    public let inverted: Bool
+  enum Condition: ExpressibleByStringLiteral, Hashable {
+    case value(Bool)
+    case variable(name: String, inverted: Bool)
 
     public init(
       variableName: String,
       inverted: Bool
     ) {
-      self.variableName = variableName
-      self.inverted = inverted;
+      self = .variable(name: variableName, inverted: inverted)
     }
 
     public init(stringLiteral value: StringLiteralType) {
-      self.variableName = value
-      self.inverted = false
+      self = .variable(name: value, inverted: false)
     }
 
-    @inlinable public static prefix func !(value: Condition) -> Condition {
-      .init(variableName: value.variableName, inverted: !value.inverted)
+    @inlinable public static prefix func !(condition: Condition) -> Condition {
+      switch condition {
+      case let .value(value):
+        return .value(!value)
+      case let .variable(name, inverted):
+        return .init(variableName: name, inverted: !inverted)
+      }
     }
 
     @inlinable public static func &&(_ lhs: Condition, rhs: Condition) -> [Condition] {
@@ -103,19 +106,24 @@ fileprivate extension Array where Element == Selection.Condition {
 // MARK: Conditions - Individual
 fileprivate extension Selection.Condition {
   func evaluate(with variables: GraphQLOperation.Variables?) -> Bool {
-    switch variables?[variableName] {
-    case let boolValue as Bool:
-      return inverted ? !boolValue : boolValue
+    switch self {
+    case let .value(value):
+      return value
+    case let .variable(variableName, inverted):
+      switch variables?[variableName] {
+      case let boolValue as Bool:
+        return inverted ? !boolValue : boolValue
 
-    case let nullable as GraphQLNullable<Bool>:
-      let evaluated = nullable.unwrapped ?? false
-      return inverted ? !evaluated : evaluated
+      case let nullable as GraphQLNullable<Bool>:
+        let evaluated = nullable.unwrapped ?? false
+        return inverted ? !evaluated : evaluated
 
-    case .none:
-      return false
+      case .none:
+        return false
 
-    case let .some(wrapped):
-      fatalError("Expected Bool for \(variableName), got \(wrapped)")
+      case let .some(wrapped):
+        fatalError("Expected Bool for \(variableName), got \(wrapped)")
+      }
     }
   }
 }

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -4,9 +4,9 @@ public enum Selection {
   /// A single field selection.
   case field(Field)
   /// A fragment spread of a named fragment definition.
-  case fragment(any Fragment.Type, deferred: Bool = false)
+  case fragment(any Fragment.Type, deferred: Condition? = nil)
   /// An inline fragment with a child selection set nested in a parent selection set.
-  case inlineFragment(any InlineFragment.Type, deferred: Bool = false)
+  case inlineFragment(any InlineFragment.Type, deferred: Condition? = nil)
   /// A group of selections that have `@include/@skip` directives.
   case conditional(Conditions, [Selection])
 

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -4,9 +4,9 @@ public enum Selection {
   /// A single field selection.
   case field(Field)
   /// A fragment spread of a named fragment definition.
-  case fragment(any Fragment.Type)
+  case fragment(any Fragment.Type, deferred: Bool = false)
   /// An inline fragment with a child selection set nested in a parent selection set.
-  case inlineFragment(any InlineFragment.Type)
+  case inlineFragment(any InlineFragment.Type, deferred: Bool = false)
   /// A group of selections that have `@include/@skip` directives.
   case conditional(Conditions, [Selection])
 
@@ -131,14 +131,13 @@ extension Selection: Hashable {
     switch (lhs, rhs) {
     case let (.field(lhs), .field(rhs)):
       return lhs == rhs
-    case let (.fragment(lhs), .fragment(rhs)):
-      return lhs == rhs
-    case let (.inlineFragment(lhs), .inlineFragment(rhs)):
-      return lhs == rhs
+    case let (.fragment(lhsFragment, lhsDeferred), .fragment(rhsFragment, rhsDeferred)):
+      return lhsFragment == rhsFragment && lhsDeferred == rhsDeferred
+    case let (.inlineFragment(lhsFragment, lhsDeferred), .inlineFragment(rhsFragment, rhsDeferred)):
+      return lhsFragment == rhsFragment && lhsDeferred == rhsDeferred
     case let (.conditional(lhsConditions, lhsSelections),
               .conditional(rhsConditions, rhsSelections)):
-      return lhsConditions == rhsConditions &&
-      lhsSelections == rhsSelections
+      return lhsConditions == rhsConditions && lhsSelections == rhsSelections
     default: return false
     }
   }

--- a/Tests/ApolloTests/SelectionSetTests.swift
+++ b/Tests/ApolloTests/SelectionSetTests.swift
@@ -1629,4 +1629,48 @@ class SelectionSetTests: XCTestCase {
     expect(actual.names?[2]).to(equal("Leia"))
   }
 
+  // MARK: Condition Tests
+
+  func test__condition__givenStringLiteral_initializesVariableCase() {
+    let condition: Selection.Condition = "filter"
+    let expected: Selection.Condition = .variable(name: "filter", inverted: false)
+
+    expect(condition).to(equal(expected))
+  }
+
+  func test__condition__givenInvertedStringLiteral_initializesInvertedVariableCase() {
+    let condition: Selection.Condition = !"filter"
+    let expected: Selection.Condition = .variable(name: "filter", inverted: true)
+
+    expect(condition).to(equal(expected))
+  }
+
+  func test__condition__givenBooleanLiteral_initializesValueCase() {
+    let condition: Selection.Condition = true
+    let expected: Selection.Condition = .value(true)
+
+    expect(condition).to(equal(expected))
+  }
+
+  func test__condition__givenInvertedBooleanLiteral_initializesInvertedValueCase() {
+    let condition: Selection.Condition = !true
+    let expected: Selection.Condition = .value(false)
+
+    expect(condition).to(equal(expected))
+  }
+
+  func test__condition__givenIfConvenienceStringLiteral_initializesVariableCase() {
+    let condition: Selection.Condition = .if("filter")
+    let expected: Selection.Condition = .variable(name: "filter", inverted: false)
+
+    expect(condition).to(equal(expected))
+  }
+
+  func test__condition__givenIfConvenienceInvertedStringLiteral_initializesInvertedVariableCase() {
+    let condition: Selection.Condition = .if(!"filter")
+    let expected: Selection.Condition = .variable(name: "filter", inverted: true)
+
+    expect(condition).to(equal(expected))
+  }
+
 }


### PR DESCRIPTION
Closes #3140 

This covers the work to refactor the `Selection` enum allowed for the `.inlineFragment` and `.fragment` cases to be generated with support for `@defer`.