### PR TITLE
feature: `@defer` generated models

### DIFF
--- a/Apollo.xcodeproj/project.pbxproj
+++ b/Apollo.xcodeproj/project.pbxproj
@@ -713,6 +713,7 @@
 		DEF330352A4B6DEE0081883D /* PersistedQueriesOperationManifestTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF330342A4B6DEE0081883D /* PersistedQueriesOperationManifestTemplate.swift */; };
 		DEF330372A4B6EAA0081883D /* PersistedQueriesOperationManifestTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF330362A4B6EAA0081883D /* PersistedQueriesOperationManifestTemplateTests.swift */; };
 		DEFBBC86273470F70088AABC /* IR+Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFBBC85273470F70088AABC /* IR+Field.swift */; };
+		DEFD17732A8436720032B66C /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD17722A8436720032B66C /* Deferred.swift */; };
 		DEFE0FC52748822900FFA440 /* IR+EntitySelectionTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE0FC42748822900FFA440 /* IR+EntitySelectionTree.swift */; };
 		DEFE694E280F6CBE001CF4E8 /* IR+FieldCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE694D280F6CBE001CF4E8 /* IR+FieldCollector.swift */; };
 		DEFE695128134028001CF4E8 /* IRFieldCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE694F28133E9B001CF4E8 /* IRFieldCollectorTests.swift */; };
@@ -1901,6 +1902,7 @@
 		DEF330342A4B6DEE0081883D /* PersistedQueriesOperationManifestTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedQueriesOperationManifestTemplate.swift; sourceTree = "<group>"; };
 		DEF330362A4B6EAA0081883D /* PersistedQueriesOperationManifestTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedQueriesOperationManifestTemplateTests.swift; sourceTree = "<group>"; };
 		DEFBBC85273470F70088AABC /* IR+Field.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+Field.swift"; sourceTree = "<group>"; };
+		DEFD17722A8436720032B66C /* Deferred.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deferred.swift; sourceTree = "<group>"; };
 		DEFE0FC42748822900FFA440 /* IR+EntitySelectionTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+EntitySelectionTree.swift"; sourceTree = "<group>"; };
 		DEFE694D280F6CBE001CF4E8 /* IR+FieldCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IR+FieldCollector.swift"; sourceTree = "<group>"; };
 		DEFE694F28133E9B001CF4E8 /* IRFieldCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRFieldCollectorTests.swift; sourceTree = "<group>"; };
@@ -2876,6 +2878,7 @@
 				DE3C7B12260A6FC900D2F4FF /* FragmentProtocols.swift */,
 				DE3C7B14260A6FCA00D2F4FF /* GraphQLEnum.swift */,
 				DE3C7B10260A6FC900D2F4FF /* SelectionSet.swift */,
+				DEFD17722A8436720032B66C /* Deferred.swift */,
 				DEA6A83326F298660091AF8A /* ParentType.swift */,
 				DE03FDDA2784D0B2007425BD /* DataDict.swift */,
 				DE2FCF1C26E806710057EA67 /* SchemaConfiguration.swift */,
@@ -5700,6 +5703,7 @@
 			files = (
 				DE058609266978A100265760 /* Selection.swift in Sources */,
 				DE64C1F7284033BA00F64B9D /* LocalCacheMutation.swift in Sources */,
+				DEFD17732A8436720032B66C /* Deferred.swift in Sources */,
 				DE05860B266978A100265760 /* SelectionSet.swift in Sources */,
 				DE80003428B5608E00C827BD /* SchemaMetadata.swift in Sources */,
 				DE9C04AC26EAAE4400EC35E7 /* JSON.swift in Sources */,

--- a/Sources/Apollo/FieldSelectionCollector.swift
+++ b/Sources/Apollo/FieldSelectionCollector.swift
@@ -77,8 +77,9 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
                             info: info)
         }
 
