### PR TITLE
fix: Updated the target codegen configuration

### DIFF
--- a/SwiftScripts/Sources/TargetConfig/Target.swift
+++ b/SwiftScripts/Sources/TargetConfig/Target.swift
@@ -97,14 +97,7 @@ public enum Target: CaseIterable {
         moduleType: moduleType
       ),
       operations: .inSchemaModule,
-      testMocks: includeTestMocks ? .swiftPackage() : .none,
-      operationManifest: includeOperationIdentifiers ?
-        .init(
-          path: try graphQLFolder(fromTargetRoot: targetRootURL)
-            .childFileURL(fileName: "operationIDs.json")
-            .path
-        )
-      : nil
+      testMocks: includeTestMocks ? .swiftPackage() : .none
     )
   }
 


### PR DESCRIPTION
This updates the target codegen configuration to match recent configuration changes re. the operation manifest. Looks like the operation manifest output was already done but I needed to fix the `FileOutput` initializer being used.