### PR TITLE
Convert `AnyHashable` references to `any Hashable & Sendable`, using the existing `AnySendableHashable` type

### DIFF
--- a/Sources/Apollo/Caching/RecordSet.swift
+++ b/Sources/Apollo/Caching/RecordSet.swift
@@ -1,3 +1,5 @@
+@_spi(Internal) import ApolloAPI
+
 /// A set of cache records.
 public struct RecordSet: Sendable, Hashable {
   public private(set) var storage: [CacheKey: Record] = [:]
@@ -60,7 +62,7 @@ public struct RecordSet: Sendable, Hashable {
       var updatedRecord = oldRecord
       
       for (key, value) in record.fields {
-        if let oldValue = oldRecord.fields[key], AnyHashable(oldValue) == AnyHashable(value) {
+        if let oldValue = oldRecord.fields[key], AnySendableHashable.equatableCheck(oldValue, value) {
           continue
         }
         updatedRecord[key] = value

--- a/Sources/Apollo/SelectionSet+DictionaryIntializer.swift
+++ b/Sources/Apollo/SelectionSet+DictionaryIntializer.swift
@@ -20,24 +20,26 @@ extension RootSelectionSet {
     data: [String: Any],
     variables: GraphQLOperation.Variables? = nil
   ) async throws {
-    let jsonObject = try Self.convertToAnyHashableValueDict(dict: data)
+    let jsonObject = try Self.convertToSendableHashableValueDict(dict: data)
     try await self.init(data: jsonObject, variables: variables)
   }
   
-  /// Convert dictionary type [String: Any] to [String: AnyHashable]
+  /// Convert dictionary type [String: Any] to [String: any Sendable & Hashable]
   /// - Parameter dict: [String: Any] type dictionary
-  /// - Returns: converted [String: AnyHashable] type dictionary
-  private static func convertToAnyHashableValueDict(dict: [String: Any]) throws -> JSONObject {
+  /// - Returns: converted [String: any Sendable & Hashable] type dictionary
+  private static func convertToSendableHashableValueDict(dict: [String: Any]) throws -> JSONObject {
     var result = JSONObject()
 
     for (key, value) in dict {
       if let arrayValue = value as? [Any] {
-        result[key] = try convertToAnyHashableArray(array: arrayValue) as JSONValue
+        result[key] = try convertToSendableHashableArray(array: arrayValue) as JSONValue
       } else  {
         if let dictValue = value as? [String: Any] {
-          result[key] = try convertToAnyHashableValueDict(dict: dictValue) as JSONValue
-        } else if let hashableValue = value as? AnyHashable {
-          result[key] = hashableValue as JSONValue
+          result[key] = try convertToSendableHashableValueDict(dict: dictValue) as JSONValue
+        } else if value is any Hashable {
+          // Conditional casts to compositions with the marker protocol `Sendable` are not allowed, so we verify `Hashable` conformance and force cast (matching `JSONSerializationFormat`).
+          let hashableValue = value as! JSONValue
+          result[key] = hashableValue
         } else {
           throw RootSelectionSetInitializeError.hasNonHashableValue
         }
@@ -46,18 +48,19 @@ extension RootSelectionSet {
     return result
   }
 
-  /// Convert Any type Array type to AnyHashable type Array
+  /// Convert Any type Array type to (any Sendable & Hashable) type Array
   /// - Parameter array: Any type Array
-  /// - Returns: AnyHashable type Array
-  private static func convertToAnyHashableArray(array: [Any]) throws -> [JSONValue] {
+  /// - Returns: (any Sendable & Hashable) type Array
+  private static func convertToSendableHashableArray(array: [Any]) throws -> [JSONValue] {
     var result: [JSONValue] = []
     for value in array {
       if let array = value as? [Any] {
-        result.append(try convertToAnyHashableArray(array: array) as JSONValue)
+        result.append(try convertToSendableHashableArray(array: array) as JSONValue)
       } else if let dict = value as? [String: Any] {
-        result.append(try convertToAnyHashableValueDict(dict: dict) as JSONValue)
-      } else if let hashable = value as? AnyHashable {
-        result.append(hashable as JSONValue)
+        result.append(try convertToSendableHashableValueDict(dict: dict) as JSONValue)
+      } else if value is any Hashable {
+        // Conditional casts to compositions with the marker protocol `Sendable` are not allowed, so we verify `Hashable` conformance and force cast (matching `JSONSerializationFormat`).
+        result.append(value as! JSONValue)
       } else {
         throw RootSelectionSetInitializeError.hasNonHashableValue
       }

--- a/Sources/ApolloAPI/GraphQLOperation.swift
+++ b/Sources/ApolloAPI/GraphQLOperation.swift
@@ -99,8 +99,10 @@ public extension GraphQLOperation {
     case (.none, .none): return true
     case (.some, .none), (.none, .some): return false
     case let (.some(lhsVariables), .some(rhsVariables)):
-      return AnyHashable(lhsVariables._jsonEncodableObject._jsonValue)
-        == AnyHashable(rhsVariables._jsonEncodableObject._jsonValue)
+      return AnySendableHashable.equatableCheck(
+        lhsVariables._jsonEncodableObject._jsonValue,
+        rhsVariables._jsonEncodableObject._jsonValue
+      )
     }
   }
 }

--- a/Sources/ApolloAPI/JSONDecodingError.swift
+++ b/Sources/ApolloAPI/JSONDecodingError.swift
@@ -39,7 +39,7 @@ public enum JSONDecodingError: Error, LocalizedError, Hashable {
 
     case let (.couldNotConvert(value: lhsValue, to: lhsType),
               .couldNotConvert(value: rhsValue, to: rhsType)):
-      return AnyHashable(lhsValue) == AnyHashable(rhsValue) && lhsType == rhsType
+      return AnySendableHashable.equatableCheck(lhsValue, rhsValue) && lhsType == rhsType
 
     default:
       return false

--- a/Sources/ApolloAPI/SchemaTypes/InputObject.swift
+++ b/Sources/ApolloAPI/SchemaTypes/InputObject.swift
@@ -68,8 +68,10 @@ public struct InputDict: GraphQLOperationVariableValue, Hashable {
   }
 
   public static func == (lhs: InputDict, rhs: InputDict) -> Bool {
-    AnyHashable(lhs.data._jsonEncodableObject._jsonValue) ==
-    AnyHashable(rhs.data._jsonEncodableObject._jsonValue)
+    AnySendableHashable.equatableCheck(
+      lhs.data._jsonEncodableObject._jsonValue,
+      rhs.data._jsonEncodableObject._jsonValue
+    )
   }
 
   public func hash(into hasher: inout Hasher) {

--- a/Sources/ApolloTestSupport/TestMock.swift
+++ b/Sources/ApolloTestSupport/TestMock.swift
@@ -102,7 +102,8 @@ public class Mock<O: MockObject>: AnyMock, Hashable {
       if let mockArray = $0 as? Array<Any> {
         return mockArray._unsafelyConvertToSelectionSetData() as JSONValue
       }
-      return $0 as JSONValue
+      // `AnyHashable` no longer conforms to `Sendable`, so unwrap the box and force cast its `Hashable` base (Sendable is unchecked, matching the previous behavior).
+      return $0.base as! JSONValue
     }
   }
 


### PR DESCRIPTION
In Swift 6, `AnyHashable` no longer conforms to `Sendable`, which was raising errors when I built with the Xcode beta for iOS 27.0. This fixes this by replacing types `any Hashable & Sendable` and equality comparisons with [`AnySendableHashable`](https://github.com/apollographql/apollo-ios/blob/31da013665000677ba5a802966a8fd2d75c8ee3e/Sources/ApolloAPI/AnySendableHashable.swift#L12-L60), an existing type. 
