### PR TITLE
Updating Persisted Query Configuration

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		54DDB0921EA045870009DD99 /* InMemoryNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */; };
 		5AC6CA4322AAF7B200B7C94D /* GraphQLHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */; };
 		5BB2C0232380836100774170 /* VersionNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB2C0222380836100774170 /* VersionNumberTests.swift */; };
+		6608B3362A7D402B006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6608B3342A7D3FF5006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift */; };
 		662EA65E2A701483008A1931 /* GenerateOperationManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662EA65D2A701483008A1931 /* GenerateOperationManifest.swift */; };
 		662EA6602A705BD7008A1931 /* GenerateOperationManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662EA65F2A705BD7008A1931 /* GenerateOperationManifestTests.swift */; };
 		66321AE72A126C4400CC35CB /* IR+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66321AE62A126C4400CC35CB /* IR+Formatting.swift */; };
@@ -1140,6 +1141,7 @@
 		54DDB0911EA045870009DD99 /* InMemoryNormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryNormalizedCache.swift; sourceTree = "<group>"; };
 		5AC6CA4222AAF7B200B7C94D /* GraphQLHTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPMethod.swift; sourceTree = "<group>"; };
 		5BB2C0222380836100774170 /* VersionNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionNumberTests.swift; sourceTree = "<group>"; };
+		6608B3342A7D3FF5006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApolloCodegenConfiguration+OperationManifestConfiguration.swift"; sourceTree = "<group>"; };
 		662EA65D2A701483008A1931 /* GenerateOperationManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateOperationManifest.swift; sourceTree = "<group>"; };
 		662EA65F2A705BD7008A1931 /* GenerateOperationManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateOperationManifestTests.swift; sourceTree = "<group>"; };
 		66321AE62A126C4400CC35CB /* IR+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+Formatting.swift"; sourceTree = "<group>"; };
@@ -2206,6 +2208,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6608B3332A7D3FCB006FB655 /* CodegenConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				6608B3342A7D3FF5006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift */,
+			);
+			path = CodegenConfiguration;
+			sourceTree = "<group>";
+		};
 		66B18E862A15366400525DFB /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -2548,6 +2558,7 @@
 		9BD681332405F6BB000874CB /* Codegen */ = {
 			isa = PBXGroup;
 			children = (
+				6608B3332A7D3FCB006FB655 /* CodegenConfiguration */,
 				9B7B6F57233C287100F32205 /* ApolloCodegen.swift */,
 				9B7B6F58233C287100F32205 /* ApolloCodegenConfiguration.swift */,
 				E674DB40274C0A9B009BB90E /* Glob.swift */,
@@ -5053,6 +5064,7 @@
 				E6203342284F1C9600A291D1 /* MockUnionsFileGenerator.swift in Sources */,
 				DE6D07F927BC3B6D009F5F33 /* GraphQLInputField+Rendered.swift in Sources */,
 				9F1A966C258F34BB00A06EEB /* GraphQLSchema.swift in Sources */,
+				6608B3362A7D402B006FB655 /* ApolloCodegenConfiguration+OperationManifestConfiguration.swift in Sources */,
 				9BE74D3D23FB4A8E006D354F /* FileFinder.swift in Sources */,
 				E64F7EBC27A11A510059C021 /* GraphQLNamedType+SwiftName.swift in Sources */,
 				9B7B6F59233C287200F32205 /* ApolloCodegen.swift in Sources */,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -67,6 +67,22 @@ public class ApolloCodegen {
       }
     }
   }
+  
+  public struct CodeGenerationBuildOptions: OptionSet {
+    public var rawValue: Int
+    
+    public static let code = CodeGenerationBuildOptions(rawValue: 1 << 0)
+    public static let operationManifest = CodeGenerationBuildOptions(rawValue: 1 << 1)
+    public static let all = [
+      CodeGenerationBuildOptions.code,
+      CodeGenerationBuildOptions.operationManifest
+    ]
+    
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+    
+  }
 
   /// Executes the code generation engine with a specified configuration.
   ///
