### PR TITLE
refactor: Fragment types in IR

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -306,7 +306,8 @@ public class ApolloCodegen {
     }
     
     // gather nested fragments to loop through and check as well
-    var nestedSelectionSets: [IR.SelectionSet] = selectionSet.selections.direct?.inlineFragments.values.elements ?? []
+    #warning("Does it need to be both values.elements?")
+    var nestedSelectionSets: [IR.SelectionSet] = selectionSet.selections.direct?.inlineFragments.values.elements.map { $0.selectionSet } ?? []
     nestedSelectionSets.append(contentsOf: selectionSet.selections.merged.inlineFragments.values)
     
     try nestedSelectionSets.forEach { nestedSet in

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -292,10 +292,10 @@ public class ApolloCodegen {
       )
     }
     
-    var fragments: [IR.NamedFragment] = selectionSet.selections.direct?.fragments.values.map { $0.fragment } ?? []
-    fragments.append(contentsOf: selectionSet.selections.merged.fragments.values.map { $0.fragment })
+    var namedFragments: [IR.NamedFragment] = selectionSet.selections.direct?.namedFragments.values.map { $0.fragment } ?? []
+    namedFragments.append(contentsOf: selectionSet.selections.merged.namedFragments.values.map { $0.fragment })
     
-    try fragments.forEach { fragment in
+    try namedFragments.forEach { fragment in
       if let existingTypeName = combinedTypeNames[fragment.generatedDefinitionName] {
         throw Error.typeNameConflict(
           name: existingTypeName,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -292,8 +292,8 @@ public class ApolloCodegen {
       )
     }
     
-    var namedFragments: [IR.NamedFragment] = selectionSet.selections.direct?.namedFragments.values.map { $0.fragment } ?? []
-    namedFragments.append(contentsOf: selectionSet.selections.merged.namedFragments.values.map { $0.fragment })
+    var namedFragments: [IR.NamedFragment] = selectionSet.selections.direct?.namedFragments.values.map(\.fragment) ?? []
+    namedFragments.append(contentsOf: selectionSet.selections.merged.namedFragments.values.map(\.fragment))
     
     try namedFragments.forEach { fragment in
       if let existingTypeName = combinedTypeNames[fragment.generatedDefinitionName] {
@@ -305,10 +305,9 @@ public class ApolloCodegen {
       }
     }
     
-    // gather nested fragments to loop through and check as well
-    #warning("Does it need to be both values.elements?")
-    var nestedSelectionSets: [IR.SelectionSet] = selectionSet.selections.direct?.inlineFragments.values.elements.map { $0.selectionSet } ?? []
-    nestedSelectionSets.append(contentsOf: selectionSet.selections.merged.inlineFragments.values)
+    // gather nested fragments to loop through and check as well    
+    var nestedSelectionSets: [IR.SelectionSet] = selectionSet.selections.direct?.inlineFragments.values.map(\.selectionSet) ?? []
+    nestedSelectionSets.append(contentsOf: selectionSet.selections.merged.inlineFragments.values.map(\.selectionSet))
     
     try nestedSelectionSets.forEach { nestedSet in
       try validateTypeConflicts(

--- a/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
@@ -255,7 +255,8 @@ extension IR {
       fileprivate func scopeConditionNode(for condition: ScopeCondition) -> EntityNode {
         let nodeCondition = ScopeCondition(
           type: condition.type == self.type ? nil : condition.type,
-          conditions: condition.conditions
+          conditions: condition.conditions,
+          isDeferred: condition.isDeferred
         )
 
         func createNode() -> EntityNode {
@@ -407,7 +408,8 @@ extension IR.EntitySelectionTree.EntityNode {
       for conditionGroup in inclusionConditions.elements {
         let scope = IR.ScopeCondition(
           type: rootTypesMatch ? nil : fragmentType,
-          conditions: conditionGroup
+          conditions: conditionGroup,
+          isDeferred: fragment.isDeferred
         )
         let nextNode = rootNodeToStartMerge.scopeConditionNode(for: scope)
 
@@ -421,7 +423,9 @@ extension IR.EntitySelectionTree.EntityNode {
     } else {
       let nextNode = rootTypesMatch ?
       rootNodeToStartMerge :
-      rootNodeToStartMerge.scopeConditionNode(for: IR.ScopeCondition(type: fragmentType))
+      rootNodeToStartMerge.scopeConditionNode(
+        for: IR.ScopeCondition(type: fragmentType, isDeferred: fragment.isDeferred)
+      )
 
       nextNode.mergeIn(
         fragmentTree.rootNode,
@@ -512,7 +516,8 @@ extension IR.EntitySelectionTree.EntityNode {
             entity: entity,
             scopePath: oldFragment.typeInfo.scopePath
           ),
-          inclusionConditions: oldFragment.inclusionConditions
+          inclusionConditions: oldFragment.inclusionConditions,
+          isDeferred: oldFragment.isDeferred
         )
       }
 

--- a/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
@@ -292,13 +292,13 @@ extension IR {
   class EntityTreeScopeSelections: Equatable {
 
     fileprivate(set) var fields: OrderedDictionary<String, Field> = [:]
-    fileprivate(set) var fragments: OrderedDictionary<String, FragmentSpread> = [:]
+    fileprivate(set) var fragments: OrderedDictionary<String, NamedFragmentSpread> = [:]
 
     init() {}
 
     fileprivate init(
       fields: OrderedDictionary<String, Field>,
-      fragments: OrderedDictionary<String, FragmentSpread>
+      fragments: OrderedDictionary<String, NamedFragmentSpread>
     ) {
       self.fields = fields
       self.fragments = fragments
@@ -316,11 +316,11 @@ extension IR {
       fields.forEach { mergeIn($0) }
     }
 
-    private func mergeIn(_ fragment: FragmentSpread) {
+    private func mergeIn(_ fragment: NamedFragmentSpread) {
       fragments[fragment.hashForSelectionSetScope] = fragment
     }
 
-    private func mergeIn<T: Sequence>(_ fragments: T) where T.Element == FragmentSpread {
+    private func mergeIn<T: Sequence>(_ fragments: T) where T.Element == NamedFragmentSpread {
       fragments.forEach { mergeIn($0) }
     }
 
@@ -353,7 +353,7 @@ extension IR.EntitySelectionTree {
   /// programming error and will result in undefined behavior.
   func mergeIn(
     _ otherTree: IR.EntitySelectionTree,
-    from fragment: IR.FragmentSpread,
+    from fragment: IR.NamedFragmentSpread,
     using entityStorage: IR.RootFieldEntityStorage
   ) {
     let otherTreeCount = otherTree.rootTypePath.count
@@ -392,7 +392,7 @@ extension IR.EntitySelectionTree.EntityNode {
 
   fileprivate func mergeIn(
     _ fragmentTree: IR.EntitySelectionTree,
-    from fragment: IR.FragmentSpread,
+    from fragment: IR.NamedFragmentSpread,
     with inclusionConditions: AnyOf<IR.InclusionConditions>?,
     using entityStorage: IR.RootFieldEntityStorage
   ) {
@@ -437,7 +437,7 @@ extension IR.EntitySelectionTree.EntityNode {
 
   fileprivate func mergeIn(
     _ otherNode: IR.EntitySelectionTree.EntityNode,
-    from fragment: IR.FragmentSpread,
+    from fragment: IR.NamedFragmentSpread,
     using entityStorage: IR.RootFieldEntityStorage
   ) {
     switch otherNode.child {
@@ -474,7 +474,7 @@ extension IR.EntitySelectionTree.EntityNode {
 
   fileprivate func mergeIn(
     _ selections: Selections,
-    from fragment: IR.FragmentSpread,
+    from fragment: IR.NamedFragmentSpread,
     using entityStorage: IR.RootFieldEntityStorage
   ) {
     for (source, selections) in selections {
@@ -505,12 +505,12 @@ extension IR.EntitySelectionTree.EntityNode {
         }
       }
 
-      let fragments = selections.fragments.mapValues { oldFragment -> IR.FragmentSpread in
+      let fragments = selections.fragments.mapValues { oldFragment -> IR.NamedFragmentSpread in
         let entity = entityStorage.entity(
           for: oldFragment.typeInfo.entity,
           inFragmentSpreadAtTypePath: fragment.typeInfo
         )
-        return IR.FragmentSpread(
+        return IR.NamedFragmentSpread(
           fragment: oldFragment.fragment,
           typeInfo: IR.SelectionSet.TypeInfo(
             entity: entity,

--- a/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+EntitySelectionTree.swift
@@ -34,7 +34,7 @@ extension IR {
     }
 
     private func mergeIn(selections: DirectSelections.ReadOnly, from source: MergedSelections.MergedSource) {
-      guard (!selections.fields.isEmpty || !selections.fragments.isEmpty) else {
+      guard (!selections.fields.isEmpty || !selections.namedFragments.isEmpty) else {
         return
       }
 
@@ -292,20 +292,20 @@ extension IR {
   class EntityTreeScopeSelections: Equatable {
 
     fileprivate(set) var fields: OrderedDictionary<String, Field> = [:]
-    fileprivate(set) var fragments: OrderedDictionary<String, NamedFragmentSpread> = [:]
+    fileprivate(set) var namedFragments: OrderedDictionary<String, NamedFragmentSpread> = [:]
 
     init() {}
 
     fileprivate init(
       fields: OrderedDictionary<String, Field>,
-      fragments: OrderedDictionary<String, NamedFragmentSpread>
+      namedFragments: OrderedDictionary<String, NamedFragmentSpread>
     ) {
       self.fields = fields
-      self.fragments = fragments
+      self.namedFragments = namedFragments
     }
 
     var isEmpty: Bool {
-      fields.isEmpty && fragments.isEmpty
+      fields.isEmpty && namedFragments.isEmpty
     }
 
     private func mergeIn(_ field: Field) {
@@ -317,7 +317,7 @@ extension IR {
     }
 
     private func mergeIn(_ fragment: NamedFragmentSpread) {
-      fragments[fragment.hashForSelectionSetScope] = fragment
+      namedFragments[fragment.hashForSelectionSetScope] = fragment
     }
 
     private func mergeIn<T: Sequence>(_ fragments: T) where T.Element == NamedFragmentSpread {
@@ -326,17 +326,17 @@ extension IR {
 
     func mergeIn(_ selections: DirectSelections.ReadOnly) {
       mergeIn(selections.fields.values)
-      mergeIn(selections.fragments.values)
+      mergeIn(selections.namedFragments.values)
     }
 
     func mergeIn(_ selections: EntityTreeScopeSelections) {
       mergeIn(selections.fields.values)
-      mergeIn(selections.fragments.values)
+      mergeIn(selections.namedFragments.values)
     }
 
     static func == (lhs: IR.EntityTreeScopeSelections, rhs: IR.EntityTreeScopeSelections) -> Bool {
       lhs.fields == rhs.fields &&
-      lhs.fragments == rhs.fragments
+      lhs.namedFragments == rhs.namedFragments
     }
   }
 }
@@ -505,7 +505,7 @@ extension IR.EntitySelectionTree.EntityNode {
         }
       }
 
-      let fragments = selections.fragments.mapValues { oldFragment -> IR.NamedFragmentSpread in
+      let fragments = selections.namedFragments.mapValues { oldFragment -> IR.NamedFragmentSpread in
         let entity = entityStorage.entity(
           for: oldFragment.typeInfo.entity,
           inFragmentSpreadAtTypePath: fragment.typeInfo
@@ -522,7 +522,7 @@ extension IR.EntitySelectionTree.EntityNode {
       }
 
       self.mergeIn(
-        IR.EntityTreeScopeSelections(fields: fields, fragments: fragments),
+        IR.EntityTreeScopeSelections(fields: fields, namedFragments: fragments),
         from: newSource
       )
     }
@@ -582,7 +582,7 @@ extension IR.EntityTreeScopeSelections: CustomDebugStringConvertible {
   var debugDescription: String {
     """
     Fields: \(fields.values.elements)
-    Fragments: \(fragments.values.elements.description)
+    Fragments: \(namedFragments.values.elements.description)
     """
   }
 }

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -1,7 +1,7 @@
 import OrderedCollections
 
 extension IR {
-
+  
   /// A condition representing an `@include` or `@skip` directive to determine if a field
   /// or fragment should be included.
   struct InclusionCondition: Hashable, CustomDebugStringConvertible {
@@ -27,7 +27,7 @@ extension IR {
     static func skip(if variable: String) -> InclusionCondition {
       .init(variable, isInverted: true)
     }
-    
+
     func inverted() -> InclusionCondition {
       InclusionCondition(variable, isInverted: !isInverted)
     }

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -28,6 +28,11 @@ extension IR {
       .init(variable, isInverted: true)
     }
 
+    /// Creates an `InclusionCondition` representing a `@defer` directive.
+    static func `defer`(if variable: String) -> InclusionCondition {
+      .init(variable, isInverted: false)
+    }
+
     func inverted() -> InclusionCondition {
       InclusionCondition(variable, isInverted: !isInverted)
     }

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -27,12 +27,7 @@ extension IR {
     static func skip(if variable: String) -> InclusionCondition {
       .init(variable, isInverted: true)
     }
-
-    /// Creates an `InclusionCondition` representing a `@defer` directive.
-    static func `defer`(if variable: String) -> InclusionCondition {
-      .init(variable, isInverted: false)
-    }
-
+    
     func inverted() -> InclusionCondition {
       InclusionCondition(variable, isInverted: !isInverted)
     }

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -360,7 +360,8 @@ extension IR {
       let fragmentSpread = FragmentSpread(
         fragment: fragment,
         typeInfo: typeInfo,
-        inclusionConditions: AnyOf(scopeCondition.conditions)
+        inclusionConditions: AnyOf(scopeCondition.conditions),
+        isDeferred: .if(.defer(if: <#T##String#>))
       )
 
       entityStorage.mergeAllSelectionsIntoEntitySelectionTrees(from: fragmentSpread)

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -56,7 +56,7 @@ extension IR {
       return entity
     }
 
-    fileprivate func mergeAllSelectionsIntoEntitySelectionTrees(from fragmentSpread: FragmentSpread) {
+    fileprivate func mergeAllSelectionsIntoEntitySelectionTrees(from fragmentSpread: NamedFragmentSpread) {
       for (_, fragmentEntity) in fragmentSpread.fragment.entities {
         let entity = entity(for: fragmentEntity, inFragmentSpreadAtTypePath: fragmentSpread.typeInfo)
         entity.selectionTree.mergeIn(fragmentEntity.selectionTree, from: fragmentSpread, using: self)
@@ -179,7 +179,7 @@ extension IR {
           )
 
         } else {
-          let irTypeCase = buildConditionalSelectionSet(
+          let irTypeCase = buildInlineFragmentSpread(
             from: inlineSelectionSet,
             with: scope,
             inParentTypePath: typeInfo
@@ -200,7 +200,7 @@ extension IR {
         let matchesScope = selectionSetScope.matches(scope)
 
         if matchesScope {
-          let irFragmentSpread = buildFragmentSpread(
+          let irFragmentSpread = buildNamedFragmentSpread(
             fromFragment: fragmentSpread,
             with: scope,
             spreadIntoParentWithTypePath: typeInfo
@@ -208,7 +208,7 @@ extension IR {
           target.mergeIn(irFragmentSpread)
 
         } else {
-          let irTypeCaseEnclosingFragment = buildConditionalSelectionSet(
+          let irTypeCaseEnclosingFragment = buildInlineFragmentSpread(
             from: CompilationResult.SelectionSet(
               parentType: fragmentSpread.parentType,
               selections: [selection]
@@ -221,7 +221,7 @@ extension IR {
 
           if matchesType {
             typeInfo.entity.selectionTree.mergeIn(
-              selections: irTypeCaseEnclosingFragment.selections.direct.unsafelyUnwrapped.readOnlyView,
+              selections: irTypeCaseEnclosingFragment.selectionSet.selections.direct.unsafelyUnwrapped.readOnlyView,
               with: typeInfo
             )
           }
@@ -313,11 +313,11 @@ extension IR {
       return irSelectionSet
     }
 
-    private func buildConditionalSelectionSet(
+    private func buildInlineFragmentSpread(
       from selectionSet: CompilationResult.SelectionSet?,
       with scopeCondition: ScopeCondition,
       inParentTypePath enclosingTypeInfo: SelectionSet.TypeInfo
-    ) -> SelectionSet {
+    ) -> InlineFragmentSpread {
       let typePath = enclosingTypeInfo.scopePath.mutatingLast {
         $0.appending(scopeCondition)
       }
@@ -334,14 +334,18 @@ extension IR {
           from: selectionSet
         )
       }
-      return irSelectionSet
-    }
 
-    private func buildFragmentSpread(
+      return InlineFragmentSpread(
+        selectionSet: irSelectionSet,
+        isDeferred: scopeCondition.isDeferred
+      )
+    }    
+
+    private func buildNamedFragmentSpread(
       fromFragment fragmentSpread: CompilationResult.FragmentSpread,
       with scopeCondition: ScopeCondition,
       spreadIntoParentWithTypePath parentTypeInfo: SelectionSet.TypeInfo
-    ) -> FragmentSpread {
+    ) -> NamedFragmentSpread {
       let fragment = ir.build(fragment: fragmentSpread.fragment)
       referencedFragments.append(fragment)
       referencedFragments.append(contentsOf: fragment.referencedFragments)
@@ -357,15 +361,15 @@ extension IR {
         scopePath: scopePath
       )
 
-      let fragmentSpread = FragmentSpread(
+      let fragmentSpread = NamedFragmentSpread(
         fragment: fragment,
         typeInfo: typeInfo,
         inclusionConditions: AnyOf(scopeCondition.conditions),
-        isDeferred: .if(.defer(if: <#T##String#>))
+        isDeferred: scopeCondition.isDeferred
       )
 
       entityStorage.mergeAllSelectionsIntoEntitySelectionTrees(from: fragmentSpread)
-      
+
       return fragmentSpread
     }
     

--- a/Sources/ApolloCodegenLib/IR/IR+SelectionSet.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+SelectionSet.swift
@@ -1,6 +1,6 @@
 extension IR {
   @dynamicMemberLookup
-  class SelectionSet: Equatable, CustomDebugStringConvertible {
+  class SelectionSet: Hashable, CustomDebugStringConvertible {
     class TypeInfo: Hashable, CustomDebugStringConvertible {
       /// The entity that the `selections` are being selected on.
       ///
@@ -141,9 +141,15 @@ extension IR {
     }
 
     static func ==(lhs: IR.SelectionSet, rhs: IR.SelectionSet) -> Bool {
-      lhs.typeInfo.entity === rhs.typeInfo.entity &&
-      lhs.typeInfo.scopePath == rhs.typeInfo.scopePath &&
-      lhs.selections.direct == rhs.selections.direct
+      lhs.typeInfo === rhs.typeInfo &&
+      lhs.selections.direct === rhs.selections.direct
+    }
+
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(typeInfo)
+      if let directSelections = selections.direct {
+        hasher.combine(ObjectIdentifier(directSelections))
+      }
     }
 
     subscript<T>(dynamicMember keyPath: KeyPath<TypeInfo, T>) -> T {

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -309,13 +309,15 @@ class IR {
     static func == (lhs: IR.NamedFragmentSpread, rhs: IR.NamedFragmentSpread) -> Bool {
       lhs.fragment === rhs.fragment &&
       lhs.typeInfo == rhs.typeInfo &&
-      lhs.inclusionConditions == rhs.inclusionConditions
+      lhs.inclusionConditions == rhs.inclusionConditions &&
+      lhs.isDeferred == rhs.isDeferred
     }
 
     func hash(into hasher: inout Hasher) {
       hasher.combine(ObjectIdentifier(fragment))
       hasher.combine(typeInfo)
       hasher.combine(inclusionConditions)
+      hasher.combine(isDeferred)
     }
 
     var debugDescription: String {

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -289,7 +289,13 @@ class IR {
     }
 
     #warning("Add isDeferred to this")
-    var debugDescription: String { selectionSet.debugDescription }
+    var debugDescription: String {      
+      var string = typeInfo.parentType.debugDescription
+      if let conditions = typeInfo.inclusionConditions {
+        string += " \(conditions.debugDescription)"
+      }
+      return string
+    }
   }
 
   /// Represents a Named Fragment that has been "spread into" another SelectionSet using the

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -57,6 +57,22 @@ class IR {
     }
   }
 
+  #warning("TODO: Document")
+  enum IsDeferred: Hashable, ExpressibleByBooleanLiteral {
+    case `true`
+    case `false`
+    case `if`(IR.InclusionCondition)
+
+    init(booleanLiteral value: BooleanLiteralType) {
+      switch value {
+      case true:
+        self = .true
+      case false:
+        self = .false
+      }
+    }
+  }
+
   /// Represents a concrete entity in an operation or fragment that fields are selected upon.
   ///
   /// Multiple `SelectionSet`s may select fields on the same `Entity`. All `SelectionSet`s that will
@@ -238,12 +254,28 @@ class IR {
     }
   }
 
-  /// Represents a Fragment that has been "spread into" another SelectionSet using the
+  /// Represents an Inline Fragment that has been "spread into" another SelectionSet using the
+  /// spread operator (`...`).
+  class InlineFragmentSpread: Hashable, CustomDebugStringConvertible {
+    /// The `SelectionSet` representing the inline fragment that has been "spread into" its
+    /// enclosing operation/fragment.
+    let selectionSet: SelectionSet
+
+    /// Indicates the location where the inline fragment has been "spread into" its enclosing
+    /// operation/fragment.
+    var typeInfo: SelectionSet.TypeInfo { selectionSet.typeInfo }
+
+    var inclusionConditions: InclusionConditions? { selectionSet.inclusionConditions }
+
+    let isDeferred: IsDeferred { ... }
+  }
+
+  /// Represents a Named Fragment that has been "spread into" another SelectionSet using the
   /// spread operator (`...`).
   ///
-  /// While a `NamedFragment` can be shared between operations, a `FragmentSpread` represents a
+  /// While a `NamedFragment` can be shared between operations, a `NamedFragmentSpread` represents a
   /// `NamedFragment` included in a specific operation.
-  class FragmentSpread: Hashable, CustomDebugStringConvertible {
+  class NamedFragmentSpread: Hashable, CustomDebugStringConvertible {
 
     /// The `NamedFragment` that this fragment refers to.
     ///
@@ -260,6 +292,8 @@ class IR {
 
     var inclusionConditions: AnyOf<InclusionConditions>?
 
+    let isDeferred: IsDeferred { ... }
+
     var definition: CompilationResult.FragmentDefinition { fragment.definition }
 
     init(
@@ -272,7 +306,7 @@ class IR {
       self.inclusionConditions = inclusionConditions
     }
 
-    static func == (lhs: IR.FragmentSpread, rhs: IR.FragmentSpread) -> Bool {
+    static func == (lhs: IR.NamedFragmentSpread, rhs: IR.NamedFragmentSpread) -> Bool {
       lhs.fragment === rhs.fragment &&
       lhs.typeInfo == rhs.typeInfo &&
       lhs.inclusionConditions == rhs.inclusionConditions

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -267,7 +267,29 @@ class IR {
 
     var inclusionConditions: InclusionConditions? { selectionSet.inclusionConditions }
 
-    let isDeferred: IsDeferred { ... }
+    let isDeferred: IsDeferred
+
+    init(
+      selectionSet: SelectionSet,
+      isDeferred: IsDeferred
+    ) {
+      self.selectionSet = selectionSet
+      self.isDeferred = isDeferred
+    }
+
+    static func == (lhs: IR.InlineFragmentSpread, rhs: IR.InlineFragmentSpread) -> Bool {
+      lhs.selectionSet == rhs.selectionSet &&
+      lhs.isDeferred == rhs.isDeferred
+    }
+
+    func hash(into hasher: inout Hasher) {
+      #warning("is this correct?")
+      hasher.combine(selectionSet.hashValue)
+      hasher.combine(isDeferred)
+    }
+
+    #warning("Add isDeferred to this")
+    var debugDescription: String { selectionSet.debugDescription }
   }
 
   /// Represents a Named Fragment that has been "spread into" another SelectionSet using the
@@ -292,18 +314,20 @@ class IR {
 
     var inclusionConditions: AnyOf<InclusionConditions>?
 
-    let isDeferred: IsDeferred { ... }
+    let isDeferred: IsDeferred
 
     var definition: CompilationResult.FragmentDefinition { fragment.definition }
 
     init(
       fragment: NamedFragment,
       typeInfo: SelectionSet.TypeInfo,
-      inclusionConditions: AnyOf<InclusionConditions>?
+      inclusionConditions: AnyOf<InclusionConditions>?,
+      isDeferred: IsDeferred
     ) {
       self.fragment = fragment
       self.typeInfo = typeInfo
       self.inclusionConditions = inclusionConditions
+      self.isDeferred = isDeferred
     }
 
     static func == (lhs: IR.NamedFragmentSpread, rhs: IR.NamedFragmentSpread) -> Bool {
@@ -320,6 +344,7 @@ class IR {
       hasher.combine(isDeferred)
     }
 
+    #warning("Add isDeferred to this")
     var debugDescription: String {
       var description = fragment.debugDescription
       if let inclusionConditions = inclusionConditions {

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -12,7 +12,7 @@ extension IR {
     init(
       type: GraphQLCompositeType? = nil,
       conditions: InclusionConditions? = nil,
-      isDeferred: IsDeferred
+      isDeferred: IsDeferred = false
     ) {
       self.type = type
       self.conditions = conditions
@@ -103,7 +103,10 @@ extension IR {
     ) -> ScopeDescriptor {
       let scope = Self.typeScope(addingType: type, to: nil, givenAllTypes: allTypes)
       return ScopeDescriptor(
-        typePath: LinkedList(.init(type: type, conditions: inclusionConditions)),
+        typePath: LinkedList(.init(
+          type: type,
+          conditions: inclusionConditions
+        )),
         type: type,
         matchingTypes: scope,
         matchingConditions: inclusionConditions,

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -3,13 +3,20 @@ import OrderedCollections
 
 extension IR {
 
+  #warning("TODO: Write tests that two inline fragments with same type and inclusion conditions, but different defer conditions don't merge together.")
   struct ScopeCondition: Hashable, CustomDebugStringConvertible {
     let type: GraphQLCompositeType?
     let conditions: InclusionConditions?
+    let isDeferred: IsDeferred
 
-    init(type: GraphQLCompositeType? = nil, conditions: InclusionConditions? = nil) {
+    init(
+      type: GraphQLCompositeType? = nil,
+      conditions: InclusionConditions? = nil,
+      isDeferred: IsDeferred
+    ) {
       self.type = type
       self.conditions = conditions
+      self.isDeferred = isDeferred
     }
 
     var debugDescription: String {

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -3,7 +3,9 @@ import OrderedCollections
 
 extension IR {
 
-  #warning("TODO: Write tests that two inline fragments with same type and inclusion conditions, but different defer conditions don't merge together.")
+  // TODO: Write tests that two inline fragments with same type and inclusion conditions,
+  // but different defer conditions don't  merge together.
+  // To be done in issue #3141
   struct ScopeCondition: Hashable, CustomDebugStringConvertible {
     let type: GraphQLCompositeType?
     let conditions: InclusionConditions?

--- a/Sources/ApolloCodegenLib/IR/ScopedSelectionSetHashable.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopedSelectionSetHashable.swift
@@ -25,7 +25,7 @@ extension CompilationResult.FragmentSpread: ScopedSelectionSetHashable {
   }
 }
 
-extension IR.FragmentSpread: ScopedSelectionSetHashable {
+extension IR.NamedFragmentSpread: ScopedSelectionSetHashable {
   var hashForSelectionSetScope: String {
     fragment.definition.name
   }

--- a/Sources/ApolloCodegenLib/IR/SortedSelections.swift
+++ b/Sources/ApolloCodegenLib/IR/SortedSelections.swift
@@ -115,15 +115,15 @@ extension IR {
       }
     }
 
-    func mergeIn(_ conditionalSelectionSet: SelectionSet) {
-      let scopeCondition = conditionalSelectionSet.scope.scopePath.last.value
+    func mergeIn(_ fragment: InlineFragmentSpread) {
+      let scopeCondition = fragment.selectionSet.scope.scopePath.last.value
 
-      if let existingTypeCase = inlineFragments[scopeCondition] {
+      if let existingTypeCase = inlineFragments[scopeCondition]?.selectionSet {
         existingTypeCase.selections.direct!
-          .mergeIn(conditionalSelectionSet.selections.direct!)
+          .mergeIn(fragment.selectionSet.selections.direct!)
 
       } else {
-        inlineFragments[scopeCondition] = conditionalSelectionSet
+        inlineFragments[scopeCondition] = fragment
       }
     }
 
@@ -162,7 +162,7 @@ extension IR {
     var debugDescription: String {
       """
       Fields: \(fields.values.elements)
-      InlineFragments: \(inlineFragments.values.elements.map(\.inlineFragmentDebugDescription))
+      InlineFragments: \(inlineFragments.values.elements.map(\.selectionSet.inlineFragmentDebugDescription))
       Fragments: \(fragments.values.elements.map(\.debugDescription))
       """
     }
@@ -175,7 +175,7 @@ extension IR {
       fileprivate let value: DirectSelections
 
       var fields: OrderedDictionary<String, Field> { value.fields }
-      var inlineFragments: OrderedDictionary<ScopeCondition, SelectionSet> { value.inlineFragments }
+      var inlineFragments: OrderedDictionary<ScopeCondition, InlineFragmentSpread> { value.inlineFragments }
       var fragments: OrderedDictionary<String, NamedFragmentSpread> { value.fragments }
       var isEmpty: Bool { value.isEmpty }
     }

--- a/Sources/ApolloCodegenLib/IR/SortedSelections.swift
+++ b/Sources/ApolloCodegenLib/IR/SortedSelections.swift
@@ -6,15 +6,15 @@ extension IR {
   class DirectSelections: Equatable, CustomDebugStringConvertible {
 
     fileprivate(set) var fields: OrderedDictionary<String, Field> = [:]
-    fileprivate(set) var inlineFragments: OrderedDictionary<ScopeCondition, SelectionSet> = [:]
-    fileprivate(set) var fragments: OrderedDictionary<String, FragmentSpread> = [:]
+    fileprivate(set) var inlineFragments: OrderedDictionary<ScopeCondition, InlineFragmentSpread> = [:]
+    fileprivate(set) var fragments: OrderedDictionary<String, NamedFragmentSpread> = [:]
 
     init() {}
 
     init(
       fields: [Field] = [],
       conditionalSelectionSets: [SelectionSet] = [],
-      fragments: [FragmentSpread] = []
+      fragments: [NamedFragmentSpread] = []
     ) {
       mergeIn(fields)
       mergeIn(conditionalSelectionSets)
@@ -24,7 +24,7 @@ extension IR {
     init(
       fields: OrderedDictionary<String, Field> = [:],
       conditionalSelectionSets: OrderedDictionary<ScopeCondition, SelectionSet> = [:],
-      fragments: OrderedDictionary<String, FragmentSpread> = [:]
+      fragments: OrderedDictionary<String, NamedFragmentSpread> = [:]
     ) {
       mergeIn(fields.values)
       mergeIn(conditionalSelectionSets.values)
@@ -127,7 +127,7 @@ extension IR {
       }
     }
 
-    func mergeIn(_ fragment: FragmentSpread) {
+    func mergeIn(_ fragment: NamedFragmentSpread) {
       if let existingFragment = fragments[fragment.hashForSelectionSetScope] {
         existingFragment.inclusionConditions =
         (existingFragment.inclusionConditions || fragment.inclusionConditions)
@@ -145,7 +145,7 @@ extension IR {
       conditionalSelectionSets.forEach { mergeIn($0) }
     }
 
-    func mergeIn<T: Sequence>(_ fragments: T) where T.Element == FragmentSpread {
+    func mergeIn<T: Sequence>(_ fragments: T) where T.Element == NamedFragmentSpread {
       fragments.forEach { mergeIn($0) }
     }
 
@@ -176,7 +176,7 @@ extension IR {
 
       var fields: OrderedDictionary<String, Field> { value.fields }
       var inlineFragments: OrderedDictionary<ScopeCondition, SelectionSet> { value.inlineFragments }
-      var fragments: OrderedDictionary<String, FragmentSpread> { value.fragments }
+      var fragments: OrderedDictionary<String, NamedFragmentSpread> { value.fragments }
       var isEmpty: Bool { value.isEmpty }
     }
 
@@ -264,7 +264,7 @@ extension IR {
     fileprivate(set) var mergedSources: MergedSources = []
     fileprivate(set) var fields: OrderedDictionary<String, Field> = [:]
     fileprivate(set) var inlineFragments: OrderedDictionary<ScopeCondition, SelectionSet> = [:]
-    fileprivate(set) var fragments: OrderedDictionary<String, FragmentSpread> = [:]
+    fileprivate(set) var fragments: OrderedDictionary<String, NamedFragmentSpread> = [:]
 
     init(
       directSelections: DirectSelections.ReadOnly?,
@@ -317,7 +317,7 @@ extension IR {
       )
     }
 
-    private func mergeIn(_ fragment: IR.FragmentSpread) -> Bool {
+    private func mergeIn(_ fragment: IR.NamedFragmentSpread) -> Bool {
       let keyInScope = fragment.hashForSelectionSetScope
       if let directSelections = directSelections,
           directSelections.fragments.keys.contains(keyInScope) {

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -205,7 +205,7 @@ struct SelectionSetTemplate {
   ) -> [TemplateString] {
     selections.fields.values.map { FieldSelectionTemplate($0, &deprecatedArguments) } +
     selections.inlineFragments.values.map { InlineFragmentSelectionTemplate($0.selectionSet) } +
-    selections.fragments.values.map { FragmentSelectionTemplate($0) }
+    selections.namedFragments.values.map { FragmentSelectionTemplate($0) }
   }
 
   private func renderedConditionalSelectionGroup(
@@ -331,7 +331,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.inlineFragments.values, {
       "\($0.map { InlineFragmentAccessorTemplate($0.selectionSet) }, separator: "\n")"
       })
-    \(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")
+    \(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0.selectionSet) }, separator: "\n")
     """
   }
 
@@ -534,7 +534,7 @@ struct SelectionSetTemplate {
     \(ifLet: selections.direct?.inlineFragments.values, {
       "\($0.map { render(inlineFragment: $0.selectionSet) }, separator: "\n\n")"
       })
-    \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")
+    \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0.selectionSet) }, separator: "\n\n")
     """    
   }
 

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -329,7 +329,7 @@ struct SelectionSetTemplate {
   ) -> TemplateString {
     """
     \(ifLet: selections.direct?.inlineFragments.values, {
-        "\($0.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")"
+      "\($0.map { InlineFragmentAccessorTemplate($0.selectionSet) }, separator: "\n")"
       })
     \(selections.merged.inlineFragments.values.map { InlineFragmentAccessorTemplate($0) }, separator: "\n")
     """
@@ -532,7 +532,7 @@ struct SelectionSetTemplate {
   private func ChildTypeCaseSelectionSets(_ selections: IR.SelectionSet.Selections) -> TemplateString {
     """
     \(ifLet: selections.direct?.inlineFragments.values, {
-        "\($0.map { render(inlineFragment: $0) }, separator: "\n\n")"
+      "\($0.map { render(inlineFragment: $0.selectionSet) }, separator: "\n\n")"
       })
     \(selections.merged.inlineFragments.values.map { render(inlineFragment: $0) }, separator: "\n\n")
     """    

--- a/Tests/ApolloCodegenInternalTestHelpers/MockIRSubscripts.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockIRSubscripts.swift
@@ -107,7 +107,7 @@ extension IR.EntityTreeScopeSelections {
   }
 
   public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
-    fragments[fragment]
+    namedFragments[fragment]
   }
 }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/MockIRSubscripts.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockIRSubscripts.swift
@@ -79,11 +79,11 @@ extension IR.DirectSelections: ScopeConditionalSubscriptAccessing {
   }
 
   public subscript(conditions: IR.ScopeCondition) -> IR.SelectionSet? {
-    inlineFragments[conditions]
+    inlineFragments[conditions]?.selectionSet
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    namedFragments[fragment]
   }
 }
 
@@ -93,11 +93,11 @@ extension IR.MergedSelections: ScopeConditionalSubscriptAccessing {
   }
 
   public subscript(conditions: IR.ScopeCondition) -> IR.SelectionSet? {
-    inlineFragments[conditions]
+    inlineFragments[conditions]?.selectionSet
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    namedFragments[fragment]
   }
 }
 
@@ -106,7 +106,7 @@ extension IR.EntityTreeScopeSelections {
     fields[field]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     fragments[fragment]
   }
 }
@@ -121,7 +121,7 @@ extension IR.Field: ScopeConditionalSubscriptAccessing {
     return selectionSet?[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     return selectionSet?[fragment: fragment]
   }
 
@@ -140,7 +140,7 @@ extension IR.SelectionSet: ScopeConditionalSubscriptAccessing {
     selections[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     selections[fragment: fragment]
   }
 }
@@ -151,11 +151,12 @@ extension IR.SelectionSet.Selections: ScopeConditionalSubscriptAccessing {
   }
 
   public subscript(conditions: IR.ScopeCondition) -> IR.SelectionSet? {
-    return direct?.inlineFragments[conditions] ?? merged.inlineFragments[conditions]
+    return direct?.inlineFragments[conditions]?.selectionSet ??
+    merged.inlineFragments[conditions]?.selectionSet
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
-    direct?.fragments[fragment] ?? merged.fragments[fragment]
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
+    direct?.namedFragments[fragment] ?? merged.namedFragments[fragment]
   }
 }
 
@@ -168,7 +169,7 @@ extension IR.Operation: ScopeConditionalSubscriptAccessing {
     rootField[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     rootField[fragment: fragment]
   }
 }
@@ -182,7 +183,7 @@ extension IR.NamedFragment: ScopeConditionalSubscriptAccessing {
     return rootField.selectionSet[conditions]
   }
 
-  public subscript(fragment fragment: String) -> IR.FragmentSpread? {
+  public subscript(fragment fragment: String) -> IR.NamedFragmentSpread? {
     rootField.selectionSet[fragment: fragment]
   }
 }

--- a/Tests/ApolloCodegenInternalTestHelpers/MockMergedSelections.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockMergedSelections.swift
@@ -27,7 +27,7 @@ extension IR.MergedSelections.MergedSource {
   }
 
   public static func mock(
-    _ fragment: IR.FragmentSpread?,
+    _ fragment: IR.NamedFragmentSpread?,
     file: StaticString = #file,
     line: UInt = #line
   ) throws -> Self {
@@ -40,7 +40,7 @@ extension IR.MergedSelections.MergedSource {
 
   public static func mock(
     for field: IR.Field?,
-    from fragment: IR.FragmentSpread?,
+    from fragment: IR.NamedFragmentSpread?,
     file: StaticString = #file,
     line: UInt = #line
   ) throws -> Self {

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -370,10 +370,21 @@ class IRRootFieldBuilderTests: XCTestCase {
     // when
     try buildSubjectRootField()
 
+    let Scalar_String = try XCTUnwrap(schema[scalar: "String"])
+    let Object_B = try XCTUnwrap(schema[object: "B"])
+
     let bField = subject[field: "bField"]
 
+    let expected = SelectionSetMatcher(
+      parentType: Object_B,
+      directSelections: [
+        .field("A", type: .nonNull(.scalar(Scalar_String))),
+        .field("B", type: .nonNull(.scalar(Scalar_String))),
+      ]
+    )
+
     // then
-    expect(bField?.selectionSet?.selections.direct?.inlineFragments).to(beEmpty())
+    expect(bField?.selectionSet).to(shallowlyMatch(expected))
   }
 
   func test__children__givenInlineFragment_onNonMatchingType_doesNotMergeTypeCaseIn_hasChildTypeCase() throws {

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -245,8 +245,8 @@ class IRRootFieldBuilderTests: XCTestCase {
 
     let child = rocks?[as: "Animal"]
     expect(child?.parentType).to(equal(Interface_Animal))
-    expect(child?.selections.direct?.fragments.count).to(equal(1))
-    expect(child?.selections.direct?.fragments.values[0].definition).to(equal(Fragment_AnimalDetails))
+    expect(child?.selections.direct?.namedFragments.count).to(equal(1))
+    expect(child?.selections.direct?.namedFragments.values[0].definition).to(equal(Fragment_AnimalDetails))
   }
 
   // MARK: Children Computation - Union Type

--- a/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGenIR/IRRootFieldBuilderTests.swift
@@ -127,7 +127,7 @@ class IRRootFieldBuilderTests: XCTestCase {
 
     let child = allAnimals?[as: "Bird"]
     expect(child?.parentType).to(equal(Object_Bird))
-    expect(child?.selections.direct?.fragments.values).to(shallowlyMatch([Fragment_BirdDetails]))
+    expect(child?.selections.direct?.namedFragments.values).to(shallowlyMatch([Fragment_BirdDetails]))
   }
 
   func test__children__isObjectType_initWithNamedFragmentOnLessSpecificMatchingType_hasNoChildTypeCase() throws {


### PR DESCRIPTION
This brings clarity to parts of the IR with regards to when work is being done on an inline fragment spread vs. a named fragment spread.

What was previously `IR.SelectionSet` when dealing with inline fragment spreads is now `IR.InlineFragmentSpread` which in turn now contains a selection set, deferred property, type info and inclusion conditions. Similarly `IR.FragmentSpread` is now `IR.NamedFragmentSpread`.