### PR TITLE
[Legacy] Remove nil values from `variables` field in `requestBody`

### DIFF
--- a/Sources/Apollo/RequestBodyCreator.swift
+++ b/Sources/Apollo/RequestBodyCreator.swift
@@ -27,9 +27,12 @@ extension RequestBodyCreator {
                                                        sendQueryDocument: Bool,
                                                        autoPersistQuery: Bool) -> GraphQLMap {
     var body: GraphQLMap = [
-      "variables": operation.variables,
       "operationName": operation.operationName,
     ]
+
+    if let variables = operation.variables?.compactMapValues({ $0 }) {
+      body["variables"] = variables
+    }
 
     if sendOperationIdentifiers {
       guard let operationIdentifier = operation.operationIdentifier else {

--- a/Tests/ApolloTests/RequestBodyCreatorTests.swift
+++ b/Tests/ApolloTests/RequestBodyCreatorTests.swift
@@ -37,4 +37,19 @@ class RequestBodyCreatorTests: XCTestCase {
 
     XCTAssertEqual(query.queryDocument, req["test_query"] as? String)
   }
+
+  func testRequestBodyOmitsVariablesFieldWhenValuesAreNil() {
+    let query = HeroNameQuery(episode: nil)
+    let req = self.create(with: apolloRequestBodyCreator, for: query)
+
+    XCTAssertFalse(req.keys.contains(where: { $0 == "variables" }))
+  }
+
+  func testRequestBodyIncludesVariablesFieldWhenItContainsNonNilValues() {
+    let episode = Episode.empire
+    let query = HeroNameQuery(episode: episode)
+    let req = self.create(with: apolloRequestBodyCreator, for: query)
+
+    XCTAssertEqual(req["variables"], ["episode": episode.rawValue])
+  }
 }


### PR DESCRIPTION
### Summary

Fixes an issue in legacy versions of the Apollo SDK. In my testing, this only occurred in my project when working with Xcode 16 Beta. This issue did not occur with previous versions of Xcode.

**Apollo version**: 0.53.0 (legacy)

### Issue Description

I have a GQL query which takes in an optional value as part of the request body. During serialization, I'd hit a `fatalError` in the Apollo library which reads `Dictionary is only JSONEncodable if Value is (and if Key is String)` ([permalink](https://github.com/apollographql/apollo-ios/blob/5c231061afab1929073a3f4f2789498cfd6d41f5/Sources/Apollo/JSONStandardTypeConversions.swift#L133)). This occurred because the `variables` dictionary contained a key-value pair where the key was present and the value was `nil`. In this version of Xcode, casting an `Optional<Wrapped>` value to `Wrapped` does not succeed.

I don't believe this is an issue in v1.0+ versions of the library, however, we cannot yet upgrade the Apollo version due to [this issue](https://github.com/apollographql/apollo-ios/issues/2560).

### Proposed Solution

In this PR, I've changed the way that values in the `variables` dictionary are included in the `requestBody`. Now, nil values in `variables` are removed before serialization. Additionally, if all values in `variables` are `nil`, `variables` won't be included in the `requestBody`.