### PR TITLE
feature: Adds request `Accept` header

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -740,6 +740,7 @@
 		E6203344284F1D1100A291D1 /* MockUnionsTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6203343284F1D1100A291D1 /* MockUnionsTemplate.swift */; };
 		E6203346284F252A00A291D1 /* MockUnionsFileGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6203345284F252A00A291D1 /* MockUnionsFileGeneratorTests.swift */; };
 		E6203348284F25DF00A291D1 /* MockUnionsTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6203347284F25DF00A291D1 /* MockUnionsTemplateTests.swift */; };
+		E6207AF72A78503A00DF7DF7 /* MultipartResponseDeferParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207AF62A78503A00DF7DF7 /* MultipartResponseDeferParser.swift */; };
 		E623FD2A2797A6F4008B4CED /* InterfaceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */; };
 		E63F0C0328EE0F2A009069EA /* ApolloCodegenFrontendBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F0C0028EE099A009069EA /* ApolloCodegenFrontendBundle.swift */; };
 		E64F226D28B8B3FE0011292F /* LogLevelSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64F226C28B8B3FE0011292F /* LogLevelSetter.swift */; };
@@ -1927,6 +1928,7 @@
 		E6203343284F1D1100A291D1 /* MockUnionsTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUnionsTemplate.swift; sourceTree = "<group>"; };
 		E6203345284F252A00A291D1 /* MockUnionsFileGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUnionsFileGeneratorTests.swift; sourceTree = "<group>"; };
 		E6203347284F25DF00A291D1 /* MockUnionsTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUnionsTemplateTests.swift; sourceTree = "<group>"; };
+		E6207AF62A78503A00DF7DF7 /* MultipartResponseDeferParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartResponseDeferParser.swift; sourceTree = "<group>"; };
 		E623FD292797A6F4008B4CED /* InterfaceTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplate.swift; sourceTree = "<group>"; };
 		E623FD2B2797A700008B4CED /* InterfaceTemplateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceTemplateTests.swift; sourceTree = "<group>"; };
 		E63F0C0028EE099A009069EA /* ApolloCodegenFrontendBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApolloCodegenFrontendBundle.swift; sourceTree = "<group>"; };
@@ -2481,6 +2483,7 @@
 				9B260C09245A532500562176 /* JSONResponseParsingInterceptor.swift */,
 				E69F437129BBD958006FF548 /* MultipartResponseParsingInterceptor.swift */,
 				E656047A2A5F2AAD006692A3 /* MultipartResponseSubscriptionParser.swift */,
+				E6207AF62A78503A00DF7DF7 /* MultipartResponseDeferParser.swift */,
 				9B9BBAF424DB4F890021C30F /* AutomaticPersistedQueryInterceptor.swift */,
 				9BC742AD24CFB6450029282C /* CacheWriteInterceptor.swift */,
 			);
@@ -5525,6 +5528,7 @@
 				9FA6F3681E65DF4700BF8D73 /* GraphQLResultAccumulator.swift in Sources */,
 				9FF90A651DDDEB100034C3B6 /* GraphQLExecutor.swift in Sources */,
 				9BDE43DF22C6708600FD7C7F /* GraphQLHTTPRequestError.swift in Sources */,
+				E6207AF72A78503A00DF7DF7 /* MultipartResponseDeferParser.swift in Sources */,
 				9B1CCDD92360F02C007C9032 /* Bundle+Helpers.swift in Sources */,
 				9B260BF5245A028D00562176 /* HTTPResponse.swift in Sources */,
 				5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */,