@@ -77,7 +93,8 @@ public class ApolloCodegen {
   ///     If `nil`, the current working directory of the executing process will be used.
   public static func build(
     with configuration: ApolloCodegenConfiguration,
-    withRootURL rootURL: URL? = nil
+    withRootURL rootURL: URL? = nil,
+    buildOptions: CodeGenerationBuildOptions = [.code]
   ) throws {
     try build(with: configuration, rootURL: rootURL)
   }
@@ -85,7 +102,8 @@ public class ApolloCodegen {
   internal static func build(
     with configuration: ApolloCodegenConfiguration,
     rootURL: URL? = nil,
-    fileManager: ApolloFileManager = .default
+    fileManager: ApolloFileManager = .default,
+    buildOptions: CodeGenerationBuildOptions = [.code]
   ) throws {
 
     let configContext = ConfigurationContext(
@@ -103,57 +121,39 @@ public class ApolloCodegen {
     try validate(configContext, with: compilationResult)
 
     let ir = IR(compilationResult: compilationResult)
+    
+    if buildOptions.contains(.operationManifest) {
+      var operationIDsFileGenerator = OperationManifestFileGenerator(config: configContext)
+      
+      for operation in compilationResult.operations {
+        let irOperation = ir.build(operation: operation)
+        operationIDsFileGenerator?.collectOperationIdentifier(irOperation)
+      }
+      
+      try operationIDsFileGenerator?.generate(fileManager: fileManager)
+    }
 
-    var existingGeneratedFilePaths = configuration.options.pruneGeneratedFiles ?
-    try findExistingGeneratedFilePaths(
-      config: configContext,
-      fileManager: fileManager
-    ) : []
+    if buildOptions.contains(.code) {
+      var existingGeneratedFilePaths = configuration.options.pruneGeneratedFiles ?
+      try findExistingGeneratedFilePaths(
+        config: configContext,
+        fileManager: fileManager
+      ) : []
 
-    try generateFiles(
-      compilationResult: compilationResult,
-      ir: ir,
-      config: configContext,
-      fileManager: fileManager
-    )
-
-    if configuration.options.pruneGeneratedFiles {
-      try deleteExtraneousGeneratedFiles(
-        from: &existingGeneratedFilePaths,
-        afterCodeGenerationUsing: fileManager
+      try generateFiles(
+        compilationResult: compilationResult,
+        ir: ir,
+        config: configContext,
+        fileManager: fileManager
       )
-    }
-  }
 
-  public static func generateOperationManifest(
-    with configuration: ApolloCodegenConfiguration,
-    withRootURL rootURL: URL? = nil,
-    fileManager: ApolloFileManager = .default
-  ) throws {
-    let configContext = ConfigurationContext(
-      config: configuration,
-      rootURL: rootURL
-    )
-    
-    try validate(configContext)
-    
-    let compilationResult = try compileGraphQLResult(
-      configContext,
-      experimentalFeatures: configuration.experimentalFeatures
-    )
-    
-    try validate(configContext, with: compilationResult)
-    
-    let ir = IR(compilationResult: compilationResult)
-    
-    var operationIDsFileGenerator = OperationManifestFileGenerator(config: configContext)
-    
-    for operation in compilationResult.operations {
-      let irOperation = ir.build(operation: operation)
-      operationIDsFileGenerator?.collectOperationIdentifier(irOperation)
+      if configuration.options.pruneGeneratedFiles {
+        try deleteExtraneousGeneratedFiles(
+          from: &existingGeneratedFilePaths,
+          afterCodeGenerationUsing: fileManager
+        )
+      }
     }
-    
-    try operationIDsFileGenerator?.generate(fileManager: fileManager)
   }
 
   // MARK: Internal

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -73,9 +73,9 @@ public class ApolloCodegen {
     
     public static let code = ItemsToGenerate(rawValue: 1 << 0)
     public static let operationManifest = ItemsToGenerate(rawValue: 1 << 1)
-    public static let all = [
-      ItemsToGenerate.code,
-      ItemsToGenerate.operationManifest
+    public static let all: ItemsToGenerate = [
+      .code,
+      .operationManifest
     ]
     
     public init(rawValue: Int) {

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -124,7 +124,7 @@ public class ApolloCodegen {
       )
     }
   }
-  
+
   public static func generateOperationManifest(
     with configuration: ApolloCodegenConfiguration,
     withRootURL rootURL: URL? = nil,

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -122,7 +122,7 @@ public class ApolloCodegen {
 
     let ir = IR(compilationResult: compilationResult)
     
-    if itemsToGenerate.contains(.operationManifest) {
+    if itemsToGenerate == .operationManifest {
       var operationIDsFileGenerator = OperationManifestFileGenerator(config: configContext)
       
       for operation in compilationResult.operations {

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1012,7 +1012,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       if let operationIDsPath = fileOutput.operationIDsPath {
         operationManifestConfiguration = OperationManifestConfiguration(
           path: operationIDsPath,
-          version: .legacyAPQ
+          version: .legacy
         )
       }
     }

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -1247,7 +1247,7 @@ extension ApolloCodegenConfiguration.FileOutput {
   ///  If `.none`, test mocks will not be generated. Defaults to `.none`.
   ///  - operationIdentifiersPath: An absolute location to an operation id JSON map file
   ///  for use with APQ registration. Defaults to `nil`.
-  @available(*, deprecated, renamed: "init(schemaTypes:operations:testMocks:operationManifest:)")
+  @available(*, deprecated, renamed: "init(schemaTypes:operations:testMocks:)")
   public init(
     schemaTypes: ApolloCodegenConfiguration.SchemaTypesFileOutput,
     operations: ApolloCodegenConfiguration.OperationsFileOutput = Default.operations,

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -167,7 +167,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// Configures the generation of an operation manifest JSON file for use with persisted queries
     /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
     /// Defaults to `nil`.
-    public let operationManifest: OperationManifestFileOutput?
+    public var operationManifest: OperationManifestFileOutput?
 
     /// Default property values
     public struct Default {
@@ -480,11 +480,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// Defaults to `nil`.
   public struct OperationManifestFileOutput: Codable, Equatable {
     /// Local path where the generated operation manifest file should be written.
-    let path: String
+    public let path: String
     /// The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
-    let version: Version
+    public let version: Version
 
-    public enum Version: String, Codable, Equatable {
+    public enum Version: String, Codable, Equatable, CaseIterable {
       /// Generates an operation manifest for use with persisted queries.
       case persistedQueries
       /// Generates an operation manifest for pre-registering operations with the legacy
@@ -944,7 +944,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// The input files required for code generation.
   public let input: FileInput
   /// The paths and files output by code generation.
-  public let output: FileOutput
+  public var output: FileOutput
   /// Rules and options to customize the generated code.
   public let options: OutputOptions
   /// Allows users to enable experimental features.

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -165,8 +165,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// The local path structure for the test mock operation object files.
     public let testMocks: TestMockFileOutput
     
-    /// This var helps maintain backwards compatibility with legacy APQ config with the new
-    /// `OperationManifestConfiguration` and will be fully removed in v2.0
+    /// This var helps maintain backwards compatibility with legacy operation manifest generation
+    /// with the new `OperationManifestConfiguration` and will be fully removed in v2.0
     fileprivate let operationIDsPath: String?
 
     /// Default property values
@@ -906,7 +906,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   public let experimentalFeatures: ExperimentalFeatures
   /// Schema download configuration.
   public let schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration?
-  /// `OperationManifestConfiguration` for persisted queries or legacy APQs
+  /// `OperationManifestConfiguration` for persisted queries
   public let operationManifestConfiguration: OperationManifestConfiguration?
 
   public struct Default {

--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -905,15 +905,15 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   /// available.
   public let experimentalFeatures: ExperimentalFeatures
   /// Schema download configuration.
-  public let schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration?
+  public let schemaDownload: ApolloSchemaDownloadConfiguration?
   /// Configuration for generating an operation manifest for use with persisted queries.
-  public let operationManifestConfiguration: OperationManifestConfiguration?
+  public let operationManifest: OperationManifestConfiguration?
 
   public struct Default {
     public static let options: OutputOptions = OutputOptions()
     public static let experimentalFeatures: ExperimentalFeatures = ExperimentalFeatures()
-    public static let schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = nil
-    public static let operationManifestConfiguration: OperationManifestConfiguration? = nil
+    public static let schemaDownload: ApolloSchemaDownloadConfiguration? = nil
+    public static let operationManifest: OperationManifestConfiguration? = nil
   }
 
   // MARK: - Helper Properties
@@ -936,16 +936,16 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     output: FileOutput,
     options: OutputOptions = Default.options,
     experimentalFeatures: ExperimentalFeatures = Default.experimentalFeatures,
-    schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = Default.schemaDownloadConfiguration,
-    operationManifestConfiguration: OperationManifestConfiguration? = Default.operationManifestConfiguration
+    schemaDownload: ApolloSchemaDownloadConfiguration? = Default.schemaDownload,
+    operationManifest: OperationManifestConfiguration? = Default.operationManifest
   ) {
     self.schemaNamespace = schemaNamespace
     self.input = input
     self.output = output
     self.options = options
     self.experimentalFeatures = experimentalFeatures
-    self.schemaDownloadConfiguration = schemaDownloadConfiguration
-    self.operationManifestConfiguration = operationManifestConfiguration
+    self.schemaDownload = schemaDownload
+    self.operationManifest = operationManifest
     self.ApolloAPITargetName = options.cocoapodsCompatibleImportStatements ? "Apollo" : "ApolloAPI"
   }
 
@@ -959,7 +959,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     case options
     case experimentalFeatures
     case schemaDownloadConfiguration
-    case operationManifestConfiguration
+    case schemaDownload
+    case operationManifest
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -971,12 +972,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     try container.encode(self.options, forKey: .options)
     try container.encode(experimentalFeatures, forKey: .experimentalFeatures)
 
-    if let schemaDownloadConfiguration {
-      try container.encode(schemaDownloadConfiguration, forKey: .schemaDownloadConfiguration)
+    if let schemaDownload {
+      try container.encode(schemaDownload, forKey: .schemaDownload)
     }
     
-    if let operationManifestConfiguration {
-      try container.encode(operationManifestConfiguration, forKey: .operationManifestConfiguration)
+    if let operationManifest {
+      try container.encode(operationManifest, forKey: .operationManifest)
     }
   }
 
@@ -1007,14 +1008,19 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       forKey: .options
     ) ?? Default.options
     
-    var operationManifestConfiguration = try values.decodeIfPresent(OperationManifestConfiguration.self, forKey: .operationManifestConfiguration)
-    if operationManifestConfiguration == nil {
+    var operationManifest = try values.decodeIfPresent(OperationManifestConfiguration.self, forKey: .operationManifest)
+    if operationManifest == nil {
       if let operationIDsPath = fileOutput.operationIDsPath {
-        operationManifestConfiguration = OperationManifestConfiguration(
+        operationManifest = OperationManifestConfiguration(
           path: operationIDsPath,
           version: .legacy
         )
       }
+    }
+    
+    var schemaDownload = try values.decodeIfPresent(ApolloSchemaDownloadConfiguration.self, forKey: .schemaDownload)
+    if schemaDownload == nil {
+      schemaDownload = try values.decodeIfPresent(ApolloSchemaDownloadConfiguration.self, forKey: .schemaDownloadConfiguration)
     }
 
     self.init(
@@ -1026,11 +1032,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         ExperimentalFeatures.self,
         forKey: .experimentalFeatures
       ) ?? Default.experimentalFeatures,
-      schemaDownloadConfiguration: try values.decodeIfPresent(
-        ApolloSchemaDownloadConfiguration.self,
-        forKey: .schemaDownloadConfiguration
-      ) ?? Default.schemaDownloadConfiguration,
-      operationManifestConfiguration: operationManifestConfiguration ?? Default.operationManifestConfiguration
+      schemaDownload: schemaDownload ?? Default.schemaDownload,
+      operationManifest: operationManifest ?? Default.operationManifest
     )
   }
 }
@@ -1169,7 +1172,7 @@ extension ApolloCodegenConfiguration {
   @available(*, deprecated, renamed: "schemaNamespace")
   public var schemaName: String { schemaNamespace }
 
-  /// Deprecated initializer - use `init(schemaNamespace:input:output:options:experimentalFeatures:schemaDownloadConfiguration:)`
+  /// Deprecated initializer - use `init(schemaNamespace:input:output:options:experimentalFeatures:schemaDownload:operationManifest:)`
   /// instead.
   ///
   /// - Parameters:
@@ -1178,14 +1181,14 @@ extension ApolloCodegenConfiguration {
   ///  - output: The paths and files output by code generation.
   ///  - options: Rules and options to customize the generated code.
   ///  - experimentalFeatures: Allows users to enable experimental features.
-  @available(*, deprecated, renamed: "init(schemaNamespace:input:output:options:experimentalFeatures:schemaDownloadConfiguration:)")
+  @available(*, deprecated, renamed: "init(schemaNamespace:input:output:options:experimentalFeatures:schemaDownload:operationManifest:)")
   public init(
     schemaName: String,
     input: FileInput,
     output: FileOutput,
     options: OutputOptions = Default.options,
     experimentalFeatures: ExperimentalFeatures = Default.experimentalFeatures,
-    schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = Default.schemaDownloadConfiguration
+    schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration? = Default.schemaDownload
   ) {
     self.init(
       schemaNamespace: schemaName,
@@ -1193,7 +1196,7 @@ extension ApolloCodegenConfiguration {
       output: output,
       options: options,
       experimentalFeatures: experimentalFeatures,
-      schemaDownloadConfiguration: schemaDownloadConfiguration)
+      schemaDownload: schemaDownloadConfiguration)
   }
 
   /// Enum to enable using

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -6,22 +6,27 @@ extension ApolloCodegenConfiguration {
     
     // MARK: - Properties
     
-    /// Configures the generation of an operation manifest JSON file for use with persisted queries
-    /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
-    /// Defaults to `nil`.
-    public let operationManifest: OperationManifestFileOutput?
-    
-    /// How to generate the operation documents for your generated operations.
-    public let operationDocumentFormat: OperationDocumentFormat
+    /// Local path where the generated operation manifest file should be written.
+    public let path: String
+    /// The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
+    public let version: Version
+
+    public enum Version: String, Codable, Equatable {
+      /// Generates an operation manifest for use with persisted queries.
+      case persistedQueries
+      /// Generates an operation manifest for pre-registering operations with the legacy
+      /// [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
+      /// functionality of Apollo Server/Router.
+      case legacyAPQ
+    }
     
     /// If set to `true` will generate the operation manfiest every time code generation is run. Defaults to `false`
-    public let autoGenerate: Bool
+    public let generateManifestOnCodeGeneration: Bool
     
     /// Default property values
     public struct Default {
-      public static let operationManifest: OperationManifestFileOutput? = nil
-      public static let operationDocumentFormat: OperationDocumentFormat = .definition
-      public static let autoGenerate: Bool = false
+      public static let version: Version = .persistedQueries
+      public static let generateManifestOnCodeGeneration: Bool = false
     }
     
     // MARK: - Initializers
@@ -32,21 +37,21 @@ extension ApolloCodegenConfiguration {
     ///   - operationManifes: The `OperationManifestFileOutput` used to determine where and how to output the operation manifest JSON
     ///   - operationDocumentFormat: The `OperationDocumentFormat` used to determine how to output operations in the generated code files.
     public init(
-      operationManifest: OperationManifestFileOutput? = Default.operationManifest,
-      operationDocumentFormat: OperationDocumentFormat = Default.operationDocumentFormat,
-      autoGenerate: Bool = Default.autoGenerate
+      path: String,
+      version: Version = Default.version,
+      generateManifestOnCodeGeneration: Bool = Default.generateManifestOnCodeGeneration
     ) {
-      self.operationManifest = operationManifest
-      self.operationDocumentFormat = operationDocumentFormat
-      self.autoGenerate = autoGenerate
+      self.path = path
+      self.version = version
+      self.generateManifestOnCodeGeneration = generateManifestOnCodeGeneration
     }
     
     // MARK: - Codable
     
     enum CodingKeys: CodingKey, CaseIterable {
-      case operationManifest
-      case operationDocumentFormat
-      case autoGenerate
+      case path
+      case version
+      case generateManifestOnCodeGeneration
     }
     
     public init(from decoder: Decoder) throws {
@@ -57,121 +62,28 @@ extension ApolloCodegenConfiguration {
         decoder: decoder
       )
       
-      operationManifest = try values.decode(
-        OperationManifestFileOutput.self,
-        forKey: .operationManifest
+      path = try values.decode(
+        String.self,
+        forKey: .path
       )
       
-      operationDocumentFormat = try values.decode(
-        OperationDocumentFormat.self,
-        forKey: .operationDocumentFormat
+      version = try values.decode(
+        Version.self,
+        forKey: .version
       )
       
-      autoGenerate = try values.decode(
+      generateManifestOnCodeGeneration = try values.decode(
         Bool.self,
-        forKey: .autoGenerate
+        forKey: .generateManifestOnCodeGeneration
       )
     }
     
     public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       
-      try container.encode(self.operationManifest, forKey: .operationManifest)
-      try container.encode(self.operationDocumentFormat, forKey: .operationDocumentFormat)
-      try container.encode(self.autoGenerate, forKey: .autoGenerate)
-    }
-    
-    // MARK: - OperationManifestFileOutput
-    
-    /// Configures the generation of an operation manifest JSON file for use with persisted queries
-    /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
-    ///
-    /// The operation manifest is a JSON file that maps all generated GraphQL operations to an
-    /// operation identifier. This manifest can be used to register operations with a server utilizing
-    /// persisted queries
-    /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
-    /// Defaults to `nil`.
-    public struct OperationManifestFileOutput: Codable, Equatable {
-      /// Local path where the generated operation manifest file should be written.
-      public let path: String
-      /// The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
-      public let version: Version
-
-      public enum Version: String, Codable, Equatable {
-        /// Generates an operation manifest for use with persisted queries.
-        case persistedQueries
-        /// Generates an operation manifest for pre-registering operations with the legacy
-        /// [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
-        /// functionality of Apollo Server/Router.
-        case legacyAPQ
-      }
-
-      /// Designated Initializer
-      /// - Parameters:
-      ///   - path: Local path where the generated operation manifest file should be written.
-      ///   - version: The version format to use when generating the operation manifest.
-      ///   Defaults to `.persistedQueries`.
-      public init(path: String, version: Version = .persistedQueries) {
-        self.path = path
-        self.version = version
-      }
-
-    }
-    
-    // MARK: - OperationDocumentFormat
-    
-    public struct OperationDocumentFormat: OptionSet, Codable, Equatable {
-      /// Include the GraphQL source document for the operation in the generated operation models.
-      public static let definition = Self(rawValue: 1)
-      /// Include the computed operation identifier hash for use with persisted queries
-      /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
-      public static let operationId = Self(rawValue: 1 << 1)
-
-      public var rawValue: UInt8
-      public init(rawValue: UInt8) {
-        self.rawValue = rawValue
-      }
-
-      // MARK: Codable
-
-      public enum CodingKeys: String, CodingKey {
-        case definition
-        case operationId
-      }
-
-      public init(from decoder: Decoder) throws {
-        self = OperationDocumentFormat(rawValue: 0)
-
-        var container = try decoder.unkeyedContainer()
-        while !container.isAtEnd {
-          let value = try container.decode(String.self)
-          switch CodingKeys(rawValue: value) {
-          case .definition:
-            self.insert(.definition)
-          case .operationId:
-            self.insert(.operationId)
-          default: continue
-          }
-        }
-        guard self.rawValue != 0 else {
-          throw DecodingError.valueNotFound(
-            OperationDocumentFormat.self,
-            .init(codingPath: [
-              ApolloCodegenConfiguration.CodingKeys.options,
-              OutputOptions.CodingKeys.operationDocumentFormat
-            ], debugDescription: "operationDocumentFormat configuration cannot be empty."))
-        }
-      }
-
-      public func encode(to encoder: Encoder) throws {
-        var container = encoder.unkeyedContainer()
-        if self.contains(.definition) {
-          try container.encode(CodingKeys.definition.rawValue)
-        }
-        if self.contains(.operationId) {
-          try container.encode(CodingKeys.operationId.rawValue)
-        }
-      }
+      try container.encode(self.path, forKey: .path)
+      try container.encode(self.version, forKey: .version)
+      try container.encode(self.generateManifestOnCodeGeneration, forKey: .generateManifestOnCodeGeneration)
     }
     
   }

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -17,7 +17,7 @@ extension ApolloCodegenConfiguration {
       /// Generates an operation manifest for pre-registering operations with the legacy
       /// [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
       /// functionality of Apollo Server/Router.
-      case legacyAPQ
+      case legacy
     }
     
     /// If set to `true` will generate the operation manfiest every time code generation is run. Defaults to `false`

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+extension ApolloCodegenConfiguration {
+  
+  public struct OperationManifestConfiguration: Codable, Equatable {
+    
+    // MARK: - Properties
+    
+    /// Configures the generation of an operation manifest JSON file for use with persisted queries
+    /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
+    /// Defaults to `nil`.
+    public let operationManifest: OperationManifestFileOutput?
+    
+    /// How to generate the operation documents for your generated operations.
+    public let operationDocumentFormat: OperationDocumentFormat
+    
+    /// Default property values
+    public struct Default {
+      public static let operationManifest: OperationManifestFileOutput? = nil
+      public static let operationDocumentFormat: OperationDocumentFormat = .definition
+    }
+    
+    // MARK: - Initializers
+    
+    /// Designated initializer
+    ///
+    /// - Parameters:
+    ///   - operationManifes: The `OperationManifestFileOutput` used to determine where and how to output the operation manifest JSON
+    ///   - operationDocumentFormat: The `OperationDocumentFormat` used to determine how to output operations in the generated code files.
+    public init(
+      operationManifest: OperationManifestFileOutput? = Default.operationManifest,
+      operationDocumentFormat: OperationDocumentFormat = Default.operationDocumentFormat
+    ) {
+      self.operationManifest = operationManifest
+      self.operationDocumentFormat = operationDocumentFormat
+    }
+    
+    // MARK: - Codable
+    
+    enum CodingKeys: CodingKey, CaseIterable {
+      case operationManifest
+      case operationDocumentFormat
+    }
+    
+    public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      try throwIfContainsUnexpectedKey(
+        container: values,
+        type: Self.self,
+        decoder: decoder
+      )
+      
+      operationManifest = try values.decode(
+        OperationManifestFileOutput.self,
+        forKey: .operationManifest
+      )
+      
+      operationDocumentFormat = try values.decode(
+        OperationDocumentFormat.self,
+        forKey: .operationDocumentFormat
+      )
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      
+      try container.encode(self.operationManifest, forKey: .operationManifest)
+      try container.encode(self.operationDocumentFormat, forKey: .operationDocumentFormat)
+    }
+    
+    // MARK: - OperationManifestFileOutput
+    
+    /// Configures the generation of an operation manifest JSON file for use with persisted queries
+    /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
+    ///
+    /// The operation manifest is a JSON file that maps all generated GraphQL operations to an
+    /// operation identifier. This manifest can be used to register operations with a server utilizing
+    /// persisted queries
+    /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
+    /// Defaults to `nil`.
+    public struct OperationManifestFileOutput: Codable, Equatable {
+      /// Local path where the generated operation manifest file should be written.
+      let path: String
+      /// The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
+      let version: Version
+
+      public enum Version: String, Codable, Equatable {
+        /// Generates an operation manifest for use with persisted queries.
+        case persistedQueries
+        /// Generates an operation manifest for pre-registering operations with the legacy
+        /// [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
+        /// functionality of Apollo Server/Router.
+        case legacyAPQ
+      }
+
+      /// Designated Initializer
+      /// - Parameters:
+      ///   - path: Local path where the generated operation manifest file should be written.
+      ///   - version: The version format to use when generating the operation manifest.
+      ///   Defaults to `.persistedQueries`.
+      public init(path: String, version: Version = .persistedQueries) {
+        self.path = path
+        self.version = version
+      }
+
+    }
+    
+    // MARK: - OperationDocumentFormat
+    
+    public struct OperationDocumentFormat: OptionSet, Codable, Equatable {
+      /// Include the GraphQL source document for the operation in the generated operation models.
+      public static let definition = Self(rawValue: 1)
+      /// Include the computed operation identifier hash for use with persisted queries
+      /// or [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
+      public static let operationId = Self(rawValue: 1 << 1)
+
+      public var rawValue: UInt8
+      public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+      }
+
+      // MARK: Codable
+
+      public enum CodingKeys: String, CodingKey {
+        case definition
+        case operationId
+      }
+
+      public init(from decoder: Decoder) throws {
+        self = OperationDocumentFormat(rawValue: 0)
+
+        var container = try decoder.unkeyedContainer()
+        while !container.isAtEnd {
+          let value = try container.decode(String.self)
+          switch CodingKeys(rawValue: value) {
+          case .definition:
+            self.insert(.definition)
+          case .operationId:
+            self.insert(.operationId)
+          default: continue
+          }
+        }
+        guard self.rawValue != 0 else {
+          throw DecodingError.valueNotFound(
+            OperationDocumentFormat.self,
+            .init(codingPath: [
+              ApolloCodegenConfiguration.CodingKeys.options,
+              OutputOptions.CodingKeys.operationDocumentFormat
+            ], debugDescription: "operationDocumentFormat configuration cannot be empty."))
+        }
+      }
+
+      public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        if self.contains(.definition) {
+          try container.encode(CodingKeys.definition.rawValue)
+        }
+        if self.contains(.operationId) {
+          try container.encode(CodingKeys.operationId.rawValue)
+        }
+      }
+    }
+    
+  }
+  
+}

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -14,10 +14,14 @@ extension ApolloCodegenConfiguration {
     /// How to generate the operation documents for your generated operations.
     public let operationDocumentFormat: OperationDocumentFormat
     
+    /// If set to `true` will generate the operation manfiest every time code generation is run. Defaults to `false`
+    public let autoGenerate: Bool
+    
     /// Default property values
     public struct Default {
       public static let operationManifest: OperationManifestFileOutput? = nil
       public static let operationDocumentFormat: OperationDocumentFormat = .definition
+      public static let autoGenerate: Bool = false
     }
     
     // MARK: - Initializers
@@ -29,10 +33,12 @@ extension ApolloCodegenConfiguration {
     ///   - operationDocumentFormat: The `OperationDocumentFormat` used to determine how to output operations in the generated code files.
     public init(
       operationManifest: OperationManifestFileOutput? = Default.operationManifest,
-      operationDocumentFormat: OperationDocumentFormat = Default.operationDocumentFormat
+      operationDocumentFormat: OperationDocumentFormat = Default.operationDocumentFormat,
+      autoGenerate: Bool = Default.autoGenerate
     ) {
       self.operationManifest = operationManifest
       self.operationDocumentFormat = operationDocumentFormat
+      self.autoGenerate = autoGenerate
     }
     
     // MARK: - Codable
@@ -40,6 +46,7 @@ extension ApolloCodegenConfiguration {
     enum CodingKeys: CodingKey, CaseIterable {
       case operationManifest
       case operationDocumentFormat
+      case autoGenerate
     }
     
     public init(from decoder: Decoder) throws {
@@ -59,6 +66,11 @@ extension ApolloCodegenConfiguration {
         OperationDocumentFormat.self,
         forKey: .operationDocumentFormat
       )
+      
+      autoGenerate = try values.decode(
+        Bool.self,
+        forKey: .autoGenerate
+      )
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -66,6 +78,7 @@ extension ApolloCodegenConfiguration {
       
       try container.encode(self.operationManifest, forKey: .operationManifest)
       try container.encode(self.operationDocumentFormat, forKey: .operationDocumentFormat)
+      try container.encode(self.autoGenerate, forKey: .autoGenerate)
     }
     
     // MARK: - OperationManifestFileOutput
@@ -80,9 +93,9 @@ extension ApolloCodegenConfiguration {
     /// Defaults to `nil`.
     public struct OperationManifestFileOutput: Codable, Equatable {
       /// Local path where the generated operation manifest file should be written.
-      let path: String
+      public let path: String
       /// The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
-      let version: Version
+      public let version: Version
 
       public enum Version: String, Codable, Equatable {
         /// Generates an operation manifest for use with persisted queries.

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -14,12 +14,12 @@ extension ApolloCodegenConfiguration {
     public enum Version: String, Codable, Equatable {
       /// Generates an operation manifest for use with persisted queries.
       case persistedQueries
-      /// Generates an operation manifest for in the legacy format used prior to the
+      /// Generates an operation manifest in the legacy safelisting format used prior to the
       /// [Persisted Queries](https://www.apollographql.com/docs/ios/fetching/persisted-queries) feature.
       case legacy
     }
     
-    /// If set to `true` will generate the operation manfiest every time code generation is run. Defaults to `false`
+    /// If set to `true` will generate the operation manifest every time code generation is run. Defaults to `false`
     public let generateManifestOnCodeGeneration: Bool
     
     /// Default property values
@@ -33,8 +33,9 @@ extension ApolloCodegenConfiguration {
     /// Designated initializer
     ///
     /// - Parameters:
-    ///   - operationManifes: The `OperationManifestFileOutput` used to determine where and how to output the operation manifest JSON
-    ///   - operationDocumentFormat: The `OperationDocumentFormat` used to determine how to output operations in the generated code files.
+    ///   - path: Local path where the generated operation manifest file should be written.
+    ///   - version: The version format to use when generating the operation manifest. Defaults to `.persistedQueries`.
+    ///   - generateManifestOnCodeGeneration: Whether or nor the operation manifest should be generated whenever code generation is run. Defaults to `false`.
     public init(
       path: String,
       version: Version = Default.version,

--- a/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
+++ b/Sources/ApolloCodegenLib/CodegenConfiguration/ApolloCodegenConfiguration+OperationManifestConfiguration.swift
@@ -14,9 +14,8 @@ extension ApolloCodegenConfiguration {
     public enum Version: String, Codable, Equatable {
       /// Generates an operation manifest for use with persisted queries.
       case persistedQueries
-      /// Generates an operation manifest for pre-registering operations with the legacy
-      /// [Automatic Persisted Queries (APQs)](https://www.apollographql.com/docs/apollo-server/performance/apq).
-      /// functionality of Apollo Server/Router.
+      /// Generates an operation manifest for in the legacy format used prior to the
+      /// [Persisted Queries](https://www.apollographql.com/docs/ios/fetching/persisted-queries) feature.
       case legacy
     }
     

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -37,7 +37,7 @@ struct OperationManifestFileGenerator {
   /// Parameters:
   ///  - config: A configuration object specifying output behavior.
   init?(config: ApolloCodegen.ConfigurationContext) {
-    guard config.operationManifestConfiguration != nil else {
+    guard config.operationManifest != nil else {
       return nil
     }
 
@@ -57,7 +57,7 @@ struct OperationManifestFileGenerator {
   func generate(fileManager: ApolloFileManager = .default) throws {
     let rendered: String = try template.render(operations: operationManifest)
 
-    var manifestPath = config.operationManifestConfiguration.unsafelyUnwrapped.path
+    var manifestPath = config.operationManifest.unsafelyUnwrapped.path
     let relativePrefix = "./"
       
     // if path begins with './' the path should be relative to the config.rootURL
@@ -80,7 +80,7 @@ struct OperationManifestFileGenerator {
   }
 
   var template: any OperationManifestTemplate {
-    switch config.operationManifestConfiguration.unsafelyUnwrapped.version {
+    switch config.operationManifest.unsafelyUnwrapped.version {
     case .persistedQueries:
       return PersistedQueriesOperationManifestTemplate(config: config)
     case .legacy:

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -83,7 +83,7 @@ struct OperationManifestFileGenerator {
     switch config.operationManifestConfiguration.unsafelyUnwrapped.version {
     case .persistedQueries:
       return PersistedQueriesOperationManifestTemplate(config: config)
-    case .legacyAPQ:
+    case .legacy:
       return LegacyAPQOperationManifestTemplate()
     }
   }

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -37,7 +37,7 @@ struct OperationManifestFileGenerator {
   /// Parameters:
   ///  - config: A configuration object specifying output behavior.
   init?(config: ApolloCodegen.ConfigurationContext) {
-    guard config.output.operationManifest != nil else {
+    guard config.operationManifestConfiguration?.operationManifest != nil else {
       return nil
     }
 
@@ -57,7 +57,7 @@ struct OperationManifestFileGenerator {
   func generate(fileManager: ApolloFileManager = .default) throws {
     let rendered: String = try template.render(operations: operationManifest)
 
-    var manifestPath = config.output.operationManifest.unsafelyUnwrapped.path
+    var manifestPath = config.operationManifestConfiguration.unsafelyUnwrapped.operationManifest.unsafelyUnwrapped.path
     let relativePrefix = "./"
       
     // if path begins with './' the path should be relative to the config.rootURL
@@ -80,7 +80,7 @@ struct OperationManifestFileGenerator {
   }
 
   var template: any OperationManifestTemplate {
-    switch config.output.operationManifest.unsafelyUnwrapped.version {
+    switch config.operationManifestConfiguration.unsafelyUnwrapped.operationManifest.unsafelyUnwrapped.version {
     case .persistedQueries:
       return PersistedQueriesOperationManifestTemplate(config: config)
     case .legacyAPQ:

--- a/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
+++ b/Sources/ApolloCodegenLib/FileGenerators/OperationManifestFileGenerator.swift
@@ -37,7 +37,7 @@ struct OperationManifestFileGenerator {
   /// Parameters:
   ///  - config: A configuration object specifying output behavior.
   init?(config: ApolloCodegen.ConfigurationContext) {
-    guard config.operationManifestConfiguration?.operationManifest != nil else {
+    guard config.operationManifestConfiguration != nil else {
       return nil
     }
 
@@ -57,7 +57,7 @@ struct OperationManifestFileGenerator {
   func generate(fileManager: ApolloFileManager = .default) throws {
     let rendered: String = try template.render(operations: operationManifest)
 
-    var manifestPath = config.operationManifestConfiguration.unsafelyUnwrapped.operationManifest.unsafelyUnwrapped.path
+    var manifestPath = config.operationManifestConfiguration.unsafelyUnwrapped.path
     let relativePrefix = "./"
       
     // if path begins with './' the path should be relative to the config.rootURL
@@ -80,7 +80,7 @@ struct OperationManifestFileGenerator {
   }
 
   var template: any OperationManifestTemplate {
-    switch config.operationManifestConfiguration.unsafelyUnwrapped.operationManifest.unsafelyUnwrapped.version {
+    switch config.operationManifestConfiguration.unsafelyUnwrapped.version {
     case .persistedQueries:
       return PersistedQueriesOperationManifestTemplate(config: config)
     case .legacyAPQ:

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -62,12 +62,12 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
       accessControlRenderer: @autoclosure () -> String
     ) -> TemplateString {
       let includeFragments = !fragments.isEmpty
-      let includeDefinition = config.options.operationDocumentFormat.contains(.definition)
+      let includeDefinition = config.operationManifestConfiguration?.operationDocumentFormat.contains(.definition) ?? false
 
       return TemplateString("""
       \(accessControlRenderer())\
       static let operationDocument: \(config.ApolloAPITargetName).OperationDocument = .init(
-      \(if: config.options.operationDocumentFormat.contains(.operationId), """
+      \(if: config.operationManifestConfiguration?.operationDocumentFormat.contains(.operationId) ?? false, """
         operationIdentifier: \"\(identifier())\"\(if: includeDefinition, ",")
       """)
       \(if: includeDefinition, """

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -62,12 +62,12 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
       accessControlRenderer: @autoclosure () -> String
     ) -> TemplateString {
       let includeFragments = !fragments.isEmpty
-      let includeDefinition = config.operationManifestConfiguration?.operationDocumentFormat.contains(.definition) ?? false
+      let includeDefinition = config.options.operationDocumentFormat.contains(.definition)
 
       return TemplateString("""
       \(accessControlRenderer())\
       static let operationDocument: \(config.ApolloAPITargetName).OperationDocument = .init(
-      \(if: config.operationManifestConfiguration?.operationDocumentFormat.contains(.operationId) ?? false, """
+      \(if: config.options.operationDocumentFormat.contains(.operationId), """
         operationIdentifier: \"\(identifier())\"\(if: includeDefinition, ",")
       """)
       \(if: includeDefinition, """

--- a/Sources/CodegenCLI/Commands/FetchSchema.swift
+++ b/Sources/CodegenCLI/Commands/FetchSchema.swift
@@ -28,22 +28,16 @@ public struct FetchSchema: ParsableCommand {
   ) throws {
     logger.SetLoggingLevel(verbose: inputs.verbose)
 
-    switch (inputs.string, inputs.path) {
-    case let (.some(string), _):
-      try fetchSchema(data: try string.asData(), schemaDownloadProvider: schemaDownloadProvider)
-
-    case let (nil, path):
-      let data = try fileManager.unwrappedContents(atPath: path)
-      try fetchSchema(data: data, schemaDownloadProvider: schemaDownloadProvider)
-    }
+    try fetchSchema(
+      configuration: inputs.getCodegenConfiguration(fileManager: fileManager),
+      schemaDownloadProvider: schemaDownloadProvider
+    )    
   }
 
   private func fetchSchema(
-    data: Data,
+    configuration codegenConfiguration: ApolloCodegenConfiguration,
     schemaDownloadProvider: SchemaDownloadProvider.Type
   ) throws {
-    let codegenConfiguration = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: data)
-
     guard let schemaDownloadConfiguration = codegenConfiguration.schemaDownloadConfiguration else {
       throw Error(errorDescription: """
         Missing schema download configuration. Hint: check the `schemaDownloadConfiguration` \

--- a/Sources/CodegenCLI/Commands/FetchSchema.swift
+++ b/Sources/CodegenCLI/Commands/FetchSchema.swift
@@ -38,16 +38,16 @@ public struct FetchSchema: ParsableCommand {
     configuration codegenConfiguration: ApolloCodegenConfiguration,
     schemaDownloadProvider: SchemaDownloadProvider.Type
   ) throws {
-    guard let schemaDownloadConfiguration = codegenConfiguration.schemaDownloadConfiguration else {
+    guard let schemaDownload = codegenConfiguration.schemaDownload else {
       throw Error(errorDescription: """
-        Missing schema download configuration. Hint: check the `schemaDownloadConfiguration` \
+        Missing schema download configuration. Hint: check the `schemaDownload` \
         property of your configuration.
         """
       )
     }
 
     try schemaDownloadProvider.fetch(
-      configuration: schemaDownloadConfiguration,
+      configuration: schemaDownload,
       withRootURL: rootOutputURL(for: inputs)
     )
   }

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -66,7 +66,13 @@ public struct Generate: ParsableCommand {
         schemaDownloadProvider: schemaDownloadProvider
       )
     }
-    let itemsToGenerate: ApolloCodegen.ItemsToGenerate = (configuration.operationManifest?.generateManifestOnCodeGeneration ?? false) ? [.code, .operationManifest] : [.code]
+    
+    var itemsToGenerate: ApolloCodegen.ItemsToGenerate = .code
+        
+    if let operationManifest = configuration.operationManifest,
+        operationManifest.generateManifestOnCodeGeneration {
+      itemsToGenerate.insert(.operationManifest)
+    }
 
     try codegenProvider.build(
       with: configuration,

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -66,7 +66,7 @@ public struct Generate: ParsableCommand {
         schemaDownloadProvider: schemaDownloadProvider
       )
     }
-    let buildOptions: ApolloCodegen.CodeGenerationBuildOptions = (configuration.operationManifestConfiguration?.autoGenerate ?? false) ? [.code, .operationManifest] : [.code]
+    let buildOptions: ApolloCodegen.CodeGenerationBuildOptions = (configuration.operationManifestConfiguration?.generateManifestOnCodeGeneration ?? false) ? [.code, .operationManifest] : [.code]
 
     try codegenProvider.build(
       with: configuration,

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -52,21 +52,21 @@ public struct Generate: ParsableCommand {
   ) throws {
     if fetchSchema {
       guard
-        let schemaDownloadConfiguration = configuration.schemaDownloadConfiguration
+        let schemaDownload = configuration.schemaDownload
       else {
         throw Error(errorDescription: """
-          Missing schema download configuration. Hint: check the `schemaDownloadConfiguration` \
+          Missing schema download configuration. Hint: check the `schemaDownload` \
           property of your configuration.
           """
         )
       }
 
       try fetchSchema(
-        configuration: schemaDownloadConfiguration,
+        configuration: schemaDownload,
         schemaDownloadProvider: schemaDownloadProvider
       )
     }
-    let itemsToGenerate: ApolloCodegen.ItemsToGenerate = (configuration.operationManifestConfiguration?.generateManifestOnCodeGeneration ?? false) ? [.code, .operationManifest] : [.code]
+    let itemsToGenerate: ApolloCodegen.ItemsToGenerate = (configuration.operationManifest?.generateManifestOnCodeGeneration ?? false) ? [.code, .operationManifest] : [.code]
 
     try codegenProvider.build(
       with: configuration,

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -66,8 +66,13 @@ public struct Generate: ParsableCommand {
         schemaDownloadProvider: schemaDownloadProvider
       )
     }
+    let buildOptions: ApolloCodegen.CodeGenerationBuildOptions = (configuration.operationManifestConfiguration?.autoGenerate ?? false) ? [.code, .operationManifest] : [.code]
 
-    try codegenProvider.build(with: configuration, withRootURL: rootOutputURL(for: inputs))
+    try codegenProvider.build(
+      with: configuration,
+      withRootURL: rootOutputURL(for: inputs),
+      buildOptions: buildOptions
+    )
   }
 
   private func fetchSchema(

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -38,31 +38,18 @@ public struct Generate: ParsableCommand {
       with: inputs
     )
 
-    switch (inputs.string, inputs.path) {
-    case let (.some(string), _):
-      try generate(
-        data: try string.asData(),
-        codegenProvider: codegenProvider,
-        schemaDownloadProvider: schemaDownloadProvider
-      )
-
-    case let (nil, path):
-      let data = try fileManager.unwrappedContents(atPath: path)
-      try generate(
-        data: data,
-        codegenProvider: codegenProvider,
-        schemaDownloadProvider: schemaDownloadProvider
-      )
-    }
+    try generate(
+      configuration: inputs.getCodegenConfiguration(fileManager: fileManager),
+      codegenProvider: codegenProvider,
+      schemaDownloadProvider: schemaDownloadProvider
+    )
   }
 
   private func generate(
-    data: Data,
+    configuration: ApolloCodegenConfiguration,
     codegenProvider: CodegenProvider.Type,
     schemaDownloadProvider: SchemaDownloadProvider.Type
   ) throws {
-    let configuration = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: data)
-
     if fetchSchema {
       guard
         let schemaDownloadConfiguration = configuration.schemaDownloadConfiguration

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -66,12 +66,12 @@ public struct Generate: ParsableCommand {
         schemaDownloadProvider: schemaDownloadProvider
       )
     }
-    let buildOptions: ApolloCodegen.CodeGenerationBuildOptions = (configuration.operationManifestConfiguration?.generateManifestOnCodeGeneration ?? false) ? [.code, .operationManifest] : [.code]
+    let itemsToGenerate: ApolloCodegen.ItemsToGenerate = (configuration.operationManifestConfiguration?.generateManifestOnCodeGeneration ?? false) ? [.code, .operationManifest] : [.code]
 
     try codegenProvider.build(
       with: configuration,
       withRootURL: rootOutputURL(for: inputs),
-      buildOptions: buildOptions
+      itemsToGenerate: itemsToGenerate
     )
   }
 

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -44,7 +44,7 @@ public struct GenerateOperationManifest: ParsableCommand {
     try codegenProvider.build(
       with: configuration,
       withRootURL: rootOutputURL(for: inputs),
-      buildOptions: [.operationManifest]
+      itemsToGenerate: [.operationManifest]
     )
   }
 

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -53,16 +53,10 @@ public struct GenerateOperationManifest: ParsableCommand {
   func validate(configuration: ApolloCodegenConfiguration) throws {
     try checkForCLIVersionMismatch(with: inputs)
 
-    guard let operationManifestConfiguration = configuration.operationManifestConfiguration else {
+    guard configuration.operationManifestConfiguration != nil else {
       throw ValidationError("""
           `operationManifestConfiguration` section must be set in the codegen configuration JSON in order
           to generate and operation manifest.
-          """)
-    }
-    
-    if operationManifestConfiguration.operationManifest == nil {
-      throw ValidationError("""
-          `operationManifest` option missing from codegen configuration JSON section `operationManifestConfiguration`.
           """)
     }
   }

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -30,27 +30,17 @@ public struct GenerateOperationManifest: ParsableCommand {
     try checkForCLIVersionMismatch(
       with: inputs
     )
-    
-    switch (inputs.string, inputs.path) {
-    case let (.some(string), _):
-      try generateManifest(
-        data: try string.asData(),
-        codegenProvider: codegenProvider
-      )
-    case let (nil, path):
-      try generateManifest(
-        data: try fileManager.unwrappedContents(atPath: path),
-        codegenProvider: codegenProvider
-      )
-    }
+
+    try generateManifest(
+      configuration: inputs.getCodegenConfiguration(fileManager: fileManager),
+      codegenProvider: codegenProvider
+    )    
   }
   
   private func generateManifest(
-    data: Data,
+    configuration: ApolloCodegenConfiguration,
     codegenProvider: CodegenProvider.Type
   ) throws {
-    let configuration = try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: data)
-    
     try codegenProvider.generateOperationManifest(
       with: configuration,
       withRootURL: rootOutputURL(for: inputs),

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -53,9 +53,9 @@ public struct GenerateOperationManifest: ParsableCommand {
   func validate(configuration: ApolloCodegenConfiguration) throws {
     try checkForCLIVersionMismatch(with: inputs)
 
-    guard configuration.operationManifestConfiguration != nil else {
+    guard configuration.operationManifest != nil else {
       throw ValidationError("""
-          `operationManifestConfiguration` section must be set in the codegen configuration JSON in order
+          `operationManifest` section must be set in the codegen configuration JSON in order
           to generate and operation manifest.
           """)
     }

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -83,39 +83,25 @@ public struct GenerateOperationManifest: ParsableCommand {
 
   // MARK: - Validation
 
-  enum ParsingError: Swift.Error {
-    case manifestVersionMissing
-    case outputPathMissing
-
-    var errorDescription: String? {
-      switch self {
-      case .manifestVersionMissing:
-        return """
-            `manifest-version` argument missing. When `output-path` is used, `manifest-version` \
-            must also be present.
-            """
-      case .outputPathMissing:
-        return """
-            No output path for operation manifest found. You must either provide the `output-path` \
-            argument or your codegen configuration must have a value present for the \
-            `output.operationManifest` option.
-            """
-      }
-    }
-  }
-
   func validate(configuration: ApolloCodegenConfiguration) throws {
     try checkForCLIVersionMismatch(with: inputs)
 
     if configuration.output.operationManifest == nil {
       guard outputOptions.outputPath != nil else {
-        throw ParsingError.outputPathMissing
+        throw ValidationError("""
+            `manifest-version` argument missing. When `output-path` is used, `manifest-version` \
+            must also be present.
+            """)
       }
     }
 
     if outputOptions.outputPath != nil {
       guard outputOptions.manifestVersion != nil else {
-        throw ParsingError.manifestVersionMissing
+        throw ValidationError("""
+            No output path for operation manifest found. You must either provide the `output-path` \
+            argument or your codegen configuration must have a value present for the \
+            `output.operationManifest` option.
+            """)
       }
     }
   }

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -56,7 +56,7 @@ public struct GenerateOperationManifest: ParsableCommand {
     guard configuration.operationManifest != nil else {
       throw ValidationError("""
           `operationManifest` section must be set in the codegen configuration JSON in order
-          to generate and operation manifest.
+          to generate an operation manifest.
           """)
     }
   }

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -9,9 +9,34 @@ public struct GenerateOperationManifest: ParsableCommand {
   public static var configuration = CommandConfiguration(
     abstract: "Generate Persisted Queries operation manifest based on a code generation configuration."
   )
-  
+
+  struct OutputOptions: ParsableArguments {
+    @Option(
+      name: .shortAndLong,
+      help: """
+      Output the operation manifest to the given path. This overrides the value of the \
+      `output.operationManifest.path` in your configuration.
+      
+      **If the `output.operationManifest` is not included in your configuration, this is required.**
+      """
+    )
+    var outputPath: String?
+    
+    @Option(
+      name: .long,
+      help: """
+      The version for the operation manifest format to generate. This overrides the value of the \
+      `output.operationManifest.path` in your configuration.
+      
+      **If the `output.operationManifest` is not included in your configuration, this is required.**
+      """
+    )
+    var manifestVersion: ApolloCodegenConfiguration.OperationManifestFileOutput.Version?
+  }
+
   @OptionGroup var inputs: InputOptions
-  
+  @OptionGroup var outputOptions: OutputOptions
+
   // MARK: - Implementation
   
   public init() { }
@@ -26,15 +51,23 @@ public struct GenerateOperationManifest: ParsableCommand {
     logger: LogLevelSetter.Type = CodegenLogger.self
   ) throws {
     logger.SetLoggingLevel(verbose: inputs.verbose)
-    
-    try checkForCLIVersionMismatch(
-      with: inputs
-    )
+
+    var configuration = try inputs.getCodegenConfiguration(fileManager: fileManager)
+
+    try validate(configuration: configuration)
+
+    if let outputPath = outputOptions.outputPath,
+       let manifestVersion = outputOptions.manifestVersion {
+      configuration.output.operationManifest = .init(
+        path: outputPath,
+        version: manifestVersion
+      )
+    }
 
     try generateManifest(
-      configuration: inputs.getCodegenConfiguration(fileManager: fileManager),
+      configuration: configuration,
       codegenProvider: codegenProvider
-    )    
+    )
   }
   
   private func generateManifest(
@@ -47,5 +80,46 @@ public struct GenerateOperationManifest: ParsableCommand {
       fileManager: .default
     )
   }
+
+  // MARK: - Validation
+
+  enum ParsingError: Swift.Error {
+    case manifestVersionMissing
+    case outputPathMissing
+
+    var errorDescription: String? {
+      switch self {
+      case .manifestVersionMissing:
+        return """
+            `manifest-version` argument missing. When `output-path` is used, `manifest-version` \
+            must also be present.
+            """
+      case .outputPathMissing:
+        return """
+            No output path for operation manifest found. You must either provide the `output-path` \
+            argument or your codegen configuration must have a value present for the \
+            `output.operationManifest` option.
+            """
+      }
+    }
+  }
+
+  func validate(configuration: ApolloCodegenConfiguration) throws {
+    try checkForCLIVersionMismatch(with: inputs)
+
+    if configuration.output.operationManifest == nil {
+      guard outputOptions.outputPath != nil else {
+        throw ParsingError.outputPathMissing
+      }
+    }
+
+    if outputOptions.outputPath != nil {
+      guard outputOptions.manifestVersion != nil else {
+        throw ParsingError.manifestVersionMissing
+      }
+    }
+  }
   
 }
+
+extension ApolloCodegenConfiguration.OperationManifestFileOutput.Version: ExpressibleByArgument {}

--- a/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
+++ b/Sources/CodegenCLI/Commands/GenerateOperationManifest.swift
@@ -10,32 +10,7 @@ public struct GenerateOperationManifest: ParsableCommand {
     abstract: "Generate Persisted Queries operation manifest based on a code generation configuration."
   )
 
-  struct OutputOptions: ParsableArguments {
-    @Option(
-      name: .shortAndLong,
-      help: """
-      Output the operation manifest to the given path. This overrides the value of the \
-      `output.operationManifest.path` in your configuration.
-      
-      **If the `output.operationManifest` is not included in your configuration, this is required.**
-      """
-    )
-    var outputPath: String?
-    
-    @Option(
-      name: .long,
-      help: """
-      The version for the operation manifest format to generate. This overrides the value of the \
-      `output.operationManifest.path` in your configuration.
-      
-      **If the `output.operationManifest` is not included in your configuration, this is required.**
-      """
-    )
-    var manifestVersion: ApolloCodegenConfiguration.OperationManifestFileOutput.Version?
-  }
-
   @OptionGroup var inputs: InputOptions
-  @OptionGroup var outputOptions: OutputOptions
 
   // MARK: - Implementation
   
@@ -52,17 +27,9 @@ public struct GenerateOperationManifest: ParsableCommand {
   ) throws {
     logger.SetLoggingLevel(verbose: inputs.verbose)
 
-    var configuration = try inputs.getCodegenConfiguration(fileManager: fileManager)
+    let configuration = try inputs.getCodegenConfiguration(fileManager: fileManager)
 
     try validate(configuration: configuration)
-
-    if let outputPath = outputOptions.outputPath,
-       let manifestVersion = outputOptions.manifestVersion {
-      configuration.output.operationManifest = .init(
-        path: outputPath,
-        version: manifestVersion
-      )
-    }
 
     try generateManifest(
       configuration: configuration,
@@ -74,10 +41,10 @@ public struct GenerateOperationManifest: ParsableCommand {
     configuration: ApolloCodegenConfiguration,
     codegenProvider: CodegenProvider.Type
   ) throws {
-    try codegenProvider.generateOperationManifest(
+    try codegenProvider.build(
       with: configuration,
       withRootURL: rootOutputURL(for: inputs),
-      fileManager: .default
+      buildOptions: [.operationManifest]
     )
   }
 
@@ -86,26 +53,18 @@ public struct GenerateOperationManifest: ParsableCommand {
   func validate(configuration: ApolloCodegenConfiguration) throws {
     try checkForCLIVersionMismatch(with: inputs)
 
-    if configuration.output.operationManifest == nil {
-      guard outputOptions.outputPath != nil else {
-        throw ValidationError("""
-            `manifest-version` argument missing. When `output-path` is used, `manifest-version` \
-            must also be present.
-            """)
-      }
+    guard let operationManifestConfiguration = configuration.operationManifestConfiguration else {
+      throw ValidationError("""
+          `operationManifestConfiguration` section must be set in the codegen configuration JSON in order
+          to generate and operation manifest.
+          """)
     }
-
-    if outputOptions.outputPath != nil {
-      guard outputOptions.manifestVersion != nil else {
-        throw ValidationError("""
-            No output path for operation manifest found. You must either provide the `output-path` \
-            argument or your codegen configuration must have a value present for the \
-            `output.operationManifest` option.
-            """)
-      }
+    
+    if operationManifestConfiguration.operationManifest == nil {
+      throw ValidationError("""
+          `operationManifest` option missing from codegen configuration JSON section `operationManifestConfiguration`.
+          """)
     }
   }
   
 }
-
-extension ApolloCodegenConfiguration.OperationManifestFileOutput.Version: ExpressibleByArgument {}

--- a/Sources/CodegenCLI/OptionGroups/InputOptions.swift
+++ b/Sources/CodegenCLI/OptionGroups/InputOptions.swift
@@ -1,4 +1,6 @@
+import Foundation
 import ArgumentParser
+import ApolloCodegenLib
 
 /// Shared group of common arguments used in commands for input parameters.
 struct InputOptions: ParsableArguments {
@@ -28,4 +30,16 @@ struct InputOptions: ParsableArguments {
     help: "Ignore Apollo version mismatch errors. Warning: This may lead to incompatible generated objects."
   )
   var ignoreVersionMismatch: Bool = false
+
+  func getCodegenConfiguration(fileManager: FileManager) throws -> ApolloCodegenConfiguration {
+    var data: Data
+    switch (string, path) {
+    case let (.some(string), _):
+      data = try string.asData()
+
+    case let (nil, path):
+      data = try fileManager.unwrappedContents(atPath: path)
+    }
+    return try JSONDecoder().decode(ApolloCodegenConfiguration.self, from: data)
+  }
 }

--- a/Sources/CodegenCLI/Protocols/CodegenProvider.swift
+++ b/Sources/CodegenCLI/Protocols/CodegenProvider.swift
@@ -6,7 +6,7 @@ public protocol CodegenProvider {
   static func build(
     with configuration: ApolloCodegenConfiguration,
     withRootURL rootURL: URL?,
-    buildOptions: ApolloCodegen.CodeGenerationBuildOptions
+    itemsToGenerate: ApolloCodegen.ItemsToGenerate
   ) throws
 }
 

--- a/Sources/CodegenCLI/Protocols/CodegenProvider.swift
+++ b/Sources/CodegenCLI/Protocols/CodegenProvider.swift
@@ -5,13 +5,8 @@ import ApolloCodegenLib
 public protocol CodegenProvider {
   static func build(
     with configuration: ApolloCodegenConfiguration,
-    withRootURL rootURL: URL?
-  ) throws
-  
-  static func generateOperationManifest(
-    with configuration: ApolloCodegenConfiguration,
     withRootURL rootURL: URL?,
-    fileManager: ApolloFileManager
+    buildOptions: ApolloCodegen.CodeGenerationBuildOptions
   ) throws
 }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -15,7 +15,7 @@ extension ApolloCodegenConfiguration {
     ),
     options: OutputOptions = .init(schemaDocumentation: .exclude),
     experimentalFeatures: ExperimentalFeatures = .init(),
-    operationManifestConfiguration: OperationManifestConfiguration = .init(operationDocumentFormat: [.definition])
+    operationManifestConfiguration: OperationManifestConfiguration? = nil
   ) -> Self {
     .init(
       schemaNamespace: schemaNamespace,

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -14,14 +14,16 @@ extension ApolloCodegenConfiguration {
       )
     ),
     options: OutputOptions = .init(schemaDocumentation: .exclude),
-    experimentalFeatures: ExperimentalFeatures = .init()
+    experimentalFeatures: ExperimentalFeatures = .init(),
+    operationManifestConfiguration: OperationManifestConfiguration = .init(operationDocumentFormat: [.definition])
   ) -> Self {
     .init(
       schemaNamespace: schemaNamespace,
       input: input,
       output: output,
       options: options,
-      experimentalFeatures: experimentalFeatures
+      experimentalFeatures: experimentalFeatures,
+      operationManifestConfiguration: operationManifestConfiguration
     )
   }
 

--- a/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
+++ b/Tests/ApolloCodegenInternalTestHelpers/MockApolloCodegenConfiguration.swift
@@ -15,7 +15,7 @@ extension ApolloCodegenConfiguration {
     ),
     options: OutputOptions = .init(schemaDocumentation: .exclude),
     experimentalFeatures: ExperimentalFeatures = .init(),
-    operationManifestConfiguration: OperationManifestConfiguration? = nil
+    operationManifest: OperationManifestConfiguration? = nil
   ) -> Self {
     .init(
       schemaNamespace: schemaNamespace,
@@ -23,7 +23,7 @@ extension ApolloCodegenConfiguration {
       output: output,
       options: options,
       experimentalFeatures: experimentalFeatures,
-      operationManifestConfiguration: operationManifestConfiguration
+      operationManifest: operationManifest
     )
   }
 

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -53,9 +53,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           legacySafelistingCompatibleOperations: true
         ),
         operationManifestConfiguration: .init(
-          operationManifest: .init(path: "/operation/identifiers/path"),
-          operationDocumentFormat: .definition,
-          autoGenerate: false
+          path: "/operation/identifiers/path",
+          version: .persistedQueries,
+          generateManifestOnCodeGeneration: false
         )
       )
     }
@@ -76,14 +76,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           ]
         },
         "operationManifestConfiguration" : {
-          "autoGenerate" : false,
-          "operationDocumentFormat" : [
-            "definition"
-          ],
-          "operationManifest" : {
-            "path" : "/operation/identifiers/path",
-            "version" : "persistedQueries"
-          }
+          "generateManifestOnCodeGeneration" : false,
+          "path" : "/operation/identifiers/path",
+          "version" : "persistedQueries"
         },
         "options" : {
           "additionalInflectionRules" : [
@@ -99,6 +94,9 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "enumCases" : "none"
           },
           "deprecatedEnumCases" : "exclude",
+          "operationDocumentFormat" : [
+            "definition"
+          ],
           "pruneGeneratedFiles" : false,
           "schemaDocumentation" : "exclude",
           "selectionSetInitializers" : {
@@ -141,7 +139,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     // when
     let encodedJSON = try testJSONEncoder.encode(subject)
     let actual = encodedJSON.asString
-    print(actual)
+
     // then
     expect(actual).to(equalLineByLine(MockApolloCodegenConfiguration.encodedJSON))
   }
@@ -625,7 +623,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   // MARK: - OperationDocumentFormat Tests
 
-  func encodedValue(_ case: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat) -> String {
+  func encodedValue(_ case: ApolloCodegenConfiguration.OperationDocumentFormat) -> String {
     switch `case` {
     case .definition:
       return """
@@ -654,7 +652,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeOperationDocumentFormat__givenDefinition_shouldReturnStringArray() throws {
     // given
-    let subject = ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.definition
+    let subject = ApolloCodegenConfiguration.OperationDocumentFormat.definition
 
     // when
     let actual = try testJSONEncoder.encode(subject).asString
@@ -665,7 +663,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeOperationDocumentFormat__givenOperationId_shouldReturnStringArray() throws {
     // given
-    let subject = ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.operationId
+    let subject = ApolloCodegenConfiguration.OperationDocumentFormat.operationId
 
     // when
     let actual = try testJSONEncoder.encode(subject).asString
@@ -676,7 +674,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeOperationDocumentFormat__givenBoth_shouldReturnStringArray() throws {
     // given
-    let subject: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat = [
+    let subject: ApolloCodegenConfiguration.OperationDocumentFormat = [
       .definition, .operationId
     ]
 
@@ -693,7 +691,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let actual = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
+      ApolloCodegenConfiguration.OperationDocumentFormat.self,
       from: subject
     )
 
@@ -707,7 +705,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let actual = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
+      ApolloCodegenConfiguration.OperationDocumentFormat.self,
       from: subject
     )
 
@@ -721,7 +719,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let actual = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
+      ApolloCodegenConfiguration.OperationDocumentFormat.self,
       from: subject
     )
 
@@ -736,7 +734,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     // then
     expect(
       try JSONDecoder().decode(
-        ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
+        ApolloCodegenConfiguration.OperationDocumentFormat.self,
         from: subject
       )
     ).to(throwError())
@@ -749,7 +747,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     // then
     expect(
       try JSONDecoder().decode(
-        ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
+        ApolloCodegenConfiguration.OperationDocumentFormat.self,
         from: subject
       )
     ).to(throwError())

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -52,7 +52,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           clientControlledNullability: true,
           legacySafelistingCompatibleOperations: true
         ),
-        operationManifestConfiguration: .init(
+        operationManifest: .init(
           path: "/operation/identifiers/path",
           version: .persistedQueries,
           generateManifestOnCodeGeneration: false
@@ -75,7 +75,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "/path/to/schema.graphqls"
           ]
         },
-        "operationManifestConfiguration" : {
+        "operationManifest" : {
           "generateManifestOnCodeGeneration" : false,
           "path" : "/operation/identifiers/path",
           "version" : "persistedQueries"

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -54,7 +54,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
         ),
         operationManifestConfiguration: .init(
           operationManifest: .init(path: "/operation/identifiers/path"),
-          operationDocumentFormat: .definition
+          operationDocumentFormat: .definition,
+          autoGenerate: false
         )
       )
     }
@@ -75,6 +76,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           ]
         },
         "operationManifestConfiguration" : {
+          "autoGenerate" : false,
           "operationDocumentFormat" : [
             "definition"
           ],

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -35,8 +35,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             moduleType: .embeddedInTarget(name: "SomeTarget", accessModifier: .public)
           ),
           operations: .absolute(path: "/absolute/path", accessModifier: .internal),
-          testMocks: .swiftPackage(targetName: "SchemaTestMocks"),
-          operationManifest: .init(path: "/operation/identifiers/path")
+          testMocks: .swiftPackage(targetName: "SchemaTestMocks")
         ),
         options: .init(
           additionalInflectionRules: [
@@ -44,7 +43,6 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           ],
           deprecatedEnumCases: .exclude,
           schemaDocumentation: .exclude,
-          operationDocumentFormat: .definition,
           cocoapodsCompatibleImportStatements: true,
           warningsOnDeprecatedUsage: .exclude,
           conversionStrategies:.init(enumCases: .none),
@@ -53,6 +51,10 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
         experimentalFeatures: .init(
           clientControlledNullability: true,
           legacySafelistingCompatibleOperations: true
+        ),
+        operationManifestConfiguration: .init(
+          operationManifest: .init(path: "/operation/identifiers/path"),
+          operationDocumentFormat: .definition
         )
       )
     }
@@ -72,6 +74,15 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "/path/to/schema.graphqls"
           ]
         },
+        "operationManifestConfiguration" : {
+          "operationDocumentFormat" : [
+            "definition"
+          ],
+          "operationManifest" : {
+            "path" : "/operation/identifiers/path",
+            "version" : "persistedQueries"
+          }
+        },
         "options" : {
           "additionalInflectionRules" : [
             {
@@ -86,9 +97,6 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "enumCases" : "none"
           },
           "deprecatedEnumCases" : "exclude",
-          "operationDocumentFormat" : [
-            "definition"
-          ],
           "pruneGeneratedFiles" : false,
           "schemaDocumentation" : "exclude",
           "selectionSetInitializers" : {
@@ -97,10 +105,6 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
           "warningsOnDeprecatedUsage" : "exclude"
         },
         "output" : {
-          "operationManifest" : {
-            "path" : "/operation/identifiers/path",
-            "version" : "persistedQueries"
-          },
           "operations" : {
             "absolute" : {
               "accessModifier" : "internal",
@@ -135,7 +139,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     // when
     let encodedJSON = try testJSONEncoder.encode(subject)
     let actual = encodedJSON.asString
-
+    print(actual)
     // then
     expect(actual).to(equalLineByLine(MockApolloCodegenConfiguration.encodedJSON))
   }
@@ -619,7 +623,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   // MARK: - OperationDocumentFormat Tests
 
-  func encodedValue(_ case: ApolloCodegenConfiguration.OperationDocumentFormat) -> String {
+  func encodedValue(_ case: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat) -> String {
     switch `case` {
     case .definition:
       return """
@@ -648,7 +652,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeOperationDocumentFormat__givenDefinition_shouldReturnStringArray() throws {
     // given
-    let subject = ApolloCodegenConfiguration.OperationDocumentFormat.definition
+    let subject = ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.definition
 
     // when
     let actual = try testJSONEncoder.encode(subject).asString
@@ -659,7 +663,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeOperationDocumentFormat__givenOperationId_shouldReturnStringArray() throws {
     // given
-    let subject = ApolloCodegenConfiguration.OperationDocumentFormat.operationId
+    let subject = ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.operationId
 
     // when
     let actual = try testJSONEncoder.encode(subject).asString
@@ -670,7 +674,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
   func test__encodeOperationDocumentFormat__givenBoth_shouldReturnStringArray() throws {
     // given
-    let subject: ApolloCodegenConfiguration.OperationDocumentFormat = [
+    let subject: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat = [
       .definition, .operationId
     ]
 
@@ -687,7 +691,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let actual = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.OperationDocumentFormat.self,
+      ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
       from: subject
     )
 
@@ -701,7 +705,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let actual = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.OperationDocumentFormat.self,
+      ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
       from: subject
     )
 
@@ -715,7 +719,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
 
     // when
     let actual = try JSONDecoder().decode(
-      ApolloCodegenConfiguration.OperationDocumentFormat.self,
+      ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
       from: subject
     )
 
@@ -730,7 +734,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     // then
     expect(
       try JSONDecoder().decode(
-        ApolloCodegenConfiguration.OperationDocumentFormat.self,
+        ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
         from: subject
       )
     ).to(throwError())
@@ -743,7 +747,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
     // then
     expect(
       try JSONDecoder().decode(
-        ApolloCodegenConfiguration.OperationDocumentFormat.self,
+        ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat.self,
         from: subject
       )
     ).to(throwError())

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationTests.swift
@@ -69,7 +69,6 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     )
 
     // then
-    expect(output.operationManifest).to(beNil())
     expect(output.operations).to(equal(.inSchemaModule))
   }
 
@@ -85,6 +84,5 @@ class ApolloCodegenConfigurationTests: XCTestCase {
     expect(config.options.additionalInflectionRules).to(beEmpty())
     expect(config.options.deprecatedEnumCases).to(equal(.include))
     expect(config.options.schemaDocumentation).to(equal(.include))
-    expect(config.options.operationDocumentFormat).to(equal([.definition]))
   }
 }

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -1184,7 +1184,7 @@ class ApolloCodegenTests: XCTestCase {
       options: .init(pruneGeneratedFiles: false)
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beTrue())
@@ -1241,7 +1241,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beFalse())
@@ -1295,7 +1295,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beFalse())
@@ -1364,7 +1364,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beFalse())
@@ -1437,7 +1437,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beFalse())
@@ -1495,13 +1495,13 @@ class ApolloCodegenTests: XCTestCase {
     // then
     
     // running codegen multiple times to validate symlink related file creation/deletion bug
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
     expect(ApolloFileManager.default.doesFileExist(atPath: fileValidationPath)).to(beTrue())
     
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
     expect(ApolloFileManager.default.doesFileExist(atPath: fileValidationPath)).to(beTrue())
     
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
     expect(ApolloFileManager.default.doesFileExist(atPath: fileValidationPath)).to(beTrue())
 
   }
@@ -1586,7 +1586,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beTrue())
@@ -1694,7 +1694,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beTrue())
@@ -1796,7 +1796,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testGeneratedFileInRootPath)).to(beTrue())
@@ -1861,7 +1861,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testFile)).to(beFalse())
@@ -1917,7 +1917,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testInTestMocksFolderFile)).to(beFalse())
@@ -1975,7 +1975,7 @@ class ApolloCodegenTests: XCTestCase {
       )
     )
 
-    try ApolloCodegen.build(with: config, rootURL: directoryURL)
+    try ApolloCodegen.build(with: config, withRootURL: directoryURL)
 
     // then
     expect(ApolloFileManager.default.doesFileExist(atPath: testInTestMocksFolderFile)).to(beFalse())

--- a/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenTests.swift
@@ -671,7 +671,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -768,7 +769,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -871,7 +873,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -935,7 +938,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -1037,7 +1041,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then
@@ -1137,7 +1142,8 @@ class ApolloCodegenTests: XCTestCase {
       compilationResult: compilationResult,
       ir: ir,
       config: config,
-      fileManager: fileManager
+      fileManager: fileManager,
+      itemsToGenerate: [.code]
     )
 
     // then

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
@@ -34,7 +34,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
         output: .init(
           schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
         ),
-        operationManifestConfiguration: manifest
+        operationManifest: manifest
       ))
     ).xctUnwrapped()
   }
@@ -47,7 +47,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
       output: .init(
         schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
       ),
-      operationManifestConfiguration: .init(
+      operationManifest: .init(
         path: "a/file/path"
       )
     )
@@ -65,7 +65,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
       output: .init(
         schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
       ),
-      operationManifestConfiguration: nil
+      operationManifest: nil
     )
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
@@ -273,7 +273,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   // MARK: - Template Type Selection Tests
 
-  func test__template__givenOperationManifestVersion_apqLegacy__isLegacyAPQTemplate() throws {
+  func test__template__givenOperationManifestVersion_legacy__isLegacyTemplate() throws {
     // given
     try buildSubject(path: "a/path", version: .legacy)
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
@@ -22,9 +22,9 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   private func buildSubject(
     path: String? = nil,
-    version: ApolloCodegenConfiguration.OperationManifestFileOutput.Version = .legacyAPQ
+    version: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationManifestFileOutput.Version = .legacyAPQ
   ) throws {
-    let manifest: ApolloCodegenConfiguration.OperationManifestFileOutput? = {
+    let manifest: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationManifestFileOutput? = {
       guard let path else { return nil }
       return .init(path: path, version: version)
     }()
@@ -32,7 +32,9 @@ class OperationManifestFileGeneratorTests: XCTestCase {
     subject = try OperationManifestFileGenerator(
       config: ApolloCodegen.ConfigurationContext(config: ApolloCodegenConfiguration.mock(
         output: .init(
-          schemaTypes: .init(path: "", moduleType: .swiftPackageManager),
+          schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
+        ),
+        operationManifestConfiguration: .init(
           operationManifest: manifest
         )
       ))
@@ -43,10 +45,14 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   func test__initializer__givenPath_shouldReturnInstance() {
     // given
-    let config = ApolloCodegenConfiguration.mock(output: .init(
-      schemaTypes: .init(path: "", moduleType: .swiftPackageManager),
-      operationManifest: .init(path: "a/file/path")
-    ))
+    let config = ApolloCodegenConfiguration.mock(
+      output: .init(
+        schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
+      ),
+      operationManifestConfiguration: .init(
+        operationManifest: .init(path: "a/file/path")
+      )
+    )
 
     // when
     let instance = OperationManifestFileGenerator(config: .init(config: config))
@@ -57,10 +63,14 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   func test__initializer__givenNilPath_shouldReturnNil() {
     // given
-    let config = ApolloCodegenConfiguration.mock(output: .init(
-      schemaTypes: .init(path: "", moduleType: .swiftPackageManager),
-      operationManifest: nil
-    ))
+    let config = ApolloCodegenConfiguration.mock(
+      output: .init(
+        schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
+      ),
+      operationManifestConfiguration: .init(
+        operationManifest: nil
+      )
+    )
 
     // when
     let instance = OperationManifestFileGenerator(config: .init(config: config))

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
@@ -22,7 +22,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   private func buildSubject(
     path: String? = nil,
-    version: ApolloCodegenConfiguration.OperationManifestConfiguration.Version = .legacyAPQ
+    version: ApolloCodegenConfiguration.OperationManifestConfiguration.Version = .legacy
   ) throws {
     let manifest: ApolloCodegenConfiguration.OperationManifestConfiguration? = {
       guard let path else { return nil }
@@ -275,7 +275,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   func test__template__givenOperationManifestVersion_apqLegacy__isLegacyAPQTemplate() throws {
     // given
-    try buildSubject(path: "a/path", version: .legacyAPQ)
+    try buildSubject(path: "a/path", version: .legacy)
 
     // when
     let actual = subject.template

--- a/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/FileGenerators/OperationManifestFileGeneratorTests.swift
@@ -22,9 +22,9 @@ class OperationManifestFileGeneratorTests: XCTestCase {
 
   private func buildSubject(
     path: String? = nil,
-    version: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationManifestFileOutput.Version = .legacyAPQ
+    version: ApolloCodegenConfiguration.OperationManifestConfiguration.Version = .legacyAPQ
   ) throws {
-    let manifest: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationManifestFileOutput? = {
+    let manifest: ApolloCodegenConfiguration.OperationManifestConfiguration? = {
       guard let path else { return nil }
       return .init(path: path, version: version)
     }()
@@ -34,9 +34,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
         output: .init(
           schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
         ),
-        operationManifestConfiguration: .init(
-          operationManifest: manifest
-        )
+        operationManifestConfiguration: manifest
       ))
     ).xctUnwrapped()
   }
@@ -50,7 +48,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
         schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
       ),
       operationManifestConfiguration: .init(
-        operationManifest: .init(path: "a/file/path")
+        path: "a/file/path"
       )
     )
 
@@ -67,9 +65,7 @@ class OperationManifestFileGeneratorTests: XCTestCase {
       output: .init(
         schemaTypes: .init(path: "", moduleType: .swiftPackageManager)
       ),
-      operationManifestConfiguration: .init(
-        operationManifest: nil
-      )
+      operationManifestConfiguration: nil
     )
 
     // when

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -27,15 +27,15 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
   func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager,
     operations: ApolloCodegenConfiguration.OperationsFileOutput = .inSchemaModule,
-    operationDocumentFormat: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat = .definition,
+    operationDocumentFormat: ApolloCodegenConfiguration.OperationDocumentFormat = .definition,
     cocoapodsCompatibleImportStatements: Bool = false
   ) {
     config = .mock(
       output: .mock(moduleType: moduleType, operations: operations),
       options: .init(
+        operationDocumentFormat: operationDocumentFormat,
         cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements
-      ),
-      operationManifestConfiguration: .init(operationDocumentFormat: operationDocumentFormat)
+      )
     )
   }
 

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplate_DocumentType_Tests.swift
@@ -27,15 +27,15 @@ class OperationDefinitionTemplate_DocumentType_Tests: XCTestCase {
   func buildConfig(
     moduleType: ApolloCodegenConfiguration.SchemaTypesFileOutput.ModuleType = .swiftPackageManager,
     operations: ApolloCodegenConfiguration.OperationsFileOutput = .inSchemaModule,
-    operationDocumentFormat: ApolloCodegenConfiguration.OperationDocumentFormat = .definition,
+    operationDocumentFormat: ApolloCodegenConfiguration.OperationManifestConfiguration.OperationDocumentFormat = .definition,
     cocoapodsCompatibleImportStatements: Bool = false
   ) {
     config = .mock(
       output: .mock(moduleType: moduleType, operations: operations),
       options: .init(
-        operationDocumentFormat: operationDocumentFormat,
         cocoapodsCompatibleImportStatements: cocoapodsCompatibleImportStatements
-      )
+      ),
+      operationManifestConfiguration: .init(operationDocumentFormat: operationDocumentFormat)
     )
   }
 

--- a/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
+++ b/Tests/CodegenCLITests/Commands/FetchSchemaTests.swift
@@ -48,7 +48,7 @@ class FetchSchemaTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -80,7 +80,7 @@ class FetchSchemaTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -110,7 +110,7 @@ class FetchSchemaTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }

--- a/Tests/CodegenCLITests/Commands/GenerateOperationManifestTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateOperationManifestTests.swift
@@ -3,7 +3,7 @@ import Nimble
 import ApolloInternalTestHelpers
 @testable import CodegenCLI
 import ApolloCodegenLib
-import ArgumentParser
+@testable import ArgumentParser
 
 class GenerateOperationManifestTests: XCTestCase {
 
@@ -48,7 +48,7 @@ class GenerateOperationManifestTests: XCTestCase {
     }))
 
     var didCallBuild = false
-    MockApolloCodegen.buildHandler = { configuration in
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in
       expect(configuration).to(equal(mockConfiguration))
 
       didCallBuild = true
@@ -77,7 +77,7 @@ class GenerateOperationManifestTests: XCTestCase {
     ]
 
     var didCallBuild = false
-    MockApolloCodegen.buildHandler = { configuration in
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in
       expect(configuration).to(equal(mockConfiguration))
 
       didCallBuild = true
@@ -107,7 +107,7 @@ class GenerateOperationManifestTests: XCTestCase {
     ]
 
     var didCallBuild = false
-    MockApolloCodegen.buildHandler = { configuration in
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in
       expect(configuration).to(equal(mockConfiguration))
 
       didCallBuild = true
@@ -135,7 +135,7 @@ class GenerateOperationManifestTests: XCTestCase {
       "--string=\(jsonString)"
     ]
 
-    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in }
     MockApolloSchemaDownloader.fetchHandler = { configuration in }
 
     var level: CodegenLogger.LogLevel?
@@ -169,7 +169,7 @@ class GenerateOperationManifestTests: XCTestCase {
       "--verbose"
     ]
 
-    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in }
     MockApolloSchemaDownloader.fetchHandler = { configuration in }
 
     var level: CodegenLogger.LogLevel?
@@ -188,6 +188,145 @@ class GenerateOperationManifestTests: XCTestCase {
     // then
     expect(level).toEventually(equal(.debug))
   }
+
+  func test__generate__givenParameters_outputPathAndManifestVersion_configHasOperationManifestOption__overridesOperationManifestInConfiguration() throws {
+    // given
+    let inputPath = "./config.json"
+    let outputPath = "./operationManifest.json"
+
+    let options = [
+      "--path=\(inputPath)",
+      "--output-path=\(outputPath)",
+      "--manifest-version=persistedQueries"
+    ]
+
+    var didCallGenerate = false
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in
+      let actual = configuration.output.operationManifest
+      expect(actual?.path).to(equal(outputPath))
+      expect(actual?.version).to(equal(.persistedQueries))
+
+      didCallGenerate = true
+    }
+
+    let mockFileManager = MockApolloFileManager(strict: true)
+
+    mockFileManager.mock(closure: .contents({ path in
+      return try! JSONEncoder().encode(ApolloCodegenConfiguration.mock())
+    }))
+
+    // when
+    let command = try parse(options)
+    try command._run(fileManager: mockFileManager.base, codegenProvider: MockApolloCodegen.self)
+
+    // then
+    expect(didCallGenerate).to(beTrue())
+  }
+
+  func test__generate__givenParameters_manifestVersion_legacyAPQs__overridesOperationManifestInConfiguration() throws {
+    // given
+    let inputPath = "./config.json"
+    let outputPath = "./operationManifest.json"
+
+    let options = [
+      "--path=\(inputPath)",
+      "--output-path=\(outputPath)",
+      "--manifest-version=legacyAPQ"
+    ]
+
+    var didCallGenerate = false
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in
+      let actual = configuration.output.operationManifest
+      expect(actual?.path).to(equal(outputPath))
+      expect(actual?.version).to(equal(.legacyAPQ))
+
+      didCallGenerate = true
+    }
+
+    let mockFileManager = MockApolloFileManager(strict: true)
+
+    mockFileManager.mock(closure: .contents({ path in
+      return try! JSONEncoder().encode(ApolloCodegenConfiguration.mock())
+    }))
+
+    // when
+    let command = try parse(options)
+    try command._run(fileManager: mockFileManager.base, codegenProvider: MockApolloCodegen.self)
+
+    // then
+    expect(didCallGenerate).to(beTrue())
+  }
+
+  // MARK: Argument Validation Tests
+
+  func test__generate__givenParameters_outputPath_noManifestVersion_throwsValidationError() throws {
+    // given
+    let mockConfiguration = ApolloCodegenConfiguration.mock()
+
+    let jsonString = String(
+      data: try! JSONEncoder().encode(mockConfiguration),
+      encoding: .utf8
+    )!
+
+
+    let options = [
+      "--output-path=./operationManifest.json",
+      "--string=\(jsonString)"
+    ]
+
+    // when
+    let command = try parse(options)
+
+    // then
+    expect(
+      try command._run(codegenProvider: MockApolloCodegen.self)
+    ).to(throwError(GenerateOperationManifest.ParsingError.manifestVersionMissing))
+  }
+
+  func test__generate__givenConfigHasNoOperationManifestOption_outputPathMissing__throwsValidationError() throws {
+    // given
+    let inputPath = "./config.json"
+
+    let options = [
+      "--path=\(inputPath)"
+    ]
+
+    let mockConfiguration = ApolloCodegenConfiguration(
+      schemaNamespace: "MockSchema",
+      input: .init(
+        schemaPath: "./schema.graphqls"
+      ),
+      output: .init(
+        schemaTypes: .init(path: ".", moduleType: .swiftPackageManager)
+      ),
+      options: .init(
+        operationDocumentFormat: [.definition, .operationId]
+      ),
+      schemaDownloadConfiguration: .init(
+        using: .introspection(endpointURL: URL(string: "http://some.server")!),
+        outputPath: "./schema.graphqls"
+      )
+    )
+
+    let mockFileManager = MockApolloFileManager(strict: true)
+
+    mockFileManager.mock(closure: .contents({ path in
+      let actualPath = URL(fileURLWithPath: path).standardizedFileURL.path
+      let expectedPath = URL(fileURLWithPath: inputPath).standardizedFileURL.path
+
+      expect(actualPath).to(equal(expectedPath))
+
+      return try! JSONEncoder().encode(mockConfiguration)
+    }))
+
+    // when
+    let command = try parse(options)
+
+    // then
+    expect(
+      try command._run(fileManager: mockFileManager.base, codegenProvider: MockApolloCodegen.self)
+    ).to(throwError(GenerateOperationManifest.ParsingError.outputPathMissing))
+  }
   
   // MARK: Version Checking Tests
 
@@ -205,7 +344,7 @@ class GenerateOperationManifestTests: XCTestCase {
       "--verbose"
     ]
 
-    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in }
     MockApolloSchemaDownloader.fetchHandler = { configuration in }
 
     try self.testIsolatedFileManager().createFile(
@@ -254,7 +393,7 @@ class GenerateOperationManifestTests: XCTestCase {
       "--ignore-version-mismatch"
     ]
 
-    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in }
     MockApolloSchemaDownloader.fetchHandler = { configuration in }
 
     try self.testIsolatedFileManager().createFile(
@@ -302,7 +441,7 @@ class GenerateOperationManifestTests: XCTestCase {
       "--verbose"
     ]
 
-    MockApolloCodegen.buildHandler = { configuration in }
+    MockApolloCodegen.generateOperationManifestHandler = { configuration in }
     MockApolloSchemaDownloader.fetchHandler = { configuration in }
 
     // when

--- a/Tests/CodegenCLITests/Commands/GenerateOperationManifestTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateOperationManifestTests.swift
@@ -280,7 +280,7 @@ class GenerateOperationManifestTests: XCTestCase {
     // then
     expect(
       try command._run(codegenProvider: MockApolloCodegen.self)
-    ).to(throwError(GenerateOperationManifest.ParsingError.manifestVersionMissing))
+    ).to(throwError())
   }
 
   func test__generate__givenConfigHasNoOperationManifestOption_outputPathMissing__throwsValidationError() throws {
@@ -325,7 +325,7 @@ class GenerateOperationManifestTests: XCTestCase {
     // then
     expect(
       try command._run(fileManager: mockFileManager.base, codegenProvider: MockApolloCodegen.self)
-    ).to(throwError(GenerateOperationManifest.ParsingError.outputPathMissing))
+    ).to(throwError())
   }
   
   // MARK: Version Checking Tests

--- a/Tests/CodegenCLITests/Commands/GenerateTests.swift
+++ b/Tests/CodegenCLITests/Commands/GenerateTests.swift
@@ -144,7 +144,7 @@ class GenerateTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -185,7 +185,7 @@ class GenerateTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }
@@ -234,7 +234,7 @@ class GenerateTests: XCTestCase {
 
     var didCallFetch = false
     MockApolloSchemaDownloader.fetchHandler = { configuration in
-      expect(configuration).to(equal(mockConfiguration.schemaDownloadConfiguration))
+      expect(configuration).to(equal(mockConfiguration.schemaDownload))
 
       didCallFetch = true
     }

--- a/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
@@ -4,11 +4,11 @@ import ApolloCodegenLib
 
 class MockApolloCodegen: CodegenProvider {
   static var buildHandler: ((ApolloCodegenConfiguration) throws -> Void)? = nil
-  static var generateOperationManifestHandler: ((ApolloCodegenConfiguration) throws -> Void)? = nil
 
   static func build(
     with configuration: ApolloCodegenConfiguration,
-    withRootURL rootURL: URL?
+    withRootURL rootURL: URL?,
+    buildOptions: ApolloCodegen.CodeGenerationBuildOptions
   ) throws {
     guard let handler = buildHandler else {
       fatalError("You must set buildHandler before calling \(#function)!")
@@ -21,19 +21,4 @@ class MockApolloCodegen: CodegenProvider {
     try handler(configuration)
   }
   
-  static func generateOperationManifest(
-    with configuration: ApolloCodegenLib.ApolloCodegenConfiguration,
-    withRootURL rootURL: URL?,
-    fileManager: ApolloCodegenLib.ApolloFileManager
-  ) throws {
-    guard let handler = generateOperationManifestHandler else {
-      fatalError("You must set generateOperationManifestHandler before calling \(#function)!")
-    }
-    
-    defer {
-      generateOperationManifestHandler = nil
-    }
-    
-    try handler(configuration)
-  }
 }

--- a/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
@@ -4,6 +4,7 @@ import ApolloCodegenLib
 
 class MockApolloCodegen: CodegenProvider {
   static var buildHandler: ((ApolloCodegenConfiguration) throws -> Void)? = nil
+  static var generateOperationManifestHandler: ((ApolloCodegenConfiguration) throws -> Void)? = nil
 
   static func build(
     with configuration: ApolloCodegenConfiguration,
@@ -25,12 +26,12 @@ class MockApolloCodegen: CodegenProvider {
     withRootURL rootURL: URL?,
     fileManager: ApolloCodegenLib.ApolloFileManager
   ) throws {
-    guard let handler = buildHandler else {
-      fatalError("You must set buildHandler before calling \(#function)!")
+    guard let handler = generateOperationManifestHandler else {
+      fatalError("You must set generateOperationManifestHandler before calling \(#function)!")
     }
     
     defer {
-      buildHandler = nil
+      generateOperationManifestHandler = nil
     }
     
     try handler(configuration)

--- a/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegen.swift
@@ -8,7 +8,7 @@ class MockApolloCodegen: CodegenProvider {
   static func build(
     with configuration: ApolloCodegenConfiguration,
     withRootURL rootURL: URL?,
-    buildOptions: ApolloCodegen.CodeGenerationBuildOptions
+    itemsToGenerate: ApolloCodegen.ItemsToGenerate
   ) throws {
     guard let handler = buildHandler else {
       fatalError("You must set buildHandler before calling \(#function)!")

--- a/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
@@ -14,11 +14,11 @@ extension ApolloCodegenConfiguration {
       options: .init(
         operationDocumentFormat: [.definition, .operationId]
       ),
-      schemaDownloadConfiguration: .init(
+      schemaDownload: .init(
         using: .introspection(endpointURL: URL(string: "http://some.server")!),
         outputPath: "./schema.graphqls"
       ),
-      operationManifestConfiguration: .init(
+      operationManifest: .init(
         path: "./manifest",
         version: .persistedQueries,
         generateManifestOnCodeGeneration: false

--- a/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
@@ -11,15 +11,17 @@ extension ApolloCodegenConfiguration {
       output: .init(
         schemaTypes: .init(path: ".", moduleType: .swiftPackageManager)
       ),
-      options: .init(),
+      options: .init(
+        operationDocumentFormat: [.definition, .operationId]
+      ),
       schemaDownloadConfiguration: .init(
         using: .introspection(endpointURL: URL(string: "http://some.server")!),
         outputPath: "./schema.graphqls"
       ),
       operationManifestConfiguration: .init(
-        operationManifest: .init(path: "./manifest", version: .persistedQueries),
-        operationDocumentFormat: [.definition, .operationId],
-        autoGenerate: false
+        path: "./manifest",
+        version: .persistedQueries,
+        generateManifestOnCodeGeneration: false
       )
     )
   }

--- a/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloCodegenConfiguration.swift
@@ -9,15 +9,17 @@ extension ApolloCodegenConfiguration {
         schemaPath: "./schema.graphqls"
       ),
       output: .init(
-        schemaTypes: .init(path: ".", moduleType: .swiftPackageManager),
-        operationManifest: .init(path: "./manifest", version: .persistedQueries)
+        schemaTypes: .init(path: ".", moduleType: .swiftPackageManager)
       ),
-      options: .init(
-        operationDocumentFormat: [.definition, .operationId]
-      ),
+      options: .init(),
       schemaDownloadConfiguration: .init(
         using: .introspection(endpointURL: URL(string: "http://some.server")!),
         outputPath: "./schema.graphqls"
+      ),
+      operationManifestConfiguration: .init(
+        operationManifest: .init(path: "./manifest", version: .persistedQueries),
+        operationDocumentFormat: [.definition, .operationId],
+        autoGenerate: false
       )
     )
   }

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -407,6 +407,7 @@ The top-level properties are:
 | [`deprecatedEnumCases`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/deprecatedenumcases) | Annotate generated Swift enums with the Swift `@available` attribute for GraphQL enum cases annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`schemaDocumentation`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/schemadocumentation) | Include or exclude [schema documentation](https://spec.graphql.org/draft/#sec-Descriptions) in the generated files. |
 | [`selectionSetInitializers`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/selectionsetinitializers) | Generate initializers for your generated selection set models. |
+| [`operationDocumentFormat`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/operationdocumentformat) | How to generate the operation documents for your generated operations. This can be used to generate operation identifiers for use with a server that supports [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) |
 | [`cocoapodsCompatibleImportStatements`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/cocoapodscompatibleimportstatements) | Generate import statements that are compatible with including `Apollo` via Cocoapods. |
 | [`warningsOnDeprecatedUsage`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/warningsondeprecatedusage) | Annotate generated Swift code with the Swift `@available` attribute and `@deprecated` argument for parts of the GraphQL schema annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`conversionStrategies`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/conversionstrategies) | Rules for how to convert the names of values from the schema in generated code. |
@@ -434,6 +435,7 @@ The top-level properties are:
 			"MyFragment"
 		]
 	},
+    "operationDocumentFormat" : ["definition", "operationId"],
 	"cocoapodsCompatibleImportStatements": false,
 	"warningsOnDeprecatedUsage": "include",
 	"conversionStrategies": {
@@ -635,22 +637,32 @@ Optional settings used to configure the usage of [Persisted Queries or Automatic
 
 | Property Name | Description |
 | ------------- | ----------- |
-| [`operationManifest`](#operation-manifest) | Configures the generation of an operation manifest JSON file for use with [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) or Automatic Persisted Queries. |
-| [`operationDocumentFormat`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/operationdocumentformat) | How to generate the operation documents for your generated operations. This can be used to generate operation identifiers for use with a server that supports [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) |
-| [`autoGenerate`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/autogenerate) | Whether or not the operation manifest should be generated every time code generation is run. Defaults to false. |
+| `path` | Local path where the generated operation manifest file should be written. |
+| [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
+| [`generateManifestOnCodeGeneration`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/autogenerate) | Whether or not the operation manifest should be generated every time code generation is run. Defaults to false. |
+
+<MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
 "operationManifestConfiguration" : {
-  "autoGenerate" : false,
-  "operationDocumentFormat" : [
-    "definition"
-  ],
-  "operationManifest" : {
-    "path" : "/operation/identifiers/path",
-    "version" : "persistedQueries"
-  }
+  "generateManifestOnCodeGeneration" : false,
+  "path" : "/operation/identifiers/path",
+  "version" : "persistedQueries"
 }
 ```
+
+```swift title="Swift Codegen Setup"
+let configuration = ApolloCodegenConfiguration(
+    // Other properties not shown
+    operationManifestConfiguration: .init(
+        path: "./manifest/operationManifest.json",
+        version: .persistedQueries,
+        generateManifestOnCodeGeneration: false
+    )
+)
+```
+
+</MultiCodeBlock>
 
 ### Operation Manifest
 

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -21,7 +21,8 @@ There are a number of base configuration properties, each representing a specifi
 | [`output`](#file-output) | Location and structure of the generated files and modules. |
 | [`options`](#output-options) | Rules and options to customize the generated code. |
 | [`experimentalFeatures`](#experimental-features) | Used to enable experimental features.<br/>*Note: These features could change at any time and are not guaranteed to always be available.* |
-| [`schemaDownloadConfiguration`](#schema-download-configuration) | Configuration to fetch a GraphQL schema before generation. |
+| [`schemaDownload`](#schema-download-configuration) | Configuration to fetch a GraphQL schema before generation. |
+| [`operationManifest`](#operation-manifest-configuration) | Configuration to generate operation manifests for persisted queries |
 
 ## Schema namespace
 
@@ -542,7 +543,7 @@ The properties you will need to configure are:
 <MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
-"schemaDownloadConfiguration": {
+"schemaDownload": {
 	"downloadMethod": {
 		"apolloRegistry": {
 			"_0": {
@@ -564,7 +565,7 @@ The properties you will need to configure are:
 ```swift title="Swift Codegen Setup"
 let configuration = ApolloCodegenConfiguration(
   // Other properties not shown
-  schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration(
+  schemaDownload: ApolloSchemaDownloadConfiguration(
     using: .apolloRegistry(.init(
       apiKey: "your-api-key",
       graphID: "your-graphid",
@@ -598,7 +599,7 @@ The properties you will need to configure are:
 <MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
-"schemaDownloadConfiguration": {
+"schemaDownload": {
 	"downloadMethod": {
 		"introspection": {
 			"endpointURL": "https://server.com",
@@ -618,7 +619,7 @@ The properties you will need to configure are:
 ```swift title="Swift Codegen Setup"
 let configuration = ApolloCodegenConfiguration(
 	// Other properties not shown
-	schemaDownloadConfiguration: ApolloSchemaDownloadConfiguration(
+	schemaDownload: ApolloSchemaDownloadConfiguration(
 		using: .introspection(
 			endpointURL: URL(string: "https://server.com")!),
 		timeout: 60.0,
@@ -639,12 +640,12 @@ Optional settings used to configure the usage of [Persisted Queries or Automatic
 | ------------- | ----------- |
 | `path` | Local path where the generated operation manifest file should be written. |
 | [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
-| [`generateManifestOnCodeGeneration`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/autogenerate) | Whether or not the operation manifest should be generated every time code generation is run. Defaults to false. |
+| [`generateManifestOnCodeGeneration`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/generateManifestOnCodeGeneration) | Whether or not the operation manifest should be generated every time code generation is run. Defaults to false. |
 
 <MultiCodeBlock>
 
 ```json title="CLI Configuration JSON"
-"operationManifestConfiguration" : {
+"operationManifest" : {
   "generateManifestOnCodeGeneration" : false,
   "path" : "/operation/identifiers/path",
   "version" : "persistedQueries"
@@ -654,7 +655,7 @@ Optional settings used to configure the usage of [Persisted Queries or Automatic
 ```swift title="Swift Codegen Setup"
 let configuration = ApolloCodegenConfiguration(
     // Other properties not shown
-    operationManifestConfiguration: .init(
+    operationManifest: .init(
         path: "./manifest/operationManifest.json",
         version: .persistedQueries,
         generateManifestOnCodeGeneration: false

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -98,7 +98,6 @@ The properties to configure `output` are:
 | [`schemaTypes`](#schema-types) | Location and structure of the generated schema types files. |
 | [`operations`](#operations)    | Location and structure of the generated operation files such as queries, mutations, subscriptions, and fragments. |
 | [`testMocks`](#test-mocks)     | Location and structure of the test mock operation object files.<br/><br/>If `.none`, test mocks will not be generated. |
-| [`operationManifest`](#operation-manifest) | Configures the generation of an operation manifest JSON file for use with persisted queries or [Automatic Persisted Queries](../fetching/apqs). |
 
 <MultiCodeBlock>
 
@@ -395,42 +394,6 @@ Specify the directory for your test mocks using the `path` parameter. This is re
 >
 > Test mocks generated this way may also be manually embedded in a test utility module that is imported by your test target.
 
-### Operation Manifest
-
-Providing a value for this property will generate a JSON document with all your operations and their computed identifier hashes. This document can be used to pre-register the identifiers for your operations with a server that supports [persisted queries or Automatic Persisted Queries](./../fetching/apqs).
-
-The properties of the Operation Manifest configuration object are:
-
-| Property Name | Description |
-| ----- | ----------- |
-| `path` | Local path where the generated operation manifest file should be written. |
-| [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
-
-<MultiCodeBlock>
-
-```json title="CLI Configuration JSON"
-"output": {
-	"operationManifest" : {
-		"path" : "./generated/operationIdentifiers.json",
-		"version" : "persistedQueries"
-	}
-}
-```
-
-```swift title="Swift Codegen Setup"
-let configuration = ApolloCodegenConfiguration(
-	// Other properties not shown
-	output: ApolloCodegenConfiguration.FileOutput(
-		operationManifest: .init(
-			path: "./generated/operationIdentifiers.json",
-			version: .persistedQueries
-		)
-	)
-)
-```
-
-</MultiCodeBlock>
-
 ## Output options
 
 The code generation engine supports a number of configuration options to change the behaviour of the generator and tailor the generated Swift code to your specific needs.
@@ -444,7 +407,6 @@ The top-level properties are:
 | [`deprecatedEnumCases`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/deprecatedenumcases) | Annotate generated Swift enums with the Swift `@available` attribute for GraphQL enum cases annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`schemaDocumentation`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/schemadocumentation) | Include or exclude [schema documentation](https://spec.graphql.org/draft/#sec-Descriptions) in the generated files. |
 | [`selectionSetInitializers`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/selectionsetinitializers) | Generate initializers for your generated selection set models. |
-| [`operationDocumentFormat`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/operationdocumentformat) | How to generate the operation documents for your generated operations. This can be used to generate operation identifiers for use with a server that supports [persisted queries or Automatic Persisted Queries](./../fetching/apqs) |
 | [`cocoapodsCompatibleImportStatements`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/cocoapodscompatibleimportstatements) | Generate import statements that are compatible with including `Apollo` via Cocoapods. |
 | [`warningsOnDeprecatedUsage`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/warningsondeprecatedusage) | Annotate generated Swift code with the Swift `@available` attribute and `@deprecated` argument for parts of the GraphQL schema annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`conversionStrategies`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/conversionstrategies) | Rules for how to convert the names of values from the schema in generated code. |
@@ -472,7 +434,6 @@ The top-level properties are:
 			"MyFragment"
 		]
 	},
-	"operationDocumentFormat" : ["definition", "operationId"],
 	"cocoapodsCompatibleImportStatements": false,
 	"warningsOnDeprecatedUsage": "include",
 	"conversionStrategies": {
@@ -667,3 +628,62 @@ let configuration = ApolloCodegenConfiguration(
 </MultiCodeBlock>
 
 For more details, see the section on [downloading a schema](./downloading-schema).
+
+## Operation Manifest Configuration
+
+Optional settings used to configure the usage of [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) in order to generate the operation identfier manifest and determine how operation files are generated.
+
+| Property Name | Description |
+| ------------- | ----------- |
+| [`operationManifest`](#operation-manifest) | Configures the generation of an operation manifest JSON file for use with [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) or Automatic Persisted Queries. |
+| [`operationDocumentFormat`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/operationdocumentformat) | How to generate the operation documents for your generated operations. This can be used to generate operation identifiers for use with a server that supports [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) |
+| [`autoGenerate`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestconfiguration/autogenerate) | Whether or not the operation manifest should be generated every time code generation is run. Defaults to false. |
+
+```json title="CLI Configuration JSON"
+"operationManifestConfiguration" : {
+  "autoGenerate" : false,
+  "operationDocumentFormat" : [
+    "definition"
+  ],
+  "operationManifest" : {
+    "path" : "/operation/identifiers/path",
+    "version" : "persistedQueries"
+  }
+}
+```
+
+### Operation Manifest
+
+Providing a value for this property will generate a JSON document with all your operations and their computed identifier hashes. This document can be used to pre-register the identifiers for your operations with a server that supports [persisted queries or Automatic Persisted Queries](./../fetching/apqs).
+
+The properties of the Operation Manifest configuration object are:
+
+| Property Name | Description |
+| ----- | ----------- |
+| `path` | Local path where the generated operation manifest file should be written. |
+| [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
+
+<MultiCodeBlock>
+
+```json title="CLI Configuration JSON"
+"output": {
+    "operationManifest" : {
+        "path" : "./generated/operationIdentifiers.json",
+        "version" : "persistedQueries"
+    }
+}
+```
+
+```swift title="Swift Codegen Setup"
+let configuration = ApolloCodegenConfiguration(
+    // Other properties not shown
+    output: ApolloCodegenConfiguration.FileOutput(
+        operationManifest: .init(
+            path: "./generated/operationIdentifiers.json",
+            version: .persistedQueries
+        )
+    )
+)
+```
+
+</MultiCodeBlock>

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -634,7 +634,7 @@ For more details, see the section on [downloading a schema](./downloading-schema
 
 ## Operation Manifest Configuration
 
-Optional settings used to configure the usage of [Persisted Queries or Automatic Persisted Queries](./../fetching/persisted-queries) in order to generate the operation identfier manifest and determine how operation files are generated.
+Optional settings used to configure generation of the operation identifier manifest for use with [Persisted Queries](./../fetching/persisted-queries).
 
 | Property Name | Description |
 | ------------- | ----------- |

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -436,7 +436,7 @@ The top-level properties are:
 			"MyFragment"
 		]
 	},
-    "operationDocumentFormat" : ["definition", "operationId"],
+	"operationDocumentFormat" : ["definition", "operationId"],
 	"cocoapodsCompatibleImportStatements": false,
 	"warningsOnDeprecatedUsage": "include",
 	"conversionStrategies": {
@@ -659,42 +659,6 @@ let configuration = ApolloCodegenConfiguration(
         path: "./manifest/operationManifest.json",
         version: .persistedQueries,
         generateManifestOnCodeGeneration: false
-    )
-)
-```
-
-</MultiCodeBlock>
-
-### Operation Manifest
-
-Providing a value for this property will generate a JSON document with all your operations and their computed identifier hashes. This document can be used to pre-register the identifiers for your operations with a server that supports [persisted queries or Automatic Persisted Queries](./../fetching/apqs).
-
-The properties of the Operation Manifest configuration object are:
-
-| Property Name | Description |
-| ----- | ----------- |
-| `path` | Local path where the generated operation manifest file should be written. |
-| [`version`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/operationmanifestfileoutput/version) | The version format to use when generating the operation manifest. |
-
-<MultiCodeBlock>
-
-```json title="CLI Configuration JSON"
-"output": {
-    "operationManifest" : {
-        "path" : "./generated/operationIdentifiers.json",
-        "version" : "persistedQueries"
-    }
-}
-```
-
-```swift title="Swift Codegen Setup"
-let configuration = ApolloCodegenConfiguration(
-    // Other properties not shown
-    output: ApolloCodegenConfiguration.FileOutput(
-        operationManifest: .init(
-            path: "./generated/operationIdentifiers.json",
-            version: .persistedQueries
-        )
     )
 )
 ```


### PR DESCRIPTION
-Moved all codegen config options related to persisted queries to a new top level `OperationManifestConfiguration` object
-Added an `autoGenerate` option to determine if the operation manifest should be generated when using the `generate` cli command
-Cleaned up/combined some code