### PR TITLE
Fix merged selection set name ambiguity at definition root

### DIFF
--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsIncludeSkipQuery.graphql.swift
@@ -692,7 +692,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
               ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.self),
               ObjectIdentifier(WarmBloodedDetails.self),
               ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
-              ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self),
               ObjectIdentifier(HeightInMeters.self)
             ]
           ))
@@ -853,7 +852,6 @@ public class AllAnimalsIncludeSkipQuery: GraphQLQuery {
                 ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.self),
                 ObjectIdentifier(WarmBloodedDetails.self),
                 ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
-                ObjectIdentifier(AllAnimalsIncludeSkipQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self),
                 ObjectIdentifier(HeightInMeters.self)
               ]
             ))

--- a/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
+++ b/Sources/AnimalKingdomAPI/AnimalKingdomAPI/Sources/Operations/Queries/AllAnimalsQuery.graphql.swift
@@ -625,8 +625,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
               ObjectIdentifier(PetDetails.self),
               ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
-              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
-              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self)
             ]
           ))
         }
@@ -822,8 +821,7 @@ public class AllAnimalsQuery: GraphQLQuery {
                 ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
                 ObjectIdentifier(PetDetails.self),
                 ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
-                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
-                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self)
+                ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self)
               ]
             ))
           }
@@ -936,8 +934,7 @@ public class AllAnimalsQuery: GraphQLQuery {
               ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsWarmBlooded.self),
               ObjectIdentifier(PetDetails.self),
               ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.self),
-              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self),
-              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.AsWarmBlooded.self)
+              ObjectIdentifier(AllAnimalsQuery.Data.AllAnimal.AsPet.AsWarmBlooded.self)
             ]
           ))
         }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -647,6 +647,14 @@ fileprivate extension IR.MergedSelections.MergedSource {
       nodesToSharedRoot += 1
     }
 
