### PR TITLE
Remove: Error inheritance

### DIFF
--- a/Sources/Apollo/ApolloClient.swift
+++ b/Sources/Apollo/ApolloClient.swift
@@ -34,7 +34,7 @@ public class ApolloClient {
 
   public let store: ApolloStore
 
-  public enum ApolloClientError: Error, LocalizedError, Hashable {
+  public enum ApolloClientError: LocalizedError, Hashable {
     case noUploadTransport
 
     public var errorDescription: String? {

--- a/Sources/Apollo/CacheWriteInterceptor.swift
+++ b/Sources/Apollo/CacheWriteInterceptor.swift
@@ -6,7 +6,7 @@ import ApolloAPI
 /// An interceptor which writes data to the cache, following the `HTTPRequest`'s `cachePolicy`.
 public struct CacheWriteInterceptor: ApolloInterceptor {
   
-  public enum CacheWriteError: Error, LocalizedError {
+  public enum CacheWriteError: LocalizedError {
     case noResponseToParse
     
     public var errorDescription: String? {

--- a/Sources/Apollo/GraphQLExecutor.swift
+++ b/Sources/Apollo/GraphQLExecutor.swift
@@ -150,7 +150,7 @@ class FieldExecutionInfo {
 }
 
 /// An error which has occurred during GraphQL execution.
-public struct GraphQLExecutionError: Error, LocalizedError {
+public struct GraphQLExecutionError: LocalizedError {
   let path: ResponsePath
 
   public var pathString: String { path.description }

--- a/Sources/Apollo/GraphQLFile.swift
+++ b/Sources/Apollo/GraphQLFile.swift
@@ -9,7 +9,7 @@ public struct GraphQLFile: Hashable {
   public let fileURL: URL?
   public let contentLength: UInt64
   
-  public enum GraphQLFileError: Error, LocalizedError {
+  public enum GraphQLFileError: LocalizedError {
     case couldNotCreateInputStream
     case couldNotGetFileSize(fileURL: URL)
     

--- a/Sources/Apollo/GraphQLHTTPRequestError.swift
+++ b/Sources/Apollo/GraphQLHTTPRequestError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An error which has occurred during the serialization of a request.
-public enum GraphQLHTTPRequestError: Error, LocalizedError, Hashable {
+public enum GraphQLHTTPRequestError: LocalizedError, Hashable {
   case serializedBodyMessageError
   case serializedQueryParamsMessageError
 

--- a/Sources/Apollo/InterceptorRequestChain.swift
+++ b/Sources/Apollo/InterceptorRequestChain.swift
@@ -6,7 +6,7 @@ import ApolloAPI
 /// A chain that allows a single network request to be created and executed.
 final public class InterceptorRequestChain: Cancellable, RequestChain {
 
-  public enum ChainError: Error, LocalizedError {
+  public enum ChainError: LocalizedError {
     case invalidIndex(chain: RequestChain, index: Int)
     case noInterceptors
     case unknownInterceptor(id: String)

--- a/Sources/Apollo/JSONResponseParsingInterceptor.swift
+++ b/Sources/Apollo/JSONResponseParsingInterceptor.swift
@@ -6,7 +6,7 @@ import ApolloAPI
 /// An interceptor which parses JSON response data into a `GraphQLResult` and attaches it to the `HTTPResponse`.
 public struct JSONResponseParsingInterceptor: ApolloInterceptor {
   
-  public enum JSONResponseParsingError: Error, LocalizedError {
+  public enum JSONResponseParsingError: LocalizedError {
     case noResponseToParse
     case couldNotParseToJSON(data: Data)
     

--- a/Sources/Apollo/MaxRetryInterceptor.swift
+++ b/Sources/Apollo/MaxRetryInterceptor.swift
@@ -11,7 +11,7 @@ public class MaxRetryInterceptor: ApolloInterceptor {
 
   public var id: String = UUID().uuidString
   
-  public enum RetryError: Error, LocalizedError {
+  public enum RetryError: LocalizedError {
     case hitMaxRetryCount(count: Int, operationName: String)
     
     public var errorDescription: String? {

--- a/Sources/Apollo/MultipartFormData.swift
+++ b/Sources/Apollo/MultipartFormData.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A helper for building out multi-part form data for upload
 public final class MultipartFormData {
 
-  enum FormDataError: Error, LocalizedError {
+  enum FormDataError: LocalizedError {
     case encodingStringToDataFailed(_ string: String)
 
     var errorDescription: String? {

--- a/Sources/Apollo/MultipartResponseParsingInterceptor.swift
+++ b/Sources/Apollo/MultipartResponseParsingInterceptor.swift
@@ -6,7 +6,7 @@ import ApolloAPI
 /// Parses multipart response data into chunks and forwards each on to the next interceptor.
 public struct MultipartResponseParsingInterceptor: ApolloInterceptor {
 
-  public enum MultipartResponseParsingError: Error, LocalizedError, Equatable {
+  public enum MultipartResponseParsingError: LocalizedError, Equatable {
     case noResponseToParse
     case cannotParseResponseData
     case unsupportedContentType(type: String)

--- a/Sources/Apollo/ResponseCodeInterceptor.swift
+++ b/Sources/Apollo/ResponseCodeInterceptor.swift
@@ -8,7 +8,7 @@ public struct ResponseCodeInterceptor: ApolloInterceptor {
 
   public var id: String = UUID().uuidString
   
-  public enum ResponseCodeError: Error, LocalizedError {
+  public enum ResponseCodeError: LocalizedError {
     case invalidResponseCode(response: HTTPURLResponse?, rawData: Data?)
     
     public var errorDescription: String? {

--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -10,7 +10,7 @@ import Foundation
 /// when for background sessions.
 open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate {
   
-  public enum URLSessionClientError: Error, LocalizedError {
+  public enum URLSessionClientError: LocalizedError {
     case noHTTPResponse(request: URLRequest?)
     case sessionBecameInvalidWithoutUnderlyingError
     case dataForRequestNotFound(request: URLRequest?)

--- a/Sources/ApolloAPI/JSONDecodingError.swift
+++ b/Sources/ApolloAPI/JSONDecodingError.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// This error should be thrown when a ``JSONDecodable`` initialization fails.
 /// `GraphQLExecutor` and `ApolloStore` may also throw this error when decoding a `JSON` fails.
-public enum JSONDecodingError: Error, LocalizedError, Hashable {
+public enum JSONDecodingError: LocalizedError, Hashable {
   /// A value that is expected to be present is missing from the ``JSONObject``.
   case missingValue
   /// A value that is non-null has a `null`value.

--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -10,7 +10,7 @@ public class ApolloCodegen {
   // MARK: Public
 
   /// Errors that can occur during code generation.
-  public enum Error: Swift.Error, LocalizedError {
+  public enum Error: LocalizedError {
     /// An error occured during validation of the GraphQL schema or operations.
     case graphQLSourceValidationFailure(atLines: [String])
     case testMocksInvalidSwiftPackageConfiguration

--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -5,7 +5,7 @@ import Foundation
 /// A wrapper to facilitate downloading a GraphQL schema.
 public struct ApolloSchemaDownloader {
   
-  public enum SchemaDownloadError: Error, LocalizedError {
+  public enum SchemaDownloadError: LocalizedError {
     case downloadedRegistryJSONFileNotFound(underlying: Error)
     case downloadedIntrospectionJSONFileNotFound(underlying: Error)
     case couldNotParseRegistryJSON(underlying: Error)

--- a/Sources/ApolloCodegenLib/FileManager+Apollo.swift
+++ b/Sources/ApolloCodegenLib/FileManager+Apollo.swift
@@ -113,7 +113,7 @@ public class ApolloFileManager {
 
 // MARK: - FileManagerPathError
 
-public enum FileManagerPathError: Swift.Error, LocalizedError, Equatable {
+public enum FileManagerPathError: LocalizedError, Equatable {
   case notAFile(path: String)
   case notADirectory(path: String)
   case cannotCreateFile(at: String)

--- a/Sources/ApolloCodegenLib/Glob.swift
+++ b/Sources/ApolloCodegenLib/Glob.swift
@@ -29,7 +29,7 @@ public struct Glob {
   private let flags = GLOB_ERR | GLOB_MARK | GLOB_NOSORT | GLOB_TILDE | GLOB_BRACE
 
   /// An error object that indicates why pattern matching failed.
-  public enum MatchError: Error, LocalizedError, Equatable {
+  public enum MatchError: LocalizedError, Equatable {
     case noSpace // GLOB_NOSPACE
     case aborted // GLOB_ABORTED
     case cannotEnumerate(path: String)

--- a/Sources/ApolloCodegenLib/URL+Apollo.swift
+++ b/Sources/ApolloCodegenLib/URL+Apollo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ApolloURLError: Error, LocalizedError {
+public enum ApolloURLError: LocalizedError {
   case fileNameIsEmpty
   
   public var errorDescription: String? {

--- a/Sources/ApolloCodegenLib/URLDownloader.swift
+++ b/Sources/ApolloCodegenLib/URLDownloader.swift
@@ -35,7 +35,7 @@ extension URLSession: NetworkSession {
 class URLDownloader {
   let session: NetworkSession
   
-  enum DownloadError: Error, LocalizedError {
+  enum DownloadError: LocalizedError {
     case badResponse(code: Int, response: String?)
     case emptyDataReceived
     case noDataReceived

--- a/Sources/ApolloWebSocket/WebSocketError.swift
+++ b/Sources/ApolloWebSocket/WebSocketError.swift
@@ -4,7 +4,7 @@ import ApolloAPI
 import Foundation
 
 /// A structure for capturing problems and any associated errors from a `WebSocketTransport`.
-public struct WebSocketError: Error, LocalizedError {
+public struct WebSocketError: LocalizedError {
   public enum ErrorKind {
     case errorResponse
     case networkError


### PR DESCRIPTION
Since LocalizedError inherits from Error, there is no need to inherit both Error and LocalizedError. 

https://developer.apple.com/documentation/foundation/localizederror > Inherits From Error