### PR TITLE
feature: Add support for field casing strategy to code gen

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */; };
 		5BB2C0232380836100774170 /* VersionNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2C0222380836100774170 /* VersionNumberTests.swift */; };
+		6608B3362A7D402B006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6608B3342A7D3FF5006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift */; };
 		662EA65E2A701483008A1931 /* GenerateOperationManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662EA65D2A701483008A1931 /* GenerateOperationManifest.swift */; };
 		662EA6602A705BD7008A1931 /* GenerateOperationManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662EA65F2A705BD7008A1931 /* GenerateOperationManifestTests.swift */; };
 		66321AE72A126C4400CC35CB /* IR+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66321AE62A126C4400CC35CB /* IR+Formatting.swift */; };
@@ -1140,6 +1141,7 @@
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
 		5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPMethod.swift; sourceTree = "<group>"; };
 		5BB2C0222380836100774170 /* VersionNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionNumberTests.swift; sourceTree = "<group>"; };
+		6608B3342A7D3FF5006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApolloCodegenConfiguration+OperationManifestConfiguration.swift"; sourceTree = "<group>"; };
 		662EA65D2A701483008A1931 /* GenerateOperationManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateOperationManifest.swift; sourceTree = "<group>"; };
 		662EA65F2A705BD7008A1931 /* GenerateOperationManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateOperationManifestTests.swift; sourceTree = "<group>"; };
 		66321AE62A126C4400CC35CB /* IR+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+Formatting.swift"; sourceTree = "<group>"; };
@@ -2206,6 +2208,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6608B3332A7D3FCB006FB655 /* CodegenConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				6608B3342A7D3FF5006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift */,
+			);
+			path = CodegenConfiguration;
+			sourceTree = "<group>";
+		};
 		66B18E862A15366400525DFB /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -2548,6 +2558,7 @@
 		9BD681332405F6BB000874CB /* Codegen */ = {
 			isa = PBXGroup;
 			children = (
+				6608B3332A7D3FCB006FB655 /* CodegenConfiguration */,
 				9B7B6F57233C287100F32205 /* ApolloCodegen.swift */,
 				9B7B6F58233C287100F32205 /* ApolloCodegenConfiguration.swift */,
 				E674DB40274C0A9B009BB90E /* Glob.swift */,
@@ -5053,6 +5064,7 @@
 				E6203342284F1C9600A291D1 /* MockUnionsFileGenerator.swift in Sources */,
 				DE6D07F927BC3B6D009F5F33 /* GraphQLInputField+Rendered.swift in Sources */,
 				9F1A966C258F34BB00A06EEB /* GraphQLSchema.swift in Sources */,
+				6608B3362A7D402B006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				E64F7EBC27A11A510059C021 /* GraphQLNamedType+SwiftName.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -292,10 +292,10 @@ public class ApolloCodegen {
       )
     }
     
-    var fragments: [IR.NamedFragment] = selectionSet.selections.direct?.fragments.values.map { $0.fragment } ?? []
-    fragments.append(contentsOf: selectionSet.selections.merged.fragments.values.map { $0.fragment })
+    var namedFragments: [IR.NamedFragment] = selectionSet.selections.direct?.namedFragments.values.map(\.fragment) ?? []
+    namedFragments.append(contentsOf: selectionSet.selections.merged.namedFragments.values.map(\.fragment))
     
-    try fragments.forEach { fragment in
+    try namedFragments.forEach { fragment in
       if let existingTypeName = combinedTypeNames[fragment.generatedDefinitionName] {
         throw Error.typeNameConflict(
           name: existingTypeName,
@@ -305,9 +305,9 @@ public class ApolloCodegen {
       }
     }
     
-    // gather nested fragments to loop through and check as well
-    var nestedSelectionSets: [IR.SelectionSet] = selectionSet.selections.direct?.inlineFragments.values.elements ?? []
-    nestedSelectionSets.append(contentsOf: selectionSet.selections.merged.inlineFragments.values)
+    // gather nested fragments to loop through and check as well    
+    var nestedSelectionSets: [IR.SelectionSet] = selectionSet.selections.direct?.inlineFragments.values.map(\.selectionSet) ?? []
+    nestedSelectionSets.append(contentsOf: selectionSet.selections.merged.inlineFragments.values.map(\.selectionSet))
     
     try nestedSelectionSets.forEach { nestedSet in
       try validateTypeConflicts(

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -668,20 +668,31 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// cases on the generated Swift enums.
     /// Defaultss to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
     public let enumCases: CaseConversionStrategy
+    
+    /// Determines how the names of fields in the GraphQL schema will be converted into
+    /// properties in the generated Swift code.
+    /// Defaultss to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
+    public let fieldCasing: CaseConversionStrategy
 
     /// Default property values
     public struct Default {
       public static let enumCases: CaseConversionStrategy = .camelCase
+      public static let fieldCasing: CaseConversionStrategy = .camelCase
     }
 
-    public init(enumCases: CaseConversionStrategy = Default.enumCases) {
+    public init(
+      enumCases: CaseConversionStrategy = Default.enumCases,
+      fieldCasing: CaseConversionStrategy = Default.fieldCasing
+    ) {
       self.enumCases = enumCases
+      self.fieldCasing = fieldCasing
     }
 
     // MARK: Codable
 
     public enum CodingKeys: CodingKey {
       case enumCases
+      case fieldCasing
     }
 
     public init(from decoder: Decoder) throws {
@@ -698,6 +709,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         CaseConversionStrategy.self,
         forKey: .enumCases
       ) ?? Default.enumCases
+      
+      fieldCasing = try values.decodeIfPresent(
+        CaseConversionStrategy.self,
+        forKey: .fieldCasing
+      ) ?? Default.fieldCasing
     }
   }
   

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -651,24 +651,13 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     case exclude
   }
 
-  /// ``CaseConversionStrategy`` is used to specify the strategy used to convert the casing of
-  /// GraphQL schema values into generated Swift code.
-  @available(*, deprecated, message: "Use EnumCaseConversionStrategy instead.")
-    public enum CaseConversionStrategy: String, Codable, Equatable {
-      /// Generates swift code using the exact name provided in the GraphQL schema
-      /// performing no conversion.
-      case none
-      /// Convert to lower camel case from `snake_case`, `UpperCamelCase`, or `UPPERCASE`.
-      case camelCase
-  }
-
   /// ``ConversionStrategies`` configures rules for how to convert the names of values from the
   /// schema in generated code.
   public struct ConversionStrategies: Codable, Equatable {
 
     /// ``ApolloCodegenConfiguration/ConversionStrategies/EnumCase`` is used to specify the strategy
     /// used to convert the casing of enum cases in a GraphQL schema into generated Swift code.
-    public enum EnumCase: String, Codable, Equatable {
+    public enum EnumCases: String, Codable, Equatable {
       /// Generates swift code using the exact name provided in the GraphQL schema
       /// performing no conversion.
       case none
@@ -676,10 +665,10 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case camelCase
     }
 
-    /// ``ApolloCodegenConfiguration/ConversionStrategies/FieldAccessor`` is used to specify the
+    /// ``ApolloCodegenConfiguration/ConversionStrategies/FieldAccessors`` is used to specify the
     /// strategy used to convert the casing of fields on GraphQL selection sets into field accessors
     /// on the response models in generated Swift code.
-    public enum FieldAccessor: String, Codable, Equatable {
+    public enum FieldAccessors: String, Codable, Equatable {
       /// This conversion strategy will:
       /// - Lowercase the first letter of all fields.
       /// - Convert field names that are all `UPPERCASE` to all `lowercase`.
@@ -693,45 +682,32 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// Determines how the names of enum cases in the GraphQL schema will be converted into
     /// cases on the generated Swift enums.
     /// Defaultss to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
-    public let enumCases: EnumCase
+    public let enumCases: EnumCases
     
     /// Determines how the names of fields in the GraphQL schema will be converted into
     /// properties in the generated Swift code.
     /// Defaults to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
-    public let fieldAccessor: FieldAccessor
+    public let fieldAccessors: FieldAccessors
 
     /// Default property values
     public struct Default {
-      public static let enumCases: EnumCase = .camelCase
-      public static let fieldAccessor: FieldAccessor = .idiomatic
-    }
-
-    @available(*, deprecated, renamed: "init(enumCases:fieldAccessor:)")
-    public init(
-      enumCases: CaseConversionStrategy
-    ) {
-      switch enumCases {
-      case .none:
-        self.enumCases = .none
-      case .camelCase:
-        self.enumCases = .camelCase
-      }
-      self.fieldAccessor = Default.fieldAccessor
+      public static let enumCases: EnumCases = .camelCase
+      public static let fieldAccessors: FieldAccessors = .idiomatic
     }
       
     public init(
-      enumCases: EnumCase = Default.enumCases,
-      fieldAccessor: FieldAccessor = Default.fieldAccessor
+      enumCases: EnumCases = Default.enumCases,
+      fieldAccessors: FieldAccessors = Default.fieldAccessors
     ) {
       self.enumCases = enumCases
-      self.fieldAccessor = fieldAccessor
+      self.fieldAccessors = fieldAccessors
     }
 
     // MARK: Codable
 
     public enum CodingKeys: CodingKey {
       case enumCases
-      case fieldAccessor
+      case fieldAccessors
     }
 
     public init(from decoder: Decoder) throws {
@@ -756,15 +732,15 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         }
       } else {
         enumCases = try values.decodeIfPresent(
-          EnumCase.self,
+          EnumCases.self,
           forKey: .enumCases
         ) ?? Default.enumCases
       }
       
-      fieldAccessor = try values.decodeIfPresent(
-        FieldAccessor.self,
-        forKey: .fieldAccessor
-      ) ?? Default.fieldAccessor
+      fieldAccessors = try values.decodeIfPresent(
+        FieldAccessors.self,
+        forKey: .fieldAccessors
+      ) ?? Default.fieldAccessors
     }
   }
   
@@ -1461,6 +1437,34 @@ extension ApolloCodegenConfiguration.OutputOptions {
     @available(*, deprecated, message: "Query strings are now always in single line format.")
     case multiline
   }
+}
+
+extension ApolloCodegenConfiguration.ConversionStrategies {
+  
+  @available(*, deprecated, renamed: "init(enumCases:fieldAccessors:)")
+  public init(
+    enumCases: CaseConversionStrategy
+  ) {
+    switch enumCases {
+    case .none:
+      self.enumCases = .none
+    case .camelCase:
+      self.enumCases = .camelCase
+    }
+    self.fieldAccessors = Default.fieldAccessors
+  }
+  
+  /// ``CaseConversionStrategy`` is used to specify the strategy used to convert the casing of
+  /// GraphQL schema values into generated Swift code.
+  @available(*, deprecated, message: "Use EnumCaseConversionStrategy instead.")
+    public enum CaseConversionStrategy: String, Codable, Equatable {
+      /// Generates swift code using the exact name provided in the GraphQL schema
+      /// performing no conversion.
+      case none
+      /// Convert to lower camel case from `snake_case`, `UpperCamelCase`, or `UPPERCASE`.
+      case camelCase
+  }
+  
 }
 
 private struct AnyCodingKey: CodingKey {

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -697,7 +697,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     
     /// Determines how the names of fields in the GraphQL schema will be converted into
     /// properties in the generated Swift code.
-    /// Defaultss to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
+    /// Defaults to ``ApolloCodegenConfiguration/CaseConversionStrategy/camelCase``
     public let fieldAccessor: FieldAccessor
 
     /// Default property values

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -654,11 +654,28 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// ``CaseConversionStrategy`` is used to specify the strategy used to convert the casing of
   /// GraphQL schema values into generated Swift code.
   public enum CaseConversionStrategy: String, Codable, Equatable {
-    /// Generates swift code using the exact name provided in the GraphQL schema
-    /// performing no conversion.
+    @available(*, deprecated, message: "`none` casing strategy has been renamed to `default`")
     case none
+    /// Generates swift code using a default casing strategy determined based on the type of code
+    /// being generated.
+    ///
+    /// For enums, this will render as provided in the GraphQL schema and will escape certina reserved keywords.
+    ///
+    /// For fields, this will convert all uppercase names to all lowercase, otherwise it will lower case the first letter. As well
+    /// as escaping reserved keywords.
+    case `default`
     /// Convert to lower camel case from `snake_case`, `UpperCamelCase`, or `UPPERCASE`.
     case camelCase
+    
+    var isDefault: Bool {
+      switch self {
+      case .none,
+           .`default`:
+        return true
+      default:
+        return false
+      }
+    }
   }
 
   /// ``ConversionStrategies`` configures rules for how to convert the names of values from the
@@ -677,7 +694,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// Default property values
     public struct Default {
       public static let enumCases: CaseConversionStrategy = .camelCase
-      public static let fieldCasing: CaseConversionStrategy = .camelCase
+      public static let fieldCasing: CaseConversionStrategy = .default
     }
 
     public init(

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -739,7 +739,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       guard values.allKeys.first != nil else {
         throw DecodingError.typeMismatch(Self.self, DecodingError.Context.init(
           codingPath: values.codingPath,
-          debugDescription: "Invalid number of keys found, expected one.",
+          debugDescription: "Invalid value found.",
           underlyingError: nil
         ))
       }

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension ApolloCodegenConfiguration {
+  
+  public struct OperationManifestConfiguration: Codable, Equatable {
+    
+    // MARK: - Properties
+    
+    /// Local path where the generated operation manifest file should be written.
+    public let path: String
+    /// The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
+    public let version: Version
+
+    public enum Version: String, Codable, Equatable {
+      /// Generates an operation manifest for use with persisted queries.
+      case persistedQueries
+      /// Generates an operation manifest in the legacy safelisting format used prior to the
+      /// [Persisted Queries](https://www.apollographql.com/docs/ios/fetching/persisted-queries) feature.
+      case legacy
+    }
+    
+    /// If set to `true` will generate the operation manifest every time code generation is run. Defaults to `false`
+    public let generateManifestOnCodeGeneration: Bool
+    
+    /// Default property values
+    public struct Default {
+      public static let version: Version = .persistedQueries
+      public static let generateManifestOnCodeGeneration: Bool = false
+    }
+    
+    // MARK: - Initializers
+    
+    /// Designated initializer
+    ///
+    /// - Parameters:
+    ///   - path: Local path where the generated operation manifest file should be written.
+    ///   - version: The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
+    ///   - generateManifestOnCodeGeneration: Whether or nor the operation manifest should be generated whenever code generation is run. Defaults to `false`.
+    public init(
+      path: String,
+      version: Version = Default.version,
+      generateManifestOnCodeGeneration: Bool = Default.generateManifestOnCodeGeneration
+    ) {
+      self.path = path
+      self.version = version
+      self.generateManifestOnCodeGeneration = generateManifestOnCodeGeneration
+    }
+    
+    // MARK: - Codable
+    
+    enum CodingKeys: CodingKey, CaseIterable {
+      case path
+      case version
+      case generateManifestOnCodeGeneration
+    }
+    
+    public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      try throwIfContainsUnexpectedKey(
+        container: values,
+        type: Self.self,
+        decoder: decoder
+      )
+      
+      path = try values.decode(
+        String.self,
+        forKey: .path
+      )
+      
+      version = try values.decode(
+        Version.self,
+        forKey: .version
+      )
+      
+      generateManifestOnCodeGeneration = try values.decode(
+        Bool.self,
+        forKey: .generateManifestOnCodeGeneration
+      )
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      
+      try container.encode(self.path, forKey: .path)
+      try container.encode(self.version, forKey: .version)
+      try container.encode(self.generateManifestOnCodeGeneration, forKey: .generateManifestOnCodeGeneration)
+    }
+    
+  }
+  
+}

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -37,7 +37,7 @@ struct OperationManifestFileGenerator {
   /// Parameters:
   ///  - config: A configuration object specifying output behavior.
   init?(config: ApolloCodegen.ConfigurationContext) {
-    guard config.output.operationManifest != nil else {
+    guard config.operationManifest != nil else {
       return nil
     }
 
@@ -57,7 +57,7 @@ struct OperationManifestFileGenerator {
   func generate(fileManager: ApolloFileManager = .default) throws {
     let rendered: String = try template.render(operations: operationManifest)
 
-    var manifestPath = config.output.operationManifest.unsafelyUnwrapped.path
+    var manifestPath = config.operationManifest.unsafelyUnwrapped.path
     let relativePrefix = "./"
       
     // if path begins with './' the path should be relative to the config.rootURL
@@ -80,10 +80,10 @@ struct OperationManifestFileGenerator {
   }
 
   var template: any OperationManifestTemplate {
-    switch config.output.operationManifest.unsafelyUnwrapped.version {
+    switch config.operationManifest.unsafelyUnwrapped.version {
     case .persistedQueries:
       return PersistedQueriesOperationManifestTemplate(config: config)
-    case .legacyAPQ:
+    case .legacy:
       return LegacyAPQOperationManifestTemplate()
     }
   }

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -1,7 +1,7 @@
 import OrderedCollections
 
 extension IR {
-
+  
   /// A condition representing an `@include` or `@skip` directive to determine if a field
   /// or fragment should be included.
   struct InclusionCondition: Hashable, CustomDebugStringConvertible {

--- a/Sources/ApolloCodegenLib/IR/IR+SelectionSet.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+SelectionSet.swift
@@ -1,6 +1,6 @@
 extension IR {
   @dynamicMemberLookup
-  class SelectionSet: Equatable, CustomDebugStringConvertible {
+  class SelectionSet: Hashable, CustomDebugStringConvertible {
     class TypeInfo: Hashable, CustomDebugStringConvertible {
       /// The entity that the `selections` are being selected on.
       ///
@@ -141,9 +141,15 @@ extension IR {
     }
 
     static func ==(lhs: IR.SelectionSet, rhs: IR.SelectionSet) -> Bool {
-      lhs.typeInfo.entity === rhs.typeInfo.entity &&
-      lhs.typeInfo.scopePath == rhs.typeInfo.scopePath &&
-      lhs.selections.direct == rhs.selections.direct
+      lhs.typeInfo === rhs.typeInfo &&
+      lhs.selections.direct === rhs.selections.direct
+    }
+
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(typeInfo)
+      if let directSelections = selections.direct {
+        hasher.combine(ObjectIdentifier(directSelections))
+      }
     }
 
     subscript<T>(dynamicMember keyPath: KeyPath<TypeInfo, T>) -> T {

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -3,13 +3,22 @@ import OrderedCollections
 
 extension IR {
 
+  // TODO: Write tests that two inline fragments with same type and inclusion conditions,
+  // but different defer conditions don't  merge together.
+  // To be done in issue #3141
   struct ScopeCondition: Hashable, CustomDebugStringConvertible {
     let type: GraphQLCompositeType?
     let conditions: InclusionConditions?
+    let isDeferred: IsDeferred
 
-    init(type: GraphQLCompositeType? = nil, conditions: InclusionConditions? = nil) {
+    init(
+      type: GraphQLCompositeType? = nil,
+      conditions: InclusionConditions? = nil,
+      isDeferred: IsDeferred = false
+    ) {
       self.type = type
       self.conditions = conditions
+      self.isDeferred = isDeferred
     }
 
     var debugDescription: String {
@@ -96,7 +105,10 @@ extension IR {
     ) -> ScopeDescriptor {
       let scope = Self.typeScope(addingType: type, to: nil, givenAllTypes: allTypes)
       return ScopeDescriptor(
-        typePath: LinkedList(.init(type: type, conditions: inclusionConditions)),
+        typePath: LinkedList(.init(
+          type: type,
+          conditions: inclusionConditions
+        )),
         type: type,
         matchingTypes: scope,
         matchingConditions: inclusionConditions,

--- a/Sources/ApolloCodegenLib/IR/ScopedSelectionSetHashable.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopedSelectionSetHashable.swift
@@ -25,7 +25,7 @@ extension CompilationResult.FragmentSpread: ScopedSelectionSetHashable {
   }
 }
 
-extension IR.FragmentSpread: ScopedSelectionSetHashable {
+extension IR.NamedFragmentSpread: ScopedSelectionSetHashable {
   var hashForSelectionSetScope: String {
     fragment.definition.name
   }

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -46,7 +46,7 @@ struct EnumTemplate: TemplateRenderer {
   private func caseDefinition(for graphqlEnumValue: GraphQLEnumValue) -> TemplateString {
     """
     case \(graphqlEnumValue.name.rendered(as: .swiftEnumCase, config: config.config))\
-    \(if: config.options.conversionStrategies.enumCases != .none, """
+    \(if: !config.options.conversionStrategies.enumCases.isDefault, """
        = "\(graphqlEnumValue.name.rendered(as: .rawValue, config: config.config))"
       """)
     """

--- a/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/EnumTemplate.swift
@@ -46,7 +46,7 @@ struct EnumTemplate: TemplateRenderer {
   private func caseDefinition(for graphqlEnumValue: GraphQLEnumValue) -> TemplateString {
     """
     case \(graphqlEnumValue.name.rendered(as: .swiftEnumCase, config: config.config))\
-    \(if: !config.options.conversionStrategies.enumCases.isDefault, """
+    \(if: config.options.conversionStrategies.enumCases != .none, """
        = "\(graphqlEnumValue.name.rendered(as: .rawValue, config: config.config))"
       """)
     """

--- a/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/InputObjectTemplate.swift
@@ -92,7 +92,7 @@ struct InputObjectTemplate: TemplateRenderer {
   ) -> TemplateString {
     TemplateString("""
     \(fields.map({
-      "\($1.name.asFieldPropertyName): \($1.renderInputValueType(includeDefault: true, config: config.config))"
+      "\($1.name.renderAsFieldPropertyName(config: config.config)): \($1.renderInputValueType(includeDefault: true, config: config.config))"
     }), separator: ",\n")
     """)
   }
@@ -101,7 +101,7 @@ struct InputObjectTemplate: TemplateRenderer {
     _ fields: GraphQLInputFieldDictionary
   ) -> TemplateString {
     TemplateString("""
-    \(fields.map({ "\"\($1.name)\": \($1.name.asFieldPropertyName)" }), separator: ",\n")
+    \(fields.map({ "\"\($1.name)\": \($1.name.renderAsFieldPropertyName(config: config.config))" }), separator: ",\n")
     """)
   }
 
@@ -110,7 +110,7 @@ struct InputObjectTemplate: TemplateRenderer {
     \(documentation: field.documentation, config: config)
     \(deprecationReason: field.deprecationReason, config: config)
     \(accessControlModifier(for: .member))\
-    var \(field.name.asFieldPropertyName): \(field.renderInputValueType(config: config.config)) {
+    var \(field.name.renderAsFieldPropertyName(config: config.config)): \(field.renderInputValueType(config: config.config)) {
       get { __data["\(field.name)"] }
       set { __data["\(field.name)"] = newValue }
     }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -19,27 +19,8 @@ extension GraphQLEnumValue.Name {
       return value.asEnumCaseName
 
     case (.swiftEnumCase, .camelCase):
-      return convertToCamelCase(value).asEnumCaseName
+      return value.convertToCamelCase().asEnumCaseName
     }
-  }
-
-  /// Convert to `camelCase` from a number of different `snake_case` variants.
-  ///
-  /// All inner `_` characters will be removed, each 'word' will be capitalized, returning a final
-  /// firstLowercased string while preserving original leading and trailing `_` characters.
-  private func convertToCamelCase(_ value: String) -> String {
-    guard value.firstIndex(of: "_") != nil else {
-      if value.firstIndex(where: { $0.isLowercase }) != nil {
-        return value.firstLowercased
-      } else {
-        return value.lowercased()
-      }
-    }
-
-    return value.components(separatedBy: "_")
-      .map({ $0.isEmpty ? "_" : $0.capitalized })
-      .joined()
-      .firstLowercased
   }
 
 }

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -15,7 +15,8 @@ extension GraphQLEnumValue.Name {
     case (.rawValue, _):
       return value
 
-    case (.swiftEnumCase, .none):
+    case (.swiftEnumCase, .none),
+      (.swiftEnumCase, .default):
       return value.asEnumCaseName
 
     case (.swiftEnumCase, .camelCase):

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/GraphQLEnumValue+Rendered.swift
@@ -15,8 +15,7 @@ extension GraphQLEnumValue.Name {
     case (.rawValue, _):
       return value
 
-    case (.swiftEnumCase, .none),
-      (.swiftEnumCase, .default):
+    case (.swiftEnumCase, .none):
       return value.asEnumCaseName
 
     case (.swiftEnumCase, .camelCase):

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/OperationTemplateRenderer.swift
@@ -13,7 +13,7 @@ extension OperationTemplateRenderer {
     return """
     \(`init`)(\(list: variables.map(VariableParameter))) {
       \(variables.map {
-        let name = $0.name.asFieldPropertyName
+        let name = $0.name.renderAsFieldPropertyName(config: config.config)
         return "self.\(name) = \(name)"
       }, separator: "\n")
     }
@@ -24,7 +24,7 @@ extension OperationTemplateRenderer {
     _ variables: [CompilationResult.VariableDefinition]
   ) -> TemplateString {
     """
-    \(variables.map { "public var \($0.name.asFieldPropertyName): \($0.type.rendered(as: .inputValue, config: config.config))"}, separator: "\n")
+    \(variables.map { "public var \($0.name.renderAsFieldPropertyName(config: config.config)): \($0.type.rendered(as: .inputValue, config: config.config))"}, separator: "\n")
     """
   }
 
@@ -32,7 +32,7 @@ extension OperationTemplateRenderer {
     _ variable: CompilationResult.VariableDefinition
   ) -> TemplateString {
       """
-      \(variable.name.asFieldPropertyName): \(variable.type.rendered(as: .inputValue, config: config.config))\
+      \(variable.name.renderAsFieldPropertyName(config: config.config)): \(variable.type.rendered(as: .inputValue, config: config.config))\
       \(if: variable.defaultValue != nil, " = " + variable.renderVariableDefaultValue(config: config.config))
       """
   }
@@ -46,7 +46,7 @@ extension OperationTemplateRenderer {
     }
 
     return """
-      public var __variables: \(if: !graphQLOperation, "GraphQLOperation.")Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.asFieldPropertyName)"})] }
+      public var __variables: \(if: !graphQLOperation, "GraphQLOperation.")Variables? { [\(list: variables.map { "\"\($0.name)\": \($0.name.renderAsFieldPropertyName(config: config.config))"})] }
       """
   }
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -45,11 +45,12 @@ extension String {
     switch config.options.conversionStrategies.fieldCasing {
     case .camelCase:
       propertyName = propertyName.convertToCamelCase()
-      propertyName = propertyName.isAllUppercased ? propertyName.lowercased() : propertyName.firstLowercased
-    case .none:
+    case .none,
+         .`default`:
       break
     }
     
+    propertyName = propertyName.isAllUppercased ? propertyName.lowercased() : propertyName.firstLowercased
     return propertyName.escapeIf(in: SwiftKeywords.FieldAccessorNamesToEscape)
   }
   

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -2,12 +2,6 @@ import Foundation
 
 
 extension String {
-  /// Renders the string as the property name for a field accessor on a generated `SelectionSet`.
-  /// This escapes the names of properties that would conflict with Swift reserved keywords.
-  var asFieldPropertyName: String {
-    let str = self.isAllUppercased ? self.lowercased() : self.firstLowercased
-    return str.escapeIf(in: SwiftKeywords.FieldAccessorNamesToEscape)
-  }
 
   var asEnumCaseName: String {
     escapeIf(in: SwiftKeywords.FieldAccessorNamesToEscape)
@@ -39,6 +33,43 @@ extension String {
 
   private func escapeIf(in set: Set<String>) -> String {
     set.contains(self) ? "`\(self)`" : self
+  }
+  
+  /// Renders the string as the property name for a field accessor on a generated `SelectionSet`.
+  /// This escapes the names of properties that would conflict with Swift reserved keywords.
+  func renderAsFieldPropertyName(
+    config: ApolloCodegenConfiguration
+  ) -> String {
+    var propertyName = self
+    
+    switch config.options.conversionStrategies.fieldCasing {
+    case .camelCase:
+      propertyName = propertyName.convertToCamelCase()
+      propertyName = propertyName.isAllUppercased ? propertyName.lowercased() : propertyName.firstLowercased
+    case .none:
+      break
+    }
+    
+    return propertyName.escapeIf(in: SwiftKeywords.FieldAccessorNamesToEscape)
+  }
+  
+  /// Convert to `camelCase` from a number of different `snake_case` variants.
+  ///
+  /// All inner `_` characters will be removed, each 'word' will be capitalized, returning a final
+  /// firstLowercased string while preserving original leading and trailing `_` characters.
+  func convertToCamelCase() -> String {
+    guard self.firstIndex(of: "_") != nil else {
+      if self.firstIndex(where: { $0.isLowercase }) != nil {
+        return self.firstLowercased
+      } else {
+        return self.lowercased()
+      }
+    }
+
+    return self.components(separatedBy: "_")
+      .map({ $0.isEmpty ? "_" : $0.capitalized })
+      .joined()
+      .firstLowercased
   }
 }
 

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -42,7 +42,7 @@ extension String {
   ) -> String {
     var propertyName = self
     
-    switch config.options.conversionStrategies.fieldAccessor {
+    switch config.options.conversionStrategies.fieldAccessors {
     case .camelCase:
       propertyName = propertyName.convertToCamelCase()
     case .idiomatic:

--- a/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
+++ b/Sources/ApolloCodegenLib/Templates/RenderingHelpers/String+SwiftNameEscaping.swift
@@ -42,11 +42,10 @@ extension String {
   ) -> String {
     var propertyName = self
     
-    switch config.options.conversionStrategies.fieldCasing {
+    switch config.options.conversionStrategies.fieldAccessor {
     case .camelCase:
       propertyName = propertyName.convertToCamelCase()
-    case .none,
-         .`default`:
+    case .idiomatic:
       break
     }
     

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -309,7 +309,7 @@ struct SelectionSetTemplate {
     return """
     \(documentation: field.underlyingField.documentation, config: config)
     \(deprecationReason: field.underlyingField.deprecationReason, config: config)
-    \(renderAccessControl())var \(field.responseKey.asFieldPropertyName): \
+          \(renderAccessControl())var \(field.responseKey.renderAsFieldPropertyName(config: config.config)): \
     \(typeName(for: field, forceOptional: field.isConditionallyIncluded(in: scope))) {\
     \(if: isMutable,
       """
@@ -443,7 +443,7 @@ struct SelectionSetTemplate {
   ) -> TemplateString {
     let isOptional: Bool = field.type.isNullable || field.isConditionallyIncluded(in: scope)
     return """
-    \(field.responseKey.asFieldPropertyName): \(typeName(for: field, forceOptional: isOptional))\
+    \(field.responseKey.renderAsFieldPropertyName(config: config.config)): \(typeName(for: field, forceOptional: isOptional))\
     \(if: isOptional, " = nil")
     """
   }
@@ -475,7 +475,7 @@ struct SelectionSetTemplate {
     }()
 
     return """
-    "\(field.responseKey)": \(field.responseKey.asFieldPropertyName)\
+    "\(field.responseKey)": \(field.responseKey.renderAsFieldPropertyName(config: config.config))\
     \(if: isEntityField, "._fieldData")
     """
   }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -204,8 +204,8 @@ struct SelectionSetTemplate {
     _ deprecatedArguments: inout [DeprecatedArgument]?
   ) -> [TemplateString] {
     selections.fields.values.map { FieldSelectionTemplate($0, &deprecatedArguments) } +
-    selections.inlineFragments.values.map { InlineFragmentSelectionTemplate($0) } +
-    selections.fragments.values.map { FragmentSelectionTemplate($0) }
+    selections.inlineFragments.values.map { InlineFragmentSelectionTemplate($0.selectionSet) } +
+    selections.namedFragments.values.map { FragmentSelectionTemplate($0) }
   }
 
   private func renderedConditionalSelectionGroup(
@@ -283,7 +283,7 @@ struct SelectionSetTemplate {
     """
   }
 
-  private func FragmentSelectionTemplate(_ fragment: IR.FragmentSpread) -> TemplateString {
+  private func FragmentSelectionTemplate(_ fragment: IR.NamedFragmentSpread) -> TemplateString {
     """
     .fragment(\(fragment.definition.name.asFragmentName).self)
     """
@@ -329,9 +329,9 @@ struct SelectionSetTemplate {
   ) -> TemplateString {
     """
     \(ifLet: selections.direct?.inlineFragments.values, {
-        "\($0.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")"
+      "\($0.map { InlineFragmentAccessorTemplate($0.selectionSet) }, separator: "\n")"
       })
-    \(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")
+    \(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0.selectionSet) }, separator: "\n")
     """
   }
 
@@ -355,8 +355,8 @@ struct SelectionSetTemplate {
     _ selections: IR.SelectionSet.Selections,
     in scope: IR.ScopeDescriptor
   ) -> TemplateString {
-    guard !(selections.direct?.fragments.isEmpty ?? true) ||
-            !selections.merged.fragments.isEmpty else {
+    guard !(selections.direct?.namedFragments.isEmpty ?? true) ||
+            !selections.merged.namedFragments.isEmpty else {
       return ""
     }
 
@@ -364,18 +364,18 @@ struct SelectionSetTemplate {
     \(renderAccessControl())struct Fragments: FragmentContainer {
       \(DataFieldAndInitializerTemplate())
 
-      \(ifLet: selections.direct?.fragments.values, {
-        "\($0.map { FragmentAccessorTemplate($0, in: scope) }, separator: "\n")"
+      \(ifLet: selections.direct?.namedFragments.values, {
+        "\($0.map { NamedFragmentAccessorTemplate($0, in: scope) }, separator: "\n")"
         })
-      \(selections.merged.fragments.values.map {
-          FragmentAccessorTemplate($0, in: scope)
+      \(selections.merged.namedFragments.values.map {
+          NamedFragmentAccessorTemplate($0, in: scope)
         }, separator: "\n")
     }
     """
   }
 
-  private func FragmentAccessorTemplate(
-    _ fragment: IR.FragmentSpread,
+  private func NamedFragmentAccessorTemplate(
+    _ fragment: IR.NamedFragmentSpread,
     in scope: IR.ScopeDescriptor
   ) -> TemplateString {
     let name = fragment.definition.name
@@ -532,9 +532,9 @@ struct SelectionSetTemplate {
   private func ChildTypeCaseSelectionSets(_ selections: IR.SelectionSet.Selections) -> TemplateString {
     """
     \(ifLet: selections.direct?.inlineFragments.values, {
-        "\($0.map { render(inlineFragment: $0) }, separator: "\n\n")"
+      "\($0.map { render(inlineFragment: $0.selectionSet) }, separator: "\n\n")"
       })
-    \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")
+    \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0.selectionSet) }, separator: "\n\n")
     """    
   }
 
@@ -950,8 +950,8 @@ extension IR.SelectionSet.Selections {
     SelectionsIterator(direct: direct?.fields, merged: merged.fields)
   }
 
-  fileprivate func makeFragmentIterator() -> SelectionsIterator<IR.FragmentSpread> {
-    SelectionsIterator(direct: direct?.fragments, merged: merged.fragments)
+  fileprivate func makeFragmentIterator() -> SelectionsIterator<IR.NamedFragmentSpread> {
+    SelectionsIterator(direct: direct?.namedFragments, merged: merged.namedFragments)
   }
 
   fileprivate struct SelectionsIterator<SelectionType>: IteratorProtocol {

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -309,7 +309,7 @@ struct SelectionSetTemplate {
     return """
     \(documentation: field.underlyingField.documentation, config: config)
     \(deprecationReason: field.underlyingField.deprecationReason, config: config)
-          \(renderAccessControl())var \(field.responseKey.renderAsFieldPropertyName(config: config.config)): \
+    \(renderAccessControl())var \(field.responseKey.renderAsFieldPropertyName(config: config.config)): \
     \(typeName(for: field, forceOptional: field.isConditionallyIncluded(in: scope))) {\
     \(if: isMutable,
       """

--- a/Sources/CodegenCLI/OptionGroups/InputOptions.swift
+++ b/Sources/CodegenCLI/OptionGroups/InputOptions.swift
@@ -1,4 +1,6 @@
+import Foundation
 import ArgumentParser
+import ApolloCodegenLib
 
 /// Shared group of common arguments used in commands for input parameters.
 struct InputOptions: ParsableArguments {
@@ -28,4 +30,16 @@ struct InputOptions: ParsableArguments {
     help: "Ignore Apollo version mismatch errors. Warning: This may lead to incompatible generated objects."
   )
   var ignoreVersionMismatch: Bool = false
+
+  func getCodegenConfiguration(fileManager: FileManager) throws -> ApolloCodegenConfiguration {
+    var data: Data
+    switch (string, path) {
+    case let (.some(string), _):
+      data = try string.asData()
+
+    case let (nil, path):
+      data = try fileManager.unwrappedContents(atPath: path)
+    }
+    return try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: data)
+  }
 }

--- a/Sources/CodegenCLI/Protocols/CodegenProvider.swift
+++ b/Sources/CodegenCLI/Protocols/CodegenProvider.swift
@@ -5,13 +5,8 @@ import ApolloCodegenLib
 public protocol CodegenProvider {
   static func build(
     with configuration: ApolloCodegenConfiguration,
-    withRootURL rootURL: URL?
-  ) throws
-  
-  static func generateOperationManifest(
-    with configuration: ApolloCodegenConfiguration,
     withRootURL rootURL: URL?,
-    fileManager: ApolloFileManager
+    itemsToGenerate: ApolloCodegen.ItemsToGenerate
   ) throws
 }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -14,14 +14,16 @@ extension ApolloCodegenConfiguration {
       )
     ),
     options: OutputOptions = .init(schemaDocumentation: .exclude),
-    experimentalFeatures: ExperimentalFeatures = .init()
+    experimentalFeatures: ExperimentalFeatures = .init(),
+    operationManifest: OperationManifestConfiguration? = nil
   ) -> Self {
     .init(
       schemaNamespace: schemaNamespace,
       input: input,
       output: output,
       options: options,
-      experimentalFeatures: experimentalFeatures
+      experimentalFeatures: experimentalFeatures,
+      operationManifest: operationManifest
     )
   }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/MockIRSubscripts.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockIRSubscripts.swift
@@ -79,11 +79,11 @@ extension IR.DirectSelections: ScopeConditionalSubscriptAccessing {
   }
 
   public subscript(conditions: IR.ScopeCondition) -> IR.SelectionSet? {
-    inlineFragments[conditions]
+    inlineFragments[conditions]?.selectionSet
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    namedFragments[fragment]
   }
 }
 
@@ -93,11 +93,11 @@ extension IR.MergedSelections: ScopeConditionalSubscriptAccessing {
   }
 
   public subscript(conditions: IR.ScopeCondition) -> IR.SelectionSet? {
-    inlineFragments[conditions]
+    inlineFragments[conditions]?.selectionSet
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    namedFragments[fragment]
   }
 }
 
@@ -106,8 +106,8 @@ extension IR.EntityTreeScopeSelections {
     fields[field]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    namedFragments[fragment]
   }
 }
 
@@ -121,7 +121,7 @@ extension IR.Field: ScopeConditionalSubscriptAccessing {
     return selectionSet?[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     return selectionSet?[fragment: fragment]
   }
 
@@ -140,7 +140,7 @@ extension IR.SelectionSet: ScopeConditionalSubscriptAccessing {
     selections[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     selections[fragment: fragment]
   }
 }
@@ -151,11 +151,12 @@ extension IR.SelectionSet.Selections: ScopeConditionalSubscriptAccessing {
   }
 
   public subscript(conditions: IR.ScopeCondition) -> IR.SelectionSet? {
-    return direct?.inlineFragments[conditions] ?? merged.inlineFragments[conditions]
+    return direct?.inlineFragments[conditions]?.selectionSet ??
+    merged.inlineFragments[conditions]?.selectionSet
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    direct?.fragments[fragment] ?? merged.fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    direct?.namedFragments[fragment] ?? merged.namedFragments[fragment]
   }
 }
 
@@ -168,7 +169,7 @@ extension IR.Operation: ScopeConditionalSubscriptAccessing {
     rootField[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     rootField[fragment: fragment]
   }
 }
@@ -182,7 +183,7 @@ extension IR.NamedFragment: ScopeConditionalSubscriptAccessing {
     return rootField.selectionSet[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     rootField.selectionSet[fragment: fragment]
   }
 }

--- a/Tests/ApolloCodegenInternalTestHelpers/MockMergedSelections.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockMergedSelections.swift
@@ -27,7 +27,7 @@ extension IR.MergedSelections.MergedSource {
   }
 
   public static func mock(
-    _ fragment: IR.FragmentSpread?,
+    _ fragment: IR.NamedFragmentSpread?,
     file: StaticString = #file,
     line: UInt = #line
   ) throws -> Self {
@@ -40,7 +40,7 @@ extension IR.MergedSelections.MergedSource {
 
   public static func mock(
     for field: IR.Field?,
-    from fragment: IR.FragmentSpread?,
+    from fragment: IR.NamedFragmentSpread?,
     file: StaticString = #file,
     line: UInt = #line
   ) throws -> Self {

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -35,8 +35,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             moduleType: .embeddedInTarget(name: "SomeTarget", accessModifier: .public)
           ),
           operations: .absolute(path: "/absolute/path", accessModifier: .internal),
-          testMocks: .swiftPackage(targetName: "SchemaTestMocks"),
-          operationManifest: .init(path: "/operation/identifiers/path")
+          testMocks: .swiftPackage(targetName: "SchemaTestMocks")
         ),
         options: .init(
           additionalInflectionRules: [
@@ -44,7 +43,6 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           ],
           deprecatedEnumCases: .exclude,
           schemaDocumentation: .exclude,
-          operationDocumentFormat: .definition,
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(enumCases: .none),
@@ -53,6 +51,11 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
         experimentalFeatures: .init(
           clientControlledNullability: true,
           legacySafelistingCompatibleOperations: true
+        ),
+        operationManifest: .init(
+          path: "/operation/identifiers/path",
+          version: .persistedQueries,
+          generateManifestOnCodeGeneration: false
         )
       )
     }
@@ -71,6 +74,11 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           "schemaSearchPaths" : [
             "/path/to/schema.graphqls"
           ]
+        },
+        "operationManifest" : {
+          "generateManifestOnCodeGeneration" : false,
+          "path" : "/operation/identifiers/path",
+          "version" : "persistedQueries"
         },
         "options" : {
           "additionalInflectionRules" : [
@@ -97,10 +105,6 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           "warningsOnDeprecatedUsage" : "exclude"
         },
         "output" : {
-          "operationManifest" : {
-            "path" : "/operation/identifiers/path",
-            "version" : "persistedQueries"
-          },
           "operations" : {
             "absolute" : {
               "accessModifier" : "internal",

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -46,8 +46,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(
-            enumCases: .default,
-            fieldCasing: .camelCase
+            enumCases: .none,
+            fieldAccessor: .camelCase
           ),
           pruneGeneratedFiles: false
         ),
@@ -94,8 +94,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           ],
           "cocoapodsCompatibleImportStatements" : true,
           "conversionStrategies" : {
-            "enumCases" : "default",
-            "fieldCasing" : "camelCase"
+            "enumCases" : "none",
+            "fieldAccessor" : "camelCase"
           },
           "deprecatedEnumCases" : "exclude",
           "operationDocumentFormat" : [

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -95,7 +95,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           "cocoapodsCompatibleImportStatements" : true,
           "conversionStrategies" : {
             "enumCases" : "none",
-            "fieldAccessor" : "camelCase"
+            "fieldAccessors" : "camelCase"
           },
           "deprecatedEnumCases" : "exclude",
           "operationDocumentFormat" : [

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -45,7 +45,10 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           schemaDocumentation: .exclude,
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
-          conversionStrategies:.init(enumCases: .none),
+          conversionStrategies:.init(
+            enumCases: .default,
+            fieldCasing: .camelCase
+          ),
           pruneGeneratedFiles: false
         ),
         experimentalFeatures: .init(
@@ -91,7 +94,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           ],
           "cocoapodsCompatibleImportStatements" : true,
           "conversionStrategies" : {
-            "enumCases" : "none"
+            "enumCases" : "default",
+            "fieldCasing" : "camelCase"
           },
           "deprecatedEnumCases" : "exclude",
           "operationDocumentFormat" : [

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -47,7 +47,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(
             enumCases: .none,
-            fieldAccessor: .camelCase
+            fieldAccessors: .camelCase
           ),
           pruneGeneratedFiles: false
         ),

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -69,7 +69,6 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     )
 
     // then
-    expect(output.operationManifest).to(beNil())
     expect(output.operations).to(equal(.inSchemaModule))
   }
 
@@ -85,6 +84,5 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(config.options.additionalInflectionRules).to(beEmpty())
     expect(config.options.deprecatedEnumCases).to(equal(.include))
     expect(config.options.schemaDocumentation).to(equal(.include))
-    expect(config.options.operationDocumentFormat).to(equal([.definition]))
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -671,7 +671,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -768,7 +769,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -871,7 +873,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -935,7 +938,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -1037,7 +1041,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -1137,7 +1142,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -1184,7 +1190,7 @@ class ApolloCodegenTests: XCTestCase {
       options: .init(pruneGeneratedFiles: false)
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beTrue())
@@ -1241,7 +1247,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beFalse())
@@ -1295,7 +1301,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beFalse())
@@ -1364,7 +1370,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beFalse())
@@ -1437,7 +1443,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beFalse())
@@ -1495,13 +1501,13 @@ class ApolloCodegenTests: XCTestCase {
     // then
     
     // running codegen multiple times to validate symlink related file creation/deletion bug
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
     expect(ApolloFileManager.default.doesFileExist(atPath: fileValidationPath)).to(beTrue())
     
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
     expect(ApolloFileManager.default.doesFileExist(atPath: fileValidationPath)).to(beTrue())
     
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
     expect(ApolloFileManager.default.doesFileExist(atPath: fileValidationPath)).to(beTrue())
 
   }
@@ -1586,7 +1592,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beTrue())
@@ -1694,7 +1700,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beTrue())
@@ -1796,7 +1802,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beTrue())
@@ -1861,7 +1867,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beFalse())
@@ -1917,7 +1923,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testInTestMocksFolderFile)).to(beFalse())
@@ -1975,7 +1981,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testInTestMocksFolderFile)).to(beFalse())

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -127,7 +127,7 @@ class IRRootFieldBuilderTests: XCTestCase {
 
     let child = allAnimals?[as: "Bird"]
     expect(child?.parentType).to(equal(Object_Bird))
-    expect(child?.selections.direct?.fragments.values).to(shallowlyMatch([Fragment_BirdDetails]))
+    expect(child?.selections.direct?.namedFragments.values).to(shallowlyMatch([Fragment_BirdDetails]))
   }
 
   func test__children__isObjectType_initWithNamedFragmentOnLessSpecificMatchingType_hasNoChildTypeCase() throws {
@@ -245,8 +245,8 @@ class IRRootFieldBuilderTests: XCTestCase {
 
     let child = rocks?[as: "Animal"]
     expect(child?.parentType).to(equal(Interface_Animal))
-    expect(child?.selections.direct?.fragments.count).to(equal(1))
-    expect(child?.selections.direct?.fragments.values[0].definition).to(equal(Fragment_AnimalDetails))
+    expect(child?.selections.direct?.namedFragments.count).to(equal(1))
+    expect(child?.selections.direct?.namedFragments.values[0].definition).to(equal(Fragment_AnimalDetails))
   }
 
   // MARK: Children Computation - Union Type
@@ -370,10 +370,21 @@ class IRRootFieldBuilderTests: XCTestCase {
     // when
     try buildSubjectRootField()
 
+    let Scalar_String = try XCTUnwrap(schema[scalar: "String"])
+    let Object_B = try XCTUnwrap(schema[object: "B"])
+
     let bField = subject[field: "bField"]
 
+    let expected = SelectionSetMatcher(
+      parentType: Object_B,
+      directSelections: [
+        .field("A", type: .nonNull(.scalar(Scalar_String))),
+        .field("B", type: .nonNull(.scalar(Scalar_String))),
+      ]
+    )
+
     // then
-    expect(bField?.selectionSet?.selections.direct?.inlineFragments).to(beEmpty())
+    expect(bField?.selectionSet).to(shallowlyMatch(expected))
   }
 
   func test__children__givenInlineFragment_onNonMatchingType_doesNotMergeTypeCaseIn_hasChildTypeCase() throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
@@ -22,9 +22,9 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   private func buildSubject(
     path: String? = nil,
-    version: ApolloCodegenConfiguration.OperationManifestFileOutput.Version = .legacyAPQ
+    version: ApolloCodegenConfiguration.OperationManifestConfiguration.Version = .legacy
   ) throws {
-    let manifest: ApolloCodegenConfiguration.OperationManifestFileOutput? = {
+    let manifest: ApolloCodegenConfiguration.OperationManifestConfiguration? = {
       guard let path else { return nil }
       return .init(path: path, version: version)
     }()
@@ -32,9 +32,9 @@ class OperationManifestFileGeneratorTests: XCTestCase {
     subject = try OperationManifestFileGenerator(
       config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
         output: .init(
-          schemaTypes: .init(path: "", moduleType: .swiftPackageManager),
-          operationManifest: manifest
-        )
+          schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
+        ),
+        operationManifest: manifest
       ))
     ).xctUnwrapped()
   }
@@ -43,10 +43,14 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   func test__initializer__givenPath_shouldReturnInstance() {
     // given
-    let config = ApolloCodegenConfiguration.mock(output: .init(
-      schemaTypes: .init(path: "", moduleType: .swiftPackageManager),
-      operationManifest: .init(path: "a/file/path")
-    ))
+    let config = ApolloCodegenConfiguration.mock(
+      output: .init(
+        schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
+      ),
+      operationManifest: .init(
+        path: "a/file/path"
+      )
+    )
 
     // when
     let instance = OperationManifestFileGenerator(config: .init(config: config))
@@ -57,10 +61,12 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   func test__initializer__givenNilPath_shouldReturnNil() {
     // given
-    let config = ApolloCodegenConfiguration.mock(output: .init(
-      schemaTypes: .init(path: "", moduleType: .swiftPackageManager),
+    let config = ApolloCodegenConfiguration.mock(
+      output: .init(
+        schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
+      ),
       operationManifest: nil
-    ))
+    )
 
     // when
     let instance = OperationManifestFileGenerator(config: .init(config: config))
@@ -267,9 +273,9 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   // MARK: - Template Type Selection Tests
 
-  func test__template__givenOperationManifestVersion_apqLegacy__isLegacyAPQTemplate() throws {
+  func test__template__givenOperationManifestVersion_legacy__isLegacyTemplate() throws {
     // given
-    try buildSubject(path: "a/path", version: .legacyAPQ)
+    try buildSubject(path: "a/path", version: .legacy)
 
     // when
     let actual = subject.template

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -176,7 +176,7 @@ class EnumTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test_render_givenOption_caseConversionStrategy_none_generatesSwiftEnumValues_respectingSchemaValueCasing() throws {
+  func test_render_givenOption_caseConversionStrategy_default_generatesSwiftEnumValues_respectingSchemaValueCasing() throws {
     // given
     buildSubject(
       name: "casedEnum",
@@ -198,7 +198,7 @@ class EnumTemplateTests: XCTestCase {
         ("Protocol", nil, nil),
       ],
       config: .mock(
-        options: .init(conversionStrategies: .init(enumCases: .none))
+        options: .init(conversionStrategies: .init(enumCases: .default))
       )
     )
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/EnumTemplateTests.swift
@@ -198,7 +198,7 @@ class EnumTemplateTests: XCTestCase {
         ("Protocol", nil, nil),
       ],
       config: .mock(
-        options: .init(conversionStrategies: .init(enumCases: .default))
+        options: .init(conversionStrategies: .init(enumCases: .none))
       )
     )
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -483,7 +483,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
     expect(actual).to(equalLineByLine(expected))
   }
 
-  func test__renderOperationVariableParameter__givenEnumCaseConversion_none_givenEnumField_withDefaultValue__generatesCorrectParametersWithInitializer() throws {
+  func test__renderOperationVariableParameter__givenEnumCaseConversion_default_givenEnumField_withDefaultValue__generatesCorrectParametersWithInitializer() throws {
     // given
     let tests: [(variable: CompilationResult.VariableDefinition, expected: String)] = [
       (
@@ -506,7 +506,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
 
     for test in tests {
       // when
-      buildTemplate(options: .init(conversionStrategies: .init(enumCases: .none)))
+      buildTemplate(options: .init(conversionStrategies: .init(enumCases: .default)))
       let actual = template.VariableParameter(test.variable).description
 
       // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinition_VariableDefinition_Tests.swift
@@ -506,7 +506,7 @@ class OperationDefinition_VariableDefinition_Tests: XCTestCase {
 
     for test in tests {
       // when
-      buildTemplate(options: .init(conversionStrategies: .init(enumCases: .default)))
+      buildTemplate(options: .init(conversionStrategies: .init(enumCases: .none)))
       let actual = template.VariableParameter(test.variable).description
 
       // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -2596,7 +2596,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(conversionStrategies: .init(fieldCasing: .camelCase))
+    try buildSubjectAndOperation(conversionStrategies: .init(fieldAccessor: .camelCase))
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "AllAnimals"] as? IR.EntityField
     )
@@ -2632,7 +2632,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(conversionStrategies: .init(fieldCasing: .camelCase))
+    try buildSubjectAndOperation(conversionStrategies: .init(fieldAccessor: .camelCase))
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "AllAnimals"] as? IR.EntityField
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -2596,7 +2596,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(conversionStrategies: .init(fieldAccessor: .camelCase))
+    try buildSubjectAndOperation(conversionStrategies: .init(fieldAccessors: .camelCase))
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "AllAnimals"] as? IR.EntityField
     )
@@ -2632,7 +2632,7 @@ class SelectionSetTemplateTests: XCTestCase {
     """
 
     // when
-    try buildSubjectAndOperation(conversionStrategies: .init(fieldAccessor: .camelCase))
+    try buildSubjectAndOperation(conversionStrategies: .init(fieldAccessors: .camelCase))
     let allAnimals = try XCTUnwrap(
       operation[field: "query"]?[field: "AllAnimals"] as? IR.EntityField
     )

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -32,6 +32,7 @@ class SelectionSetTemplateTests: XCTestCase {
     inflectionRules: [ApolloCodegenLib.InflectionRule] = [],
     schemaDocumentation: ApolloCodegenConfiguration.Composition = .exclude,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = .exclude,
+    conversionStrategies: ApolloCodegenConfiguration.ConversionStrategies = .init(),
     cocoapodsImportStatements: Bool = false
   ) throws {
     ir = try .mock(schema: schemaSDL, document: document)
@@ -44,7 +45,8 @@ class SelectionSetTemplateTests: XCTestCase {
         additionalInflectionRules: inflectionRules,
         schemaDocumentation: schemaDocumentation,
         cocoapodsCompatibleImportStatements: cocoapodsImportStatements,
-        warningsOnDeprecatedUsage: warningsOnDeprecatedUsage
+        warningsOnDeprecatedUsage: warningsOnDeprecatedUsage,
+        conversionStrategies: conversionStrategies
       )
     ))
     let mockTemplateRenderer = MockTemplateRenderer(
@@ -2564,6 +2566,78 @@ class SelectionSetTemplateTests: XCTestCase {
     )
 
     let actual = subject.render(inlineFragment: dog)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
+  }
+  
+  func test__render_fieldAccessors__givenFieldWithSnakeCaseName_rendersFieldAccessorAsCamelCase() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      AllAnimals: [Animal!]
+    }
+
+    type Animal {
+      field_name: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      AllAnimals {
+        field_name
+      }
+    }
+    """
+
+    let expected = """
+      public var fieldName: String { __data["field_name"] }
+    """
+
+    // when
+    try buildSubjectAndOperation(conversionStrategies: .init(fieldCasing: .camelCase))
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "AllAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))
+  }
+  
+  func test__render_fieldAccessors__givenFieldWithSnakeCaseUppercaseName_rendersFieldAccessorAsCamelCase() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      AllAnimals: [Animal!]
+    }
+
+    type Animal {
+      FIELD_NAME: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      AllAnimals {
+        FIELD_NAME
+      }
+    }
+    """
+
+    let expected = """
+      public var fieldName: String { __data["FIELD_NAME"] }
+    """
+
+    // when
+    try buildSubjectAndOperation(conversionStrategies: .init(fieldCasing: .camelCase))
+    let allAnimals = try XCTUnwrap(
+      operation[field: "query"]?[field: "AllAnimals"] as? IR.EntityField
+    )
+
+    let actual = subject.render(field: allAnimals)
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 12, ignoringExtraLines: true))

--- a/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
+++ b/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
@@ -48,7 +48,7 @@ class FetchSchemaTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -80,7 +80,7 @@ class FetchSchemaTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -110,7 +110,7 @@ class FetchSchemaTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }

--- a/Tests/CodegenCLITests/Commands/GenerateOperationManifestTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateOperationManifestTests.swift
@@ -3,7 +3,6 @@ import Nimble
 import ApolloInternalTestHelpers
 @testable import CodegenCLI
 import ApolloCodegenLib
-import ArgumentParser
 
 class GenerateOperationManifestTests: XCTestCase {
 

--- a/Tests/CodegenCLITests/Commands/GenerateTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateTests.swift
@@ -144,7 +144,7 @@ class GenerateTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -185,7 +185,7 @@ class GenerateTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -234,7 +234,7 @@ class GenerateTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }

--- a/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
@@ -7,7 +7,8 @@ class MockApolloCodegen: CodegenProvider {
 
   static func build(
     with configuration: ApolloCodegenConfiguration,
-    withRootURL rootURL: URL?
+    withRootURL rootURL: URL?,
+    itemsToGenerate: ApolloCodegen.ItemsToGenerate
   ) throws {
     guard let handler = buildHandler else {
       fatalError("You must set buildHandler before calling \(#function)!")
@@ -20,19 +21,4 @@ class MockApolloCodegen: CodegenProvider {
     try handler(configuration)
   }
   
-  static func generateOperationManifest(
-    with configuration: ApolloCodegenLib.ApolloCodegenConfiguration,
-    withRootURL rootURL: URL?,
-    fileManager: ApolloCodegenLib.ApolloFileManager
-  ) throws {
-    guard let handler = buildHandler else {
-      fatalError("You must set buildHandler before calling \(#function)!")
-    }
-    
-    defer {
-      buildHandler = nil
-    }
-    
-    try handler(configuration)
-  }
 }

--- a/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
@@ -9,15 +9,19 @@ extension ApolloCodegenConfiguration {
         schemaPath: "./schema.graphqls"
       ),
       output: .init(
-        schemaTypes: .init(path: ".", moduleType: .swiftPackageManager),
-        operationManifest: .init(path: "./manifest", version: .persistedQueries)
+        schemaTypes: .init(path: ".", moduleType: .swiftPackageManager)
       ),
       options: .init(
         operationDocumentFormat: [.definition, .operationId]
       ),
-      schemaDownloadConfiguration: .init(
+      schemaDownload: .init(
         using: .introspection(endpointURL: URL(string: "http://some.server")!),
         outputPath: "./schema.graphqls"
+      ),
+      operationManifest: .init(
+        path: "./manifest",
+        version: .persistedQueries,
+        generateManifestOnCodeGeneration: false
       )
     )
   }

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -21,7 +21,8 @@ There are a number of base configuration properties, each representing a specifi
 | [`output`](#file-output) | Location and structure of the generated files and modules. |
 | [`options`](#output-options) | Rules and options to customize the generated code. |
 | [`experimentalFeatures`](#experimental-features) | Used to enable experimental features.<br/>*Note: These features could change at any time and are not guaranteed to always be available.* |
-| [`schemaDownloadConfiguration`](#schema-download-configuration) | Configuration to fetch a GraphQL schema before generation. |
+| [`schemaDownload`](#schema-download-configuration) | Configuration to fetch a GraphQL schema before generation. |
+| [`operationManifest`](#operation-manifest-configuration) | Configuration to generate operation manifests for persisted queries |
 
 ## Schema namespace
 
@@ -98,7 +99,6 @@ The properties to configure `output` are:
 | [`schemaTypes`](#schema-types) | Location and structure of the generated schema types files. |
 | [`operations`](#operations)    | Location and structure of the generated operation files such as queries, mutations, subscriptions, and fragments. |
 | [`testMocks`](#test-mocks)     | Location and structure of the test mock operation object files.<br/><br/>If `.none`, test mocks will not be generated. |
-| [`operationManifest`](#operation-manifest) | Configures the generation of an operation manifest JSON file for use with persisted queries or [Automatic Persisted Queries](../fetching/apqs). |
 
 <MultiCodeBlock>
 
@@ -395,42 +395,6 @@ Specify the directory for your test mocks using the `path` parameter. This is re
 >
 > Test mocks generated this way may also be manually embedded in a test utility module that is imported by your test target.
 
-### Operation Manifest
-
-Providing a value for this property will generate a JSON document with all your operations and their computed identifier hashes. This document can be used to pre-register the identifiers for your operations with a server that supports [persisted queries or Automatic Persisted Queries](./../fetching/apqs).
-
-The properties of the Operation Manifest configuration object are:
-
-| Property Name | Description |
-| ----- | ----------- |
-| `path` | Local path where the generated operation manifest file should be written. |
-| [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
-
-<MultiCodeBlock>
-
-```json title="CLI Configuration JSON"
-"output": {
-	"operationManifest" : {
-		"path" : "./generated/operationIdentifiers.json",
-		"version" : "persistedQueries"
-	}
-}
-```
-
-```swift title="Swift Codegen Setup"
-let configuration = ApolloCodegenConfiguration(
-	// Other properties not shown
-	output: ApolloCodegenConfiguration.FileOutput(
-		operationManifest: .init(
-			path: "./generated/operationIdentifiers.json",
-			version: .persistedQueries
-		)
-	)
-)
-```
-
-</MultiCodeBlock>
-
 ## Output options
 
 The code generation engine supports a number of configuration options to change the behaviour of the generator and tailor the generated Swift code to your specific needs.
@@ -444,7 +408,7 @@ The top-level properties are:
 | [`deprecatedEnumCases`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/deprecatedenumcases) | Annotate generated Swift enums with the Swift `@available` attribute for GraphQL enum cases annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`schemaDocumentation`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/schemadocumentation) | Include or exclude [schema documentation](https://spec.graphql.org/draft/#sec-Descriptions) in the generated files. |
 | [`selectionSetInitializers`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/selectionsetinitializers) | Generate initializers for your generated selection set models. |
-| [`operationDocumentFormat`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/operationdocumentformat) | How to generate the operation documents for your generated operations. This can be used to generate operation identifiers for use with a server that supports [persisted queries or Automatic Persisted Queries](./../fetching/apqs) |
+| [`operationDocumentFormat`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/operationdocumentformat) | How to generate the operation documents for your generated operations. This can be used to generate operation identifiers for use with a server that supports [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) |
 | [`cocoapodsCompatibleImportStatements`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/cocoapodscompatibleimportstatements) | Generate import statements that are compatible with including `Apollo` via Cocoapods. |
 | [`warningsOnDeprecatedUsage`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/warningsondeprecatedusage) | Annotate generated Swift code with the Swift `@available` attribute and `@deprecated` argument for parts of the GraphQL schema annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`conversionStrategies`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/conversionstrategies) | Rules for how to convert the names of values from the schema in generated code. |
@@ -579,7 +543,7 @@ The properties you will need to configure are:
 <MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
-"schemaDownloadConfiguration": {
+"schemaDownload": {
 	"downloadMethod": {
 		"apolloRegistry": {
 			"_0": {
@@ -601,7 +565,7 @@ The properties you will need to configure are:
 ```swift title="Swift Codegen Setup"
 let configuration = ApolloCodegenConfiguration(
   // Other properties not shown
-  schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration(
+  schemaDownload: ApolloSchemaDownloadConfiguration(
     using: .apolloRegistry(.init(
       apiKey: "your-api-key",
       graphID: "your-graphid",
@@ -635,7 +599,7 @@ The properties you will need to configure are:
 <MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
-"schemaDownloadConfiguration": {
+"schemaDownload": {
 	"downloadMethod": {
 		"introspection": {
 			"endpointURL": "https://server.com",
@@ -655,7 +619,7 @@ The properties you will need to configure are:
 ```swift title="Swift Codegen Setup"
 let configuration = ApolloCodegenConfiguration(
 	// Other properties not shown
-	schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration(
+	schemaDownload: ApolloSchemaDownloadConfiguration(
 		using: .introspection(
 			endpointURL: URL(string: "https://server.com")!),
 		timeout: 60.0,
@@ -667,3 +631,36 @@ let configuration = ApolloCodegenConfiguration(
 </MultiCodeBlock>
 
 For more details, see the section on [downloading a schema](./downloading-schema).
+
+## Operation Manifest Configuration
+
+Optional settings used to configure generation of the operation identifier manifest for use with [Persisted Queries](./../fetching/persisted-queries).
+
+| Property Name | Description |
+| ------------- | ----------- |
+| `path` | Local path where the generated operation manifest file should be written. |
+| [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
+| [`generateManifestOnCodeGeneration`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/generateManifestOnCodeGeneration) | Whether or not the operation manifest should be generated every time code generation is run. Defaults to false. |
+
+<MultiCodeBlock>
+
+```json title="CLI Configuration JSON"
+"operationManifest" : {
+  "generateManifestOnCodeGeneration" : false,
+  "path" : "/operation/identifiers/path",
+  "version" : "persistedQueries"
+}
+```
+
+```swift title="Swift Codegen Setup"
+let configuration = ApolloCodegenConfiguration(
+    // Other properties not shown
+    operationManifest: .init(
+        path: "./manifest/operationManifest.json",
+        version: .persistedQueries,
+        generateManifestOnCodeGeneration: false
+    )
+)
+```
+
+</MultiCodeBlock>

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -440,7 +440,8 @@ The top-level properties are:
 	"cocoapodsCompatibleImportStatements": false,
 	"warningsOnDeprecatedUsage": "include",
 	"conversionStrategies": {
-		"enumCases": "camelCase"
+		"enumCases": "camelCase",
+		"fieldCasing": "default"
 	},
 	"pruneGeneratedFiles": true
 }
@@ -468,7 +469,8 @@ let configuration = ApolloCodegenConfiguration(
 		cocoapodsCompatibleImportStatements: false,
 		warningsOnDeprecatedUsage: .include,
 		conversionStrategies: ApolloCodegenConfiguration.ConversionStrategies(
-			enumCases: .camelCase
+			enumCases: .camelCase,
+			fieldCasing: .default
 		),
 		pruneGeneratedFiles: true
 	)


### PR DESCRIPTION
- Added new codegen configuration option under `ConversionStrategies` for `fieldCasing` to allow customization of how field names are generated.
- This will default to the new `default` `CaseConversionStrategy` which will function the same way field generation has previously.
- The `camelCase` option will apply camel case conversion to the field names
- Also deprecated the `none` case and replaced it with the `default` case for enum casing

Closes #2738 