+    /// If the shared root is the root of the definition, we should just generate the fully
+    /// qualified name.
+    if sourceTypePathCurrentNode.isHead {
+      return SelectionSetNameGenerator.generatedSelectionSetName(
+        for: self, format: .fullyQualified, pluralizer: pluralizer
+      )
+    }
+
     let sharedRootIndex =
       typeInfo.entity.location.fieldPath!.count - (nodesToSharedRoot + 1)
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -665,11 +665,7 @@ fileprivate extension IR.MergedSelections.MergedSource {
     ///
     /// Example: The `height` field on `AllAnimals.AsPet` can reference the `AllAnimals.Height`
     /// object as just `Height`.
-    ///
-    /// However, if the shared root is the root of the definition, the component that would be
-    /// removed is the location's `source`. This is not included in the field path and is already
-    /// omitted by this function. In this case, the `sharedRootIndex` is `-1`.
-    let removeFirstComponent = nodesToSharedRoot <= 1 && !(sharedRootIndex < 0)
+    let removeFirstComponent = nodesToSharedRoot <= 1
 
     let fieldPath = typeInfo.entity.location.fieldPath!.node(
       at: max(0, sharedRootIndex)

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -732,7 +732,7 @@ fileprivate extension IR.MergedSelections.MergedSource {
         mergedFragmentEntityConditionPathNode = node
       }
       selectionSetNameComponents.append(
-        SelectionSetNameGenerator.ConditionPath.path(for: node)
+        node.value.selectionSetNameComponent
       )
       fulfilledFragments.append(selectionSetNameComponents.joined(separator: "."))
     }

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -3667,7 +3667,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
-  func test__render_fieldAccessors__givenEntityFieldMergedFromParent_atOperationRoot_rendersFieldAccessorWithNameNotIncludingParent() throws {
+  func test__render_fieldAccessors__givenEntityFieldMergedFromParent_atOperationRoot_rendersFieldAccessorWithFullyQualifiedName() throws {
     // given
     schemaSDL = """
     type Query {
@@ -3696,7 +3696,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public var name: String { __data["name"] }
-      public var allAnimals: [AllAnimal]? { __data["allAnimals"] }
+      public var allAnimals: [TestOperationQuery.Data.AllAnimal]? { __data["allAnimals"] }
     """
 
     // when
@@ -3767,7 +3767,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
   }
 
-  func test__render_fieldAccessors__givenEntityFieldMergedFromSiblingTypeCase_atOperationRoot_rendersFieldAccessorWithNotIncludingSharedParent() throws {
+  func test__render_fieldAccessors__givenEntityFieldMergedFromSiblingTypeCase_atOperationRoot_rendersFieldAccessorWithFullyQualifiedName() throws {
     // given
     schemaSDL = """
     type Query {
@@ -3803,7 +3803,7 @@ class SelectionSetTemplateTests: XCTestCase {
 
     let expected = """
       public var name: String { __data["name"] }
-      public var allAnimals: [AsModeratorQuery.AllAnimal]? { __data["allAnimals"] }
+      public var allAnimals: [TestOperationQuery.Data.AsModeratorQuery.AllAnimal]? { __data["allAnimals"] }
     """
 
     // when

--- a/Tests/CodegenIntegrationTests/Tests/3168-mergedSourceFromDefinitionRootNeedsFullyQualifedName/README.MD
+++ b/Tests/CodegenIntegrationTests/Tests/3168-mergedSourceFromDefinitionRootNeedsFullyQualifedName/README.MD
@@ -1,0 +1,16 @@
+# Overview
+
+When merging a selection set with a nested child selection set into a type case that does not also select additional fields on that child selection set, we use a direct reference to the generated selection set in the defining entity selection set. This directly merged child selection set is referenced by its name relative to the type case.
+
+To calculate the relative name, we determine where the shared root between the definition of the merged child and the target it is being merged into was, and generated the name as only up to their shared root. When the shared root of the directly merged child is the root of the operation, this causes a naming ambiguity problem and a compliation error.
+
+We must use the fully qualified name in this situation.
+
+In the example for this test, the `innerChild` field on `AsEventA.Child.AsChildA` would previously have the
+type `Child.AsChildA.InnerChild`, which does not exist, because the first component (`Child`) was inferred to be the `AsEventA.Child`. The intention was to point to the `TestFragment.Child.AsChildA.InnerChild`.  
+
+## Reference Issue: https://github.com/apollographql/apollo-ios/pull/3168
+
+## Solution
+
+When the shared root for a directly merged source is the definition root, use the fully qualified selection set name.

--- a/Tests/CodegenIntegrationTests/Tests/3168-mergedSourceFromDefinitionRootNeedsFullyQualifedName/operation.graphql
+++ b/Tests/CodegenIntegrationTests/Tests/3168-mergedSourceFromDefinitionRootNeedsFullyQualifedName/operation.graphql
@@ -1,0 +1,15 @@
+fragment TestFragment on Event {
+  child {
+    ... on ChildA {
+      innerChild: child {
+        foo
+      }
+    }
+  }
+  ... on EventA {
+    bar
+  }
+  ... on EventB {
+    baz
+  }
+}

--- a/Tests/CodegenIntegrationTests/Tests/3168-mergedSourceFromDefinitionRootNeedsFullyQualifedName/schema.graphqls
+++ b/Tests/CodegenIntegrationTests/Tests/3168-mergedSourceFromDefinitionRootNeedsFullyQualifedName/schema.graphqls
@@ -1,0 +1,27 @@
+type Query {
+  test: Event!
+}
+
+interface Event {
+  child: Child!
+}
+
+type EventA implements Event {
+  child: Child!
+  bar: String!
+}
+
+type EventB implements Event {
+  child: Child!
+  baz: String!
+}
+
+interface Child {
+  foo: String!
+  child: Child
+}
+
+type ChildA implements Child {
+  foo: String!
+  child: Child
+}


### PR DESCRIPTION
When merging a selection set with a nested child selection set into a type case that does not also select additional fields on that child selection set, we use a direct reference to the generated selection set in the defining entity selection set. This directly merged child selection set is referenced by its name relative to the type case.

To calculate the relative name, we determine where the shared root between the definition of the merged child and the target it is being merged into was, and generated the name as only up to their shared root. When the shared root of the directly merged child is the root of the operation, this causes a naming ambiguity problem and a compliation error.

We must use the fully qualified name in this situation.

In the example for this test, the `innerChild` field on `AsEventA.Child.AsChildA` would previously have the
type `Child.AsChildA.InnerChild`, which does not exist, because the first component (`Child`) was inferred to be the `AsEventA.Child`. The intention was to point to the `TestFragment.Child.AsChildA.InnerChild`.  