-      // TODO: _ is fine for now but will need to be handled in #3145
-      case let .fragment(fragment, _):
+      case .deferred(_, _, _):
+        assertionFailure("Defer execution must be implemented (#3145).")
+      case let .fragment(fragment):
         groupedFields.addFulfilledFragment(fragment)
         try collectFields(from: fragment.__selections,
                           into: &groupedFields,
@@ -86,7 +87,7 @@ struct DefaultFieldSelectionCollector: FieldSelectionCollector {
                           info: info)
 
       // TODO: _ is fine for now but will need to be handled in #3145
-      case let .inlineFragment(typeCase, _):
+      case let .inlineFragment(typeCase):
         if let runtimeType = info.runtimeObjectType(for: object),
            typeCase.__parentType.canBeConverted(from: runtimeType) {
           groupedFields.addFulfilledFragment(typeCase)
@@ -147,9 +148,9 @@ struct CustomCacheDataWritingFieldSelectionCollector: FieldSelectionCollector {
                           for: object,
                           info: info,
                           asConditionalFields: true)
-
-      // TODO: _ is fine for now but will need to be handled in #3145
-      case let .fragment(fragment, _):
+      case .deferred(_, _, _):
+        assertionFailure("Defer execution must be implemented (#3145).")
+      case let .fragment(fragment):
         if groupedFields.fulfilledFragments.contains(type: fragment) {
           try collectFields(from: fragment.__selections,
                             into: &groupedFields,
@@ -158,8 +159,7 @@ struct CustomCacheDataWritingFieldSelectionCollector: FieldSelectionCollector {
                             asConditionalFields: false)
         }
 
-      // TODO: _ is fine for now but will need to be handled in #3145
-      case let .inlineFragment(typeCase, _):
+      case let .inlineFragment(typeCase):
         if groupedFields.fulfilledFragments.contains(type: typeCase) {
           try collectFields(from: typeCase.__selections,
                             into: &groupedFields,

--- a/Sources/ApolloAPI/DataDict.swift
+++ b/Sources/ApolloAPI/DataDict.swift
@@ -41,12 +41,22 @@ public struct DataDict: Hashable {
   @inlinable public var _fulfilledFragments: Set<ObjectIdentifier> {
     _storage.fulfilledFragments
   }
+  
+  @inlinable public var _deferredFragments: Set<ObjectIdentifier> {
+    _storage.deferredFragments
+  }
 
+  #warning("TODO, remove deferredFragments default value when we set these up in executor")
   public init(
     data: [String: AnyHashable],
-    fulfilledFragments: Set<ObjectIdentifier>
+    fulfilledFragments: Set<ObjectIdentifier>,
+    deferredFragments: Set<ObjectIdentifier> = []
   ) {
-    self._storage = .init(data: data, fulfilledFragments: fulfilledFragments)
+    self._storage = .init(
+      data: data,
+      fulfilledFragments: fulfilledFragments,
+      deferredFragments: deferredFragments
+    )
   }
 
   @inlinable public subscript<T: AnyScalarType & Hashable>(_ key: String) -> T {
@@ -101,27 +111,36 @@ public struct DataDict: Hashable {
   @usableFromInline class _Storage: Hashable {
     @usableFromInline var data: [String: AnyHashable]
     @usableFromInline let fulfilledFragments: Set<ObjectIdentifier>
+    @usableFromInline let deferredFragments: Set<ObjectIdentifier>
 
     init(
       data: [String: AnyHashable],
-      fulfilledFragments: Set<ObjectIdentifier>
+      fulfilledFragments: Set<ObjectIdentifier>,
+      deferredFragments: Set<ObjectIdentifier>
     ) {
       self.data = data
       self.fulfilledFragments = fulfilledFragments
+      self.deferredFragments = deferredFragments
     }
 
     @usableFromInline static func ==(lhs: DataDict._Storage, rhs: DataDict._Storage) -> Bool {
       lhs.data == rhs.data &&
-      lhs.fulfilledFragments == rhs.fulfilledFragments
+      lhs.fulfilledFragments == rhs.fulfilledFragments &&
+      lhs.deferredFragments == rhs.deferredFragments
     }
 
     @usableFromInline func hash(into hasher: inout Hasher) {
       hasher.combine(data)
       hasher.combine(fulfilledFragments)
+      hasher.combine(deferredFragments)
     }
 
     @usableFromInline func copy() -> _Storage {
-      _Storage(data: self.data, fulfilledFragments: self.fulfilledFragments)
+      _Storage(
+        data: self.data,
+        fulfilledFragments: self.fulfilledFragments,
+        deferredFragments: self.deferredFragments
+      )
     }
   }
 }

--- a/Sources/ApolloAPI/Deferred.swift
+++ b/Sources/ApolloAPI/Deferred.swift
@@ -1,0 +1,27 @@
+@propertyWrapper
+public struct Deferred<Fragment: SelectionSet> {
+  public enum State {
+    case pending
+    case fulfilled(Fragment)
+  }
+
+  public init(_dataDict: DataDict) {
+    __data = _dataDict
+  }
+
+  public var state: State {
+    guard __data._fulfilledFragments.contains(ObjectIdentifier(Fragment.self)) else {
+      return .pending
+    }
+    return .fulfilled(Fragment.init(_dataDict: __data))
+  }
+
+  private let __data: DataDict
+  public var projectedValue: State { state }
+  public var wrappedValue: Fragment? {
+    guard case let .fulfilled(value) = state else {
+      return nil
+    }
+    return value
+  }
+}

--- a/Sources/ApolloAPI/Deferred.swift
+++ b/Sources/ApolloAPI/Deferred.swift
@@ -1,5 +1,7 @@
+public protocol Deferrable: SelectionSet { }
+
 @propertyWrapper
-public struct Deferred<Fragment: SelectionSet> {
+public struct Deferred<Fragment: Deferrable> {
   public enum State {
     case pending
     case fulfilled(Fragment)

--- a/Sources/ApolloAPI/Deferred.swift
+++ b/Sources/ApolloAPI/Deferred.swift
@@ -4,6 +4,7 @@ public protocol Deferrable: SelectionSet { }
 public struct Deferred<Fragment: Deferrable> {
   public enum State {
     case pending
+    case notExecuted
     case fulfilled(Fragment)
   }
 
@@ -12,10 +13,15 @@ public struct Deferred<Fragment: Deferrable> {
   }
 
   public var state: State {
-    guard __data._fulfilledFragments.contains(ObjectIdentifier(Fragment.self)) else {
-      return .pending
+    let fragment = ObjectIdentifier(Fragment.self)
+    if __data._fulfilledFragments.contains(fragment) {
+      return .fulfilled(Fragment.init(_dataDict: __data))
     }
-    return .fulfilled(Fragment.init(_dataDict: __data))
+    else if __data._deferredFragments.contains(fragment) {
+      return .pending
+    } else {
+      return .notExecuted
+    }
   }
 
   private let __data: DataDict

--- a/Sources/ApolloAPI/FragmentProtocols.swift
+++ b/Sources/ApolloAPI/FragmentProtocols.swift
@@ -4,7 +4,7 @@
 ///
 /// A ``SelectionSet`` can be converted to any ``Fragment`` included in it's
 /// `Fragments` object via its ``SelectionSet/fragments-swift.property`` property.
-public protocol Fragment: SelectionSet {
+public protocol Fragment: SelectionSet, Deferrable {
   /// The definition of the fragment in GraphQL syntax.
   static var fragmentDefinition: StaticString { get }
 }

--- a/Sources/ApolloAPI/Selection.swift
+++ b/Sources/ApolloAPI/Selection.swift
@@ -2,9 +2,11 @@ public enum Selection {
   /// A single field selection.
   case field(Field)
   /// A fragment spread of a named fragment definition.
-  case fragment(any Fragment.Type, deferred: Condition? = nil)
+  case fragment(any Fragment.Type)
   /// An inline fragment with a child selection set nested in a parent selection set.
-  case inlineFragment(any InlineFragment.Type, deferred: Condition? = nil)
+  case inlineFragment(any InlineFragment.Type)
+
+  case deferred(if: Condition? = nil, any Deferrable.Type, label: String)
   /// A group of selections that have `@include/@skip` directives.
   case conditional(Conditions, [Selection])
 
@@ -129,10 +131,15 @@ extension Selection: Hashable {
     switch (lhs, rhs) {
     case let (.field(lhs), .field(rhs)):
       return lhs == rhs
-    case let (.fragment(lhsFragment, lhsDeferred), .fragment(rhsFragment, rhsDeferred)):
-      return lhsFragment == rhsFragment && lhsDeferred == rhsDeferred
-    case let (.inlineFragment(lhsFragment, lhsDeferred), .inlineFragment(rhsFragment, rhsDeferred)):
-      return lhsFragment == rhsFragment && lhsDeferred == rhsDeferred
+    case let (.fragment(lhsFragment), .fragment(rhsFragment)):
+      return lhsFragment == rhsFragment
+    case let (.inlineFragment(lhsFragment), .inlineFragment(rhsFragment)):
+      return lhsFragment == rhsFragment
+    case let (.deferred(lhsCondition, lhsFragment, lhsLabel),
+              .deferred(rhsCondition, rhsFragment, rhsLabel)):
+      return lhsCondition == rhsCondition &&
+      lhsFragment == rhsFragment &&
+      lhsLabel == rhsLabel
     case let (.conditional(lhsConditions, lhsSelections),
               .conditional(rhsConditions, rhsSelections)):
       return lhsConditions == rhsConditions && lhsSelections == rhsSelections
@@ -175,3 +182,4 @@ extension Selection.Field.OutputType: Hashable {
     hasher.combine(self)
   }
 }
+

--- a/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferCompilationTests.ts
+++ b/Sources/ApolloCodegenLib/Frontend/JavaScript/src/__tests__/deferCompilationTests.ts
@@ -175,4 +175,16 @@ describe("given schema", () => {
     });
   });
 
+  describe("query has defer directive with missing label argument", () => {
+    it("should throw error", () => {
+      fail('Test not written yet, to be done in #3187');
+    });
+  });
+
+  describe("query has multiple defer directive with one missing label argument", () => {
+    it("should throw error", () => {
+      fail('Test not written yet, to be done in #3187');
+    });
+  });
+
 });

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -261,7 +261,87 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
-  // MARK: Selection Set Declaration
+  // MARK: - Defer Properties
+
+  func test__generate__givenQueryWithDeferredTypeCase_generatedDeferredPropertyTrue() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog @defer {
+          species
+        }
+      }
+    }
+    """
+
+    let expected = """
+      public static let hasDeferredFragments: Bool = true
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
+
+  func test__generate__givenQueryWithDeferredNamedFragment_generatedDeferredPropertyTrue() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... DogFragment @defer
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    let expected = """
+      public static let hasDeferredFragments: Bool = true
+    """
+
+    // when
+    try buildSubjectAndOperation()
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 9, ignoringExtraLines: true))
+  }
+
+  // MARK: - Selection Set Declaration
 
   func test__generate__givenOperationSelectionSet_rendersDeclaration() throws {
     // given
@@ -299,7 +379,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 10, ignoringExtraLines: true))
   }
 
-  // MARK: - Selection Set Initializers
+  // MARK: Selection Set Initializers
 
     func test__generate_givenOperationSelectionSet_configIncludesOperations_rendersInitializer() throws {
       // given

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/SelectionSet/SelectionSetTemplateTests.swift
@@ -1969,6 +1969,608 @@ class SelectionSetTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, atLine: 7, ignoringExtraLines: true))
   }
 
+  // MARK: Selections - Defer (Inline Fragments)
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_rendersDeferredInlineFragmentSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog @defer {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_andIfArgument_rendersDeferredInlineFragmentSelectionWithVariable() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog @defer(if: $filter) {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_andIfArgumentFalse_rendersInlineFragmentSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... on Dog @defer(if: false) {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_andIncludeDirective_rendersConditionalSelection_withDeferredInlineFragmentSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog @include(if: $filter) @defer {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_andSkipDirective_rendersConditionalSelection_withDeferredInlineFragmentSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog @skip(if: $filter) @defer {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withDeferDirective_andIfArgument_andConditionalDirective_rendersConditionalSelection_withDeferredInlineFragmentSelectionWithVariable() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean, $other: Boolean) {
+      allAnimals {
+        ... on Dog @include(if: $filter) @defer(if: $other) {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withSameTypeAndInclusionConditions_differentDeferConditions_shouldNotMergeSelectionsTogether() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      genus: String!
+      species: String!
+    }
+
+    type Dog implements Animal {
+      genus: String!
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean, $other: Boolean) {
+      allAnimals {
+        ... on Dog @include(if: $filter) @defer {
+          genus
+        }
+        ... on Dog @include(if: $filter) @defer(if: $other) {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragment_withSameDeferConditions_shouldNotMergeSelectionsTogether() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      genus: String!
+      species: String!
+    }
+
+    type Dog implements Animal {
+      genus: String!
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean, $other: Boolean) {
+      allAnimals {
+        ... on Dog @defer {
+          genus
+        }
+        ... on Dog @defer {
+          species
+        }
+      }
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  // MARK: Selections - Defer (Named Fragments)
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_renders_inlineFragmentQuerySelection_andDeferredNamedFragmentTypeCaseSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... DogFragment @defer
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andIfArgument_renders_inlineFragmentQuerySelection_andDeferredNamedFragmentTypeCaseSelectionWithVariable() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... DogFragment @defer(if: $filter)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andIfArgumentFalse_renders_inlineFragmentQuerySelection_andNamedFragmentTypeCaseSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... DogFragment @defer(if: false)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andIncludeDirective_renders_conditionalSelectionWithInlineFragment_andDeferredNamedFragmentTypeCaseSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... DogFragment @include(if: $filter) @defer
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andSkipDirective_renders_conditionalSelectionWithInlineFragment_andDeferredNamedFragmentTypeCaseSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... DogFragment @skip(if: $filter) @defer
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andIfArgument_andIncludeDirective_renders_conditionalSelectionWithInlineFragment_andDeferredNamedFragmentWithVariableTypeCaseSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean, $other: Boolean) {
+      allAnimals {
+        ... DogFragment @include(if: $filter) @defer(if: $other)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andIfArgument_andSkipDirective_renders_conditionalSelectionWithInlineFragment_andDeferredNamedFragmentWithVariableTypeCaseSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean, $other: Boolean) {
+      allAnimals {
+        ... DogFragment @skip(if: $filter) @defer(if: $other)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_andIncludeDirective_withinTypeCase_renders_inlineFragmentQuerySelection_andConditionalInlineFragmentSelection_andDeferredTypeCaseConditionSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog {
+          ... DogFragment @include(if: $filter) @defer
+        }
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenNamedFragment_withDeferDirective_onTypeCase_andIncludeDirective_onNamedFragment_renders_inlineFragmentQuerySelection_andConditionalInlineFragmentSelection_andDeferredTypeCaseConditionSelection() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog @defer {
+          ... DogFragment @include(if: $filter)
+        }
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragmentAndNamedFragment_bothWithDeferDirective_renders_() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      genus: String!
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog @defer {
+          genus
+        }
+        ... DogFragment @defer
+        }
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_selection__givenInlineFragmentAndNamedFragment_bothWithDeferDirective_renders_() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      genus: String!
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... on Dog @defer {
+          genus
+        }
+        ... DogFragment @defer
+        }
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
   // MARK: Merged Sources
 
   func test__render_mergedSources__givenMergedTypeCasesFromSingleMergedTypeCaseSource_rendersMergedSources() throws {
@@ -4928,6 +5530,101 @@ class SelectionSetTemplateTests: XCTestCase {
 
     // then
     expect(actual).to(equalLineByLine(expected, atLine: 14, ignoringExtraLines: true))
+  }
+
+  // MARK: Fragment Accessors - Defer
+
+  func test__render_fragmentAccessor__givenFragmentSpread_withDeferDirective_rendersFragmentAccessorAsOptional() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... DogFragment @defer
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_fragmentAccessor__givenFragmentSpread_withDeferDirectiveWithIfArgument_rendersFragmentAccessorAsOptional() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation($filter: Boolean) {
+      allAnimals {
+        ... DogFragment @defer(if: $filter)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
+  }
+
+  func test__render_fragmentAccessor__givenFragmentSpread_withDeferDirectiveFalse_rendersFragmentAccessorAsNonOptional() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
+
+    interface Animal {
+      species: String!
+    }
+
+    type Dog implements Animal {
+      species: String!
+    }
+    """
+
+    document = """
+    query TestOperation {
+      allAnimals {
+        ... DogFragment @defer(if: false)
+      }
+    }
+
+    fragment DogFragment on Dog {
+      species
+    }
+    """
+
+    fail("Defer test case - to be implemented in #3141")
   }
 
   // MARK: - Nested Selection Sets


### PR DESCRIPTION
This sets in place some of the supporting infrastructure needed to complete #3141 and #3187. There are a bunch of tests that are forced to fail and will be built to pass as the generated models are adapted to match the updated RFC edits in #3181.