### PR TITLE
Provide a way to pass an input operation manifest file

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -56,6 +56,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///  - `!` excludes any match only if the pattern starts with a `!` character, eg: `!file.graphql`
     public let operationSearchPaths: [String]
 
+    /// A single file path to an input operation manifest file to be used as the source of truth of an generated operation's  `operationId` .
+    public let operationManifestFilePath: String?
+
     /// Designated initializer.
     ///
     /// - Parameters:
@@ -86,6 +89,9 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///
     ///     Defaults to `["**/*.graphql"]`.
     ///
+    ///   - operationManifestFilePath: A single file path to an input operation manifest file to be used as
+    ///   the source of truth of an generated operation's  `operationId` .
+    ///
     ///  You can use absolute or relative paths in path matching patterns. Relative paths will be
     ///  based off the current working directory from `FileManager`.
     ///
@@ -100,10 +106,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// number of additional SDL schema extension files.
     public init(
       schemaSearchPaths: [String] = ["**/*.graphqls"],
-      operationSearchPaths: [String] = ["**/*.graphql"]
+      operationSearchPaths: [String] = ["**/*.graphql"],
+      operationManifestFilePath: String? = nil
     ) {
       self.schemaSearchPaths = schemaSearchPaths
       self.operationSearchPaths = operationSearchPaths
+      self.operationManifestFilePath = operationManifestFilePath
     }
 
     /// Convenience initializer.
@@ -132,6 +140,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     ///     - [Fragment Definitions](https://spec.graphql.org/draft/#sec-Language.Fragments)
     ///
     ///     Defaults to `["**/*.graphql"]`.
+    ///   - operationManifestFilePath: A single file path to an input operation manifest file to be used as
+    ///   the source of truth of an generated operation's  `operationId` .
     ///
     ///  You can use absolute or relative paths in path matching patterns. Relative paths will be
     ///  based off the current working directory from `FileManager`.
@@ -147,10 +157,12 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     /// number of additional SDL schema extension files.
     public init(
       schemaPath: String,
-      operationSearchPaths: [String] = ["**/*.graphql"]
+      operationSearchPaths: [String] = ["**/*.graphql"],
+      operationManifestFilePath: String? = nil
     ) {
       self.schemaSearchPaths = [schemaPath]
       self.operationSearchPaths = operationSearchPaths
+      self.operationManifestFilePath = operationManifestFilePath
     }
   }
 

--- a/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
+++ b/Sources/ApolloCodegenLib/Frontend/CompilationResult.swift
@@ -79,7 +79,7 @@ public class CompilationResult: JavaScriptObject {
     }()
   }
   
-  public enum OperationType: String, Equatable, JavaScriptValueDecodable {
+  public enum OperationType: String, Equatable, Codable, JavaScriptValueDecodable {
     case query
     case mutation
     case subscription

--- a/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
@@ -20,11 +20,19 @@ extension IR {
       inIR: self
     )
 
-    return IR.Operation(
+    let ir = IR.Operation(
       definition: operationDefinition,
       rootField: result.rootField,
       referencedFragments: result.referencedFragments
     )
+    if let operationNamesToIdentifiers {
+      // TODO: Should this throw if there is no operationIdentifier for the operation?
+      // TODO: Is operationDefinition.name enough of an index across operation types?
+      if let operationIdentifier = operationNamesToIdentifiers[operationDefinition.name] {
+        ir.operationIdentifier = operationIdentifier
+      }
+    }
+    return ir
   }
 
 }

--- a/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
+++ b/Sources/ApolloCodegenLib/IR/IR+OperationBuilder.swift
@@ -25,10 +25,9 @@ extension IR {
       rootField: result.rootField,
       referencedFragments: result.referencedFragments
     )
-    if let operationNamesToIdentifiers {
-      // TODO: Should this throw if there is no operationIdentifier for the operation?
-      // TODO: Is operationDefinition.name enough of an index across operation types?
-      if let operationIdentifier = operationNamesToIdentifiers[operationDefinition.name] {
+    // TODO: Should this throw if inputOperationIdentifiers is set, but there is no operationIdentifier for the operation?
+    if let inputOperationIdentifiers = inputOperationIdentifiers?[operationDefinition.operationType] {
+      if let operationIdentifier = inputOperationIdentifiers[operationDefinition.name] {
         ir.operationIdentifier = operationIdentifier
       }
     }

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -11,7 +11,7 @@ class IR {
 
   var builtFragments: [String: NamedFragment] = [:]
 
-  var operationNamesToIdentifiers: [String: String]?
+  var inputOperationIdentifiers: [CompilationResult.OperationType: [String: String]]?
 
   init(compilationResult: CompilationResult) {
     self.compilationResult = compilationResult

--- a/Sources/ApolloCodegenLib/IR/IR.swift
+++ b/Sources/ApolloCodegenLib/IR/IR.swift
@@ -11,6 +11,8 @@ class IR {
 
   var builtFragments: [String: NamedFragment] = [:]
 
+  var operationNamesToIdentifiers: [String: String]?
+
   init(compilationResult: CompilationResult) {
     self.compilationResult = compilationResult
     self.schema = Schema(


### PR DESCRIPTION
TL;DR - This provides a preferred way to provide input operation IDs.

Details: We need a way to input our own operation ID during the codegen process, and this supports the following workflow:
1. Run Apollo Codegen outputting only the operationManifest.json file (with itemsToGenerate)
2. Process the previously operationManifest.json file, (using the `body` field) regenerating all the `id` fields, and resave the operationManifest.json file
3. Run Apollo Codegen **again**, but this time feeding the operationManifest.json file as input, into the source generation process

Ideally we wouldn't need to run Apollo Codegen twice for this workflow. Though I'm struggling to find a reasonable way to do it otherwise. Thoughts are appreciated.