### PR TITLE
allow the injection of a NetworkSession in the schema download fetch

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
+++ b/Sources/ApolloCodegenLib/ApolloSchemaDownloader.swift
@@ -46,7 +46,7 @@ public struct ApolloSchemaDownloader {
   ///   - configuration: The `ApolloSchemaDownloadConfiguration` used to download the schema.
   ///   - rootURL: The root `URL` to resolve relative `URL`s in the configuration's paths against.
   ///     If `nil`, the current working directory of the executing process will be used.
-  ///   - session: The network session to use for the download
+  ///   - session: The network session to use for the download. If `nil` the `URLSession.Shared` will be used by default.
   /// - Returns: Output from a successful fetch or throws an error.
   /// - Throws: Any error which occurs during the fetch.
   public static func fetch(

--- a/Sources/ApolloCodegenLib/URLDownloader.swift
+++ b/Sources/ApolloCodegenLib/URLDownloader.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A protocol to abstract the underlying network provider.
-protocol NetworkSession {
+public protocol NetworkSession {
 
   /// Load data via the abstracted network provider
   ///
@@ -18,7 +18,7 @@ protocol NetworkSession {
 }
 
 extension URLSession: NetworkSession {
-  func loadData(
+  public func loadData(
     with urlRequest: URLRequest,
     completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
   ) -> URLSessionDataTask? {
@@ -63,8 +63,8 @@ class URLDownloader {
   /// - Parameters:
   ///   - session: The NetworkSession conforming instance used for downloads, defaults to the
   ///   shared URLSession singleton object.
-  init(session: NetworkSession = URLSession.shared) {
-    self.session = session
+  init(session: NetworkSession? = nil) {
+    self.session = session ?? URLSession.shared
   }
   
   /// Downloads the contents of a given URL synchronously to the given output URL

--- a/Sources/CodegenCLI/Commands/FetchSchema.swift
+++ b/Sources/CodegenCLI/Commands/FetchSchema.swift
@@ -48,7 +48,8 @@ public struct FetchSchema: ParsableCommand {
 
     try schemaDownloadProvider.fetch(
       configuration: schemaDownload,
-      withRootURL: rootOutputURL(for: inputs)
+      withRootURL: rootOutputURL(for: inputs),
+      session: nil
     )
   }
 }

--- a/Sources/CodegenCLI/Commands/Generate.swift
+++ b/Sources/CodegenCLI/Commands/Generate.swift
@@ -85,6 +85,6 @@ public struct Generate: ParsableCommand {
     configuration: ApolloSchemaDownloadConfiguration,
     schemaDownloadProvider: SchemaDownloadProvider.Type
   ) throws {
-    try schemaDownloadProvider.fetch(configuration: configuration, withRootURL: rootOutputURL(for: inputs))
+    try schemaDownloadProvider.fetch(configuration: configuration, withRootURL: rootOutputURL(for: inputs), session: nil)
   }
 }

--- a/Sources/CodegenCLI/Protocols/SchemaDownloadProvider.swift
+++ b/Sources/CodegenCLI/Protocols/SchemaDownloadProvider.swift
@@ -5,7 +5,8 @@ import ApolloCodegenLib
 public protocol SchemaDownloadProvider {
   static func fetch(
     configuration: ApolloSchemaDownloadConfiguration,
-    withRootURL rootURL: URL?
+    withRootURL rootURL: URL?,
+    session: NetworkSession?
   ) throws
 }
 

--- a/Tests/CodegenCLITests/Support/MockApolloSchemaDownloader.swift
+++ b/Tests/CodegenCLITests/Support/MockApolloSchemaDownloader.swift
@@ -7,7 +7,8 @@ class MockApolloSchemaDownloader: SchemaDownloadProvider {
 
   static func fetch(
     configuration: ApolloSchemaDownloadConfiguration,
-    withRootURL rootURL: URL?
+    withRootURL rootURL: URL?,
+    session: NetworkSession?
   ) throws {
     guard let handler = fetchHandler else {
       fatalError("You must set fetchHandler before calling \(#function)!")


### PR DESCRIPTION
The title is pretty self explanatory, but I'll go into a little bit about our and use case can reasoning.

### Use Case

We require an enterprise level of security / authentitication, that is just easier to inject at the NetworkSession level than to try another workaround.

### Reasoning

aka, why this way?

I simply thought this was the least intrusive set of changes to achieve the use case. `NetworkSession` already existed, and was injectable in the internal `URLDownloader` initializer. I just passed it through all the way from the public static `fetch` method.