### PR TITLE
feat: Fix multipart boundary predicate

### DIFF
--- a/Sources/Apollo/URLSessionClient.swift
+++ b/Sources/Apollo/URLSessionClient.swift
@@ -298,7 +298,7 @@ open class URLSessionClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
         return
       }
 
-      let boundaryMarker = "--\(boundaryString)"
+      let boundaryMarker = "\r\n--\(boundaryString)\r\n"
       guard
         let dataString = String(data: taskData.data, encoding: .utf8)?.trimmingCharacters(in: .newlines),
         let lastBoundaryIndex = dataString.range(of: boundaryMarker, options: .backwards)?.upperBound,


### PR DESCRIPTION
Only looking for "---" is insufficient to determine the multipart boundary, as the string can occur within JSON objects.

As specified in https://datatracker.ietf.org/doc/html/rfc2046#section-5.1, the delimiter should be _on a separate line_, which means we can recognize it by the newline control characters that won't occur inside JSON objects.