### PR TITLE
feature: final class definitions for graphql codegen

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -503,6 +503,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///
     ///  Defaults to `true`.
     public let pruneGeneratedFiles: Bool
+    /// Whether generated GraphQL operation and local cache mutation class types will be marked as `final`.
+    public let markOperationDefinitionsAsFinal: Bool
 
     /// Default property values
     public struct Default {
@@ -515,6 +517,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       public static let warningsOnDeprecatedUsage: Composition = .include
       public static let conversionStrategies: ConversionStrategies = .init()
       public static let pruneGeneratedFiles: Bool = true
+      public static let markOperationDefinitionsAsFinal: Bool = false
     }
 
     /// Designated initializer.
@@ -535,6 +538,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///   - conversionStrategies: Rules for how to convert the names of values from the schema in
     ///     generated code.
     ///   - pruneGeneratedFiles: Whether unused generated files will be automatically deleted.
+    ///   - markOperationDefinitionsAsFinal: Whether generated GraphQL operation and local cache mutation class types will be marked as `final`.
     public init(
       additionalInflectionRules: [InflectionRule] = Default.additionalInflectionRules,
       deprecatedEnumCases: Composition = Default.deprecatedEnumCases,
@@ -544,7 +548,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
       warningsOnDeprecatedUsage: Composition = Default.warningsOnDeprecatedUsage,
       conversionStrategies: ConversionStrategies = Default.conversionStrategies,
-      pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles
+      pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles,
+      markOperationDefinitionsAsFinal: Bool = Default.markOperationDefinitionsAsFinal
     ) {
       self.additionalInflectionRules = additionalInflectionRules
       self.deprecatedEnumCases = deprecatedEnumCases
@@ -555,6 +560,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
       self.conversionStrategies = conversionStrategies
       self.pruneGeneratedFiles = pruneGeneratedFiles
+      self.markOperationDefinitionsAsFinal = markOperationDefinitionsAsFinal
     }
 
     // MARK: Codable
@@ -571,6 +577,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       case warningsOnDeprecatedUsage
       case conversionStrategies
       case pruneGeneratedFiles
+      case markOperationDefinitionsAsFinal
     }
 
     public init(from decoder: Decoder) throws {
@@ -626,6 +633,11 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
         Bool.self,
         forKey: .pruneGeneratedFiles
       ) ?? Default.pruneGeneratedFiles
+
+      markOperationDefinitionsAsFinal = try values.decodeIfPresent(
+        Bool.self,
+        forKey: .markOperationDefinitionsAsFinal
+      ) ?? Default.markOperationDefinitionsAsFinal
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -640,6 +652,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
       try container.encode(self.warningsOnDeprecatedUsage, forKey: .warningsOnDeprecatedUsage)
       try container.encode(self.conversionStrategies, forKey: .conversionStrategies)
       try container.encode(self.pruneGeneratedFiles, forKey: .pruneGeneratedFiles)
+      try container.encode(self.markOperationDefinitionsAsFinal, forKey: .markOperationDefinitionsAsFinal)
     }
   }
 
