### PR TITLE
docs: move legacy redirects

### DIFF
--- a/docs/source/_redirects
+++ b/docs/source/_redirects
@@ -1,2 +1,0 @@
-/tutorial /docs/ios/tutorial/tutorial-introduction
-/tutorial/tutorial-create-project /docs/ios/tutorial/tutorial-add-sdk


### PR DESCRIPTION
The docs team is centralizing redirects from `_redirects` files into the docs platform repository.  (See https://github.com/apollographql/docs-rewrite/pull/370)

Docs in external repositories can still add redirects in page frontmatter like so:

```
---
title: Apollo GraphOS Platform
description: The GraphQL API Platform
redirectFrom:
    - /intro/platform
    - /graphos
    - /federation/managed-federation/overview
---
```

Redirects in a page's frontmatter take precedence over redirects in the _redirects file but flag a warning.