### PR TITLE
Split Caching review and thoughts

### DIFF
--- a/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// Add max size and auto eviction policy
 public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
 
@@ -7,7 +8,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
     self.records = records
   }
 
-  public func loadRecords(forKeys keys: Set<CacheKey>) throws -> [CacheKey: Record] {
+  public func loadRecords(forKeys keys: Set<CacheKey>, identifier: UUID? = nil) throws -> [CacheKey: Record] {
     return keys.reduce(into: [:]) { result, key in
       result[key] = records[key]
     }
@@ -17,7 +18,7 @@ public final class InMemoryNormalizedCache: NormalizedCache {
     records.removeRecord(for: key)
   }
   
-  public func merge(records newRecords: RecordSet) throws -> Set<CacheKey> {
+  public func merge(records newRecords: RecordSet, identifier: UUID? = nil) throws -> Set<CacheKey> {
     return records.merge(records: newRecords)
   }
 

--- a/Sources/Apollo/NormalizedCache.swift
+++ b/Sources/Apollo/NormalizedCache.swift
@@ -7,14 +7,14 @@ public protocol NormalizedCache {
   /// - Parameters:
   ///   - key: The cache keys to load data for
   /// - Returns: A dictionary of cache keys to records containing the records that have been found.
-  func loadRecords(forKeys keys: Set<CacheKey>) throws -> [CacheKey: Record]
-    
+  func loadRecords(forKeys keys: Set<CacheKey>, identifier: UUID?) throws -> [CacheKey: Record]
+
   /// Merges a set of records into the cache.
   ///
   /// - Parameters:
   ///   - records: The set of records to merge.
   /// - Returns: A set of keys corresponding to *fields* that have changed (i.e. QUERY_ROOT.Foo.myField). These are the same type of keys as are returned by RecordSet.merge(records:).
-  func merge(records: RecordSet) throws -> Set<CacheKey>
+  func merge(records: RecordSet, identifier: UUID?) throws -> Set<CacheKey>
 
   /// Removes a record for the specified key. This method will only
   /// remove whole records, not individual fields.

--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -93,7 +93,7 @@ public final class SQLiteNormalizedCache {
 // MARK: - NormalizedCache conformance
 
 extension SQLiteNormalizedCache: NormalizedCache {
-  public func loadRecords(forKeys keys: Set<CacheKey>) throws -> [CacheKey: Record] {
+  public func loadRecords(forKeys keys: Set<CacheKey>, identifier: UUID? = nil) throws -> [CacheKey: Record] {
     return [CacheKey: Record](uniqueKeysWithValues:
                                 try selectRecords(for: keys)
                                 .map { record in
@@ -101,7 +101,7 @@ extension SQLiteNormalizedCache: NormalizedCache {
                                 })
   }
   
-  public func merge(records: RecordSet) throws -> Set<CacheKey> {
+  public func merge(records: RecordSet, identifier: UUID? = nil) throws -> Set<CacheKey> {
     return try mergeRecords(records: records)
   }
   


### PR DESCRIPTION
Howdy folks!

The topic of hybrid caching has been bought up multiple times and seems like you guys don't have it on your roadmap anytime soon. Gonna take a stab at this and wanted get some feedback on an idea that can help folks interested in this to get a workable solution until you guys come up with a first class support for caching

https://github.com/apollographql/apollo-ios/issues/3275
https://github.com/apollographql/apollo-ios/issues/1467

**Background**

I would like to create an API at the query level that developers can use to define the storage policy of the query when initializing an instance like so 

```
let query = HeroQuery(fetchPolicy: .returnCacheAndFetch).storagePolicy(.inMemoryAndDisk) // or .allowed like https://developer.apple.com/documentation/foundation/urlcache/storagepolicy
```
This is different than the Kotlin version of Apollo which uses cache control headers but I somehow prefer this over the Kotlin api if the storage policy is exclusively defined on the client side. 

One hurdle in implementation of a custom normalized cache based on the policy defined by query is that there is no way to associate normalized cache methods with the query's storage policy so that the custom normalized cache implementation can make decisions according to the policies. 

**Proposal** 

Noticed that we have a `contextIdentifier` which can be instantiated for each fetch operation, propagating that identifier all the way to the caching layer allows for extending the functionality of existing InMemory and SQLite implementations Apollo has by creating some wrapper classes. These wrapper classes can have a `StoragePolicyResolver` which maintains the policy vs identifier in memory till the request is complete from network chain. 

I was able to create a `NormalizedCacheChain` object that accepts implementations of NormalizedCache. 

```
guard let sqliteCache = SQLiteNormalizedCacheFactory().makeNormalizedCache(name: "apollo_db.sqlite") else { return InMemoryNormalizedCache() }
            return NormalizedCacheChain(normalizedCaches: [
                    InMemoryNormalizedChainCache(),
                    SQLiteChainedNormalizedCache(sqlite: sqliteCache)
            ])
```

Probably can extend more cache implementations as needed by the application. 

**Questions**

 - Any feedback on the solution? 
 - Would this be considered something that we can add to the sdk, considering its non-breaking 

NOTE - 
Have this built out for older versions due to familiarity, seems like can be done for 1.x versions as well
