### PR TITLE
refactor: Selection set generation for `@defer`

### DIFF
--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -2,6 +2,7 @@ import JavaScriptCore
 
 /// The output of the frontend compiler.
 public class CompilationResult: JavaScriptObject {
+  /// String constants used to match JavaScriptObject instances.
   private enum Constants {
     enum DirectiveNames {
       static let LocalCacheMutation = "apollo_client_ios_localCacheMutation"

--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -3,9 +3,16 @@ import JavaScriptCore
 /// The output of the frontend compiler.
 public class CompilationResult: JavaScriptObject {
   private enum Constants {
-    static let LocalCacheMutationDirectiveName = "apollo_client_ios_localCacheMutation"
-    static let DeferDirectiveName = "defer"
+    enum DirectiveNames {
+      static let LocalCacheMutation = "apollo_client_ios_localCacheMutation"
+      static let Defer = "defer"
+    }
+
+    enum ArgumentLabels {
+      static let `If` = "if"
+    }
   }
+
   lazy var rootTypes: RootTypeDefinition = self["rootTypes"]
   
   lazy var referencedTypes: [GraphQLNamedType] = self["referencedTypes"]
@@ -54,7 +61,7 @@ public class CompilationResult: JavaScriptObject {
     }
 
     lazy var isLocalCacheMutation: Bool = {
-      directives?.contains { $0.name == Constants.LocalCacheMutationDirectiveName } ?? false
+      directives?.contains { $0.name == Constants.DirectiveNames.LocalCacheMutation } ?? false
     }()
 
     lazy var nameWithSuffix: String = {
@@ -117,7 +124,7 @@ public class CompilationResult: JavaScriptObject {
     lazy var directives: [Directive]? = self["directives"]
 
     lazy var isLocalCacheMutation: Bool = {
-      directives?.contains { $0.name == Constants.LocalCacheMutationDirectiveName } ?? false
+      directives?.contains { $0.name == Constants.DirectiveNames.LocalCacheMutation } ?? false
     }()
 
     public override var debugDescription: String {

--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -180,6 +180,27 @@ public class CompilationResult: JavaScriptObject {
 
     lazy var directives: [Directive]? = self["directives"]
 
+    lazy var isDeferred: IsDeferred = {
+      guard let directive = directives?.first(where: { $0.name == Constants.DirectiveNames.Defer }) else {
+        return false
+      }
+
+      guard let argument = directive.arguments?.first(where: { $0.name == Constants.ArgumentLabels.If }) else {
+        return true
+      }
+
+      switch (argument.value) {
+      case let .boolean(value):
+        return .value(value)
+
+      case let .variable(variable):
+        return .variable(variable)
+
+      default:
+        preconditionFailure("Incompatible argument value. Expected Boolean or Variable, got \(argument.value).")
+      }
+    }()
+
     public override var debugDescription: String {
       selectionSet.debugDescription
     }
@@ -203,6 +224,27 @@ public class CompilationResult: JavaScriptObject {
     lazy var inclusionConditions: [InclusionCondition]? = self["inclusionConditions"]
 
     lazy var directives: [Directive]? = self["directives"]
+
+    lazy var isDeferred: IsDeferred = {
+      guard let directive = directives?.first(where: { $0.name == Constants.DirectiveNames.Defer }) else {
+        return false
+      }
+
+      guard let argument = directive.arguments?.first(where: { $0.name == Constants.ArgumentLabels.If }) else {
+        return true
+      }
+
+      switch (argument.value) {
+      case let .boolean(value):
+        return .value(value)
+
+      case let .variable(variable):
+        return .variable(variable)
+
+      default:
+        preconditionFailure("Incompatible argument value. Expected Boolean or Variable, got \(argument.value).")
+      }
+    }()
 
     var parentType: GraphQLCompositeType { fragment.type }
 
@@ -416,6 +458,19 @@ public class CompilationResult: JavaScriptObject {
 
     static func skip(if variable: String) -> Self {
       .variable(variable, isInverted: true)
+    }
+  }
+
+  public enum IsDeferred: ExpressibleByBooleanLiteral {
+    case value(Bool)
+    case variable(String)
+
+    public init(booleanLiteral value: BooleanLiteralType) {
+      self = .value(value)
+    }
+
+    static func `if`(_ variable: String) -> Self {
+      .variable(variable)
     }
   }
 

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -54,6 +54,7 @@ extension IR {
       self.conditions = [condition]
     }
 
+    /// A failable initializer to convert from an array of `CompilationResult.InclusionCondition`.
     init?(_ conditions: [CompilationResult.InclusionCondition]?) {
       guard let conditions, !conditions.isEmpty else { return nil }
 

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -54,6 +54,20 @@ extension IR {
       self.conditions = [condition]
     }
 
+    init?(_ conditions: [CompilationResult.InclusionCondition]?) {
+      guard let conditions, !conditions.isEmpty else { return nil }
+
+      self.conditions = []
+      self.conditions.append(contentsOf: conditions.map({ condition in
+        switch condition {
+        case let .variable(variable, inverted):
+          return InclusionCondition(variable, isInverted: inverted)
+        default:
+          preconditionFailure("Cannot convert condition without variable, got \(condition)!")
+        }
+      }))
+    }
+
     static func allOf<T: Sequence>(
       _ conditions: T
     ) -> Result where T.Element == InclusionCondition {

--- a/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+InclusionConditions.swift
@@ -54,21 +54,6 @@ extension IR {
       self.conditions = [condition]
     }
 
-    /// A failable initializer to convert from an array of `CompilationResult.InclusionCondition`.
-    init?(_ conditions: [CompilationResult.InclusionCondition]?) {
-      guard let conditions, !conditions.isEmpty else { return nil }
-
-      self.conditions = []
-      self.conditions.append(contentsOf: conditions.map({ condition in
-        switch condition {
-        case let .variable(variable, inverted):
-          return InclusionCondition(variable, isInverted: inverted)
-        default:
-          preconditionFailure("Cannot convert condition without variable, got \(condition)!")
-        }
-      }))
-    }
-
     static func allOf<T: Sequence>(
       _ conditions: T
     ) -> Result where T.Element == InclusionCondition {

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -233,7 +233,11 @@ extension IR {
       for inlineFragment: CompilationResult.InlineFragment,
       in parentTypePath: SelectionSet.TypeInfo
     ) -> ScopeCondition? {
-      scopeCondition(for: inlineFragment, in: parentTypePath, isDeferred: inlineFragment.isDeferred)
+      scopeCondition(
+        for: inlineFragment,
+        in: parentTypePath,
+        isDeferred: IsDeferred(compilationResult: inlineFragment.isDeferred)
+      )
     }
 
     private func scopeCondition(
@@ -249,13 +253,17 @@ extension IR {
       let scopedIsDeferred = matchedParentTypes && matchedInclusionConditions
       ? namedFragment.isDeferred : false
 
-      return scopeCondition(for: namedFragment, in: parentTypePath, isDeferred: scopedIsDeferred)
+      return scopeCondition(
+        for: namedFragment,
+        in: parentTypePath,
+        isDeferred: IR.IsDeferred(compilationResult: scopedIsDeferred)
+      )
     }
 
     private func scopeCondition(
       for conditionalSelectionSet: ConditionallyIncludable,
       in parentTypePath: SelectionSet.TypeInfo,
-      isDeferred: CompilationResult.IsDeferred
+      isDeferred: IR.IsDeferred
     ) -> ScopeCondition? {
       let inclusionResult = inclusionResult(for: conditionalSelectionSet.inclusionConditions)
       guard inclusionResult != .skipped else {
@@ -268,7 +276,7 @@ extension IR {
       return ScopeCondition(
         type: type,
         conditions: inclusionResult.conditions,
-        isDeferred: IsDeferred(compilationResult: isDeferred)
+        isDeferred: isDeferred
       )
     }
 

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -240,7 +240,9 @@ extension IR {
       for namedFragment: CompilationResult.FragmentSpread,
       in parentTypePath: SelectionSet.TypeInfo
     ) -> ScopeCondition? {
-      scopeCondition(for: namedFragment, in: parentTypePath, isDeferred: namedFragment.isDeferred)
+      let scopedIsDeferred = (parentTypePath.parentType == namedFragment.parentType) ? namedFragment.isDeferred : false
+
+      return scopeCondition(for: namedFragment, in: parentTypePath, isDeferred: scopedIsDeferred)
     }
 
     private func scopeCondition(

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -230,8 +230,23 @@ extension IR {
     }
 
     private func scopeCondition(
-      for conditionalSelectionSet: ConditionallyIncludable,
+      for inlineFragment: CompilationResult.InlineFragment,
       in parentTypePath: SelectionSet.TypeInfo
+    ) -> ScopeCondition? {
+      scopeCondition(for: inlineFragment, in: parentTypePath, isDeferred: inlineFragment.isDeferred)
+    }
+
+    private func scopeCondition(
+      for namedFragment: CompilationResult.FragmentSpread,
+      in parentTypePath: SelectionSet.TypeInfo
+    ) -> ScopeCondition? {
+      scopeCondition(for: namedFragment, in: parentTypePath, isDeferred: namedFragment.isDeferred)
+    }
+
+    private func scopeCondition(
+      for conditionalSelectionSet: ConditionallyIncludable,
+      in parentTypePath: SelectionSet.TypeInfo,
+      isDeferred: CompilationResult.IsDeferred
     ) -> ScopeCondition? {
       let inclusionResult = inclusionResult(for: conditionalSelectionSet.inclusionConditions)
       guard inclusionResult != .skipped else {
@@ -241,7 +256,11 @@ extension IR {
       let type = parentTypePath.parentType == conditionalSelectionSet.parentType ?
       nil : conditionalSelectionSet.parentType
 
-      return ScopeCondition(type: type, conditions: inclusionResult.conditions)
+      return ScopeCondition(
+        type: type,
+        conditions: inclusionResult.conditions,
+        isDeferred: IsDeferred(compilationResult: isDeferred)
+      )
     }
 
     private func inclusionResult(

--- a/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+RootFieldBuilder.swift
@@ -240,7 +240,11 @@ extension IR {
       for namedFragment: CompilationResult.FragmentSpread,
       in parentTypePath: SelectionSet.TypeInfo
     ) -> ScopeCondition? {
-      let scopedIsDeferred = (parentTypePath.parentType == namedFragment.parentType) ? namedFragment.isDeferred : false
+      let matchedParentTypes = (parentTypePath.parentType == namedFragment.parentType)
+      let matchedInclusionConditions = (parentTypePath.inclusionConditions == InclusionConditions(namedFragment.inclusionConditions))
+
+      let scopedIsDeferred = matchedParentTypes && matchedInclusionConditions
+      ? namedFragment.isDeferred : false
 
       return scopeCondition(for: namedFragment, in: parentTypePath, isDeferred: scopedIsDeferred)
     }

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -62,6 +62,16 @@ class IR {
     case value(Bool)
     case `if`(_ variable: String)
 
+    init(compilationResult isDeferred: CompilationResult.IsDeferred) {
+      switch isDeferred {
+      case let .value(value):
+        self = .value(value)
+
+      case let .variable(variable):
+        self = .if(variable)
+      }
+    }
+
     init(booleanLiteral value: BooleanLiteralType) {
       switch value {
       case true:

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -57,7 +57,8 @@ class IR {
     }
   }
 
-  // TODO: Documentation for this to be completed in issue #3141
+  /// Represents the `@defer` directive on an inline or named fragment spread. Can be expressed as
+  /// a Boolean literal or a conditional with a variable.
   enum IsDeferred: Hashable, ExpressibleByBooleanLiteral {
     case value(Bool)
     case `if`(_ variable: String)

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -221,6 +221,10 @@ extension IR {
       return true
     }
 
+    var isDeferred: Bool {
+      scopePath.contains { $0.isDeferred != false }
+    }
+
     static func == (lhs: ScopeDescriptor, rhs: ScopeDescriptor) -> Bool {
       lhs.scopePath == rhs.scopePath &&
       lhs.matchingTypes == rhs.matchingTypes

--- a/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
+++ b/Sources/ApolloCodegenLib/IR/ScopeDescriptor.swift
@@ -3,9 +3,6 @@ import OrderedCollections
 
 extension IR {
 
-  // TODO: Write tests that two inline fragments with same type and inclusion conditions,
-  // but different defer conditions don't  merge together.
-  // To be done in issue #3141
   struct ScopeCondition: Hashable, CustomDebugStringConvertible {
     let type: GraphQLCompositeType?
     let conditions: InclusionConditions?

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -24,6 +24,8 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
         accessControlRenderer: { accessControlModifier(for: .member) }()
       ))
 
+      \(section: DeferredProperties(definition))
+
       \(section: VariableProperties(operation.definition.variables))
 
       \(Initializer(operation.definition.variables))

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -381,8 +381,10 @@ struct SelectionSetTemplate {
     let name = fragment.definition.name
     let propertyName = name.firstLowercased
     let typeName = name.asFragmentName
-    let isOptional = fragment.inclusionConditions != nil &&
-    !scope.matches(fragment.inclusionConditions.unsafelyUnwrapped)
+
+    let isOptional =
+      (fragment.inclusionConditions != nil && !scope.matches(fragment.inclusionConditions.unsafelyUnwrapped))
+      || fragment.isDeferred == true
 
     return """
     \(renderAccessControl())var \(propertyName): \(typeName)\

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -278,7 +278,7 @@ struct SelectionSetTemplate {
   }
 
   private func InlineFragmentSelectionTemplate(_ inlineFragment: IR.InlineFragmentSpread) -> TemplateString {
-    return """
+    """
     .inlineFragment(\(inlineFragment.selectionSet.renderedTypeName).self\(inlineFragment.isDeferred.rendered))
     """
   }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -995,7 +995,7 @@ fileprivate extension IR.IsDeferred {
       return ""
 
     case let .if(variable):
-      return ", if(\"\(variable)\")"
+      return ", deferred: .if(\"\(variable)\")"
     }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/SelectionSetTemplate.swift
@@ -384,7 +384,7 @@ struct SelectionSetTemplate {
 
     let isOptional =
       (fragment.inclusionConditions != nil && !scope.matches(fragment.inclusionConditions.unsafelyUnwrapped))
-      || fragment.isDeferred == true
+      || fragment.isDeferred != false
 
     return """
     \(renderAccessControl())var \(propertyName): \(typeName)\

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -261,7 +261,87 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  // MARK: Selection Set Declaration
+  // MARK: - Defer Properties
+
+  func test__generate__givenQueryWithDeferredTypeCase_generatedDeferredPropertyTrue() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog @defer {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+      public static let hasDeferredFragments: Bool = true
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenQueryWithDeferredNamedFragment_generatedDeferredPropertyTrue() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... DogFragment @defer
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    let expected = """
+      public static let hasDeferredFragments: Bool = true
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
+  }
+
+  // MARK: - Selection Set Declaration
 
   func test__generate__givenOperationSelectionSet_rendersDeclaration() throws {
     // given
@@ -299,7 +379,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  // MARK: - Selection Set Initializers
+  // MARK: Selection Set Initializers
 
     func test__generate_givenOperationSelectionSet_configIncludesOperations_rendersInitializer() throws {
       // given

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -5662,6 +5662,90 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
   }
 
+  func test__render_fragmentAccessor__givenFragmentSpread_withDeferDirectiveWithIfArgument_rendersFragmentAccessorAsOptional() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... DogFragment @defer(if: $filter)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    let expected = """
+          public var dogFragment: DogFragment? { _toFragment() }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField)
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+  }
+
+  func test__render_fragmentAccessor__givenFragmentSpread_withDeferDirectiveFalse_rendersFragmentAccessorAsNonOptional() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... DogFragment @defer(if: false)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    let expected = """
+          public var dogFragment: DogFragment { _toFragment() }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField)
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 31, ignoringExtraLines: true))
+  }
+
   // MARK: - Nested Selection Sets
 
   func test__render_nestedSelectionSets__givenDirectEntityFieldAsList_rendersNestedSelectionSet() throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -1969,6 +1969,50 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
+  // MARK: Selections - Defer
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_rendersDeferredInlineFragmentSelectionSet() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog @defer {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .inlineFragment(AsDog.self, deferred: true),
+      ] }
+    """
+
+    // when
+    try buildSubjectAndOperation()
+
+    let allAnimals = try XCTUnwrap(operation[field: "query"]?[field: "allAnimals"] as? IR.EntityField)
+    let actual = subject.render(field: allAnimals)
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
+  }
   // MARK: Merged Sources
 
   func test__render_mergedSources__givenMergedTypeCasesFromSingleMergedTypeCaseSource_rendersMergedSources() throws {

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -1969,7 +1969,7 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
-  // MARK: Selections - Defer
+  // MARK: Selections - Defer (Inline Fragments)
 
   func test__render_selection__givenInlineFragment_withDeferDirective_rendersDeferredInlineFragmentSelectionSet() throws {
     // given
@@ -2014,7 +2014,9 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
-  func test__render_selection__givenFragmentSpread_withDeferDirective_rendersDeferredFragmentSpreadSelectionSet() throws {
+  // MARK: Selections - Defer (Named Fragments)
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_rendersDeferredFragmentSpreadSelectionSet() throws {
     // given
     schemaSDL = """
     type Query {


### PR DESCRIPTION
Closes #3141

Introduces `IsDeferred` expression logic which is used in the selection set template to:
* Add Operation-level `hasDeferredFragments` property
* Add `deferred` property to inline and named fragment selections
* Mark deferred fragment accessors as Optional

_If there are other tests you think would be beneficial, I'm sure there are, please let me know and get them added._