### PR TITLE
update false positive secret detection allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,18 @@
+# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs.
+# This is an Apollo-Internal link, but more information about these scans is available here:
+# https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing#Scheduled-Scans.1
+#
+# Apollo is using Gitleaks (https://github.com/gitleaks/gitleaks) to run these scans.
+# However, this file is not something that Gitleaks natively consumes. This file is an
+# Apollo-convention. Prior to scanning a repo, Apollo merges
+# our standard Gitleaks configuration (which is largely just the Gitleaks-default config) with
+# this file if it exists in a repo. The combined config is then used to scan a repo.
+#
+# We did this because the natively-supported allowlisting functionality in Gitleaks didn't do everything we wanted
+# or wasn't as robust as we needed. For example, one of the allowlisting options offered by Gitleaks depends on the line number
+# on which a false positive secret exists to allowlist it. (https://github.com/gitleaks/gitleaks#gitleaksignore).
+# This creates a fairly fragile allowlisting mechanism. This file allows us to leverage the full capabilities of the Gitleaks rule syntax
+# to create allowlisting functionality.
 
 [[ rules ]]
     id = "high-entropy-base64"
@@ -10,7 +25,17 @@
 [[ rules ]]
     id = "generic-api-key"
     [ rules.allowlist ]
-        commits = [
-            "474554504e7e33cef2a71774f825d5b3947ff797",
-            
+
+        paths = [
+            # Allowlists a false positive detection at  
+            # https://github.com/apollographql/apollo-ios/blob/474554504e7e33cef2a71774f825d5b3947ff797/Tests/ApolloCodegenTests/TestHelpers/ASTMatchers.swift#L72
+            # This was previously allowlisted via commit hash, but updating that rule
+            # To support allowlisting false positive detections in the files below as well.
+            '''Tests/ApolloCodegenTests/TestHelpers/ASTMatchers.swift''',
+
+            # Allowlist the various high-entropy strings in xcscmblueprint files
+            '''Apollo.xcodeproj/project.xcworkspace/xcshareddata/Apollo.xcscmblueprint$''',
+            '''ApolloSQLite.xcodeproj/project.xcworkspace/xcshareddata/ApolloSQLite.xcscmblueprint$''',
+            '''Apollo.xcworkspace/xcshareddata/Apollo.xcscmblueprint$''',
         ]
+


### PR DESCRIPTION
# Implements

This updates the Apollo-specific secret allowlisting file in this repo to allowlist additional false positive / benign positive detections. 

This PR allowlists a series of detections across git history in various `*.xcscmblueprint` files. From my research, all of these values are identifiers and not secret, so these detections by Gitleaks, our selected secret scanning tool were spurious. To create the allowlisting config to properly ensure  that net-new detections won't be generated when these files are modified in the future, I additionally needed to update the allowlisting config for line https://github.com/apollographql/apollo-ios/blob/474554504e7e33cef2a71774f825d5b3947ff797/Tests/ApolloCodegenTests/TestHelpers/ASTMatchers.swift#L72. This is why I removed the rule that allowlisted a commit hash from the `generic-api-key` signature and swapped to file-based allowlisting. 

Additionally, I added a bunch of commentary at the top of the file about the purpose of the `.gitleaks.toml` file to provide more information to contributors to this repo. 

I tested this by replicating our secret scanning process on this repo locally. I confirmed that no detections were generated.