### PR TITLE
Fix building ApolloSQLite with Xcode 16

### DIFF
--- a/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
+++ b/Sources/ApolloSQLite/SQLiteDotSwiftDatabase.swift
@@ -8,9 +8,9 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
   private var db: Connection!
   
   private let records: Table
-  private let keyColumn: Expression<CacheKey>
-  private let recordColumn: Expression<String>
-  
+  private let keyColumn: SQLite.Expression<CacheKey>
+  private let recordColumn: SQLite.Expression<String>
+
   public init(fileURL: URL) throws {
     self.records = Table(Self.tableName)
     self.keyColumn = Expression<CacheKey>(Self.keyColumnName)
@@ -27,9 +27,9 @@ public final class SQLiteDotSwiftDatabase: SQLiteDatabase {
   
   public func createRecordsTableIfNeeded() throws {
     try self.db.run(self.records.create(ifNotExists: true) { table in
-      table.column(Expression<Int64>(Self.idColumnName), primaryKey: .autoincrement)
+      table.column(SQLite.Expression<Int64>(Self.idColumnName), primaryKey: .autoincrement)
       table.column(keyColumn, unique: true)
-      table.column(Expression<String>(Self.recordColumName))
+      table.column(SQLite.Expression<String>(Self.recordColumName))
     })
     try self.db.run(self.records.createIndex(keyColumn, unique: true, ifNotExists: true))
   }


### PR DESCRIPTION
In Xcode 16, or rather Foundation in the iOS 18/etc. SDKs, there’s a new `Expression` type. The SQLite library also expose this type. This caused an issue compiling the `SQLiteDotSwiftDatabase.swift` file, as it imports both libraries. This PR disambiguates it for the compiler.

With this change the project once again builds with Xcode 16.

![Screenshot 2024-06-10 at 3 59 48 PM](https://github.com/apollographql/apollo-ios/assets/23453/a182186d-39e0-4a2f-87ea-8009465b8a8b)
