### PR TITLE
Update GraphQLResponse.swift

### DIFF
--- a/Sources/Apollo/GraphQLResponse.swift
+++ b/Sources/Apollo/GraphQLResponse.swift
@@ -149,3 +149,16 @@ extension GraphQLResponse {
       return val
   }
 }
+
+
+extension GraphQLResponse {
+  public func dataOrThrow() throws -> Operation.Data {
+    guard let data else {
+      if let errors, !errors.isEmpty {
+        throw  throw Error.missingData
+      }
+      throw Error.missingData
+    }
+    return data
+  }
+}


### PR DESCRIPTION
/// An error representing an invalid or unusable ``GraphQLResponse``. ///
/// This error is thrown by convenience APIs such as ``GraphQLResponse/dataOrThrow()`` when the /// response does not contain usable `data`.
///
/// A response may fail for one of two reasons:
/// - ``graphQLErrors(_:)``: The server returned one or more GraphQL errors and no data was
///   available to return.
/// - ``missingData``: The response contained neither `data` nor GraphQL errors.
///
/// This error only describes invalid GraphQL response state. Transport-level failures, request
/// execution failures, and other networking errors are surfaced separately by the network transport
/// and request chain APIs.
public enum Error: Swift.Error, Sendable {
  /// The response included one or more GraphQL errors and did not contain usable data.
  case graphQLErrors([GraphQLError])

  /// The response contained neither data nor GraphQL errors.
  case missingData
}

Similar to Kotlins dataOrThrow or dataAssertNoErrors