### PR TITLE
docs: Clarify `other` schema module type

### DIFF
--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -266,13 +266,13 @@ let configuration = ApolloCodegenConfiguration(
 
 **[`ModuleType.other`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/schematypesfileoutput/moduletype-swift.enum/other)**
 
-This option should be used when you would like to define a schema module using another package management system, such as CocoaPods, or manually creating Xcode targets.
+This value should be used when you would like to define a schema module using another package management system (such as CocoaPods), or you want more control over the generated package than what [`ModuleType.swiftPackageManager`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/schematypesfileoutput/moduletype-swift.enum/swiftpackagemanager) allows, or manually creating your own targets or modules in another way.
 
 `ModuleType.other` indicates to the Code Generation Engine that your schema types will be contained in their own target, rather than embedded in your application target. This affects the `import` statements in your generated operation definition files.
 
-Using this option, you are required to create a target for your schema module using your preferred package manager.
+Using this option, you are required to create a target, or module, for your schema module using your preferred package manager.
 
-> **Note:** The name of the target for your schema module must be the [`schemaNamespace`](#schema-namespace) provided in your configuration, as this will be used in the `import` statements of generated operation files.
+> **Note:** You must specify the name of the target, or module, you created in the [`schemaNamespace`](#schema-namespace) property of your configuration. This will be used for `import` statements as well as to fully qualify the referenced types in generated operation files.
 
 <MultiCodeBlock>
 

--- a/docs/source/project-configuration.mdx
+++ b/docs/source/project-configuration.mdx
@@ -93,9 +93,11 @@ Use the [`.swiftPackageManager`](./code-generation/codegen-configuration#swift-p
 
 You can also include schema types directly in a target that you created.
 
-To do this, use [`ModuleType.embeddedInTarget(name: String)`](./code-generation/codegen-configuration#embedded-in-target) as the value of the [`output.schemaTypes.moduleType`](./code-generation/codegen-configuration#module-type) property. The generated schema types are then enclosed in a caseless namespace enum to prevent naming conflicts with types you already defined in your target.
+To do this, use [`ModuleType.embeddedInTarget(name: String)`](./code-generation/codegen-configuration#embedded-in-target) as the value of the [`output.schemaTypes.moduleType`](./code-generation/codegen-configuration#module-type) property. The generated schema types are scoped within a caseless enum used as a namespace to prevent conflicts with types you may already have defined in your target.
 
-> This option makes you responsible for **manually** adding generated files to your chosen target. When the code generation engine creates or removes files, you'll need to manually add or remove them from Xcode's project navigator.
+If you require more control over your schema types you can use the [`ModuleType.other`](./code-generation/codegen-configuration#other) value. This gives you full control over the module and your choice of dependency manager.
+
+> These options makes you responsible for **manually** adding generated files to your chosen target or module. When the code generation engine creates or removes files, you'll need to manually add or remove them from the project navigator.
 
 ### Operation model generation
 


### PR DESCRIPTION
I've tried to add clarity to the `other` schema module type as a result of feedback in https://github.com/apollographql/apollo-ios/issues/3164. Let me know if you think we're going in the wrong direction here.