--- a/Sources/Apollo/MultipartResponseDeferParser.swift
+++ b/Sources/Apollo/MultipartResponseDeferParser.swift
@@ -1,0 +1,17 @@
+import Foundation
+#if !COCOAPODS
+import ApolloAPI
+#endif
+
+struct MultipartResponseDeferParser: MultipartResponseSpecificationParser {
+  static let protocolSpec: String = "deferSpec=20220824"
+
+  static func parse(
+    data: Data,
+    boundary: String,
+    dataHandler: ((Data) -> Void),
+    errorHandler: ((Error) -> Void)
+  ) {
+    // TODO: Will be implemented in #3146
+  }
+}

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -83,7 +83,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
     cachePolicy: CachePolicy,
     contextIdentifier: UUID? = nil
   ) -> HTTPRequest<Operation> {
-    var request = JSONRequest(
+    let request = JSONRequest(
       operation: operation,
       graphQLEndpoint: self.endpointURL,
       contextIdentifier: contextIdentifier,

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -69,7 +69,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
     self.useGETForPersistedQueryRetry = useGETForPersistedQueryRetry
   }
   
-  /// Constructs a default (ie, non-multipart) GraphQL request.
+  /// Constructs a GraphQL request for the given operation.
   ///
   /// Override this method if you need to use a custom subclass of `HTTPRequest`.
   ///
@@ -81,18 +81,37 @@ open class RequestChainNetworkTransport: NetworkTransport {
   open func constructRequest<Operation: GraphQLOperation>(
     for operation: Operation,
     cachePolicy: CachePolicy,
-    contextIdentifier: UUID? = nil) -> HTTPRequest<Operation> {
-    JSONRequest(operation: operation,
-                graphQLEndpoint: self.endpointURL,
-                contextIdentifier: contextIdentifier,
-                clientName: self.clientName,
-                clientVersion: self.clientVersion,
-                additionalHeaders: self.additionalHeaders,
-                cachePolicy: cachePolicy,
-                autoPersistQueries: self.autoPersistQueries,
-                useGETForQueries: self.useGETForQueries,
-                useGETForPersistedQueryRetry: self.useGETForPersistedQueryRetry,
-                requestBodyCreator: self.requestBodyCreator)
+    contextIdentifier: UUID? = nil
+  ) -> HTTPRequest<Operation> {
+    var request = JSONRequest(
+      operation: operation,
+      graphQLEndpoint: self.endpointURL,
+      contextIdentifier: contextIdentifier,
+      clientName: self.clientName,
+      clientVersion: self.clientVersion,
+      additionalHeaders: self.additionalHeaders,
+      cachePolicy: cachePolicy,
+      autoPersistQueries: self.autoPersistQueries,
+      useGETForQueries: self.useGETForQueries,
+      useGETForPersistedQueryRetry: self.useGETForPersistedQueryRetry,
+      requestBodyCreator: self.requestBodyCreator
+    )
+
+    if Operation.operationType == .subscription {
+      request.addHeader(
+        name: "Accept",
+        value: "multipart/mixed;boundary=\"graphql\";\(MultipartResponseSubscriptionParser.protocolSpec),application/json"
+      )
+    }
+
+    if Operation.hasDeferredFragments {
+      request.addHeader(
+        name: "Accept",
+        value: "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json"
+      )
+    }
+
+    return request
   }
   
   // MARK: - NetworkTransport Conformance
@@ -108,16 +127,10 @@ open class RequestChainNetworkTransport: NetworkTransport {
     completionHandler: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) -> Cancellable {
     
     let chain = makeChain(operation: operation, callbackQueue: callbackQueue)
-    let request = self.constructRequest(for: operation,
-                                        cachePolicy: cachePolicy,
-                                        contextIdentifier: contextIdentifier)
-
-    if Operation.operationType == .subscription {
-      request.addHeader(
-        name: "Accept",
-        value: "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0,application/json"
-      )
-    }
+    let request = self.constructRequest(
+      for: operation,
+      cachePolicy: cachePolicy,
+      contextIdentifier: contextIdentifier)
     
     chain.kickoff(request: request, completion: completionHandler)
     return chain

--- a/Sources/Apollo/RequestChainNetworkTransport.swift
+++ b/Sources/Apollo/RequestChainNetworkTransport.swift
@@ -107,7 +107,7 @@ open class RequestChainNetworkTransport: NetworkTransport {
     if Operation.hasDeferredFragments {
       request.addHeader(
         name: "Accept",
-        value: "multipart/mixed;\(MultipartResponseDeferParser.protocolSpec),application/json"
+        value: "multipart/mixed;boundary=\"graphql\";\(MultipartResponseDeferParser.protocolSpec),application/json"
       )
     }
 

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -59,6 +59,7 @@ public protocol GraphQLOperation: AnyObject, Hashable {
   static var operationName: String { get }
   static var operationType: GraphQLOperationType { get }
   static var operationDocument: OperationDocument { get }
+  static var hasDeferredFragments: Bool { get }
 
   var __variables: Variables? { get }
 
@@ -68,6 +69,10 @@ public protocol GraphQLOperation: AnyObject, Hashable {
 public extension GraphQLOperation {
   var __variables: Variables? {
     return nil
+  }
+
+  static var hasDeferredFragments: Bool {
+    false
   }
 
   static var definition: OperationDefinition? {

--- a/Tests/ApolloInternalTestHelpers/MockOperation.swift
+++ b/Tests/ApolloInternalTestHelpers/MockOperation.swift
@@ -5,6 +5,8 @@ open class MockOperation<SelectionSet: RootSelectionSet>: GraphQLOperation {
 
   open class var operationType: GraphQLOperationType { .query }
 
+  open class var hasDeferredFragments: Bool { false }
+
   open class var operationName: String { "MockOperationName" }
 
   open class var operationDocument: OperationDocument {
@@ -38,6 +40,16 @@ open class MockSubscription<SelectionSet: RootSelectionSet>: MockOperation<Selec
 
   public static func mock() -> MockSubscription<MockSelectionSet> where SelectionSet == MockSelectionSet {
     MockSubscription<MockSelectionSet>()
+  }
+}
+
+open class MockDeferredQuery<SelectionSet: RootSelectionSet>: MockOperation<SelectionSet>, GraphQLQuery {
+
+  public override class var operationType: GraphQLOperationType { .query }
+  public override class var hasDeferredFragments: Bool { true }
+
+  public static func mock() -> MockDeferredQuery<MockSelectionSet> where SelectionSet == MockSelectionSet {
+    MockDeferredQuery<MockSelectionSet>()
   }
 }
 


### PR DESCRIPTION
Closes #3143 
Related to #3146 (introduces the `MultipartResponseDeferParser`)

This PR ensures that when an operation is recognized as having deferred fragments the request automatically has the correct `Accept` HTTP header set to specify a multipart response and one that matches the currently configured defer spec parser.