### PR TITLE
fix: Removing newline characters from operation id hashes

### DIFF
--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -14,7 +14,7 @@ struct OperationManifestItem {
 
     var source = operation.definition.source.convertedToSingleLine()
     for fragment in operation.referencedFragments {
-      source += #"\n\#(fragment.definition.source.convertedToSingleLine())"#
+      source += #" \#(fragment.definition.source.convertedToSingleLine())"#
     }
     self.source = source
   }

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -14,7 +14,7 @@ struct OperationManifestItem {
 
     var source = operation.definition.source.convertedToSingleLine()
     for fragment in operation.referencedFragments {
-      source += #" \#(fragment.definition.source.convertedToSingleLine())"#
+      source += #"\n\#(fragment.definition.source.convertedToSingleLine())"#
     }
     self.source = source
   }

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -169,7 +169,7 @@ class IR {
 
         var newline: String
         for fragment in referencedFragments {
-          newline = #"\n"#
+          newline = "\n"
           updateHash(with: &newline)
           var fragmentSource = fragment.definition.source.convertedToSingleLine()
           updateHash(with: &fragmentSource)

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -167,10 +167,10 @@ class IR {
         var definitionSource = definition.source.convertedToSingleLine()
         updateHash(with: &definitionSource)
 
-        var newline: String
+        var space: String
         for fragment in referencedFragments {
-          newline = #"\n"#
-          updateHash(with: &newline)
+          space = #" "#
+          updateHash(with: &space)
           var fragmentSource = fragment.definition.source.convertedToSingleLine()
           updateHash(with: &fragmentSource)
         }

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -167,10 +167,10 @@ class IR {
         var definitionSource = definition.source.convertedToSingleLine()
         updateHash(with: &definitionSource)
 
-        var space: String
+        var newline: String
         for fragment in referencedFragments {
-          space = #" "#
-          updateHash(with: &space)
+          newline = #"\n"#
+          updateHash(with: &newline)
           var fragmentSource = fragment.definition.source.convertedToSingleLine()
           updateHash(with: &fragmentSource)
         }

--- a/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
@@ -205,7 +205,7 @@ class IROperationBuilderTests: XCTestCase {
     schemaSDL = try String(
       contentsOf: ApolloCodegenInternalTestHelpers.Resources.StarWars.JSONSchema)
 
-    let expected = "07c54599c2b5f9d4215d1bff7f5f6ff458c983aa5c13338fd44b051210d5ecc6"
+    let expected = "b6a91abb9e4ea20f17cfe02ff4b7277bf42c023754dc1ef3fee532d2159a7ba6"
 
     // when
     try buildSubjectOperation(named: "HeroAndFriendsNamesWithFragment", fromJSONSchema: true)

--- a/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
@@ -205,7 +205,7 @@ class IROperationBuilderTests: XCTestCase {
     schemaSDL = try String(
       contentsOf: ApolloCodegenInternalTestHelpers.Resources.StarWars.JSONSchema)
 
-    let expected = "07c54599c2b5f9d4215d1bff7f5f6ff458c983aa5c13338fd44b051210d5ecc6"
+    let expected = "599cd7d91ede7a5508cdb26b424e3b8e99e6c2c5575b799f6090695289ff8e99"
 
     // when
     try buildSubjectOperation(named: "HeroAndFriendsNamesWithFragment", fromJSONSchema: true)

--- a/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IROperationBuilderTests.swift
@@ -205,7 +205,7 @@ class IROperationBuilderTests: XCTestCase {
     schemaSDL = try String(
       contentsOf: ApolloCodegenInternalTestHelpers.Resources.StarWars.JSONSchema)
 
-    let expected = "b6a91abb9e4ea20f17cfe02ff4b7277bf42c023754dc1ef3fee532d2159a7ba6"
+    let expected = "07c54599c2b5f9d4215d1bff7f5f6ff458c983aa5c13338fd44b051210d5ecc6"
 
     // when
     try buildSubjectOperation(named: "HeroAndFriendsNamesWithFragment", fromJSONSchema: true)

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LegacyAPQOperationManifestTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LegacyAPQOperationManifestTemplateTests.swift
@@ -135,7 +135,7 @@ class LegacyAPQOperationManifestTemplateTests: XCTestCase {
 
     let expected = #"""
       {
-        "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154" : {
+        "efc7785ac9768b2be96e061911b97c9c898df41561dda36d9435e94994910f67" : {
           "name": "Friends",
           "source": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }"
         }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LegacyAPQOperationManifestTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LegacyAPQOperationManifestTemplateTests.swift
@@ -135,9 +135,9 @@ class LegacyAPQOperationManifestTemplateTests: XCTestCase {
 
     let expected = #"""
       {
-        "94f106d187262f678c4c9f9c4c4efd26070e0130ccd1c714a35e8f8794fa4eef" : {
+        "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154" : {
           "name": "Friends",
-          "source": "query Friends { friends { ...Name } } fragment Name on Friend { name }"
+          "source": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }"
         }
       }
       """#

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LegacyAPQOperationManifestTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LegacyAPQOperationManifestTemplateTests.swift
@@ -135,9 +135,9 @@ class LegacyAPQOperationManifestTemplateTests: XCTestCase {
 
     let expected = #"""
       {
-        "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154" : {
+        "94f106d187262f678c4c9f9c4c4efd26070e0130ccd1c714a35e8f8794fa4eef" : {
           "name": "Friends",
-          "source": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }"
+          "source": "query Friends { friends { ...Name } } fragment Name on Friend { name }"
         }
       }
       """#

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/PersistedQueriesOperationManifestTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/PersistedQueriesOperationManifestTemplateTests.swift
@@ -155,8 +155,8 @@ class PersistedQueriesOperationManifestTemplateTests: XCTestCase {
         "version": 1,
         "operations": [
           {
-            "id": "94f106d187262f678c4c9f9c4c4efd26070e0130ccd1c714a35e8f8794fa4eef",
-            "body": "query Friends { friends { ...Name } } fragment Name on Friend { name }",
+            "id": "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154",
+            "body": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }",
             "name": "Friends",
             "type": "query"
           }
@@ -207,8 +207,8 @@ class PersistedQueriesOperationManifestTemplateTests: XCTestCase {
         "version": 1,
         "operations": [
           {
-            "id": "94f106d187262f678c4c9f9c4c4efd26070e0130ccd1c714a35e8f8794fa4eef",
-            "body": "query Friends { friends { ...Name } } fragment Name on Friend { name }",
+            "id": "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154",
+            "body": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }",
             "name": "Friends",
             "type": "query"
           }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/PersistedQueriesOperationManifestTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/PersistedQueriesOperationManifestTemplateTests.swift
@@ -155,8 +155,8 @@ class PersistedQueriesOperationManifestTemplateTests: XCTestCase {
         "version": 1,
         "operations": [
           {
-            "id": "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154",
-            "body": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }",
+            "id": "94f106d187262f678c4c9f9c4c4efd26070e0130ccd1c714a35e8f8794fa4eef",
+            "body": "query Friends { friends { ...Name } } fragment Name on Friend { name }",
             "name": "Friends",
             "type": "query"
           }
@@ -207,8 +207,8 @@ class PersistedQueriesOperationManifestTemplateTests: XCTestCase {
         "version": 1,
         "operations": [
           {
-            "id": "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154",
-            "body": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }",
+            "id": "94f106d187262f678c4c9f9c4c4efd26070e0130ccd1c714a35e8f8794fa4eef",
+            "body": "query Friends { friends { ...Name } } fragment Name on Friend { name }",
             "name": "Friends",
             "type": "query"
           }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/PersistedQueriesOperationManifestTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/PersistedQueriesOperationManifestTemplateTests.swift
@@ -155,7 +155,7 @@ class PersistedQueriesOperationManifestTemplateTests: XCTestCase {
         "version": 1,
         "operations": [
           {
-            "id": "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154",
+            "id": "efc7785ac9768b2be96e061911b97c9c898df41561dda36d9435e94994910f67",
             "body": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }",
             "name": "Friends",
             "type": "query"
@@ -207,7 +207,7 @@ class PersistedQueriesOperationManifestTemplateTests: XCTestCase {
         "version": 1,
         "operations": [
           {
-            "id": "8a600240c49d72b1639fb4e41af5305ee0918f2258847eb7a9c1db09813cc154",
+            "id": "efc7785ac9768b2be96e061911b97c9c898df41561dda36d9435e94994910f67",
             "body": "query Friends { friends { ...Name } }\nfragment Name on Friend { name }",
             "name": "Friends",
             "type": "query"


### PR DESCRIPTION
- Updating operation/fragment definition handling to remove newline characters

Closes #3162 