### PR TITLE
[README] Add dark mode logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/146856/124335690-fc7ecd80-db4f-11eb-93fa-dcf4469bb07b.png" alt="Apollo GraphQL"/>
+  <img src="https://raw.githubusercontent.com/apollographql/apollo-client-devtools/main/assets/apollo-wordmark.svg" alt="Apollo GraphQL"/>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Before:
<img src="https://github.com/apollographql/apollo-ios/assets/3974977/6032c008-09fb-4d43-bc5a-516e9efc467b" width=300/>

After:
<img src="https://github.com/apollographql/apollo-ios/assets/3974977/e07c1d01-1ac3-4092-9c58-64e0a6a2d69e" width=300/>

This was taken from the apollo-client README. TIL the SVG file format supports switching from light/dark mode!