### PR TITLE
fix: Fixed reading of the itemsToGenerate property for the operation manifest

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -131,7 +131,7 @@ public class ApolloCodegen {
 
     let ir = IR(compilationResult: compilationResult)
     
-    if itemsToGenerate == .operationManifest {
+    if itemsToGenerate.contains(.operationManifest) {
       var operationIDsFileGenerator = OperationManifestFileGenerator(config: configContext)
       
       for operation in compilationResult.operations {


### PR DESCRIPTION
The current implementation of the codegen checks for `itemsToGenerate` to be exactly equal to `.operationManifest` in order to trigger its relative operation. 
I think this is a mistake, as it makes it so that the `.all` option actually only generates the `.code` part.

