### PR TITLE
chore: Changed to use isEmpty instead of count == 0

### DIFF
--- a/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
+++ b/Sources/ApolloWebSocket/DefaultImplementation/WebSocket.swift
@@ -571,7 +571,7 @@ public final class WebSocket: NSObject, WebSocketClient, StreamDelegate, WebSock
     let data = stream.read()
     guard let d = data else { return }
     var process = false
-    if inputQueue.count == 0 {
+    if inputQueue.isEmpty {
       process = true
     }
     inputQueue.append(d)


### PR DESCRIPTION
I ran grep with `count == 0` on the whole code and got only one hit.
In this case, the amount of calculation is O(1) with or without `isEmpty`, but since isEmpty is used throughout, would you like to replace?

- https://developer.apple.com/documentation/swift/array/isempty
- https://developer.apple.com/documentation/swift/collection/count-4l4qk
  - Array conforms to RandomAccessCollection, so O(1).