### PR TITLE
Fix a leak related to use of function used in a closure

### DIFF
--- a/Sources/Apollo/ApolloStore.swift
+++ b/Sources/Apollo/ApolloStore.swift
@@ -203,7 +203,11 @@ public class ApolloStore {
   public class ReadTransaction {
     fileprivate let cache: any NormalizedCache
 
-    fileprivate lazy var loader: DataLoader<CacheKey, Record> = DataLoader(self.cache.loadRecords)
+    fileprivate lazy var loader: DataLoader<CacheKey, Record> = DataLoader { [weak self] batchLoad in
+        guard let self else { return [:] }
+        return try cache.loadRecords(forKeys: batchLoad)
+    }
+      
     fileprivate lazy var executor = GraphQLExecutor(
       executionSource: CacheDataExecutionSource(transaction: self)
     ) 


### PR DESCRIPTION
There is a leak in fileprivate lazy var loader: DataLoader<CacheKey, Record> because the method implicitly uses self. Making the capture explicit and breaking the retain cycle here. This was also covered in WWDC 2024 analyze heap memory talk https://developer.apple.com/wwdc24/10173?time=1748 

Leak detected via instruments
<img width="1330" alt="Screenshot 2024-08-07 at 11 41 24 PM" src="https://github.com/user-attachments/assets/5800d7a4-7622-41d7-9eae-79c63b1cee06">