@@ -1332,8 +1345,9 @@ extension ApolloCodegenConfiguration.OutputOptions {
   ///   - conversionStrategies: Rules for how to convert the names of values from the schema in
   ///     generated code.
   ///   - pruneGeneratedFiles: Whether unused generated files will be automatically deleted.
+  ///   - markOperationDefinitionsAsFinal: Whether generated GraphQL operation and local cache mutation class types will be marked as `final`.
   @available(*, deprecated,
-              renamed: "init(additionalInflectionRules:queryStringLiteralFormat:deprecatedEnumCases:schemaDocumentation:selectionSetInitializers:operationDocumentFormat:cocoapodsCompatibleImportStatements:warningsOnDeprecatedUsage:conversionStrategies:pruneGeneratedFiles:)"
+              renamed: "init(additionalInflectionRules:queryStringLiteralFormat:deprecatedEnumCases:schemaDocumentation:selectionSetInitializers:operationDocumentFormat:cocoapodsCompatibleImportStatements:warningsOnDeprecatedUsage:conversionStrategies:pruneGeneratedFiles:markOperationDefinitionsAsFinal:)"
   )
   public init(
     additionalInflectionRules: [InflectionRule] = Default.additionalInflectionRules,
@@ -1345,7 +1359,8 @@ extension ApolloCodegenConfiguration.OutputOptions {
     cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = Default.warningsOnDeprecatedUsage,
     conversionStrategies: ApolloCodegenConfiguration.ConversionStrategies = Default.conversionStrategies,
-    pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles
+    pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles,
+    markOperationDefinitionsAsFinal: Bool = Default.markOperationDefinitionsAsFinal
   ) {
     self.additionalInflectionRules = additionalInflectionRules
     self.deprecatedEnumCases = deprecatedEnumCases
@@ -1356,6 +1371,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
     self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
     self.conversionStrategies = conversionStrategies
     self.pruneGeneratedFiles = pruneGeneratedFiles
+    self.markOperationDefinitionsAsFinal = markOperationDefinitionsAsFinal
   }
   
   /// Deprecated initializer.
@@ -1378,8 +1394,9 @@ extension ApolloCodegenConfiguration.OutputOptions {
   ///   - conversionStrategies: Rules for how to convert the names of values from the schema in
   ///     generated code.
   ///   - pruneGeneratedFiles: Whether unused generated files will be automatically deleted.
+  ///   - markOperationDefinitionsAsFinal: Whether generated GraphQL operation and local cache mutation class types will be marked as `final`.
   @available(*, deprecated,
-              renamed: "init(additionalInflectionRules:deprecatedEnumCases:schemaDocumentation:selectionSetInitializers:operationDocumentFormat:cocoapodsCompatibleImportStatements:warningsOnDeprecatedUsage:conversionStrategies:pruneGeneratedFiles:)"
+              renamed: "init(additionalInflectionRules:deprecatedEnumCases:schemaDocumentation:selectionSetInitializers:operationDocumentFormat:cocoapodsCompatibleImportStatements:warningsOnDeprecatedUsage:conversionStrategies:pruneGeneratedFiles:markOperationDefinitionsAsFinal:)"
   )
   public init(
     additionalInflectionRules: [InflectionRule] = Default.additionalInflectionRules,
@@ -1391,7 +1408,8 @@ extension ApolloCodegenConfiguration.OutputOptions {
     cocoapodsCompatibleImportStatements: Bool = Default.cocoapodsCompatibleImportStatements,
     warningsOnDeprecatedUsage: ApolloCodegenConfiguration.Composition = Default.warningsOnDeprecatedUsage,
     conversionStrategies: ApolloCodegenConfiguration.ConversionStrategies = Default.conversionStrategies,
-    pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles
+    pruneGeneratedFiles: Bool = Default.pruneGeneratedFiles,
+    markOperationDefinitionsAsFinal: Bool = Default.markOperationDefinitionsAsFinal
   ) {
     self.additionalInflectionRules = additionalInflectionRules
     self.deprecatedEnumCases = deprecatedEnumCases
@@ -1402,6 +1420,7 @@ extension ApolloCodegenConfiguration.OutputOptions {
     self.warningsOnDeprecatedUsage = warningsOnDeprecatedUsage
     self.conversionStrategies = conversionStrategies
     self.pruneGeneratedFiles = pruneGeneratedFiles
+    self.markOperationDefinitionsAsFinal = markOperationDefinitionsAsFinal
   }
 
   /// Whether the generated operations should use Automatic Persisted Queries.

--- a/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/LocalCacheMutationDefinitionTemplate.swift
@@ -15,7 +15,7 @@ struct LocalCacheMutationDefinitionTemplate: OperationTemplateRenderer {
     return TemplateString(
     """
     \(accessControlModifier(for: .parent))\
-    class \(operation.generatedDefinitionName): LocalCacheMutation {
+    \(classDefinitionKeywords) \(operation.generatedDefinitionName): LocalCacheMutation {
       \(memberAccessControl)static let operationType: GraphQLOperationType = .\(operation.definition.operationType.rawValue)
 
       \(section: VariableProperties(operation.definition.variables))

--- a/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
+++ b/Sources/ApolloCodegenLib/Templates/OperationDefinitionTemplate.swift
@@ -46,7 +46,7 @@ struct OperationDefinitionTemplate: OperationTemplateRenderer {
   private func OperationDeclaration() -> TemplateString {
     return """
     \(accessControlModifier(for: .parent))\
-    class \(operation.generatedDefinitionName): \
+    \(classDefinitionKeywords) \(operation.generatedDefinitionName): \
     \(operation.definition.operationType.renderedProtocolName) {
       \(accessControlModifier(for: .member))\
     static let operationName: String = "\(operation.definition.name)"

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -163,6 +163,8 @@ enum AccessControlScope {
 }
 
 extension TemplateRenderer {
+  var classDefinitionKeywords: String { config.options.markOperationDefinitionsAsFinal ? "final class" : "class" }
+
   func accessControlModifier(for scope: AccessControlScope) -> String {
     switch target {
     case .moduleFile, .schemaFile: return schemaAccessControlModifier(scope: scope)

--- a/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
+++ b/Tests/ApolloCodegenTests/ApolloCodegenConfigurationCodableTests.swift
@@ -49,7 +49,8 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             enumCases: .none,
             fieldAccessors: .camelCase
           ),
-          pruneGeneratedFiles: false
+          pruneGeneratedFiles: false,
+          markOperationDefinitionsAsFinal: true
         ),
         experimentalFeatures: .init(
           clientControlledNullability: true,
@@ -98,6 +99,7 @@ class ApolloCodegenConfigurationCodableTests: XCTestCase {
             "fieldAccessors" : "camelCase"
           },
           "deprecatedEnumCases" : "exclude",
+          "markOperationDefinitionsAsFinal" : true,
           "operationDocumentFormat" : [
             "definition"
           ],

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/LocalCacheMutationDefinitionTemplateTests.swift
@@ -245,6 +245,26 @@ class LocalCacheMutationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
+  func test__generate_givenQuery_configIncludesMarkOperationDefinitionsAsFinal_generatesFinalLocalCacheMutation() throws {
+    // given
+    let expected =
+    """
+    final class TestOperationLocalCacheMutation: LocalCacheMutation {
+      static let operationType: GraphQLOperationType = .query
+    """
+
+    config = .mock(options: .init(markOperationDefinitionsAsFinal: true))
+
+    // when
+    try buildSubjectAndOperation()
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
+
   func test__generate__givenQueryWithLowercasing_generatesCorrectlyCasedLocalCacheMutation() throws {
     // given
     schemaSDL = """

--- a/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
+++ b/Tests/ApolloCodegenTests/CodeGeneration/Templates/OperationDefinitionTemplateTests.swift
@@ -81,6 +81,25 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
   }
 
+  func test__generate_givenQuery_configIncludesMarkOperationDefinitionsAsFinal_generatesFinalQueryDefinitions() throws {
+    // given
+    let expected =
+    """
+    final class TestOperationQuery: GraphQLQuery {
+      static let operationName: String = "TestOperation"
+    """
+
+    config = .mock(options: .init(markOperationDefinitionsAsFinal: true))
+
+    // when
+    try buildSubjectAndOperation()
+
+    let actual = renderSubject()
+
+    // then
+    expect(actual).to(equalLineByLine(expected, ignoringExtraLines: true))
+  }
+
   func test__generate__givenQueryWithNameEndingInQuery_generatesQueryOperationWithoutDoubledTypeSuffix() throws {
     // given
     document = """
@@ -301,9 +320,9 @@ class OperationDefinitionTemplateTests: XCTestCase {
 
   // MARK: - Selection Set Initializers
 
-    func test__generate_givenOperationSelectionSet_configIncludesOperations_rendersInitializer() throws {
-      // given
-      schemaSDL = """
+  func test__generate_givenOperationSelectionSet_configIncludesOperations_rendersInitializer() throws {
+    // given
+    schemaSDL = """
       type Query {
         allAnimals: [Animal!]
       }
@@ -313,7 +332,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      document = """
+    document = """
       query TestOperation {
         allAnimals {
           species
@@ -321,7 +340,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      let expected =
+    let expected =
       """
             init(
               species: String
@@ -338,20 +357,20 @@ class OperationDefinitionTemplateTests: XCTestCase {
             }
       """
 
-      config = .mock(options: .init(selectionSetInitializers: [.operations]))
+    config = .mock(options: .init(selectionSetInitializers: [.operations]))
 
-      // when
-      try buildSubjectAndOperation()
+    // when
+    try buildSubjectAndOperation()
 
-      let actual = renderSubject()
+    let actual = renderSubject()
 
-      // then
-      expect(actual).to(equalLineByLine(expected, atLine: 50, ignoringExtraLines: true))
-    }
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 50, ignoringExtraLines: true))
+  }
 
-    func test__generate_givenOperationSelectionSet_configIncludesSpecificOperation_rendersInitializer() throws {
-      // given
-      schemaSDL = """
+  func test__generate_givenOperationSelectionSet_configIncludesSpecificOperation_rendersInitializer() throws {
+    // given
+    schemaSDL = """
       type Query {
         allAnimals: [Animal!]
       }
@@ -361,7 +380,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      document = """
+    document = """
       query TestOperation {
         allAnimals {
           species
@@ -369,7 +388,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      let expected =
+    let expected =
       """
             init(
               species: String
@@ -386,22 +405,22 @@ class OperationDefinitionTemplateTests: XCTestCase {
             }
       """
 
-      config = .mock(options: .init(selectionSetInitializers: [
-        .operation(named: "TestOperation")
-      ]))
+    config = .mock(options: .init(selectionSetInitializers: [
+      .operation(named: "TestOperation")
+    ]))
 
-      // when
-      try buildSubjectAndOperation()
+    // when
+    try buildSubjectAndOperation()
 
-      let actual = renderSubject()
+    let actual = renderSubject()
 
-      // then
-      expect(actual).to(equalLineByLine(expected, atLine: 50, ignoringExtraLines: true))
-    }
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 50, ignoringExtraLines: true))
+  }
 
-    func test__render_givenOperationSelectionSet_configDoesNotIncludeOperations_doesNotRenderInitializer() throws {
-      // given
-      schemaSDL = """
+  func test__render_givenOperationSelectionSet_configDoesNotIncludeOperations_doesNotRenderInitializer() throws {
+    // given
+    schemaSDL = """
       type Query {
         allAnimals: [Animal!]
       }
@@ -411,7 +430,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      document = """
+    document = """
       query TestOperation {
         allAnimals {
           species
@@ -419,20 +438,20 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      config = .mock(options: .init(selectionSetInitializers: [.namedFragments]))
+    config = .mock(options: .init(selectionSetInitializers: [.namedFragments]))
 
-      // when
-      try buildSubjectAndOperation()
+    // when
+    try buildSubjectAndOperation()
 
-      let actual = renderSubject()
+    let actual = renderSubject()
 
-      // then
-      expect(actual).to(equalLineByLine("    }", atLine: 35, ignoringExtraLines: true))
-    }
+    // then
+    expect(actual).to(equalLineByLine("    }", atLine: 35, ignoringExtraLines: true))
+  }
 
-    func test__render_givenOperationSelectionSet_configIncludeSpecificOperationWithOtherName_doesNotRenderInitializer() throws {
-      // given
-      schemaSDL = """
+  func test__render_givenOperationSelectionSet_configIncludeSpecificOperationWithOtherName_doesNotRenderInitializer() throws {
+    // given
+    schemaSDL = """
       type Query {
         allAnimals: [Animal!]
       }
@@ -442,7 +461,7 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      document = """
+    document = """
       query TestOperation {
         allAnimals {
           species
@@ -450,61 +469,60 @@ class OperationDefinitionTemplateTests: XCTestCase {
       }
       """
 
-      config = .mock(options: .init(selectionSetInitializers: [
-        .operation(named: "OtherOperation")
-      ]))
+    config = .mock(options: .init(selectionSetInitializers: [
+      .operation(named: "OtherOperation")
+    ]))
 
-      // when
-      try buildSubjectAndOperation()
+    // when
+    try buildSubjectAndOperation()
 
-      let actual = renderSubject()
+    let actual = renderSubject()
 
-      // then
-      expect(actual).to(equalLineByLine("    }", atLine: 35, ignoringExtraLines: true))
-    }
-
+    // then
+    expect(actual).to(equalLineByLine("    }", atLine: 35, ignoringExtraLines: true))
+  }
 
   // MARK: - Variables
 
-   func test__generate__givenQueryWithScalarVariable_generatesQueryOperationWithVariable() throws {
-     // given
-     schemaSDL = """
-     type Query {
-       allAnimals: [Animal!]
-     }
+  func test__generate__givenQueryWithScalarVariable_generatesQueryOperationWithVariable() throws {
+    // given
+    schemaSDL = """
+    type Query {
+      allAnimals: [Animal!]
+    }
 
-     type Animal {
-       species: String!
-     }
-     """
+    type Animal {
+      species: String!
+    }
+    """
 
-     document = """
-     query TestOperation($variable: String!) {
-       allAnimals {
-         species
-       }
-     }
-     """
+    document = """
+    query TestOperation($variable: String!) {
+      allAnimals {
+        species
+      }
+    }
+    """
 
-     let expected =
-     """
-       public var variable: String
+    let expected =
+    """
+      public var variable: String
 
-       public init(variable: String) {
-         self.variable = variable
-       }
+      public init(variable: String) {
+        self.variable = variable
+      }
 
-       public var __variables: Variables? { ["variable": variable] }
-     """
+      public var __variables: Variables? { ["variable": variable] }
+    """
 
-     // when
-     try buildSubjectAndOperation()
+    // when
+    try buildSubjectAndOperation()
 
-     let actual = renderSubject()
+    let actual = renderSubject()
 
-     // then
-     expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
-   }
+    // then
+    expect(actual).to(equalLineByLine(expected, atLine: 8, ignoringExtraLines: true))
+  }
 
   func test__generate__givenQueryWithMutlipleScalarVariables_generatesQueryOperationWithVariables() throws {
     // given
@@ -977,5 +995,4 @@ class OperationDefinitionTemplateTests: XCTestCase {
     expect(actual).to(equalLineByLine(expectedOne, atLine: 8, ignoringExtraLines: true))
     expect(actual).to(equalLineByLine(expectedTwo, atLine: 10, ignoringExtraLines: true))
   }
-  
 }

--- a/docs/source/code-generation/codegen-configuration.mdx
+++ b/docs/source/code-generation/codegen-configuration.mdx
@@ -412,6 +412,7 @@ The top-level properties are:
 | [`warningsOnDeprecatedUsage`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/warningsondeprecatedusage) | Annotate generated Swift code with the Swift `@available` attribute and `@deprecated` argument for parts of the GraphQL schema annotated with the built-in [`@deprecated` directive](https://spec.graphql.org/draft/#sec--deprecated). |
 | [`conversionStrategies`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/conversionstrategies) | Rules for how to convert the names of values from the schema in generated code. |
 | [`pruneGeneratedFiles`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/prunegeneratedfiles) | Whether unused generated files will be automatically deleted. |
+| [`markOperationDefinitionsAsFinal`](https://www.apollographql.com/docs/ios/docc/documentation/apollocodegenlib/apollocodegenconfiguration/outputoptions/markOperationDefinitionsAsFinal) | Whether generated GraphQL operation and local cache mutation class types will be marked as `final`. |
 
 <MultiCodeBlock>
 
@@ -441,7 +442,8 @@ The top-level properties are:
 		"enumCases": "camelCase",
 		"fieldAccessors": "default"
 	},
-	"pruneGeneratedFiles": true
+	"pruneGeneratedFiles": true,
+	"markOperationDefinitionsAsFinal": true
 }
 ```
 
@@ -469,7 +471,8 @@ let configuration = ApolloCodegenConfiguration(
 			enumCases: .camelCase,
 			fieldAccessors: .default
 		),
-		pruneGeneratedFiles: true
+		pruneGeneratedFiles: true,
+		markOperationDefinitionsAsFinal: true
 	)
 )
 ```


### PR DESCRIPTION
Re-adds generated GraphQL operations to be marked as `final` through a new `OutputOptions` property: `markClassesAsFinal`.

This is to support fixing this in a backwards-compatible way, and still allowing people control over how they use the generated operation models.

This resolves #3183