### PR TITLE
fix Array JSONEncodable

### DIFF
--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -116,7 +116,7 @@ public protocol GraphQLOperationVariableValue {
 }
 
 extension Array: GraphQLOperationVariableValue
-where Element: GraphQLOperationVariableValue & Hashable {}
+where Element: GraphQLOperationVariableValue & JSONEncodable & Hashable {}
 
 extension Dictionary: GraphQLOperationVariableValue
 where Key == String, Value == GraphQLOperationVariableValue {

--- a/Sources/ApolloAPI/JSONStandardTypeConversions.swift
+++ b/Sources/ApolloAPI/JSONStandardTypeConversions.swift
@@ -147,14 +147,8 @@ extension JSONObject: JSONDecodable {
   }
 }
 
-extension Array: JSONEncodable {
+extension Array: JSONEncodable where Element: JSONEncodable {
   @inlinable public var _jsonValue: JSONValue {
-    return map { element -> JSONValue in
-      if case let element as JSONEncodable = element {
-        return element._jsonValue
-      } else {
-        fatalError("Array is only JSONEncodable if Element is")
-      }
-    }
+    map(\._jsonValue)
   }
 }


### PR DESCRIPTION
Avoid using fatal error on `JSONEncodable` instead of conforming protocol with where clause